### PR TITLE
Feature/extra middleware step

### DIFF
--- a/packages/middleware-content-length/src/index.ts
+++ b/packages/middleware-content-length/src/index.ts
@@ -14,11 +14,7 @@ export function contentLengthMiddleware(
     ): BuildHandler<any, Output, any> => async (
         args: BuildHandlerArguments<any, any>
     ): Promise<Output> => {
-        const {request} = args;
-        if (!request) {
-            throw new Error('Unable to determine request content-length due to missing request.');
-        }
-
+        let request = {...args.request};
         const {body, headers} = request;
         if (
             body &&
@@ -28,7 +24,10 @@ export function contentLengthMiddleware(
         ) {
             const length = bodyLengthCalculator(body);
             if (length !== undefined) {
-                headers['Content-Length'] = String(length);
+                request.headers = {
+                    ...request.headers,
+                    'Content-Length': String(length),
+                }
             }
         }
 

--- a/packages/middleware-sdk-api-gateway/src/index.spec.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.spec.ts
@@ -10,12 +10,6 @@ describe('acceptsHeader', () => {
         jest.clearAllMocks();
     });
 
-    it('throws an error if request is not defined', async () => {
-        await expect(composedHandler({
-            input: {}
-        })).rejects.toHaveProperty('message');
-    });
-
     it('sets Accepts header to application/json', async () => {
         await composedHandler({
             input: {},

--- a/packages/middleware-sdk-api-gateway/src/index.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.ts
@@ -5,14 +5,15 @@ import {
 
 export function acceptsHeader(next: BuildHandler<any, any>) {
     return async (args: BuildHandlerArguments<any, any>) => {
-        const request = args.request;
-
-        if (!request) {
-            throw new Error('Unable to add Accepts header due to missing request.');
-        }
-
-        request.headers['accepts'] = 'application/json';
-
-        return next(args);
+        return next({
+            ...args,
+            request: {
+                ...args.request,
+                headers: {
+                    ...args.request.headers,
+                    accepts: 'application/json',
+                }
+            }
+        });
     }
 }

--- a/packages/middleware-serializer/src/index.ts
+++ b/packages/middleware-serializer/src/index.ts
@@ -29,8 +29,8 @@ export function serializerMiddleware<
         }
 
         return next({
+            ...args,
             request,
-            ...args
         });
     };
 }

--- a/packages/middleware-stack/src/index.ts
+++ b/packages/middleware-stack/src/index.ts
@@ -5,9 +5,8 @@ import {
     Middleware,
     MiddlewareStack as IMiddlewareStack,
     HandlerExecutionContext,
+    Step,
 } from '@aws/types';
-
-export type Step = 'initialize'|'build'|'finalize';
 
 interface HandlerListEntry<
     Input extends object,
@@ -20,11 +19,17 @@ interface HandlerListEntry<
     tags?: {[tag: string]: any};
 }
 
+export interface MiddlewareStack<
+    Input extends object,
+    Output extends object,
+    Stream = Uint8Array
+> extends IMiddlewareStack<Input, Output, Stream> {}
+
 export class MiddlewareStack<
     Input extends object,
     Output extends object,
     Stream = Uint8Array
-> implements IMiddlewareStack<Input, Output, Stream> {
+> {
     private readonly entries: Array<HandlerListEntry<Input, Output, Stream>> = [];
     private sorted: boolean = true;
 
@@ -117,7 +122,8 @@ export class MiddlewareStack<
 }
 
 const stepWeights = {
-    initialize: 3,
+    initialize: 4,
+    serialize: 3,
     build: 2,
     finalize: 1,
 };

--- a/packages/service-types-generator/src/Components/Client/customizationsFromModel/serializerConfigurationProperties.ts
+++ b/packages/service-types-generator/src/Components/Client/customizationsFromModel/serializerConfigurationProperties.ts
@@ -225,7 +225,7 @@ function serializerProperty(
     middlewareStack.add(
         ${packageNameToVariable('@aws/middleware-serializer')}.serializerMiddleware(serializerProvider),
         {
-            step: 'build',
+            step: 'serialize',
             tags: {SERIALIZER: true},
             priority: 90
         }

--- a/packages/signing-middleware/src/index.ts
+++ b/packages/signing-middleware/src/index.ts
@@ -13,9 +13,9 @@ export function signingMiddleware<
     return (
         next: FinalizeHandler<Input, Output, Stream>
     ): FinalizeHandler<Input, Output, Stream> => async (
-        {request, ...rest}: FinalizeHandlerArguments<Input, Stream>
+        args: FinalizeHandlerArguments<Input, Stream>
     ): Promise<Output> => next({
-        ...rest,
-        request: await signer.sign(request),
+        ...args,
+        request: await signer.sign(args.request),
     });
 }


### PR DESCRIPTION
This PR adds a `serialize` step to the middleware stack so that we can write `build` middleware and not need to check on the existence of the `request` parameter.