### PR TITLE
Adds Glacier middleware

### DIFF
--- a/packages/glacier-checksum-generator/.gitignore
+++ b/packages/glacier-checksum-generator/.gitignore
@@ -1,0 +1,7 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tgz
+*.log
+package-lock.json

--- a/packages/glacier-checksum-generator/.npmignore
+++ b/packages/glacier-checksum-generator/.npmignore
@@ -1,0 +1,12 @@
+/src/
+/coverage/
+/docs/
+tsconfig.test.json
+
+*.spec.js
+*.spec.d.ts
+*.spec.js.map
+
+*.fixture.js
+*.fixture.d.ts
+*.fixture.js.map

--- a/packages/glacier-checksum-generator/LICENSE
+++ b/packages/glacier-checksum-generator/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/glacier-checksum-generator/README.md
+++ b/packages/glacier-checksum-generator/README.md
@@ -1,0 +1,1 @@
+# glacier-checksum-generator

--- a/packages/glacier-checksum-generator/package.json
+++ b/packages/glacier-checksum-generator/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "@aws/glacier-checksum-generator",
+    "version": "0.0.1",
+    "scripts": {
+        "prepublishOnly": "tsc",
+        "pretest": "tsc -p tsconfig.test.json",
+        "test": "jest"
+    },
+    "main": "./build/index.js",
+    "types": "./build/index.d.ts",
+    "author": {
+        "name": "AWS SDK for JavaScript Team",
+        "email": "aws-sdk-js@amazon.com",
+        "url": "https://aws.amazon.com/javascript/"
+    },
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@aws/types": "^0.0.1",
+        "tslib": "^1.8.0"
+    },
+    "devDependencies": {
+        "@aws/crypto-sha256-js": "^0.0.1",
+        "@aws/util-hex-encoding": "^0.0.1",
+        "@aws/util-utf8-node": "^0.0.1",
+        "@types/jest": "^20.0.2",
+        "typescript": "^2.3",
+        "jest": "^20.0.4"
+    }
+}

--- a/packages/glacier-checksum-generator/src/index.spec.ts
+++ b/packages/glacier-checksum-generator/src/index.spec.ts
@@ -1,0 +1,35 @@
+import {fromHex, toHex} from '@aws/util-hex-encoding';
+import {fromUtf8,toUtf8} from '@aws/util-utf8-node';
+import {Sha256} from '@aws/crypto-sha256-js';
+import {ChecksumGenerator} from './index';
+
+describe('ChecksumGenerator', () => {
+    const generator = new ChecksumGenerator(Sha256);
+
+    it('computes linear and tree hashes of bodies < 1 MB', async () => {
+        let results = await generator.computeChecksum(
+            fromUtf8('bar')
+        );
+        expect(toHex(results.linearHash)).toEqual(
+            'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'
+        );
+        expect(toHex(results.treeHash)).toEqual(
+            'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'
+        );
+    });
+
+    it('computes linear and tree hashes of bodies > 1 MB', async () => {
+        const payload = new Uint8Array(1024 * 1024 * 5.5);
+        payload.fill(0);
+        let results = await generator.computeChecksum(
+            payload
+        );
+
+        expect(toHex(results.linearHash)).toEqual(
+            '733cf513448ce6b20ad1bc5e50eb27c06aefae0c320713a5dd99f4e51bc1ca60'
+        );
+        expect(toHex(results.treeHash)).toEqual(
+            'a3a82dbe3644dd6046be472f2e3ec1f8ef47f8f3adb86d0de4de7a254f255455'
+        );
+    });
+});

