### PR TITLE
Add IE 11 detection for crypto components

### DIFF
--- a/packages/crypto-ie11-detection/.gitignore
+++ b/packages/crypto-ie11-detection/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+*.js
+*.js.map
+*.d.ts

--- a/packages/crypto-ie11-detection/__tests__/MsWindow.ts
+++ b/packages/crypto-ie11-detection/__tests__/MsWindow.ts
@@ -1,0 +1,31 @@
+import {isMsWindow, MsWindow} from "../lib/MsWindow";
+
+const fakeMsWindow: MsWindow = {
+    MSInputMethodContext: {},
+    msCrypto: {
+        getRandomValues: () => {},
+        subtle: {
+            decrypt(alg: any, key: any) { return {} as any; },
+            digest(alg: any) { return {} as any; },
+            encrypt(alg: any, key: any) { return {} as any; },
+            exportKey(format: any, key: any) { return {} as any; },
+            generateKey(alg: any) { return {} as any; },
+            importKey(format: any, keyData: any, alg: any) { return {} as any; },
+            sign(alg: any, key: any) { return {} as any; },
+            verify(alg: any, key: any, signature: any) { return {} as any; },
+        },
+    },
+} as any;
+
+describe('isMsWindow', () => {
+    it(
+        'should return false if an object does not fulfill the MsWindow interface',
+        () => {
+            expect(isMsWindow({} as any)).toBe(false);
+        }
+    );
+
+    it('should return true if an object fulfills the MsWindow interface', () => {
+        expect(isMsWindow(fakeMsWindow)).toBe(true);
+    });
+});

--- a/packages/crypto-ie11-detection/index.ts
+++ b/packages/crypto-ie11-detection/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/CryptoOperation';
+export * from './lib/Key';
+export * from './lib/KeyOperation';
+export * from './lib/MsSubtleCrypto';
+export * from './lib/MsWindow';

--- a/packages/crypto-ie11-detection/lib/CryptoOperation.ts
+++ b/packages/crypto-ie11-detection/lib/CryptoOperation.ts
@@ -1,0 +1,21 @@
+import {Key} from "./Key";
+
+/**
+ * Represents a cryptographic operation that has been instantiated but not
+ * necessarily fed all data or finalized.
+ *
+ * @see https://msdn.microsoft.com/en-us/library/dn280996(v=vs.85).aspx
+ */
+export interface CryptoOperation {
+    readonly algorithm: string;
+    readonly key: Key;
+    onabort: (event: Event) => void;
+    oncomplete: (event: Event) => void;
+    onerror: (event: Event) => void;
+    onprogress: (event: Event) => void;
+    readonly result: ArrayBuffer|undefined;
+
+    abort(): void;
+    finish(): void;
+    process(buffer: ArrayBufferView): void;
+}

--- a/packages/crypto-ie11-detection/lib/Key.ts
+++ b/packages/crypto-ie11-detection/lib/Key.ts
@@ -1,0 +1,12 @@
+/**
+ * The result of a successful KeyOperation.
+ *
+ * @see {KeyOperation}
+ * @see https://msdn.microsoft.com/en-us/library/dn302313(v=vs.85).aspx
+ */
+export interface Key {
+    readonly algorithm: string;
+    readonly extractable: boolean;
+    readonly keyUsage: Array<string>;
+    readonly type: string;
+}

--- a/packages/crypto-ie11-detection/lib/KeyOperation.ts
+++ b/packages/crypto-ie11-detection/lib/KeyOperation.ts
@@ -1,0 +1,13 @@
+import {Key} from "./Key";
+
+/**
+ * Represents the return of a key-related operation that may or may not have
+ * been completed.
+ *
+ * @see https://msdn.microsoft.com/en-us/library/dn302314(v=vs.85).aspx
+ */
+export interface KeyOperation {
+    oncomplete: (event: Event) => void;
+    onerror: (event: Event) => void;
+    readonly result: Key|undefined;
+}

