### PR TITLE
Move control parameters to be part of input (and therefore accepted by command constructor and classic client)

### DIFF
--- a/packages/core-handler/src/index.spec.ts
+++ b/packages/core-handler/src/index.spec.ts
@@ -32,8 +32,9 @@ describe('CoreHandler', () => {
         it(`forwards abortSignal to httpHandler`, async () => {
             const mockAbortSignal = {};
             await handler({
-                abortSignal: mockAbortSignal as any,
-                input: {} as never,
+                input: {
+                    $abortSignal: mockAbortSignal
+                } as never,
                 request: {} as any
             });
 

--- a/packages/core-handler/src/index.ts
+++ b/packages/core-handler/src/index.ts
@@ -1,4 +1,5 @@
 import {
+    CommandInput,
     FinalizeHandler,
     FinalizeHandlerArguments,
     HandlerExecutionContext,
@@ -12,10 +13,13 @@ export function coreHandler<OutputConstraint extends MetadataBearer, Stream = Ui
     httpHandler: HttpHandler<Stream>,
     responseParser: ResponseParser<Stream>
 ): Terminalware<OutputConstraint, Stream> {
-    return <Input extends object, Output extends OutputConstraint>(
+    return <Input extends CommandInput, Output extends OutputConstraint>(
         {model}: HandlerExecutionContext
     ): FinalizeHandler<Input, Output, Stream> => (
-        {request, abortSignal}: FinalizeHandlerArguments<Input, Stream>
+        {
+            request,
+            input: {$abortSignal: abortSignal}
+        }: FinalizeHandlerArguments<Input, Stream>
     ): Promise<Output> => httpHandler.handle(request, {abortSignal})
             .then(response => responseParser.parse<Output>(model, response))
 }

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -45,7 +45,7 @@ export class NodeHttpHandler implements HttpHandler<Readable, NodeHttpOptions> {
             method: request.method,
             path: path,
             port: request.port
-        }
+        };
 
         return new Promise((resolve, reject) => {
             const abortSignal = options && options.abortSignal;

--- a/packages/sdk-codecommit-browser/types/BatchGetRepositoriesInput.ts
+++ b/packages/sdk-codecommit-browser/types/BatchGetRepositoriesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a batch get repositories operation.</p>
  */
@@ -6,4 +8,25 @@ export interface BatchGetRepositoriesInput {
      * <p>The names of the repositories to get information about.</p>
      */
     repositoryNames: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/CreateBranchInput.ts
+++ b/packages/sdk-codecommit-browser/types/CreateBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a create branch operation.</p>
  */
@@ -16,4 +18,25 @@ export interface CreateBranchInput {
      * <p>The ID of the commit to point the new branch to.</p>
      */
     commitId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/CreateRepositoryInput.ts
+++ b/packages/sdk-codecommit-browser/types/CreateRepositoryInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a create repository operation.</p>
  */
@@ -11,4 +13,25 @@ export interface CreateRepositoryInput {
      * <p>A comment or description about the new repository.</p> <note> <p>The description field for a repository accepts all HTML characters and all valid Unicode characters. Applications that do not HTML-encode the description and display it in a web page could expose users to potentially malicious code. Make sure that you HTML-encode the description field in any application that uses this API to display the repository description on a web page.</p> </note>
      */
     repositoryDescription?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/DeleteBranchInput.ts
+++ b/packages/sdk-codecommit-browser/types/DeleteBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a delete branch operation.</p>
  */
@@ -11,4 +13,25 @@ export interface DeleteBranchInput {
      * <p>The name of the branch to delete.</p>
      */
     branchName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/DeleteRepositoryInput.ts
+++ b/packages/sdk-codecommit-browser/types/DeleteRepositoryInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a delete repository operation.</p>
  */
@@ -6,4 +8,25 @@ export interface DeleteRepositoryInput {
      * <p>The name of the repository to delete.</p>
      */
     repositoryName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/GetBlobInput.ts
+++ b/packages/sdk-codecommit-browser/types/GetBlobInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get blob operation.</p>
  */
@@ -11,4 +13,25 @@ export interface GetBlobInput {
      * <p>The ID of the blob, which is its SHA-1 pointer.</p>
      */
     blobId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/GetBranchInput.ts
+++ b/packages/sdk-codecommit-browser/types/GetBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get branch operation.</p>
  */
@@ -11,4 +13,25 @@ export interface GetBranchInput {
      * <p>The name of the branch for which you want to retrieve information.</p>
      */
     branchName?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/GetCommitInput.ts
+++ b/packages/sdk-codecommit-browser/types/GetCommitInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get commit operation.</p>
  */
@@ -11,4 +13,25 @@ export interface GetCommitInput {
      * <p>The commit ID. Commit IDs are the full SHA of the commit.</p>
      */
     commitId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/GetDifferencesInput.ts
+++ b/packages/sdk-codecommit-browser/types/GetDifferencesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GetDifferencesInput shape
  */
@@ -36,4 +38,25 @@ export interface GetDifferencesInput {
      * <p>An enumeration token that when provided in a request, returns the next batch of the results.</p>
      */
     NextToken?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/GetRepositoryInput.ts
+++ b/packages/sdk-codecommit-browser/types/GetRepositoryInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get repository operation.</p>
  */
@@ -6,4 +8,25 @@ export interface GetRepositoryInput {
      * <p>The name of the repository to get information about.</p>
      */
     repositoryName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/GetRepositoryTriggersInput.ts
+++ b/packages/sdk-codecommit-browser/types/GetRepositoryTriggersInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get repository triggers operation.</p>
  */
@@ -6,4 +8,25 @@ export interface GetRepositoryTriggersInput {
      * <p>The name of the repository for which the trigger is configured.</p>
      */
     repositoryName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/ListBranchesInput.ts
+++ b/packages/sdk-codecommit-browser/types/ListBranchesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a list branches operation.</p>
  */
@@ -11,4 +13,25 @@ export interface ListBranchesInput {
      * <p>An enumeration token that allows the operation to batch the results.</p>
      */
     nextToken?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/ListRepositoriesInput.ts
+++ b/packages/sdk-codecommit-browser/types/ListRepositoriesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a list repositories operation.</p>
  */
@@ -16,4 +18,25 @@ export interface ListRepositoriesInput {
      * <p>The order in which to sort the results of a list repositories operation.</p>
      */
     order?: 'ascending'|'descending'|string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/PutRepositoryTriggersInput.ts
+++ b/packages/sdk-codecommit-browser/types/PutRepositoryTriggersInput.ts
@@ -1,4 +1,5 @@
 import {_RepositoryTrigger} from './_RepositoryTrigger';
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
 
 /**
  * <p>Represents the input ofa put repository triggers operation.</p>
@@ -13,4 +14,25 @@ export interface PutRepositoryTriggersInput {
      * <p>The JSON block of configuration information for each trigger.</p>
      */
     triggers: Array<_RepositoryTrigger>|Iterable<_RepositoryTrigger>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/TestRepositoryTriggersInput.ts
+++ b/packages/sdk-codecommit-browser/types/TestRepositoryTriggersInput.ts
@@ -1,4 +1,5 @@
 import {_RepositoryTrigger} from './_RepositoryTrigger';
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
 
 /**
  * <p>Represents the input of a test repository triggers operation.</p>
@@ -13,4 +14,25 @@ export interface TestRepositoryTriggersInput {
      * <p>The list of triggers to test.</p>
      */
     triggers: Array<_RepositoryTrigger>|Iterable<_RepositoryTrigger>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/UpdateDefaultBranchInput.ts
+++ b/packages/sdk-codecommit-browser/types/UpdateDefaultBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of an update default branch operation.</p>
  */
@@ -11,4 +13,25 @@ export interface UpdateDefaultBranchInput {
      * <p>The name of the branch to set as the default.</p>
      */
     defaultBranchName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/UpdateRepositoryDescriptionInput.ts
+++ b/packages/sdk-codecommit-browser/types/UpdateRepositoryDescriptionInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of an update repository description operation.</p>
  */
@@ -11,4 +13,25 @@ export interface UpdateRepositoryDescriptionInput {
      * <p>The new comment or description for the specified repository. Repository descriptions are limited to 1,000 characters.</p>
      */
     repositoryDescription?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-browser/types/UpdateRepositoryNameInput.ts
+++ b/packages/sdk-codecommit-browser/types/UpdateRepositoryNameInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, BrowserHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of an update repository description operation.</p>
  */
@@ -11,4 +13,25 @@ export interface UpdateRepositoryNameInput {
      * <p>The new name for the repository.</p>
      */
     newName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/BatchGetRepositoriesInput.ts
+++ b/packages/sdk-codecommit-node/types/BatchGetRepositoriesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a batch get repositories operation.</p>
  */
@@ -6,4 +8,25 @@ export interface BatchGetRepositoriesInput {
      * <p>The names of the repositories to get information about.</p>
      */
     repositoryNames: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/CreateBranchInput.ts
+++ b/packages/sdk-codecommit-node/types/CreateBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a create branch operation.</p>
  */
@@ -16,4 +18,25 @@ export interface CreateBranchInput {
      * <p>The ID of the commit to point the new branch to.</p>
      */
     commitId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/CreateRepositoryInput.ts
+++ b/packages/sdk-codecommit-node/types/CreateRepositoryInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a create repository operation.</p>
  */
@@ -11,4 +13,25 @@ export interface CreateRepositoryInput {
      * <p>A comment or description about the new repository.</p> <note> <p>The description field for a repository accepts all HTML characters and all valid Unicode characters. Applications that do not HTML-encode the description and display it in a web page could expose users to potentially malicious code. Make sure that you HTML-encode the description field in any application that uses this API to display the repository description on a web page.</p> </note>
      */
     repositoryDescription?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/DeleteBranchInput.ts
+++ b/packages/sdk-codecommit-node/types/DeleteBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a delete branch operation.</p>
  */
@@ -11,4 +13,25 @@ export interface DeleteBranchInput {
      * <p>The name of the branch to delete.</p>
      */
     branchName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/DeleteRepositoryInput.ts
+++ b/packages/sdk-codecommit-node/types/DeleteRepositoryInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a delete repository operation.</p>
  */
@@ -6,4 +8,25 @@ export interface DeleteRepositoryInput {
      * <p>The name of the repository to delete.</p>
      */
     repositoryName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/GetBlobInput.ts
+++ b/packages/sdk-codecommit-node/types/GetBlobInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get blob operation.</p>
  */
@@ -11,4 +13,25 @@ export interface GetBlobInput {
      * <p>The ID of the blob, which is its SHA-1 pointer.</p>
      */
     blobId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/GetBranchInput.ts
+++ b/packages/sdk-codecommit-node/types/GetBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get branch operation.</p>
  */
@@ -11,4 +13,25 @@ export interface GetBranchInput {
      * <p>The name of the branch for which you want to retrieve information.</p>
      */
     branchName?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/GetCommitInput.ts
+++ b/packages/sdk-codecommit-node/types/GetCommitInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get commit operation.</p>
  */
@@ -11,4 +13,25 @@ export interface GetCommitInput {
      * <p>The commit ID. Commit IDs are the full SHA of the commit.</p>
      */
     commitId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/GetDifferencesInput.ts
+++ b/packages/sdk-codecommit-node/types/GetDifferencesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GetDifferencesInput shape
  */
@@ -36,4 +38,25 @@ export interface GetDifferencesInput {
      * <p>An enumeration token that when provided in a request, returns the next batch of the results.</p>
      */
     NextToken?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/GetRepositoryInput.ts
+++ b/packages/sdk-codecommit-node/types/GetRepositoryInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get repository operation.</p>
  */
@@ -6,4 +8,25 @@ export interface GetRepositoryInput {
      * <p>The name of the repository to get information about.</p>
      */
     repositoryName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/GetRepositoryTriggersInput.ts
+++ b/packages/sdk-codecommit-node/types/GetRepositoryTriggersInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a get repository triggers operation.</p>
  */
@@ -6,4 +8,25 @@ export interface GetRepositoryTriggersInput {
      * <p>The name of the repository for which the trigger is configured.</p>
      */
     repositoryName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/ListBranchesInput.ts
+++ b/packages/sdk-codecommit-node/types/ListBranchesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a list branches operation.</p>
  */
@@ -11,4 +13,25 @@ export interface ListBranchesInput {
      * <p>An enumeration token that allows the operation to batch the results.</p>
      */
     nextToken?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/ListRepositoriesInput.ts
+++ b/packages/sdk-codecommit-node/types/ListRepositoriesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of a list repositories operation.</p>
  */
@@ -16,4 +18,25 @@ export interface ListRepositoriesInput {
      * <p>The order in which to sort the results of a list repositories operation.</p>
      */
     order?: 'ascending'|'descending'|string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/PutRepositoryTriggersInput.ts
+++ b/packages/sdk-codecommit-node/types/PutRepositoryTriggersInput.ts
@@ -1,4 +1,5 @@
 import {_RepositoryTrigger} from './_RepositoryTrigger';
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
 
 /**
  * <p>Represents the input ofa put repository triggers operation.</p>
@@ -13,4 +14,25 @@ export interface PutRepositoryTriggersInput {
      * <p>The JSON block of configuration information for each trigger.</p>
      */
     triggers: Array<_RepositoryTrigger>|Iterable<_RepositoryTrigger>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/TestRepositoryTriggersInput.ts
+++ b/packages/sdk-codecommit-node/types/TestRepositoryTriggersInput.ts
@@ -1,4 +1,5 @@
 import {_RepositoryTrigger} from './_RepositoryTrigger';
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
 
 /**
  * <p>Represents the input of a test repository triggers operation.</p>
@@ -13,4 +14,25 @@ export interface TestRepositoryTriggersInput {
      * <p>The list of triggers to test.</p>
      */
     triggers: Array<_RepositoryTrigger>|Iterable<_RepositoryTrigger>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/UpdateDefaultBranchInput.ts
+++ b/packages/sdk-codecommit-node/types/UpdateDefaultBranchInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of an update default branch operation.</p>
  */
@@ -11,4 +13,25 @@ export interface UpdateDefaultBranchInput {
      * <p>The name of the branch to set as the default.</p>
      */
     defaultBranchName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/UpdateRepositoryDescriptionInput.ts
+++ b/packages/sdk-codecommit-node/types/UpdateRepositoryDescriptionInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of an update repository description operation.</p>
  */
@@ -11,4 +13,25 @@ export interface UpdateRepositoryDescriptionInput {
      * <p>The new comment or description for the specified repository. Repository descriptions are limited to 1,000 characters.</p>
      */
     repositoryDescription?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-codecommit-node/types/UpdateRepositoryNameInput.ts
+++ b/packages/sdk-codecommit-node/types/UpdateRepositoryNameInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * <p>Represents the input of an update repository description operation.</p>
  */
@@ -11,4 +13,25 @@ export interface UpdateRepositoryNameInput {
      * <p>The new name for the repository.</p>
      */
     newName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/CancelKeyDeletionInput.ts
+++ b/packages/sdk-kms-node/types/CancelKeyDeletionInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * CancelKeyDeletionInput shape
  */
@@ -6,4 +8,25 @@ export interface CancelKeyDeletionInput {
      * <p>The unique identifier for the customer master key (CMK) for which to cancel deletion.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/CreateAliasInput.ts
+++ b/packages/sdk-kms-node/types/CreateAliasInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * CreateAliasInput shape
  */
@@ -11,4 +13,25 @@ export interface CreateAliasInput {
      * <p>Identifies the CMK for which you are creating the alias. This value cannot be an alias.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     TargetKeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/CreateGrantInput.ts
+++ b/packages/sdk-kms-node/types/CreateGrantInput.ts
@@ -1,4 +1,5 @@
 import {_GrantConstraints} from './_GrantConstraints';
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
 
 /**
  * CreateGrantInput shape
@@ -38,4 +39,25 @@ export interface CreateGrantInput {
      * <p>A friendly name for identifying the grant. Use this value to prevent unintended creation of duplicate grants when retrying this request.</p> <p>When this value is absent, all <code>CreateGrant</code> requests result in a new grant with a unique <code>GrantId</code> even if all the supplied parameters are identical. This can result in unintended duplicates when you retry the <code>CreateGrant</code> request.</p> <p>When this value is present, you can retry a <code>CreateGrant</code> request with identical parameters; if the grant already exists, the original <code>GrantId</code> is returned without creating a new grant. Note that the returned grant token is unique with every <code>CreateGrant</code> request, even when a duplicate <code>GrantId</code> is returned. All grant tokens obtained in this way can be used interchangeably.</p>
      */
     Name?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/CreateKeyInput.ts
+++ b/packages/sdk-kms-node/types/CreateKeyInput.ts
@@ -1,4 +1,5 @@
 import {_Tag} from './_Tag';
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
 
 /**
  * CreateKeyInput shape
@@ -33,4 +34,25 @@ export interface CreateKeyInput {
      * <p>One or more tags. Each tag consists of a tag key and a tag value. Tag keys and tag values are both required, but tag values can be empty (null) strings.</p> <p>Use this parameter to tag the CMK when it is created. Alternately, you can omit this parameter and instead tag the CMK after it is created using <a>TagResource</a>.</p>
      */
     Tags?: Array<_Tag>|Iterable<_Tag>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/DecryptInput.ts
+++ b/packages/sdk-kms-node/types/DecryptInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * DecryptInput shape
  */
@@ -16,4 +18,25 @@ export interface DecryptInput {
      * <p>A list of grant tokens.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
      */
     GrantTokens?: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/DeleteAliasInput.ts
+++ b/packages/sdk-kms-node/types/DeleteAliasInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * DeleteAliasInput shape
  */
@@ -6,4 +8,25 @@ export interface DeleteAliasInput {
      * <p>The alias to be deleted. The name must start with the word "alias" followed by a forward slash (alias/). Aliases that begin with "alias/aws" are reserved.</p>
      */
     AliasName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/DeleteImportedKeyMaterialInput.ts
+++ b/packages/sdk-kms-node/types/DeleteImportedKeyMaterialInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * DeleteImportedKeyMaterialInput shape
  */
@@ -6,4 +8,25 @@ export interface DeleteImportedKeyMaterialInput {
      * <p>The identifier of the CMK whose key material to delete. The CMK's <code>Origin</code> must be <code>EXTERNAL</code>.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/DescribeKeyInput.ts
+++ b/packages/sdk-kms-node/types/DescribeKeyInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * DescribeKeyInput shape
  */
@@ -11,4 +13,25 @@ export interface DescribeKeyInput {
      * <p>A list of grant tokens.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
      */
     GrantTokens?: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/DisableKeyInput.ts
+++ b/packages/sdk-kms-node/types/DisableKeyInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * DisableKeyInput shape
  */
@@ -6,4 +8,25 @@ export interface DisableKeyInput {
      * <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/DisableKeyRotationInput.ts
+++ b/packages/sdk-kms-node/types/DisableKeyRotationInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * DisableKeyRotationInput shape
  */
@@ -6,4 +8,25 @@ export interface DisableKeyRotationInput {
      * <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/EnableKeyInput.ts
+++ b/packages/sdk-kms-node/types/EnableKeyInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * EnableKeyInput shape
  */
@@ -6,4 +8,25 @@ export interface EnableKeyInput {
      * <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/EnableKeyRotationInput.ts
+++ b/packages/sdk-kms-node/types/EnableKeyRotationInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * EnableKeyRotationInput shape
  */
@@ -6,4 +8,25 @@ export interface EnableKeyRotationInput {
      * <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/EncryptInput.ts
+++ b/packages/sdk-kms-node/types/EncryptInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * EncryptInput shape
  */
@@ -21,4 +23,25 @@ export interface EncryptInput {
      * <p>A list of grant tokens.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
      */
     GrantTokens?: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/GenerateDataKeyInput.ts
+++ b/packages/sdk-kms-node/types/GenerateDataKeyInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GenerateDataKeyInput shape
  */
@@ -26,4 +28,25 @@ export interface GenerateDataKeyInput {
      * <p>A list of grant tokens.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
      */
     GrantTokens?: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/GenerateDataKeyWithoutPlaintextInput.ts
+++ b/packages/sdk-kms-node/types/GenerateDataKeyWithoutPlaintextInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GenerateDataKeyWithoutPlaintextInput shape
  */
@@ -26,4 +28,25 @@ export interface GenerateDataKeyWithoutPlaintextInput {
      * <p>A list of grant tokens.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
      */
     GrantTokens?: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/GenerateRandomInput.ts
+++ b/packages/sdk-kms-node/types/GenerateRandomInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GenerateRandomInput shape
  */
@@ -6,4 +8,25 @@ export interface GenerateRandomInput {
      * <p>The length of the byte string.</p>
      */
     NumberOfBytes?: number;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/GetKeyPolicyInput.ts
+++ b/packages/sdk-kms-node/types/GetKeyPolicyInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GetKeyPolicyInput shape
  */
@@ -11,4 +13,25 @@ export interface GetKeyPolicyInput {
      * <p>Specifies the name of the policy. The only valid name is <code>default</code>. To get the names of key policies, use <a>ListKeyPolicies</a>.</p>
      */
     PolicyName: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/GetKeyRotationStatusInput.ts
+++ b/packages/sdk-kms-node/types/GetKeyRotationStatusInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GetKeyRotationStatusInput shape
  */
@@ -6,4 +8,25 @@ export interface GetKeyRotationStatusInput {
      * <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify a CMK in a different AWS account, you must use the key ARN.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/GetParametersForImportInput.ts
+++ b/packages/sdk-kms-node/types/GetParametersForImportInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * GetParametersForImportInput shape
  */
@@ -16,4 +18,25 @@ export interface GetParametersForImportInput {
      * <p>The type of wrapping key (public key) to return in the response. Only 2048-bit RSA public keys are supported.</p>
      */
     WrappingKeySpec: 'RSA_2048'|string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ImportKeyMaterialInput.ts
+++ b/packages/sdk-kms-node/types/ImportKeyMaterialInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ImportKeyMaterialInput shape
  */
@@ -26,4 +28,25 @@ export interface ImportKeyMaterialInput {
      * <p>Specifies whether the key material expires. The default is <code>KEY_MATERIAL_EXPIRES</code>, in which case you must include the <code>ValidTo</code> parameter. When this parameter is set to <code>KEY_MATERIAL_DOES_NOT_EXPIRE</code>, you must omit the <code>ValidTo</code> parameter.</p>
      */
     ExpirationModel?: 'KEY_MATERIAL_EXPIRES'|'KEY_MATERIAL_DOES_NOT_EXPIRE'|string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ListAliasesInput.ts
+++ b/packages/sdk-kms-node/types/ListAliasesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ListAliasesInput shape
  */
@@ -11,4 +13,25 @@ export interface ListAliasesInput {
      * <p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>
      */
     Marker?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ListGrantsInput.ts
+++ b/packages/sdk-kms-node/types/ListGrantsInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ListGrantsInput shape
  */
@@ -16,4 +18,25 @@ export interface ListGrantsInput {
      * <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify a CMK in a different AWS account, you must use the key ARN.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
      */
     KeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ListKeyPoliciesInput.ts
+++ b/packages/sdk-kms-node/types/ListKeyPoliciesInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ListKeyPoliciesInput shape
  */
@@ -16,4 +18,25 @@ export interface ListKeyPoliciesInput {
      * <p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>
      */
     Marker?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ListKeysInput.ts
+++ b/packages/sdk-kms-node/types/ListKeysInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ListKeysInput shape
  */
@@ -11,4 +13,25 @@ export interface ListKeysInput {
      * <p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>
      */
     Marker?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ListResourceTagsInput.ts
+++ b/packages/sdk-kms-node/types/ListResourceTagsInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ListResourceTagsInput shape
  */
@@ -16,4 +18,25 @@ export interface ListResourceTagsInput {
      * <p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p> <p>Do not attempt to construct this value. Use only the value of <code>NextMarker</code> from the truncated response you just received.</p>
      */
     Marker?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ListRetirableGrantsInput.ts
+++ b/packages/sdk-kms-node/types/ListRetirableGrantsInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ListRetirableGrantsInput shape
  */
@@ -16,4 +18,25 @@ export interface ListRetirableGrantsInput {
      * <p>The retiring principal for which to list grants.</p> <p>To specify the retiring principal, use the <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Name (ARN)</a> of an AWS principal. Valid AWS principals include AWS accounts (root), IAM users, federated users, and assumed role users. For examples of the ARN syntax for specifying a principal, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam">AWS Identity and Access Management (IAM)</a> in the Example ARNs section of the <i>Amazon Web Services General Reference</i>.</p>
      */
     RetiringPrincipal: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/PutKeyPolicyInput.ts
+++ b/packages/sdk-kms-node/types/PutKeyPolicyInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * PutKeyPolicyInput shape
  */
@@ -21,4 +23,25 @@ export interface PutKeyPolicyInput {
      * <p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent <code>PutKeyPolicy</code> request on the CMK.</p> <p>The default value is false.</p>
      */
     BypassPolicyLockoutSafetyCheck?: boolean;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ReEncryptInput.ts
+++ b/packages/sdk-kms-node/types/ReEncryptInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ReEncryptInput shape
  */
@@ -26,4 +28,25 @@ export interface ReEncryptInput {
      * <p>A list of grant tokens.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
      */
     GrantTokens?: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/RetireGrantInput.ts
+++ b/packages/sdk-kms-node/types/RetireGrantInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * RetireGrantInput shape
  */
@@ -16,4 +18,25 @@ export interface RetireGrantInput {
      * <p>Unique identifier of the grant to retire. The grant ID is returned in the response to a <code>CreateGrant</code> operation.</p> <ul> <li> <p>Grant ID Example - 0123456789012345678901234567890123456789012345678901234567890123</p> </li> </ul>
      */
     GrantId?: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/RevokeGrantInput.ts
+++ b/packages/sdk-kms-node/types/RevokeGrantInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * RevokeGrantInput shape
  */
@@ -11,4 +13,25 @@ export interface RevokeGrantInput {
      * <p>Identifier of the grant to be revoked.</p>
      */
     GrantId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/ScheduleKeyDeletionInput.ts
+++ b/packages/sdk-kms-node/types/ScheduleKeyDeletionInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * ScheduleKeyDeletionInput shape
  */
@@ -11,4 +13,25 @@ export interface ScheduleKeyDeletionInput {
      * <p>The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the customer master key (CMK).</p> <p>This value is optional. If you include a value, it must be between 7 and 30, inclusive. If you do not include a value, it defaults to 30.</p>
      */
     PendingWindowInDays?: number;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/TagResourceInput.ts
+++ b/packages/sdk-kms-node/types/TagResourceInput.ts
@@ -1,4 +1,5 @@
 import {_Tag} from './_Tag';
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
 
 /**
  * TagResourceInput shape
@@ -13,4 +14,25 @@ export interface TagResourceInput {
      * <p>One or more tags. Each tag consists of a tag key and a tag value.</p>
      */
     Tags: Array<_Tag>|Iterable<_Tag>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/UntagResourceInput.ts
+++ b/packages/sdk-kms-node/types/UntagResourceInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * UntagResourceInput shape
  */
@@ -11,4 +13,25 @@ export interface UntagResourceInput {
      * <p>One or more tag keys. Specify only the tag keys, not the tag values.</p>
      */
     TagKeys: Array<string>|Iterable<string>;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/UpdateAliasInput.ts
+++ b/packages/sdk-kms-node/types/UpdateAliasInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * UpdateAliasInput shape
  */
@@ -11,4 +13,25 @@ export interface UpdateAliasInput {
      * <p>Unique identifier of the customer master key to be mapped to the alias.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p> <p>To verify that the alias is mapped to the correct CMK, use <a>ListAliases</a>.</p>
      */
     TargetKeyId: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/sdk-kms-node/types/UpdateKeyDescriptionInput.ts
+++ b/packages/sdk-kms-node/types/UpdateKeyDescriptionInput.ts
@@ -1,3 +1,5 @@
+import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+
 /**
  * UpdateKeyDescriptionInput shape
  */
@@ -11,4 +13,25 @@ export interface UpdateKeyDescriptionInput {
      * <p>New description for the CMK.</p>
      */
     Description: string;
+
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: __AbortSignal__
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: __HttpOptions__
 }

--- a/packages/service-types-generator/src/Components/Type/Exception.spec.ts
+++ b/packages/service-types-generator/src/Components/Type/Exception.spec.ts
@@ -1,7 +1,7 @@
 import {Exception} from "./Exception";
 import {IndentedSection} from "../IndentedSection";
 import {
-    METADATA_PROPERTY_IMPORT,
+    OUTPUT_TYPES_IMPORT,
     OUTPUT_METADATA_PROPERTY,
 } from "./constants";
 
@@ -17,7 +17,7 @@ describe('Exception', () => {
         });
 
         expect(exception.toString()).toEqual(
-`${METADATA_PROPERTY_IMPORT.toString()}
+`${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * <p>An exceptional state</p>
@@ -61,7 +61,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
         });
 
         expect(exception.toString()).toEqual(
-`${METADATA_PROPERTY_IMPORT.toString()}
+`${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * <p>An exceptional state</p>
@@ -105,7 +105,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
         });
 
         expect(exception.toString()).toEqual(
-`${METADATA_PROPERTY_IMPORT.toString()}
+`${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * <p>An exceptional state</p>
@@ -149,7 +149,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
         });
 
         expect(exception.toString()).toEqual(
-`${METADATA_PROPERTY_IMPORT.toString()}
+`${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * <p>An exceptional state</p>

--- a/packages/service-types-generator/src/Components/Type/Exception.ts
+++ b/packages/service-types-generator/src/Components/Type/Exception.ts
@@ -4,7 +4,7 @@ import {IndentedSection} from "../IndentedSection";
 import {getUnmarshalledShapeName} from "./helpers";
 import {Import} from "../Import";
 import {
-    METADATA_PROPERTY_IMPORT,
+    OUTPUT_TYPES_IMPORT,
     OUTPUT_METADATA_PROPERTY,
 } from "./constants";
 
@@ -40,7 +40,7 @@ ${new IndentedSection(members.join('\n\n'))}
                 `./${shape}`,
                 getUnmarshalledShapeName(shape)
             ))
-            .concat(METADATA_PROPERTY_IMPORT)
+            .concat(OUTPUT_TYPES_IMPORT)
             .join('\n');
     }
 

--- a/packages/service-types-generator/src/Components/Type/Input.spec.ts
+++ b/packages/service-types-generator/src/Components/Type/Input.spec.ts
@@ -1,5 +1,11 @@
+import {
+    INPUT_CONTROL_PROPERTIES,
+    INPUT_TYPES_IMPORT_BROWSER,
+    INPUT_TYPES_IMPORT_NODE,
+    INPUT_TYPES_IMPORT_UNIVERSAL,
+} from './constants';
+import {IndentedSection} from "../IndentedSection";
 import {Input} from "./Input";
-import {GENERIC_STREAM_TYPE} from "../../constants";
 import {getInterfaceType} from "./getInterfaceType";
 import {
     TreeModelList,
@@ -13,7 +19,7 @@ import {
 
 describe('Input', () => {
     it(
-        'should emit documentation and an empty interface for an empty structure',
+        'should emit documentation and an interface with only SDK control parameters for an empty structure',
         () => {
             const name = 'OperationInput';
             const input = new Input({
@@ -25,11 +31,13 @@ describe('Input', () => {
             }, 'universal');
 
             expect(input.toString()).toEqual(
-`/**
+`${INPUT_TYPES_IMPORT_UNIVERSAL}
+
+/**
  * Operation input
  */
 export interface ${name} {
-
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
             );
         }
@@ -52,7 +60,9 @@ export interface ${name} {
             };
 
             expect(new Input(inputShape, 'universal').toString()).toEqual(
-`/**
+`${INPUT_TYPES_IMPORT_UNIVERSAL}
+
+/**
  * ${inputShape.documentation}
  */
 export interface ${name}<StreamType = Uint8Array> {
@@ -60,6 +70,8 @@ export interface ${name}<StreamType = Uint8Array> {
      * ${StreamingBlob.documentation}
      */
     data?: ${getInterfaceType(StreamingBlob)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
             );
         }
@@ -87,7 +99,9 @@ export interface ${name}<StreamType = Uint8Array> {
             };
 
             expect(new Input(inputShape, 'universal').toString()).toEqual(
-`/**
+`${INPUT_TYPES_IMPORT_UNIVERSAL}
+
+/**
  * ${inputShape.documentation}
  */
 export interface ${name}<StreamType = Uint8Array> {
@@ -95,6 +109,8 @@ export interface ${name}<StreamType = Uint8Array> {
      * ${dataMember.documentation}
      */
     data?: ${getInterfaceType(dataMember.shape, dataMember)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
             );
         }
@@ -117,7 +133,8 @@ export interface ${name}<StreamType = Uint8Array> {
             };
 
             expect(new Input(inputShape, 'node').toString()).toEqual(
-`import {Readable} from 'stream';
+`${INPUT_TYPES_IMPORT_NODE}
+import {Readable} from 'stream';
 
 /**
  * ${inputShape.documentation}
@@ -127,6 +144,8 @@ export interface ${name}<StreamType = Readable> {
      * ${StreamingBlob.documentation}
      */
     data?: ${getInterfaceType(StreamingBlob)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
             );
         }
@@ -149,7 +168,9 @@ export interface ${name}<StreamType = Readable> {
             };
 
             expect(new Input(inputShape, 'browser').toString()).toEqual(
-`/**
+`${INPUT_TYPES_IMPORT_BROWSER}
+
+/**
  * ${inputShape.documentation}
  */
 export interface ${name}<StreamType = ReadableStream> {
@@ -157,6 +178,8 @@ export interface ${name}<StreamType = ReadableStream> {
      * ${StreamingBlob.documentation}
      */
     data?: ${getInterfaceType(StreamingBlob)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
             );
         }
@@ -185,6 +208,7 @@ export interface ${name}<StreamType = ReadableStream> {
 
         expect(new Input(inputShape, 'universal').toString()).toEqual(
 `import {${structure.name}} from './${structure.name}';
+${INPUT_TYPES_IMPORT_UNIVERSAL}
 
 /**
  * ${inputShape.documentation}
@@ -194,6 +218,8 @@ export interface ${name} {
      * ${structure.documentation}
      */
     data?: ${getInterfaceType(structure)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
         );
     });
@@ -229,6 +255,7 @@ export interface ${name} {
 
         expect(new Input(inputShape, 'universal').toString()).toEqual(
 `import {${structureName}} from './${structureName}';
+${INPUT_TYPES_IMPORT_UNIVERSAL}
 
 /**
  * ${inputShape.documentation}
@@ -238,6 +265,8 @@ export interface ${name} {
      * ${structureList.documentation}
      */
     data?: ${getInterfaceType(structureList)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
         );
     });
@@ -280,6 +309,7 @@ export interface ${name} {
 
         expect(new Input(inputShape).toString()).toEqual(
 `import {${structureName}} from './${structureName}';
+${INPUT_TYPES_IMPORT_UNIVERSAL}
 
 /**
  * ${inputShape.documentation}
@@ -289,6 +319,8 @@ export interface ${name} {
      * ${structureMap.documentation}
      */
     data?: ${getInterfaceType(structureMap)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
         );
     });

--- a/packages/service-types-generator/src/Components/Type/Input.ts
+++ b/packages/service-types-generator/src/Components/Type/Input.ts
@@ -7,11 +7,17 @@ import {
     RuntimeTarget,
     TreeModelStructure
 } from '@aws/build-types';
+import {
+    INPUT_CONTROL_PROPERTIES,
+    INPUT_TYPES_IMPORT_BROWSER,
+    INPUT_TYPES_IMPORT_NODE,
+    INPUT_TYPES_IMPORT_UNIVERSAL,
+} from './constants';
 
 export class Input extends Structure {
     constructor(
         protected readonly shape: TreeModelStructure,
-        private readonly runtime?: RuntimeTarget
+        private readonly runtime: RuntimeTarget = 'universal'
     ) {
         super(shape);
     }
@@ -26,6 +32,7 @@ export interface ${this.shape.name}${hasStreamingBody(this.shape) ? `<StreamType
 ${new IndentedSection(
     Object.keys(this.shape.members)
         .map(this.getInterfaceDefinition, this)
+        .concat(INPUT_CONTROL_PROPERTIES)
         .join('\n\n')
 )}
 }
@@ -41,9 +48,22 @@ ${new IndentedSection(
 
     private environmentImports(): Import[] {
         const toImport = [];
-        if (this.runtime === 'node' && hasStreamingBody(this.shape)) {
-            toImport.push(new Import('stream', 'Readable'));
+
+        switch (this.runtime) {
+            case 'node':
+                toImport.push(INPUT_TYPES_IMPORT_NODE);
+                if (hasStreamingBody(this.shape)) {
+                    toImport.push(new Import('stream', 'Readable'));
+                }
+                break;
+            case 'browser':
+                toImport.push(INPUT_TYPES_IMPORT_BROWSER);
+                break;
+            case 'universal':
+                toImport.push(INPUT_TYPES_IMPORT_UNIVERSAL);
+                break;
         }
+
         return toImport;
     }
 

--- a/packages/service-types-generator/src/Components/Type/Output.spec.ts
+++ b/packages/service-types-generator/src/Components/Type/Output.spec.ts
@@ -1,5 +1,4 @@
 import {Output} from "./Output";
-import {GENERIC_STREAM_TYPE} from "../../constants";
 import {getUnmarshalledShapeName} from "./helpers";
 import {
     TreeModelList,
@@ -13,7 +12,7 @@ import {
 } from "../../shapes.fixture";
 import {IndentedSection} from "../IndentedSection";
 import {
-    METADATA_PROPERTY_IMPORT,
+    OUTPUT_TYPES_IMPORT,
     OUTPUT_METADATA_PROPERTY,
 } from "./constants";
 
@@ -31,7 +30,7 @@ describe('Output', () => {
             }, 'universal');
 
             expect(output.toString()).toEqual(
-`${METADATA_PROPERTY_IMPORT.toString()}
+`${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * Operation output
@@ -60,7 +59,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
             }, 'universal');
 
             expect(output.toString()).toEqual(
-`${METADATA_PROPERTY_IMPORT.toString()}
+`${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * Operation output
@@ -99,7 +98,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
             };
 
             expect(new Output(output, 'universal').toString()).toEqual(
-`${METADATA_PROPERTY_IMPORT.toString()}
+`${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * ${output.documentation}
@@ -139,7 +138,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
 
         expect(new Output(outputShape, 'universal').toString()).toEqual(
 `import {${getUnmarshalledShapeName(structure.name)}} from './${structure.name}';
-${METADATA_PROPERTY_IMPORT.toString()}
+${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * ${outputShape.documentation}
@@ -186,7 +185,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
 
         expect(new Output(inputShape, 'universal').toString()).toEqual(
 `import {${getUnmarshalledShapeName(structureName)}} from './${structureName}';
-${METADATA_PROPERTY_IMPORT.toString()}
+${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * ${inputShape.documentation}
@@ -241,7 +240,7 @@ ${new IndentedSection(OUTPUT_METADATA_PROPERTY)}
 
         expect(new Output(inputShape, 'universal').toString()).toEqual(
 `import {${getUnmarshalledShapeName(valueStructure)}} from './${valueStructure}';
-${METADATA_PROPERTY_IMPORT.toString()}
+${OUTPUT_TYPES_IMPORT.toString()}
 
 /**
  * ${inputShape.documentation}

--- a/packages/service-types-generator/src/Components/Type/Output.ts
+++ b/packages/service-types-generator/src/Components/Type/Output.ts
@@ -3,7 +3,7 @@ import {Structure} from "./Structure";
 import {IndentedSection} from "../IndentedSection";
 import {getUnmarshalledShapeName, hasStreamingBody} from "./helpers";
 import {
-    METADATA_PROPERTY_IMPORT,
+    OUTPUT_TYPES_IMPORT,
     OUTPUT_METADATA_PROPERTY,
 } from './constants';
 import {
@@ -43,7 +43,7 @@ ${new IndentedSection(
                 `./${shape}`,
                 getUnmarshalledShapeName(shape)
             ))
-            .concat(METADATA_PROPERTY_IMPORT, this.environmentImports())
+            .concat(OUTPUT_TYPES_IMPORT, this.environmentImports())
             .join('\n');
     }
 
@@ -58,7 +58,7 @@ ${new IndentedSection(
     private getStreamType() {
         switch (this.runtime) {
             case 'browser':
-                return 'ReadableStream';
+                return 'ReadableStream|Blob';
             case 'node':
                 return 'Readable';
             case 'universal':

--- a/packages/service-types-generator/src/Components/Type/Structure.spec.ts
+++ b/packages/service-types-generator/src/Components/Type/Structure.spec.ts
@@ -1,7 +1,12 @@
-import {Input} from "./Input";
 import {getInterfaceType} from "./getInterfaceType";
 import {getMemberType} from "./getMemberType";
 import {getUnmarshalledShapeName} from "./helpers";
+import {IndentedSection} from '../IndentedSection'
+import {
+    INPUT_CONTROL_PROPERTIES,
+    INPUT_TYPES_IMPORT_UNIVERSAL,
+} from './constants';
+import {Input} from "./Input";
 import {ModeledStructure} from "./ModeledStructure";
 import {
     TreeModelShape,
@@ -71,7 +76,9 @@ export interface ${getUnmarshalledShapeName(name)} extends ${name} {
             const dataMember = inputShape.members.data;
 
             expect(new Input(inputShape, 'universal').toString()).toEqual(
-`/**
+`${INPUT_TYPES_IMPORT_UNIVERSAL}
+
+/**
  * ${inputShape.documentation}
  */
 export interface ${name} {
@@ -79,6 +86,8 @@ export interface ${name} {
      * CORRECT
      */
     data?: ${getInterfaceType(dataMember.shape, dataMember)};
+
+${new IndentedSection(INPUT_CONTROL_PROPERTIES.join('\n\n'))}
 }`
             );
         }

--- a/packages/service-types-generator/src/Components/Type/constants.ts
+++ b/packages/service-types-generator/src/Components/Type/constants.ts
@@ -2,15 +2,66 @@ import {Import} from "../Import";
 
 const MD_PROP_ALIAS = '__ResponseMetadata__';
 
-export const METADATA_PROPERTY_IMPORT = new Import(
+export const OUTPUT_TYPES_IMPORT = new Import(
     '@aws/types',
     `ResponseMetadata as ${MD_PROP_ALIAS}`
 );
 
-export const OUTPUT_METADATA_PROPERTY = `
-/**
+export const OUTPUT_METADATA_PROPERTY =
+`/**
  * Metadata about the response received, including the HTTP status code, HTTP
  * headers, and any request identifiers recognized by the SDK.
  */
-$metadata: ${MD_PROP_ALIAS};
-`.trim();
+$metadata: ${MD_PROP_ALIAS};`;
+
+const SIGNAL_PROP_ALIAS = '__AbortSignal__';
+
+const HTTP_OPTIONS_ALIAS = '__HttpOptions__';
+
+export const INPUT_TYPES_IMPORT_NODE = new Import(
+    '@aws/types',
+    `AbortSignal as ${SIGNAL_PROP_ALIAS}`,
+    `NodeHttpOptions as ${HTTP_OPTIONS_ALIAS}`
+);
+
+export const INPUT_TYPES_IMPORT_BROWSER = new Import(
+    '@aws/types',
+    `AbortSignal as ${SIGNAL_PROP_ALIAS}`,
+    `BrowserHttpOptions as ${HTTP_OPTIONS_ALIAS}`
+);
+
+export const INPUT_TYPES_IMPORT_UNIVERSAL = new Import(
+    '@aws/types',
+    `AbortSignal as ${SIGNAL_PROP_ALIAS}`,
+    `HttpOptions as ${HTTP_OPTIONS_ALIAS}`
+);
+
+export const INPUT_RETRIES_PROPERTY =
+`/**
+ * The maximum number of times this operation should be retried. If set, this
+ * value will override the \`maxRetries\` configuration set on the client for
+ * this command.
+ */
+$maxRetries?: number;`;
+
+export const INPUT_SIGNAL_PROPERTY =
+`/**
+ * An object that may be queried to determine if the underlying operation
+ * has been aborted.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+ */
+$abortSignal?: ${SIGNAL_PROP_ALIAS}`;
+
+export const INPUT_HTTP_OPTIONS_PROPERTY =
+`/**
+ * Per-request HTTP configuration options. If set, any options specified will
+ * override the corresponding HTTP option set on the client for this command.
+ */
+$httpOptions?: ${HTTP_OPTIONS_ALIAS}`;
+
+export const INPUT_CONTROL_PROPERTIES = [
+    INPUT_RETRIES_PROPERTY,
+    INPUT_SIGNAL_PROPERTY,
+    INPUT_HTTP_OPTIONS_PROPERTY,
+];

--- a/packages/types/src/command.ts
+++ b/packages/types/src/command.ts
@@ -1,11 +1,33 @@
-import {
-    Handler,
-    MiddlewareStack
-} from './middleware';
+import {AbortSignal} from './abort';
+import {HttpOptions} from './http';
+import {Handler, MiddlewareStack} from './middleware';
 import {MetadataBearer} from './response';
 
+export interface CommandInput {
+    /**
+     * The maximum number of times this operation should be retried. If set, this
+     * value will override the `maxRetries` configuration set on the client for
+     * this command.
+     */
+    $maxRetries?: number;
+
+    /**
+     * An object that may be queried to determine if the underlying operation
+     * has been aborted.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    $abortSignal?: AbortSignal;
+
+    /**
+     * Per-request HTTP configuration options. If set, any options specified will
+     * override the corresponding HTTP option set on the client for this command.
+     */
+    $httpOptions?: HttpOptions;
+}
+
 export interface Command<
-    ClientInput extends object,
+    ClientInput extends CommandInput,
     InputType extends ClientInput,
     ClientOutput extends MetadataBearer,
     OutputType extends ClientOutput,

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from './abort';
 import {HttpRequest} from './http';
 import {OperationModel} from './protocol';
 import {Logger} from './logger';
@@ -9,14 +8,6 @@ export interface HandlerArguments<Input extends object> {
      * union of data types the command can effectively handle.
      */
     input: Input;
-
-    /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
-     */
-    abortSignal?: AbortSignal;
 }
 
 export interface BuildHandlerArguments<


### PR DESCRIPTION
Putting this up to see what you guys think of this interface change. Right now, there's no way to supply SDK control parameters when creating a command or when invoking a method on a classic client -- `abortSignal` and `httpOptions` can only be injected by middleware. This change adds an `$abortSignal`, `$httpOptions`, and `$maxRetries` to all input shapes generated by the SDK and updates the core handler to use the `$abortSignal` property of the input.

/cc @kstich 