### PR TITLE
Remove dependency on @types/node from @aws/is-array-buffer

### DIFF
--- a/packages/is-array-buffer/index.ts
+++ b/packages/is-array-buffer/index.ts
@@ -1,7 +1,4 @@
 export function isArrayBuffer(arg: any): arg is ArrayBuffer {
-    return typeof ArrayBuffer === 'function'
-        && (
-            arg instanceof ArrayBuffer ||
-            Object.prototype.toString.call(arg) === '[object ArrayBuffer]'
-        );
+    return (typeof ArrayBuffer === 'function' && arg instanceof ArrayBuffer)
+        || Object.prototype.toString.call(arg) === '[object ArrayBuffer]';
 }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -12,7 +12,6 @@
   "main": "index.js",
   "devDependencies": {
     "@types/jest": "^20.0.2",
-    "@types/node": "^7.0.12",
     "jest": "^20.0.4",
     "typescript": "^2.3"
   }


### PR DESCRIPTION
The `@aws/is-array-buffer` has a dev dependency on `@types/node`, which it doesn't need and isn't using. This PR removes it, re-formats the function body, and corrects an error in parenthetical association.