--- a/packages/glacier-checksum-generator/src/index.ts
+++ b/packages/glacier-checksum-generator/src/index.ts
@@ -1,0 +1,59 @@
+import {
+    HashConstructor
+} from '@aws/types';
+
+export class ChecksumGenerator {
+    constructor(
+        private readonly Sha256: HashConstructor
+    ) {}
+
+    async computeTreeChecksum(hashes: Uint8Array[]) {
+        // merge leaf nodes
+        while (hashes.length > 1) {
+            const higherLevelHashes: Uint8Array[] = [];
+            for (let i = 0; i < hashes.length; i += 2) {
+                if (i + 1 < hashes.length) {
+                    // concatenate the pair of hashes
+                    const chunk = new Uint8Array(
+                        hashes[i].byteLength + hashes[i + 1].byteLength
+                    );
+                    chunk.set(hashes[i]);
+                    chunk.set(hashes[i + 1], hashes[i].byteLength);
+                    
+                    const hash = new this.Sha256();
+                    hash.update(chunk);
+                    higherLevelHashes.push(await hash.digest());
+                } else {
+                    // move single hash up a level
+                    higherLevelHashes.push(hashes[i]);
+                }
+            }
+            hashes = higherLevelHashes;
+        }
+
+        return hashes[0];
+    }
+
+    async computeChecksum(payload: Uint8Array) {
+        // hashes are generated on 1 MB chunks
+        // last chunk can be less than 1 MB
+        const MB = 1024 * 1024;
+
+        const hashes: Uint8Array[] = [];
+
+        // generate the leaf nodes
+        for (let i = 0; i < payload.byteLength; i += MB) {
+            const chunk = payload.subarray(i, Math.min(i + MB, payload.byteLength));
+            const hash = new this.Sha256();
+            hash.update(chunk);
+            hashes.push(await hash.digest());
+        }
+
+        const payloadHash = new this.Sha256();
+        payloadHash.update(payload);
+        return {
+            linearHash: await payloadHash.digest(),
+            treeHash: await this.computeTreeChecksum(hashes)
+        };
+    }
+}

--- a/packages/glacier-checksum-generator/tsconfig.json
+++ b/packages/glacier-checksum-generator/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": true,
+        "strict": true,
+        "sourceMap": true,
+        "downlevelIteration": true,
+        "importHelpers": true,
+        "noEmitHelpers": true,
+        "lib": [
+            "es5",
+            "es2015.promise",
+            "es2015.collection",
+            "es2015.iterable",
+            "es2015.symbol.wellknown"
+        ],
+        "rootDir": "./src",
+        "outDir": "./build"
+    }
+}

--- a/packages/glacier-checksum-generator/tsconfig.test.json
+++ b/packages/glacier-checksum-generator/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "sourceMap": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "rootDir": "./src",
+        "outDir": "./build"
+    }
+}

--- a/packages/middleware-sdk-glacier/.gitignore
+++ b/packages/middleware-sdk-glacier/.gitignore
@@ -1,0 +1,7 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tgz
+*.log
+package-lock.json

--- a/packages/middleware-sdk-glacier/.npmignore
+++ b/packages/middleware-sdk-glacier/.npmignore
@@ -1,0 +1,12 @@
+/src/
+/coverage/
+/docs/
+tsconfig.test.json
+
+*.spec.js
+*.spec.d.ts
+*.spec.js.map
+
+*.fixture.js
+*.fixture.d.ts
+*.fixture.js.map

--- a/packages/middleware-sdk-glacier/LICENSE
+++ b/packages/middleware-sdk-glacier/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-sdk-glacier/README.md
+++ b/packages/middleware-sdk-glacier/README.md
@@ -1,0 +1,1 @@
+# middleware-sdk-glacier

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "@aws/middleware-sdk-glacier",
+    "version": "0.0.1",
+    "scripts": {
+        "prepublishOnly": "tsc",
+        "pretest": "tsc -p tsconfig.test.json",
+        "test": "jest"
+    },
+    "main": "./build/index.js",
+    "types": "./build/index.d.ts",
+    "author": {
+        "name": "AWS SDK for JavaScript Team",
+        "email": "aws-sdk-js@amazon.com",
+        "url": "https://aws.amazon.com/javascript/"
+    },
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "@aws/crypto-sha256-js": "^0.0.1",
+        "@types/jest": "^20.0.2",
+        "jest": "^20.0.4",
+        "typescript": "^2.3"
+    },
+    "dependencies": {
+        "@aws/glacier-checksum-generator": "^0.0.1",
+        "@aws/util-hex-encoding": "^0.0.1",
+        "@aws/types": "^0.0.1",
+        "tslib": "^1.8.0"
+    }
+}

--- a/packages/middleware-sdk-glacier/src/add-glacier-api-version.spec.ts
+++ b/packages/middleware-sdk-glacier/src/add-glacier-api-version.spec.ts
@@ -1,0 +1,37 @@
+import {addGlacierApiVersion} from './add-glacier-api-version';
+import {UploadArchiveOperation} from './operation.mock';
+
+
+describe('addGlacierApiVersion', () => {
+    const mockNextHandler = jest.fn();
+    const mockExecutionContext = {
+        model: UploadArchiveOperation,
+        logger: {} as any
+    };
+    const mockHandlerArgs = {
+        request: {
+            headers: {}
+        }
+    };
+    const middleware = addGlacierApiVersion();
+    
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('sets the x-amz-glacier-version header', async () => {
+        const handler = middleware(mockNextHandler, mockExecutionContext)
+
+        await handler(mockHandlerArgs as any);
+        
+        // ensure the next handler was called
+        expect(mockNextHandler.mock.calls.length).toBe(1);
+        const {request} = mockNextHandler.mock.calls[0][0];
+        expect(request.headers['x-amz-glacier-version']).toBe('2012-06-01');
+    });
+
+    it('throws an error if request does not exist', async () => {
+        const handler = middleware(mockNextHandler, mockExecutionContext)
+        await expect(handler({} as any)).rejects.toHaveProperty('message');
+    });
+});

