### PR TITLE
Prioritize ini creds with explicit profile

### DIFF
--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -1,6 +1,6 @@
 import {CredentialProvider} from "@aws/types";
 import {
-    Ec2InstanceMetadataInit,
+    RemoteProviderInit,
     providerConfigFromInit,
 } from './remoteProvider/RemoteProviderInit';
 import {httpGet} from './remoteProvider/httpGet';
@@ -16,16 +16,14 @@ import {ProviderError} from '@aws/property-provider';
  * Instance Metadata Service
  */
 export function fromInstanceMetadata(
-    init: Ec2InstanceMetadataInit = {}
+    init: RemoteProviderInit = {}
 ): CredentialProvider {
     const {timeout, maxRetries} = providerConfigFromInit(init);
     return async () => {
-        const {
-            profile = (await retry<string>(
-                async () => await requestFromEc2Imds(timeout),
-                maxRetries
-            )).trim()
-        } = init;
+        const profile = (await retry<string>(
+            async () => await requestFromEc2Imds(timeout),
+            maxRetries
+        )).trim();
 
         return retry(async () => {
             const credsResponse = JSON.parse(

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -15,13 +15,6 @@ export interface RemoteProviderConfig {
 
 export type RemoteProviderInit = Partial<RemoteProviderConfig>;
 
-export interface Ec2InstanceMetadataInit extends RemoteProviderInit {
-    /**
-     * The identifier of the instance profile to read
-     */
-    profile?: string;
-}
-
 export function providerConfigFromInit(
     init: RemoteProviderInit
 ): RemoteProviderConfig {

--- a/packages/credential-provider-ini/src/index.spec.ts
+++ b/packages/credential-provider-ini/src/index.spec.ts
@@ -568,7 +568,7 @@ source_profile = bar`.trim()
 
                 return expect(provider()).rejects.toMatchObject({
                     message: 'Profile bar could not be found or parsed in shared credentials file.',
-                    tryNextLink: false,
+                    tryNextLink: true,
                 });
             }
         );

--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -200,8 +200,7 @@ async function resolveProfileData(
     // `source_profile` key).
     throw new ProviderError(
         `Profile ${profileName} could not be found or parsed in shared` +
-        ` credentials file.`,
-        profileName === DEFAULT_PROFILE
+        ` credentials file.`
     );
 }
 

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -31,6 +31,7 @@
         "tslib": "^1.8.0"
     },
     "devDependencies": {
+        "@aws/shared-ini-file-loader": "^0.0.1",
         "@types/jest": "^20.0.2",
         "@types/node": "^7.0.12",
         "jest": "^20.0.4",

--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -12,10 +12,19 @@ import {fromEnv} from '@aws/credential-provider-env';
 jest.mock('@aws/credential-provider-ini', () => {
     const iniProvider = jest.fn();
     return {
+        ENV_PROFILE: 'AWS_PROFILE',
         fromIni: jest.fn(() => iniProvider),
     };
 });
-import {fromIni, FromIniInit} from '@aws/credential-provider-ini';
+import {
+    ENV_PROFILE,
+    fromIni,
+    FromIniInit,
+} from '@aws/credential-provider-ini';
+import {
+    ENV_CONFIG_PATH,
+    ENV_CREDENTIALS_PATH,
+} from '@aws/shared-ini-file-loader';
 
 jest.mock('@aws/credential-provider-imds', () => {
     const containerMdsProvider = jest.fn();
@@ -23,10 +32,11 @@ jest.mock('@aws/credential-provider-imds', () => {
     return {
         fromContainerMetadata: jest.fn(() => containerMdsProvider),
         fromInstanceMetadata: jest.fn(() => instanceMdsProvider),
+        ENV_CMDS_FULL_URI: 'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+        ENV_CMDS_RELATIVE_URI: 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
     };
 });
 import {
-    Ec2InstanceMetadataInit,
     ENV_CMDS_FULL_URI,
     ENV_CMDS_RELATIVE_URI,
     fromContainerMetadata,
@@ -34,12 +44,25 @@ import {
     RemoteProviderInit,
 } from '@aws/credential-provider-imds';
 
-const fullUri = process.env[ENV_CMDS_FULL_URI];
-const relativeUri = process.env[ENV_CMDS_RELATIVE_URI];
+const envAtLoadTime: {[key: string]: string} = [
+    ENV_CONFIG_PATH,
+    ENV_CREDENTIALS_PATH,
+    ENV_PROFILE,
+    ENV_CMDS_FULL_URI,
+    ENV_CMDS_RELATIVE_URI,
+    'HOME',
+    'USERPROFILE',
+    'HOMEPATH',
+    'HOMEDRIVE',
+].reduce((envState: {[key: string]: string}, varName: string) => {
+    envState[varName] = process.env[varName];
+    return envState;
+}, {});
 
 beforeEach(() => {
-    delete process.env[ENV_CMDS_FULL_URI];
-    delete process.env[ENV_CMDS_RELATIVE_URI];
+    Object.keys(envAtLoadTime).forEach(envKey => {
+        delete process.env[envKey];
+    });
 
     (fromEnv() as any).mockClear();
     (fromIni() as any).mockClear();
@@ -52,8 +75,13 @@ beforeEach(() => {
 });
 
 afterAll(() => {
-    process.env[ENV_CMDS_FULL_URI] = fullUri;
-    process.env[ENV_CMDS_RELATIVE_URI] = relativeUri;
+    Object.keys(envAtLoadTime).forEach(envKey => {
+        if (envAtLoadTime[envKey] === undefined) {
+            delete process.env[envKey];
+        } else {
+            process.env[envKey] = envAtLoadTime[envKey];
+        }
+    });
 });
 
 describe('defaultProvider', () => {
@@ -164,8 +192,7 @@ describe('defaultProvider', () => {
     });
 
     it('should pass configuration on to the IMDS provider', async () => {
-        const imdsConfig: Ec2InstanceMetadataInit = {
-            profile: 'foo',
+        const imdsConfig: RemoteProviderInit = {
             timeout: 2000,
             maxRetries: 3,
         };
@@ -258,5 +285,51 @@ describe('defaultProvider', () => {
             expect((await memoized()).secretAccessKey).toEqual('bar');
             expect(provider.mock.calls.length).toBe(2);
         });
+    });
+
+    // CF https://github.com/boto/botocore/blob/1.8.32/botocore/credentials.py#L104
+    describe('explicit profiles', () => {
+        it(
+            'should only consult the ini provider if a profile has been specified',
+            async () => {
+                const creds = {
+                    accessKeyId: 'foo',
+                    secretAccessKey: 'bar',
+                };
+
+                (fromEnv() as any).mockImplementation(() => Promise.reject(new Error('PANIC')));
+                (fromIni() as any).mockImplementation(() => Promise.resolve(creds));
+                (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new Error('PANIC')));
+                (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new Error('PANIC')));
+
+                expect(await defaultProvider({profile: 'foo'})()).toEqual(creds);
+                expect((fromEnv() as any).mock.calls.length).toBe(0);
+                expect((fromIni() as any).mock.calls.length).toBe(1);
+                expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
+                expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
+            }
+        );
+
+        it(
+            'should only consult the ini provider if the profile environment variable has been set',
+            async () => {
+                const creds = {
+                    accessKeyId: 'foo',
+                    secretAccessKey: 'bar',
+                };
+
+                (fromEnv() as any).mockImplementation(() => Promise.reject(new Error('PANIC')));
+                (fromIni() as any).mockImplementation(() => Promise.resolve(creds));
+                (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new Error('PANIC')));
+                (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new Error('PANIC')));
+
+                process.env[ENV_PROFILE] = 'foo';
+                expect(await defaultProvider()()).toEqual(creds);
+                expect((fromEnv() as any).mock.calls.length).toBe(0);
+                expect((fromIni() as any).mock.calls.length).toBe(1);
+                expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
+                expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
+            }
+        );
     });
 });

--- a/packages/credential-provider-node/src/index.ts
+++ b/packages/credential-provider-node/src/index.ts
@@ -1,15 +1,18 @@
-import {chain, memoize} from '@aws/property-provider';
-import {fromEnv} from '@aws/credential-provider-env';
+import { chain, memoize } from '@aws/property-provider';
+import { fromEnv } from '@aws/credential-provider-env';
 import {
-    Ec2InstanceMetadataInit,
     ENV_CMDS_FULL_URI,
     ENV_CMDS_RELATIVE_URI,
     fromContainerMetadata,
     fromInstanceMetadata,
     RemoteProviderInit,
 } from '@aws/credential-provider-imds';
-import {fromIni, FromIniInit} from '@aws/credential-provider-ini';
-import {CredentialProvider} from '@aws/types';
+import {
+    ENV_PROFILE,
+    fromIni,
+    FromIniInit,
+} from '@aws/credential-provider-ini';
+import { CredentialProvider } from '@aws/types';
 
 /**
  * Creates a credential provider that will attempt to find credentials from the
@@ -38,16 +41,21 @@ import {CredentialProvider} from '@aws/types';
  *                              ECS Container Metadata Service
  */
 export function defaultProvider(
-    init: Ec2InstanceMetadataInit & FromIniInit & RemoteProviderInit = {}
+    init: FromIniInit & RemoteProviderInit = {}
 ): CredentialProvider {
-    return memoize(
-        chain(
+    const { profile = process.env[ENV_PROFILE] } = init;
+    const providerChain = profile
+        ? fromIni(init)
+        : chain(
             fromEnv(),
             fromIni(init),
             process.env[ENV_CMDS_RELATIVE_URI] || process.env[ENV_CMDS_FULL_URI]
                 ? fromContainerMetadata(init)
                 : fromInstanceMetadata(init)
-        ),
+        );
+
+    return memoize(
+        providerChain,
         credentials => credentials.expiration !== undefined &&
             credentials.expiration - getEpochTs() < 300,
         credentials => credentials.expiration !== undefined


### PR DESCRIPTION
It came up that the default credential chain differs from the CLI in that we will prioritize reading from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY over AWS_PROFILE. The intended behavior in the CLI is that when a profile is specified, no other credential providers should be consulted.