### PR TITLE
Add timestamp formatting package for use across multiple serializers

### DIFF
--- a/packages/protocol-timestamp/.gitignore
+++ b/packages/protocol-timestamp/.gitignore
@@ -1,0 +1,4 @@
+/node_modules/
+*.js
+*.js.map
+*.d.ts

--- a/packages/protocol-timestamp/__tests__/index.ts
+++ b/packages/protocol-timestamp/__tests__/index.ts
@@ -1,0 +1,91 @@
+import {
+    epoch,
+    iso8601,
+    rfc822,
+    toDate,
+} from "../";
+
+const toIsoString = '2017-05-22T19:33:14.175Z';
+const iso8601String = '2017-05-22T19:33:14Z';
+const rfc822String = 'Mon, 22 May 2017 19:33:14 GMT';
+const epochTs = 1495481594;
+
+describe('iso8601', () => {
+    it('should convert date objects to ISO-8601 strings', () => {
+        expect(iso8601(new Date(toIsoString))).toBe(iso8601String);
+    });
+
+    it('should convert parseable date strings to ISO-8601 strings', () => {
+        let date = new Date(toIsoString);
+
+        expect(iso8601(date.toUTCString())).toBe(iso8601String);
+        expect(iso8601(date.toISOString())).toBe(iso8601String);
+    });
+
+    it(
+        'should assume numbers are epoch timestamps and convert them to ISO-8601 strings accordingly',
+        () => {
+            expect(iso8601(epochTs)).toBe(iso8601String);
+        }
+    );
+});
+
+describe('rfc822', () => {
+    it('should convert date objects to RFC 822 strings', () => {
+        expect(rfc822(new Date(toIsoString))).toBe(rfc822String);
+    });
+
+    it('should convert parseable date strings to RFC 822 strings', () => {
+        let date = new Date(toIsoString);
+
+        expect(rfc822(date.toUTCString())).toBe(rfc822String);
+        expect(rfc822(date.toISOString())).toBe(rfc822String);
+    });
+
+    it(
+        'should assume numbers are epoch timestamps and convert them to RFC 822 strings accordingly',
+        () => {
+            expect(rfc822(epochTs)).toBe(rfc822String);
+        }
+    );
+});
+
+describe('epoch', () => {
+    it('should convert date objects to epoch timestamps', () => {
+        expect(epoch(new Date(toIsoString))).toBe(epochTs);
+    });
+
+    it('should convert parseable date strings to epoch timestamps', () => {
+        let date = new Date(toIsoString);
+
+        expect(epoch(date.toUTCString())).toBe(epochTs);
+        expect(epoch(date.toISOString())).toBe(epochTs);
+    });
+
+    it(
+        'should assume numbers are epoch timestamps and convert them to epoch timestamps accordingly',
+        () => {
+            expect(epoch(epochTs)).toBe(epochTs);
+        }
+    );
+});
+
+describe('toDate', () => {
+    it('should convert epoch timestamps to date objects', () => {
+        const date = toDate(epochTs);
+        expect(date).toBeInstanceOf(Date);
+        expect(date.valueOf()).toBe(epochTs * 1000);
+    });
+
+    it('should convert ISO-8601 strings to date objects', () => {
+        const date = toDate(iso8601String);
+        expect(date).toBeInstanceOf(Date);
+        expect(date.valueOf()).toBe(epochTs * 1000);
+    });
+
+    it('should convert RFC 822 strings to date objects', () => {
+        const date = toDate(rfc822String);
+        expect(date).toBeInstanceOf(Date);
+        expect(date.valueOf()).toBe(epochTs * 1000);
+    });
+});

--- a/packages/protocol-timestamp/index.ts
+++ b/packages/protocol-timestamp/index.ts
@@ -1,0 +1,23 @@
+export function iso8601(time: number|string|Date): string {
+    return toDate(time).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+export function rfc822(time: number|string|Date): string {
+    return toDate(time).toUTCString();
+}
+
+export function epoch(time: number|string|Date): number {
+    return Math.floor(toDate(time).valueOf() / 1000);
+}
+
+export function toDate(time: number|string|Date): Date {
+    if (typeof time === 'number') {
+        return new Date(time * 1000);
+    }
+
+    if (typeof time === 'string') {
+        return new Date(time);
+    }
+
+    return time;
+}

--- a/packages/protocol-timestamp/package.json
+++ b/packages/protocol-timestamp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@aws/protocol-timestamp",
+  "private": true,
+  "version": "0.0.1",
+  "description": "A marshaller and unmarshaller for timestamps used by the AWS SDKs",
+  "main": "lib/index.js",
+  "scripts": {
+    "prepublishOnly": "tsc",
+    "pretest": "tsc",
+    "test": "jest"
+  },
+  "author": "aws-javascript-sdk-team@amazon.com",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@aws/types": "^0.0.1"
+  },
+  "devDependencies": {
+    "@types/jest": "^19.2.2",
+    "jest": "^19.0.2",
+    "typescript": "^2.3"
+  }
+}

--- a/packages/protocol-timestamp/tsconfig.json
+++ b/packages/protocol-timestamp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true
+  }
+}


### PR DESCRIPTION
This PR adds support for the timestamp formats used by various serializers and parsers.