--- a/packages/middleware-sdk-glacier/src/add-glacier-api-version.ts
+++ b/packages/middleware-sdk-glacier/src/add-glacier-api-version.ts
@@ -1,0 +1,26 @@
+
+import {
+    BuildHandler,
+    BuildHandlerArguments,
+    HandlerExecutionContext
+} from '@aws/types';
+
+export function addGlacierApiVersion() {
+        return (
+            next: BuildHandler<any, any, any>,
+            {model}: HandlerExecutionContext
+        ) => {
+            return async(args: BuildHandlerArguments<any, any>) => {
+                const input = {...args.input};
+                const request = args.request;
+
+                if (!request) {
+                    throw new Error('Unable to add glacier version due to missing request.');
+                }
+    
+                request.headers['x-amz-glacier-version'] = model.metadata.apiVersion;
+
+                return next(args);
+            };
+        };
+    }

--- a/packages/middleware-sdk-glacier/src/checksum-generator.spec.ts
+++ b/packages/middleware-sdk-glacier/src/checksum-generator.spec.ts
@@ -1,0 +1,110 @@
+import {
+    BuildHandler,
+    BuildHandlerArguments,
+    HttpRequest
+} from '@aws/types';
+
+import {Sha256} from '@aws/crypto-sha256-js';
+import {addChecksumHeaders} from './checksum-generator';
+
+describe('addChecksumHeaders', () => {
+    const minimalRequest: HttpRequest<any> = {
+        method: 'POST',
+        protocol: 'https:',
+        path: '/',
+        headers: {},
+        hostname: 'foo.us-east-1.amazonaws.com',
+    };
+
+    const mockNextHandler = jest.fn(() => Promise.resolve());
+    const mockUtf8Decoder = jest.fn(() => {
+        return new Uint8Array([98, 97, 114]); //'bar'
+    });
+
+    const composedHandler: BuildHandler<any, any> = addChecksumHeaders(
+        Sha256,
+        mockUtf8Decoder
+    )(mockNextHandler);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws when request is unavailable', async () => {
+        await expect(composedHandler({
+            input: {}
+        })).rejects.toHaveProperty('message');
+    });
+
+    it('will not set content-sha256 headers if request body is empty', async () => {
+        await composedHandler({
+            input: {},
+            request: {
+                ...minimalRequest,
+                headers: {}
+            }
+        });
+
+        expect(mockNextHandler.mock.calls.length).toBe(1);
+        const {request} = mockNextHandler.mock.calls[0][0];
+        expect(request.headers['x-amz-content-sha256']).toBeUndefined();
+        expect(request.headers['x-amz-sha-256-tree-hash']).toBeUndefined();
+    });
+
+    it('will set sha256 headers if request body is present', async () => {
+        const body = new Uint8Array(1024 * 1024 * 5.5);
+        body.fill(0);
+
+        await composedHandler({
+            input: {},
+            request: {
+                ...minimalRequest,
+                headers: {},
+                body
+            }
+        });
+
+        expect(mockNextHandler.mock.calls.length).toBe(1);
+        const {request} = mockNextHandler.mock.calls[0][0];
+        expect(request.headers['x-amz-content-sha256']).toBe('733cf513448ce6b20ad1bc5e50eb27c06aefae0c320713a5dd99f4e51bc1ca60');
+        expect(request.headers['x-amz-sha256-tree-hash']).toBe('a3a82dbe3644dd6046be472f2e3ec1f8ef47f8f3adb86d0de4de7a254f255455');
+    });
+
+    it('will not set sha256 tree header if header is already present', async () => {
+        const body = new Uint8Array(1024 * 1024 * 5.5);
+        body.fill(0);
+
+        await composedHandler({
+            input: {},
+            request: {
+                ...minimalRequest,
+                headers: {
+                    'x-amz-sha256-tree-hash': 'foo'
+                },
+                body
+            }
+        });
+
+        expect(mockNextHandler.mock.calls.length).toBe(1);
+        const {request} = mockNextHandler.mock.calls[0][0];
+        expect(request.headers['x-amz-content-sha256']).toBe('733cf513448ce6b20ad1bc5e50eb27c06aefae0c320713a5dd99f4e51bc1ca60');
+        expect(request.headers['x-amz-sha256-tree-hash']).toBe('foo');
+    });
+
+    it('will calculate sha256 hashes when request body is a string', async () => {
+        await composedHandler({
+            input: {},
+            request: {
+                ...minimalRequest,
+                headers: {},
+                body: 'bar'
+            }
+        });
+
+        expect(mockNextHandler.mock.calls.length).toBe(1);
+        const {request} = mockNextHandler.mock.calls[0][0];
+        expect(request.headers['x-amz-content-sha256']).toBe('fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9');
+        expect(request.headers['x-amz-sha256-tree-hash']).toBe('fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9');
+    });
+
+});

