### PR TITLE
Widen region option in SignatureV4 ctor to accept a region provider and move credentials to be a ctor argument

### DIFF
--- a/packages/signature-v4/__tests__/SignatureV4.ts
+++ b/packages/signature-v4/__tests__/SignatureV4.ts
@@ -25,7 +25,11 @@ const MockDate = () => new Date('2000-01-01T00:00:00.000Z');
 const signer = new SignatureV4({
     service: 'foo',
     region: 'us-bar-1',
-    sha256: Sha256
+    sha256: Sha256,
+    credentials: {
+        accessKeyId: 'foo',
+        secretAccessKey: 'bar',
+    }
 });
 
 const minimalRequest: HttpRequest<any> = {
@@ -52,7 +56,6 @@ describe('SignatureV4', () => {
         it('should sign requests without bodies', async () => {
             const {query} = await signer.presignRequest({
                 request: minimalRequest,
-                credentials,
                 expiration,
                 currentDateConstructor: MockDate as any,
             });
@@ -72,7 +75,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     body: 'It was the best of times, it was the worst of times'
                 },
-                credentials,
                 expiration,
                 currentDateConstructor: MockDate as any,
             });
@@ -92,7 +94,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     body: new Uint8Array([0xde, 0xad, 0xbe, 0xef])
                 },
-                credentials,
                 expiration,
                 currentDateConstructor: MockDate as any,
             });
@@ -112,7 +113,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     body: new PassThrough()
                 },
-                credentials,
                 expiration,
                 currentDateConstructor: MockDate as any,
             });
