### PR TITLE
Overwrite copied HMAC keys in memory

### DIFF
--- a/packages/crypto-sha256-js/src/jsSha256.ts
+++ b/packages/crypto-sha256-js/src/jsSha256.ts
@@ -17,13 +17,16 @@ export class Sha256 implements Hash {
 
             for (let i = 0; i < BLOCK_SIZE; i++) {
                 inner[i] ^= 0x36;
-            }
-            this.hash.update(inner);
-
-            for (let i = 0; i < BLOCK_SIZE; i++) {
                 outer[i] ^= 0x5c;
             }
+
+            this.hash.update(inner);
             this.outer.update(outer);
+
+            // overwrite the copied key in memory
+            for (let i = 0; i < inner.byteLength; i++) {
+                inner[i] = 0;
+            }
         }
     }
 


### PR DESCRIPTION
This is something I noticed when working on https://github.com/aws/aws-sdk-js/pull/1880

When copying sensitive data into a buffer, it should be overwritten with zeros rather than waiting for the memory to be reclaimed by the GC. This prevents private data from showing up in a heap dump if the program crashes before GC is invoked.