--- a/packages/middleware-sdk-glacier/src/checksum-generator.ts
+++ b/packages/middleware-sdk-glacier/src/checksum-generator.ts
@@ -1,0 +1,37 @@
+import {
+    Decoder,
+    BuildHandler,
+    BuildHandlerArguments,
+    HandlerExecutionContext,
+    HashConstructor,
+} from '@aws/types';
+
+import {toHex} from '@aws/util-hex-encoding';
+import {ChecksumGenerator} from '@aws/glacier-checksum-generator';
+
+export function addChecksumHeaders(
+    Sha256: HashConstructor,
+    utf8Decoder: Decoder
+) {
+    const checksumGenerator = new ChecksumGenerator(Sha256);
+
+    return (next: BuildHandler<any, any, any>) => {
+        return async(args: BuildHandlerArguments<any, any>) => {
+            const request = args.request;
+            if (!request) {
+                throw new Error('Unable to add checksums due to missing request.');
+            }
+
+            if (request.body) {
+                const body = typeof request.body === 'string' ? utf8Decoder(request.body) : request.body;
+                const hashes = await checksumGenerator.computeChecksum(body);
+                request.headers['x-amz-content-sha256'] = toHex(hashes.linearHash);
+                if (!request.headers['x-amz-sha256-tree-hash']) {
+                    request.headers['x-amz-sha256-tree-hash'] = toHex(hashes.treeHash);
+                }
+            }
+
+            return next(args);
+        }
+    }
+}

--- a/packages/middleware-sdk-glacier/src/index.spec.ts
+++ b/packages/middleware-sdk-glacier/src/index.spec.ts
@@ -1,0 +1,19 @@
+import {
+    addChecksumHeaders,
+    addGlacierApiVersion,
+    validateAccountId
+} from './index';
+
+describe('middleware-sdk-glacier package exports', () => {
+    it('addChecksumHeaders', () => {
+        expect(typeof addChecksumHeaders).toBe('function');
+    });
+
+    it('addGlacierApiVersion', () => {
+        expect(typeof addGlacierApiVersion).toBe('function');
+    });
+
+    it('validateAccountId', () => {
+        expect(typeof validateAccountId).toBe('function');
+    });
+});

--- a/packages/middleware-sdk-glacier/src/index.ts
+++ b/packages/middleware-sdk-glacier/src/index.ts
@@ -1,0 +1,3 @@
+export * from './add-glacier-api-version';
+export * from './checksum-generator';
+export * from './validate-account-id';