@@ -129,12 +129,17 @@ describe('SignatureV4', () => {
         it(
             `should set and sign the ${TOKEN_QUERY_PARAM} query parameter if the credentials have a session token`,
             async () => {
-                const {query} = await signer.presignRequest({
-                    request: minimalRequest,
+                const signer = new SignatureV4({
+                    service: 'foo',
+                    region: 'us-bar-1',
+                    sha256: Sha256,
                     credentials: {
                         ...credentials,
                         sessionToken: 'baz',
-                    },
+                    }
+                });
+                const {query} = await signer.presignRequest({
+                    request: minimalRequest,
                     expiration,
                     currentDateConstructor: MockDate as any,
                 });
@@ -158,7 +163,8 @@ describe('SignatureV4', () => {
                     service: 'foo',
                     region: 'us-bar-1',
                     sha256: Sha256,
-                    unsignedPayload: true
+                    unsignedPayload: true,
+                    credentials,
                 });
 
                 const {query} = await signer.presignRequest({
@@ -166,7 +172,6 @@ describe('SignatureV4', () => {
                         ...minimalRequest,
                         body: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
                     },
-                    credentials,
                     expiration,
                     currentDateConstructor: MockDate as any,
                 });
@@ -196,7 +201,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     headers,
                 },
-                credentials,
                 expiration,
                 hoistHeaders: false,
                 currentDateConstructor: MockDate as any,
@@ -223,7 +227,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     headers,
                 },
-                credentials,
                 expiration,
                 hoistHeaders: false,
                 currentDateConstructor: MockDate as any,
@@ -243,7 +246,6 @@ describe('SignatureV4', () => {
                             [EXPIRES_QUERY_PARAM]: '1 week',
                         }
                     },
-                    credentials,
                     expiration,
                     hoistHeaders: false,
                     currentDateConstructor: MockDate as any,
@@ -258,7 +260,6 @@ describe('SignatureV4', () => {
                 return expect(
                     signer.presignRequest({
                         request: minimalRequest,
-                        credentials,
                         expiration: new Date(),
                         currentDateConstructor: MockDate as any,
                     })
@@ -269,7 +270,6 @@ describe('SignatureV4', () => {
         it('should use the current date if no constructor supplied', async () => {
             const {query} = await signer.presignRequest({
                 request: minimalRequest,
-                credentials,
                 expiration: Math.floor((Date.now() + 60 * 60 * 1000) / 1000),
             });
             expect((query as any)[AMZ_DATE_QUERY_PARAM]).toBe(
@@ -282,7 +282,6 @@ describe('SignatureV4', () => {
         it('should sign requests without bodies', async () => {
             const {headers} = await signer.signRequest({
                 request: minimalRequest,
-                credentials,
                 currentDateConstructor: MockDate as any,
             });
             expect(headers[AUTH_HEADER]).toBe(
@@ -296,7 +295,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     body: 'It was the best of times, it was the worst of times'
                 },
-                credentials,
                 currentDateConstructor: MockDate as any,
             });
             expect(headers[AUTH_HEADER]).toBe(
@@ -310,7 +308,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     body: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
                 },
-                credentials,
                 currentDateConstructor: MockDate as any,
             });
             expect(headers[AUTH_HEADER]).toBe(
@@ -324,7 +321,6 @@ describe('SignatureV4', () => {
                     ...minimalRequest,
                     body: new PassThrough(),
                 },
-                credentials,
                 currentDateConstructor: MockDate as any,
             });
 
@@ -337,7 +333,6 @@ describe('SignatureV4', () => {
         it(`should set the ${AMZ_DATE_HEADER}`, async () => {
             const {headers} = await signer.signRequest({
                 request: minimalRequest,
-                credentials,
                 currentDateConstructor: MockDate as any,
             });
             expect(headers[AMZ_DATE_HEADER]).toBe('20000101T000000Z');
@@ -346,12 +341,17 @@ describe('SignatureV4', () => {
         it(
             `should set and sign the ${TOKEN_HEADER} header if the credentials have a session token`,
             async () => {
-                const {headers} = await signer.signRequest({
-                    request: minimalRequest,
+                const signer = new SignatureV4({
+                    service: 'foo',
+                    region: 'us-bar-1',
+                    sha256: Sha256,
                     credentials: {
                         ...credentials,
                         sessionToken: 'baz',
                     },
+                });
+                const {headers} = await signer.signRequest({
+                    request: minimalRequest,
                     currentDateConstructor: MockDate as any,
                 });
                 expect(headers[AUTH_HEADER]).toBe(
@@ -367,7 +367,8 @@ describe('SignatureV4', () => {
                     service: 'foo',
                     region: 'us-bar-1',
                     sha256: Sha256,
-                    unsignedPayload: true
+                    unsignedPayload: true,
+                    credentials,
                 });
 
                 const {headers} = await signer.signRequest({
@@ -375,7 +376,6 @@ describe('SignatureV4', () => {
                         ...minimalRequest,
                         body: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
                     },
-                    credentials,
                     currentDateConstructor: MockDate as any,
                 });
                 expect(headers[AUTH_HEADER]).toBe(
@@ -388,7 +388,6 @@ describe('SignatureV4', () => {
         it('should use the current date if no constructor supplied', async () => {
             const {headers} = await signer.signRequest({
                 request: minimalRequest,
-                credentials,
             });
             expect(headers[AMZ_DATE_HEADER]).toBe(
                 iso8601(new Date()).replace(/[\-:]/g, '')
@@ -405,7 +404,6 @@ describe('SignatureV4', () => {
                         'user-agent': 'baz',
                     },
                 },
-                credentials,
                 currentDateConstructor: MockDate as any,
                 unsignableHeaders: {foo: true}
             });

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -12,6 +12,7 @@
   "author": "aws-javascript-sdk-team@amazon.com",
   "license": "UNLICENSED",
   "dependencies": {
+    "@aws/credential-provider-base": "^0.0.1",
     "@aws/is-array-buffer": "^0.0.1",
     "@aws/protocol-timestamp": "^0.0.1",
     "@aws/types": "^0.0.1",

--- a/packages/signature-v4/tsconfig.json
+++ b/packages/signature-v4/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "lib": [
       "es5",
-      "es2015.promise"
+      "es2015.promise",
+      "es2015.collection"
     ],
     "declaration": true,
     "inlineSourceMap": true,

--- a/packages/types/credentials.ts
+++ b/packages/types/credentials.ts
@@ -1,3 +1,5 @@
+import {Provider} from './util';
+
 /**
  * An object representing temporary or permanent AWS credentials.
  */
@@ -25,4 +27,4 @@ export interface Credentials {
     readonly expiration?: number;
 }
 
-export type CredentialProvider = () => Promise<Credentials>;
+export type CredentialProvider = Provider<Credentials>;

--- a/packages/types/signature.ts
+++ b/packages/types/signature.ts
@@ -1,4 +1,3 @@
-import {Credentials} from './credentials';
 import {HttpRequest} from './http';
 
 export interface RequestSigningArguments<StreamType> {
@@ -7,11 +6,6 @@ export interface RequestSigningArguments<StreamType> {
      * signing process but will instead be cloned.
      */
     request: HttpRequest<StreamType>;
-
-    /**
-     * The credentials with which the URL should be signed.
-     */
-    credentials: Credentials;
 
     /**
      * A zero-argument constructor used to create a JavaScript `Date` object for

--- a/packages/types/util.ts
+++ b/packages/types/util.ts
@@ -21,3 +21,14 @@ export interface Encoder {
 export interface Decoder {
     (input: string): Uint8Array;
 }
+
+/**
+ * A function that, when invoked, returns a promise that will be fulfilled with
+ * a value of type T.
+ *
+ * @example A function that reads credentials from shared SDK configuration
+ * files, assuming roles and collecting MFA tokens as necessary.
+ */
+export interface Provider<T> {
+    (): Promise<T>;
+}


### PR DESCRIPTION
This change makes `credentials` and `region` required constructor arguments for the SignatureV4 signer class but allows users to pass in asynchronous providers instead of a string or object literal. `region` was previously required but had to be a string, and `credentials` was previously a required parameter when calling the `SignatureV4::presignRequest` or `SignatureV4::signRequest`.

Making this change simplifies the calling pattern customers will need to follow to sign requests. They can pass a credential provider to the object's constructor and then invoke `signRequest` with just a request object.