--- a/packages/crypto-ie11-detection/lib/MsSubtleCrypto.ts
+++ b/packages/crypto-ie11-detection/lib/MsSubtleCrypto.ts
@@ -1,0 +1,79 @@
+import {CryptoOperation} from './CryptoOperation';
+import {Key} from './Key';
+import {KeyOperation} from './KeyOperation';
+
+export type KeyUsage = 'encrypt'|'decrypt'|'sign'|'verify'|'derive'|'wrap'|'unwrap';
+
+export type EncryptionOrVerificationAlgorithm = 'RSAES-PKCS1-v1_5';
+export type Ie11EncryptionAlgorithm = 'AES-CBC'|'AES-GCM'|'RSA-OAEP'|EncryptionOrVerificationAlgorithm;
+export type Ie11DigestAlgorithm = 'SHA-1'|'SHA-256'|'SHA-384';
+
+export interface HashAlgorithm {
+    name: Ie11DigestAlgorithm;
+}
+
+export interface HmacAlgorithm {
+    name: 'HMAC';
+    hash: HashAlgorithm;
+}
+
+export type SigningAlgorithm = HmacAlgorithm;
+
+/**
+ * Represent ths SubtleCrypto interface as implemented in Internet Explorer 11.
+ * This implementation was based on an earlier version of the WebCrypto API and
+ * differs from the `window.crypto.subtle` object exposed in Chrome, Safari,
+ * Firefox, and MS Edge.
+ *
+ * @see https://msdn.microsoft.com/en-us/library/dn302325(v=vs.85).aspx
+ */
+export interface MsSubtleCrypto {
+    decrypt(
+        algorithm: Ie11EncryptionAlgorithm,
+        key: Key,
+        buffer?: ArrayBufferView
+    ): CryptoOperation;
+
+    digest(
+        algorithm: Ie11DigestAlgorithm,
+        buffer?: ArrayBufferView
+    ): CryptoOperation;
+
+    encrypt(
+        algorithm: Ie11EncryptionAlgorithm,
+        key: Key,
+        buffer?: ArrayBufferView
+    ): CryptoOperation;
+
+    exportKey(
+        format: string,
+        key: Key
+    ): KeyOperation;
+
+    generateKey(
+        algorithm: SigningAlgorithm|Ie11EncryptionAlgorithm,
+        extractable?: boolean,
+        keyUsages?: Array<KeyUsage>
+    ): KeyOperation;
+
+    importKey(
+        format: string,
+        keyData: ArrayBufferView,
+        algorithm: any,
+        extractable?: boolean,
+        keyUsages?: Array<KeyUsage>
+    ): KeyOperation;
+
+    sign(
+        algorithm: SigningAlgorithm,
+        key: Key,
+        buffer?: ArrayBufferView,
+    ): CryptoOperation;
+
+    verify(
+        algorithm: SigningAlgorithm|EncryptionOrVerificationAlgorithm,
+        key: Key,
+        signature: ArrayBufferView,
+        buffer?: ArrayBufferView
+    ): CryptoOperation;
+}

--- a/packages/crypto-ie11-detection/lib/MsWindow.ts
+++ b/packages/crypto-ie11-detection/lib/MsWindow.ts
@@ -1,0 +1,59 @@
+import {MsSubtleCrypto} from "./MsSubtleCrypto";
+
+type SubtleCryptoMethod = 'decrypt'|'digest'|'encrypt'|'exportKey'|'generateKey'|'importKey'|'sign'|'verify';
+
+const msSubtleCryptoMethods: Array<SubtleCryptoMethod> = [
+    'decrypt',
+    'digest',
+    'encrypt',
+    'exportKey',
+    'generateKey',
+    'importKey',
+    'sign',
+    'verify',
+];
+
+/**
+ * The value accessible as `window.msCrypto` in Internet Explorer 11.
+ */
+export interface MsCrypto {
+    getRandomValues: (toFill: Uint8Array) => void;
+    subtle: MsSubtleCrypto;
+}
+
+/**
+ * The `window` object in Internet Explorer 11. This interface does not
+ * exhaustively document the prefixed features of `window` in IE11.
+ */
+export interface MsWindow extends Window {
+    MSInputMethodContext: any;
+    msCrypto: MsCrypto;
+}
+
+function quacksLikeAnMsWindow(window: Window): window is MsWindow {
+    return 'MSInputMethodContext' in window &&
+            'msCrypto' in window;
+}
+
+/**
+ * Determines if the provided window is (or is like) the window object one would
+ * expect to encounter in Internet Explorer 11.
+ */
+export function isMsWindow(window: Window): window is MsWindow {
+    if (quacksLikeAnMsWindow(window) && window.msCrypto.subtle !== undefined) {
+        const {getRandomValues, subtle} = window.msCrypto;
+        const methodsToTest = msSubtleCryptoMethods
+            .map<Function>(methodName => subtle[methodName])
+            .concat(getRandomValues);
+
+        for (let method of methodsToTest) {
+            if (typeof method !== 'function') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/packages/crypto-ie11-detection/package.json
+++ b/packages/crypto-ie11-detection/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@aws/crypto-ie11-detection",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Provides functions and types for detecting if the host environment is IE11",
+  "scripts": {
+    "pretest": "tsc",
+    "test": "jest"
+  },
+  "author": "aws-javascript-sdk-team@amazon.com",
+  "license": "UNLICENSED",
+  "main": "index.js",
+  "devDependencies": {
+    "@types/jest": "^19.2.2",
+    "jest": "^19.0.2",
+    "typescript": "^2.3"
+  }
+}

--- a/packages/crypto-ie11-detection/tsconfig.json
+++ b/packages/crypto-ie11-detection/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "strict": true,
+        "sourceMap": true,
+        "declaration": true,
+        "stripInternal": true
+    }
+}


### PR DESCRIPTION
Split off from #1 

This PR includes a way to detect if the script is running in an environment whose provided crypto interfaces are compatible with IE 11.