### PR TITLE
Add interface to be followed by HTTP handlers

### DIFF
--- a/packages/types/http.ts
+++ b/packages/types/http.ts
@@ -31,3 +31,16 @@ export interface HttpResponse<StreamType = Uint8Array> extends
 {
     statusCode: number;
 }
+
+/**
+ * A function that takes an HTTP request and returns a promise for an HTTP
+ * response.
+ *
+ * If a `StreamType` type parameter is supplied, both the request and the
+ * response may have streaming bodies. In such implementations, the promise
+ * returned should resolve as soon as headers are available, and the as-yet
+ * uncollected stream should be set as the response's `body` property.
+ */
+export interface HttpHandler<StreamType = Uint8Array> {
+    (request: HttpRequest<StreamType>): Promise<HttpResponse<StreamType>>;
+}


### PR DESCRIPTION
This interface provides a simple façade over Fetch, `http`, XmlHttpRequest, and any customer-defined HTTP handler.