### PR TITLE
Add NPM script to clean build caches and reset packages to their unbuilt, unbootstrapped state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ jspm_packages
 .yarn-integrity
 
 lerna-debug.log
-packages/*/package-lock.json
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "main": "index.js",
   "scripts": {
     "bootstrap": "lerna bootstrap",
+    "clean": "npm run clear-build-cache && lerna clean",
+    "clear-build-cache": "lerna exec -- rm -rf ./build",
     "pretest": "lerna run pretest",
     "test": "jest --coverage"
   },


### PR DESCRIPTION
I had to run the series of commands embedded in `npm run clean` frequently while integrating our combined work.