### PR TITLE
Transition SignatureV4 from using raw promise chains to async/await

### DIFF
--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -27,7 +27,7 @@ export function fromInstanceMetadata(
             )).trim()
         } = init;
 
-        return await retry(async () => {
+        return retry(async () => {
             const credsResponse = JSON.parse(
                 await requestFromEc2Imds(timeout, profile)
             );

--- a/packages/signature-v4/src/getPayloadHash.ts
+++ b/packages/signature-v4/src/getPayloadHash.ts
@@ -6,35 +6,28 @@ import {toHex} from '@aws/util-hex-encoding';
 /**
  * @internal
  */
-export function getPayloadHash(
+export async function getPayloadHash(
     {headers, body}: HttpRequest<any>,
     hashConstructor: HashConstructor
 ): Promise<string> {
     if (SHA256_HEADER in headers) {
-        return Promise.resolve(headers[SHA256_HEADER]);
+        return headers[SHA256_HEADER];
     }
-
-    let hashPromise: Promise<Uint8Array>;
 
     if (body == undefined) {
-        hashPromise = Promise.resolve(EMPTY_DATA_SHA_256);
-    } else {
-        const hash = new hashConstructor();
-
-        if (
-            typeof body === 'string'
-            || ArrayBuffer.isView(body)
-            || isArrayBuffer(body)
-        ) {
-            hash.update(body);
-            hashPromise = hash.digest();
-        } else {
-            // As any body that is not a string or binary data is a stream, this
-            // body is unsignable. Attempt to send the request with an unsigned
-            // payload, which may or may not be accepted by the service.
-            return Promise.resolve(UNSIGNED_PAYLOAD);
-        }
+        return toHex(EMPTY_DATA_SHA_256);
+    } else if (
+        typeof body === 'string'
+        || ArrayBuffer.isView(body)
+        || isArrayBuffer(body)
+    ) {
+        const hashCtor = new hashConstructor();
+        hashCtor.update(body);
+        return toHex(await hashCtor.digest());
     }
 
-    return hashPromise.then(toHex);
+    // As any defined body that is not a string or binary data is a stream, this
+    // body is unsignable. Attempt to send the request with an unsigned payload,
+    // which may or may not be accepted by the service.
+    return UNSIGNED_PAYLOAD;
 }


### PR DESCRIPTION
We've discussed the possibility of using async/await instead of raw promises in the SDK, and the request signer is a section of the code whose readability would be greatly improved by this change.

Posted mostly for comment/comparison