### PR TITLE
Simplify middleware stack and types

### DIFF
--- a/packages/middleware-stack/src/index.spec.ts
+++ b/packages/middleware-stack/src/index.spec.ts
@@ -1,117 +1,182 @@
 import {MiddlewareStack} from "./";
-import {HandlerArguments, Middleware} from "@aws/types";
+import {
+    Handler,
+    HandlerArguments,
+} from "@aws/types";
+
+type input = Array<string>;
+type output = object;
+type handler = Handler<input, output>;
+
+class ConcatMiddleware implements handler {
+    constructor(
+        private readonly message: string,
+        private readonly next: handler
+    ) {}
+
+    handle(args: HandlerArguments<input>): Promise<output> {
+        return this.next.handle({
+            ...args,
+            input: args.input.concat(this.message),
+        })
+    }
+}
+
+function shuffle<T>(arr: Array<T>): Array<T> {
+    arr = [...arr];
+    for (let i = arr.length; i > 0; i--) {
+        const rand = Math.floor(Math.random() * i);
+        const curr = i - 1;
+        [arr[curr], arr[rand]] = [arr[rand], arr[curr]];
+    }
+    return arr;
+}
 
 describe('MiddlewareStack', () => {
     it('should resolve the stack into a composed handler', async () => {
-        const stack = new MiddlewareStack<Array<string>, object>();
-        stack.prependInit(next => args => next({
-            ...args,
-            input: args.input.concat('first')
-        }));
-        stack.appendBuild(next => args => next({
-            ...args,
-            input: args.input.concat('fourth')
-        }));
-        stack.appendInit(next => args => next({
-            ...args,
-            input: args.input.concat('second')
-        }));
-        stack.prependBuild(next => args => next({
-            ...args,
-            input: args.input.concat('third')
-        }));
-        stack.appendSign(next => args => next({
-            ...args,
-            input: args.input.concat('sixth')
-        }));
-        stack.prependSign(next => args => next({
-            ...args,
-            input: args.input.concat('fifth')
-        }));
+        const stack = new MiddlewareStack<handler>();
 
-        const inner = jest.fn(({input}: HandlerArguments<Array<string>>) => {
-            expect(input).toEqual([
-                'first',
-                'second',
-                'third',
-                'fourth',
-                'fifth',
-                'sixth',
-            ]);
-            return {};
-        });
-        const composed = stack.resolve(inner);
-        await composed({input: []});
+        const middleware = shuffle([
+            [ConcatMiddleware.bind(null, 'second')],
+            [ConcatMiddleware.bind(null, 'first'), {priority: 10}],
+            [ConcatMiddleware.bind(null, 'fourth'), {step: 'build'}],
+            [
+                ConcatMiddleware.bind(null, 'third'),
+                {step: 'build', priority: 1}
+            ],
+            [ConcatMiddleware.bind(null, 'fifth'), {step: 'finalize'}],
+            [
+                ConcatMiddleware.bind(null, 'sixth'),
+                {step: 'finalize', priority: -1}
+            ],
+        ]);
 
-        expect(inner.mock.calls.length).toBe(1);
+        for (const [mw, options] of middleware) {
+            stack.add(mw, options);
+        }
+
+        const inner = {
+            handle: jest.fn(({input}: HandlerArguments<input>) => {
+                expect(input).toEqual([
+                    'first',
+                    'second',
+                    'third',
+                    'fourth',
+                    'fifth',
+                    'sixth',
+                ]);
+                return {};
+            })
+        };
+        const composed = stack.resolve(inner, {} as any);
+        await composed.handle({input: []});
+
+        expect(inner.handle.mock.calls.length).toBe(1);
     });
 
     it('should allow cloning', async () => {
-        const stack = new MiddlewareStack<Array<string>, object>();
-        stack.appendInit(next => args => next({
-            ...args,
-            input: args.input.concat('second')
-        }));
-        stack.prependInit(next => args => next({
-            ...args,
-            input: args.input.concat('first')
-        }));
+        const stack = new MiddlewareStack<handler>();
+        stack.add(ConcatMiddleware.bind(null, 'second'));
+        stack.add(ConcatMiddleware.bind(null, 'first'), {priority: 100});
 
         const secondStack = stack.clone();
 
-        let inner = jest.fn(({input}: HandlerArguments<Array<string>>) => {
-            expect(input).toEqual([
-                'first',
-                'second',
-            ]);
-            return Promise.resolve({});
-        });
-        await secondStack.resolve(inner)({input: []});
-        expect(inner.mock.calls.length).toBe(1);
+        let inner = {
+            handle: jest.fn(({input}: HandlerArguments<input>) => {
+                expect(input).toEqual([
+                    'first',
+                    'second',
+                ]);
+                return Promise.resolve({});
+            })
+        };
+        await secondStack.resolve(inner, {} as any).handle({input: []});
+        expect(inner.handle.mock.calls.length).toBe(1);
     });
 
-    it('should allow the removal of middleware by object identity', async () => {
-        const stack = new MiddlewareStack<Array<string>, object>();
-        let middleware: Middleware<Array<string>, object> = next => args => next({
-            ...args,
-            input: args.input.concat('first')
-        });
-        stack.prependInit(middleware);
+    it('should allow combining stacks', async () => {
+        const stack = new MiddlewareStack<handler>();
+        stack.add(ConcatMiddleware.bind(null, 'second'));
+        stack.add(ConcatMiddleware.bind(null, 'first'), {priority: 100});
 
-        await stack.resolve(({input}: HandlerArguments<Array<string>>) => {
-            expect(input).toEqual([
-                'first',
-            ]);
-            return Promise.resolve({});
-        })({input: []});
+        const secondStack = new MiddlewareStack<handler>();
+        secondStack.add(ConcatMiddleware.bind(null, 'fourth'), {step: 'build'});
+        secondStack.add(
+            ConcatMiddleware.bind(null, 'third'),
+            {step: 'build', priority: 100}
+        );
 
-        stack.remove(middleware);
+        let inner = {
+            handle: jest.fn(({input}: HandlerArguments<input>) => {
+                expect(input).toEqual([
+                    'first',
+                    'second',
+                    'third',
+                    'fourth',
+                ]);
+                return Promise.resolve({});
+            })
+        };
+        await stack.concat(secondStack).resolve(inner, {} as any)
+            .handle({input: []});
 
-        await stack.resolve(({input}: HandlerArguments<Array<string>>) => {
-            expect(input).toEqual([]);
-            return Promise.resolve({});
-        })({input: []});
+        expect(inner.handle.mock.calls.length).toBe(1);
     });
 
-    it('should allow the removal of middleware by name', async () => {
-        const stack = new MiddlewareStack<Array<string>, object>();
-        stack.prependInit(next => args => next({
-            ...args,
-            input: args.input.concat('first')
-        }), 'first');
+    it('should allow the removal of middleware by constructor identity', async () => {
+        const MyMiddleware = ConcatMiddleware.bind(null, 'remove me!');
+        const stack = new MiddlewareStack<handler>();
+        stack.add(MyMiddleware);
+        stack.add(ConcatMiddleware.bind(null, "don't remove me"));
 
-        await stack.resolve(({input}: HandlerArguments<Array<string>>) => {
-            expect(input).toEqual([
-                'first',
-            ]);
-            return Promise.resolve({});
-        })({input: []});
+        await stack.resolve({
+                handle: ({input}: HandlerArguments<Array<string>>) => {
+                expect(input.sort()).toEqual([
+                    "don't remove me",
+                    'remove me!',
+                ]);
+                return Promise.resolve({});
+            }
+        }, {} as any).handle({input: []});
 
-        stack.remove('first');
+        stack.remove(MyMiddleware);
 
-        await stack.resolve(({input}: HandlerArguments<Array<string>>) => {
-            expect(input).toEqual([]);
-            return Promise.resolve({});
-        })({input: []});
+        await stack.resolve({
+            handle: ({input}: HandlerArguments<Array<string>>) => {
+                expect(input).toEqual(["don't remove me"]);
+                return Promise.resolve({});
+            }
+        }, {} as any).handle({input: []});
+    });
+
+    it('should allow the removal of middleware by tag', async () => {
+        const stack = new MiddlewareStack<handler>();
+        stack.add(
+            ConcatMiddleware.bind(null, 'not removed'),
+            {tags: new Set(['foo', 'bar'])}
+        );
+        stack.add(
+            ConcatMiddleware.bind(null, 'remove me!'),
+            {tags: new Set(['foo', 'bar', 'baz'])}
+        );
+
+        await stack.resolve({
+            handle: ({input}: HandlerArguments<Array<string>>) => {
+                expect(input.sort()).toEqual([
+                    'not removed',
+                    'remove me!',
+                ]);
+                return Promise.resolve({});
+            }
+        }, {} as any).handle({input: []});
+
+        stack.remove('baz');
+
+        await stack.resolve({
+            handle: ({input}: HandlerArguments<Array<string>>) => {
+                expect(input).toEqual(['not removed']);
+                return Promise.resolve({});
+            }
+        }, {} as any).handle({input: []});
     });
 });


### PR DESCRIPTION
This PR changes the handler interface from one expecting a bare function to one expecting an object with a `handle` method. It also redefines the middleware interface as simply the constructor of a handler (rather than a higher-order function). The motivation behind this change is to discourage the allocation of a new closure each time the middleware function is invoked.

For example, a port of the RDS `SourceRegion` middleware would previously have looked something like this:

```typescript
function sourceFileMiddleware(next: Handler): Handler {
    return ({input, ...rest}: HandlerArgs) => {
        return next({
            ...rest,
            input: {
                ...input,
                PreSignedUrl: presigned_url(input),
            }
        });
    };
}
```

and now it would look something like this:

```typescript
class SourceFileMiddleware implements Handler {
    constructor(private readonly next: Handler) {}

    handle({input, ...rest}: HandlerArgs) {
        return this.next.handle({
            ...rest,
            input: {
                ...input,
                PreSignedUrl: presigned_url(input),
            }
        });
    }
}
```

They look very similar, but the former will create a new function literal and close over its environment each time it is invoked, whereas the latter will create a new instance of `SourceFileMiddleware` each time the constructor is called but will only bind `next` to its `this` context and will only create one instance of the `handle` method. As with higher-order functions, constructors that require additional parameters can capture them using `bind`.

I spent too much time trying to write a subtypes of `Handler` for each step and to cause using the wrong subtype (e.g., `stack.add(FinalizeMiddleware, {step: 'initialize'})`) to be disallowed by the compiler, but TypeScript disallows this kind of constraint (which it calls [function parameter bivariance](https://www.typescriptlang.org/docs/handbook/type-compatibility.html#function-parameter-bivariance)).