--- a/packages/middleware-sdk-glacier/src/operation.mock.ts
+++ b/packages/middleware-sdk-glacier/src/operation.mock.ts
@@ -1,0 +1,98 @@
+import {
+    OperationModel,
+    ServiceMetadata
+} from '@aws/types';
+
+const glacierMetadata: ServiceMetadata = {
+    apiVersion: '2012-06-01',
+    endpointPrefix: 'glacier',
+    protocol: 'rest-json',
+    serviceFullName: 'Amazon Glacier',
+    signatureVersion: 'v4',
+    uid: 'glacier-2012-06-01'
+};
+
+export const UploadArchiveOperation: OperationModel = {
+    metadata: glacierMetadata,
+    name: 'UploadArchiveOperation',
+    http: {
+        method: 'POST',
+        requestUri: '/{accountId}/vaults/{vaultName}/archives',
+    },
+    input: {
+        shape: {
+            type: 'structure',
+            required: [
+                'vaultName',
+                'accountId',
+            ],
+            members: {
+                vaultName: {
+                    shape: {
+                        type: 'string',
+                    },
+                    location: 'uri',
+                    locationName: 'vaultName',
+                },
+                accountId: {
+                    shape: {
+                        type: 'string',
+                    },
+                    location: 'uri',
+                    locationName: 'accountId',
+                },
+                archiveDescription: {
+                    shape: {
+                        type: 'string',
+                    },
+                    location: 'header',
+                    locationName: 'x-amz-archive-description',
+                },
+                checksum: {
+                    shape: {
+                        type: 'string',
+                    },
+                    location: 'header',
+                    locationName: 'x-amz-sha256-tree-hash',
+                },
+                body: {
+                    shape: {
+                        type: 'blob',
+                        streaming: true,
+                    },
+                },
+            },
+            payload: 'body',
+        }
+    },
+    output: {
+        shape: {
+            type: 'structure',
+            required: [],
+            members: {
+                location: {
+                    shape: {
+                        type: 'string',
+                    },
+                    location: 'header',
+                    locationName: 'Location',
+                },
+                checksum: {
+                    shape: {
+                        type: 'string',
+                    },
+                    location: 'header',
+                    locationName: 'x-amz-sha256-tree-hash',
+                },
+                archiveId: {
+                    shape: {
+                        type: 'string',
+                    },
+                    location: 'header',
+                    locationName: 'x-amz-archive-id',
+                },
+            },
+        }
+    },
+    errors: [],
+}

--- a/packages/middleware-sdk-glacier/src/validate-account-id.spec.ts
+++ b/packages/middleware-sdk-glacier/src/validate-account-id.spec.ts
@@ -1,0 +1,37 @@
+import {Handler} from '@aws/types';
+import {validateAccountId} from './validate-account-id';
+
+describe('validateAccountId', () => {
+    const mockNextHandler = jest.fn(() => Promise.resolve());
+
+    const composedHandler: Handler<any, any> = validateAccountId(mockNextHandler);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it(`sets accountId to '-' if it is undefined within user input`, async () => {
+        const userInput: {accountId?: string;} = {};
+        await composedHandler({
+            input: userInput
+        });
+
+        expect(mockNextHandler.mock.calls.length).toBe(1);
+        const {input} = mockNextHandler.mock.calls[0][0];
+        expect(input.accountId).toBe('-');
+        expect(userInput.accountId).toBeUndefined();
+    });
+
+    it('does not override accountId if it is already set by the user', async () => {
+        const userInput: {accountId?: string;} = {
+            accountId: 'fake-id'
+        };
+        await composedHandler({
+            input: userInput
+        });
+
+        expect(mockNextHandler.mock.calls.length).toBe(1);
+        const {input} = mockNextHandler.mock.calls[0][0];
+        expect(input.accountId).toBe('fake-id');
+    });
+});

--- a/packages/middleware-sdk-glacier/src/validate-account-id.ts
+++ b/packages/middleware-sdk-glacier/src/validate-account-id.ts
@@ -1,0 +1,20 @@
+import {
+    Handler,
+    HandlerArguments
+} from '@aws/types';
+
+export function validateAccountId(
+    next: Handler<any, any>
+) {
+    return async (args: HandlerArguments<any>) => {
+        const input = {...args.input};
+        if (input['accountId'] === void 0) {
+            input['accountId'] = '-';
+        }
+
+        return next({
+            ...args,
+            input
+        });
+    }
+}

--- a/packages/middleware-sdk-glacier/tsconfig.json
+++ b/packages/middleware-sdk-glacier/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": true,
+        "strict": true,
+        "sourceMap": true,
+        "downlevelIteration": true,
+        "importHelpers": true,
+        "noEmitHelpers": true,
+        "lib": [
+            "es5",
+            "es2015.promise",
+            "es2015.collection",
+            "es2015.iterable",
+            "es2015.symbol.wellknown"
+        ],
+        "rootDir": "./src",
+        "outDir": "./build"
+    }
+}

--- a/packages/middleware-sdk-glacier/tsconfig.test.json
+++ b/packages/middleware-sdk-glacier/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "sourceMap": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "rootDir": "./src",
+        "outDir": "./build"
+    }
+}


### PR DESCRIPTION
The glacier checksum generator is in its own package since it can be used on its own when performing multipart uploads. Eventually we should create a transfer manager for Glacier like we have for S3, so customers don't have to use this package directly.

For some tests, especially checksum generator tests, I pulled in some additional dev dependencies so I can be sure the hashing is done properly.