### PR TITLE
Ensure S3 customizations only attempt to import packages that exist

### DIFF
--- a/packages/crypto-sha256-js/package.json
+++ b/packages/crypto-sha256-js/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@aws/crypto-sha256-js",
-    "private": true,
     "version": "0.0.1",
     "scripts": {
         "prepublishOnly": "tsc",

--- a/packages/service-types-generator/src/ServiceCustomizations/s3/bodySigning.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/s3/bodySigning.ts
@@ -109,7 +109,7 @@ const disableBodySigningCustomization: ConfigCustomizationDefinition = {
 
 const unsignedPayload: MiddlewareCustomizationDefinition = {
     imports: [
-        IMPORTS['sigv4-unsigned-payload-middleware'],
+        IMPORTS['middleware-header-default'],
     ],
     step: 'build',
     priority: sha256Checksum.priority + 100,


### PR DESCRIPTION
Found the source of the bug Allan encountered. I must have had an old version of the imports map.