### PR TITLE
Add HTTP configuration options to client configuration and pick defaults

### DIFF
--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -20,7 +20,7 @@ export class NodeHttpHandler implements HttpHandler<Readable, NodeHttpOptions> {
     private readonly httpsAgent: https.Agent;
 
     constructor(private readonly httpOptions: NodeHttpOptions = {}) {
-        const { keepAlive, maxSockets } = httpOptions;
+        const { keepAlive, maxConcurrencyPerHost: maxSockets } = httpOptions;
         this.httpAgent = new http.Agent({ keepAlive, maxSockets });
         this.httpsAgent = new https.Agent({ keepAlive, maxSockets });
     }
@@ -57,10 +57,7 @@ export class NodeHttpHandler implements HttpHandler<Readable, NodeHttpOptions> {
 
         return new Promise((resolve, reject) => {
             const abortSignal = options && options.abortSignal;
-            const {
-                connectionTimeout,
-                socketTimeout
-            } = this.httpOptions;
+            const { connectionTimeout, timeout } = this.httpOptions;
 
             // if the request was already aborted, prevent doing extra work
             if (abortSignal && abortSignal.aborted) {
@@ -93,7 +90,7 @@ export class NodeHttpHandler implements HttpHandler<Readable, NodeHttpOptions> {
 
             // wire-up any timeout logic
             setConnectionTimeout(req, reject, connectionTimeout);
-            setSocketTimeout(req, reject, socketTimeout);
+            setSocketTimeout(req, reject, timeout);
 
             // wire-up abort logic
             if (abortSignal) {

--- a/packages/node-http-handler/src/set-socket-timeout.ts
+++ b/packages/node-http-handler/src/set-socket-timeout.ts
@@ -8,7 +8,7 @@ export function setSocketTimeout(
     request.setTimeout(timeoutInMs, function(this: ClientRequest) {
         // abort the request to destroy it
         this.abort();
-        const timeoutError = new Error(`Connection timed out after ${timeoutInMs} ms`);
+        const timeoutError = new Error(`Socket timed out after ${timeoutInMs} ms of inactivity`);
         timeoutError.name = 'TimeoutError';
         reject(timeoutError);
     });

--- a/packages/sdk-kms-node/KMS.ts
+++ b/packages/sdk-kms-node/KMS.ts
@@ -973,6 +973,7 @@ export class KMS extends KMSClient {
      * <p>Retires a grant. To clean up, you can retire a grant when you're done using it. You should revoke a grant when you intend to actively deny operations that depend on it. The following are permitted to call this API:</p> <ul> <li> <p>The AWS account (root user) under which the grant was created</p> </li> <li> <p>The <code>RetiringPrincipal</code>, if present in the grant</p> </li> <li> <p>The <code>GranteePrincipal</code>, if <code>RetireGrant</code> is an operation specified in the grant</p> </li> </ul> <p>You must identify the grant to retire by its grant token or by a combination of the grant ID and the Amazon Resource Name (ARN) of the customer master key (CMK). A grant token is a unique variable-length base64-encoded string. A grant ID is a 64 character unique identifier of a grant. The <a>CreateGrant</a> operation returns both.</p>
      *
      * This operation may fail with one of the following errors:
+     *   - {InvalidArnException} <p>The request was rejected because a specified ARN was not valid.</p>
      *   - {InvalidGrantTokenException} <p>The request was rejected because the specified grant token is not valid.</p>
      *   - {InvalidGrantIdException} <p>The request was rejected because the specified <code>GrantId</code> is not valid.</p>
      *   - {NotFoundException} <p>The request was rejected because the specified entity or resource could not be found.</p>

--- a/packages/sdk-kms-node/KMSClient.ts
+++ b/packages/sdk-kms-node/KMSClient.ts
@@ -65,7 +65,7 @@ export class KMSClient {
             );
         }
         this.middlewareStack.add(
-            __aws_signing_middleware.signingMiddleware(signer),
+            __aws_signing_middleware.signingMiddleware<_stream.Readable>(configuration.signer),
             {
                 step: 'finalize',
                 priority: 0,

--- a/packages/sdk-kms-node/KMSClient.ts
+++ b/packages/sdk-kms-node/KMSClient.ts
@@ -34,9 +34,9 @@ export class KMSClient {
         _stream.Readable
     >();
 
-    constructor(configuration: KMSConfiguration) {
-        this.config = __aws_config_resolver.resolveConfiguration(
-            configuration,
+    constructor(options: KMSConfiguration) {
+        const configuration = this.config = __aws_config_resolver.resolveConfiguration(
+            options,
             configurationProperties,
             this.middlewareStack
         );
@@ -64,6 +64,14 @@ export class KMSClient {
                 }
             );
         }
+        this.middlewareStack.add(
+            __aws_signing_middleware.signingMiddleware(signer),
+            {
+                step: 'finalize',
+                priority: 0,
+                tags: {SIGNATURE: true}
+            }
+        );
     }
 
     destroy(): void {

--- a/packages/sdk-kms-node/model/RetireGrant.ts
+++ b/packages/sdk-kms-node/model/RetireGrant.ts
@@ -1,5 +1,6 @@
 import {RetireGrantInput} from './RetireGrantInput';
 import {RetireGrantOutput} from './RetireGrantOutput';
+import {InvalidArnException} from './InvalidArnException';
 import {InvalidGrantTokenException} from './InvalidGrantTokenException';
 import {InvalidGrantIdException} from './InvalidGrantIdException';
 import {NotFoundException} from './NotFoundException';
@@ -23,6 +24,9 @@ export const RetireGrant: _Operation_ = {
         shape: RetireGrantOutput,
     },
     errors: [
+        {
+            shape: InvalidArnException,
+        },
         {
             shape: InvalidGrantTokenException,
         },

--- a/packages/sdk-kms-node/package.json
+++ b/packages/sdk-kms-node/package.json
@@ -3,9 +3,16 @@
     "description": "Node SDK for AWS Key Management Service",
     "version": "0.0.1",
     "scripts": {
+        "clean": "npm run remove-definitions && npm run remove-maps && npm run remove-js",
+        "build-documentation": "npm run clean && typedoc ./",
         "prepublishOnly": "tsc",
         "pretest": "tsc",
-        "test": "exit 0"
+        "remove-definitions": "rimraf *.d.ts && rimraf ./commands/*.d.ts && rimraf ./model/*.d.ts rimraf ./types/*.d.ts",
+        "remove-documentation": "rimraf ./docs",
+        "remove-js": "rimraf *.js && rimraf ./commands/*.js && rimraf ./model/*.js && rimraf ./types/*.js",
+        "remove-maps": "rimraf *.js.map && rimraf ./commands/*.js.map && rimraf ./model/*.js.map && rimraf ./types/*.js.map",
+        "test": "exit 0",
+        "smoke-test": "npm run pretest && node ./test/smoke/index.spec.js"
     },
     "main": "./build/index.js",
     "types": "./build/index.d.ts",
@@ -32,15 +39,18 @@
         "@aws/json-error-unmarshaller": "^0.0.1",
         "@aws/node-http-handler": "^0.0.1",
         "@aws/core-handler": "^0.0.1",
-        "@aws/credential-provider-node": "^0.0.1",
-        "@aws/hash-node": "^0.0.1",
-        "@aws/signature-v4": "^0.0.1",
-        "@aws/signing-middleware": "^0.0.1",
         "@aws/middleware-content-length": "^0.0.1",
         "@aws/util-body-length-node": "^0.0.1",
-        "@aws/retry-middleware": "^0.0.1"
+        "@aws/retry-middleware": "^0.0.1",
+        "@aws/signing-middleware": "^0.0.1",
+        "@aws/credential-provider-node": "^0.0.1",
+        "@aws/hash-node": "^0.0.1",
+        "@aws/signature-v4": "^0.0.1"
     },
     "devDependencies": {
+        "@aws/client-documentation-generator": "^0.0.1",
+        "rimraf": "^2.6.2",
+        "typedoc": "^0.10.0",
         "typescript": "^2.6",
         "@types/node": "^8.0"
     }

--- a/packages/sdk-kms-node/tsconfig.json
+++ b/packages/sdk-kms-node/tsconfig.json
@@ -15,5 +15,15 @@
             "es2015.iterable",
             "es2015.symbol.wellknown"
         ]
+    },
+    "typedocOptions": {
+        "exclude": "**/node_modules/**",
+        "excludedNotExported": true,
+        "excludePrivate": true,
+        "hideGenerator": true,
+        "ignoreCompilerErrors": true,
+        "mode": "file",
+        "out": "./docs",
+        "plugin": "@aws/client-documentation-generator"
     }
 }

--- a/packages/sdk-kms-node/types/AlreadyExistsException.ts
+++ b/packages/sdk-kms-node/types/AlreadyExistsException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because it attempted to create a resource that already exists.</p>

--- a/packages/sdk-kms-node/types/CancelKeyDeletionInput.ts
+++ b/packages/sdk-kms-node/types/CancelKeyDeletionInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CancelKeyDeletionInput shape
@@ -10,23 +11,19 @@ export interface CancelKeyDeletionInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/CancelKeyDeletionOutput.ts
+++ b/packages/sdk-kms-node/types/CancelKeyDeletionOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CancelKeyDeletionOutput shape
@@ -10,8 +10,7 @@ export interface CancelKeyDeletionOutput {
     KeyId?: string;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/CreateAliasInput.ts
+++ b/packages/sdk-kms-node/types/CreateAliasInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CreateAliasInput shape
@@ -15,23 +16,19 @@ export interface CreateAliasInput {
     TargetKeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/CreateAliasOutput.ts
+++ b/packages/sdk-kms-node/types/CreateAliasOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CreateAliasOutput shape
  */
 export interface CreateAliasOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/CreateGrantInput.ts
+++ b/packages/sdk-kms-node/types/CreateGrantInput.ts
@@ -1,5 +1,6 @@
 import {_GrantConstraints} from './_GrantConstraints';
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CreateGrantInput shape
@@ -41,23 +42,19 @@ export interface CreateGrantInput {
     Name?: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/CreateGrantOutput.ts
+++ b/packages/sdk-kms-node/types/CreateGrantOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CreateGrantOutput shape
@@ -15,8 +15,7 @@ export interface CreateGrantOutput {
     GrantId?: string;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/CreateKeyInput.ts
+++ b/packages/sdk-kms-node/types/CreateKeyInput.ts
@@ -1,5 +1,6 @@
 import {_Tag} from './_Tag';
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CreateKeyInput shape
@@ -36,23 +37,19 @@ export interface CreateKeyInput {
     Tags?: Array<_Tag>|Iterable<_Tag>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/CreateKeyOutput.ts
+++ b/packages/sdk-kms-node/types/CreateKeyOutput.ts
@@ -1,5 +1,5 @@
 import {_UnmarshalledKeyMetadata} from './_KeyMetadata';
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * CreateKeyOutput shape
@@ -11,8 +11,7 @@ export interface CreateKeyOutput {
     KeyMetadata?: _UnmarshalledKeyMetadata;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/DecryptInput.ts
+++ b/packages/sdk-kms-node/types/DecryptInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DecryptInput shape
@@ -20,23 +21,19 @@ export interface DecryptInput {
     GrantTokens?: Array<string>|Iterable<string>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/DecryptOutput.ts
+++ b/packages/sdk-kms-node/types/DecryptOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DecryptOutput shape
@@ -15,8 +15,7 @@ export interface DecryptOutput {
     Plaintext?: Uint8Array;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/DeleteAliasInput.ts
+++ b/packages/sdk-kms-node/types/DeleteAliasInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DeleteAliasInput shape
@@ -10,23 +11,19 @@ export interface DeleteAliasInput {
     AliasName: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/DeleteAliasOutput.ts
+++ b/packages/sdk-kms-node/types/DeleteAliasOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DeleteAliasOutput shape
  */
 export interface DeleteAliasOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/DeleteImportedKeyMaterialInput.ts
+++ b/packages/sdk-kms-node/types/DeleteImportedKeyMaterialInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DeleteImportedKeyMaterialInput shape
@@ -10,23 +11,19 @@ export interface DeleteImportedKeyMaterialInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/DeleteImportedKeyMaterialOutput.ts
+++ b/packages/sdk-kms-node/types/DeleteImportedKeyMaterialOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DeleteImportedKeyMaterialOutput shape
  */
 export interface DeleteImportedKeyMaterialOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/DependencyTimeoutException.ts
+++ b/packages/sdk-kms-node/types/DependencyTimeoutException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The system timed out while trying to fulfill the request. The request can be retried.</p>

--- a/packages/sdk-kms-node/types/DescribeKeyInput.ts
+++ b/packages/sdk-kms-node/types/DescribeKeyInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DescribeKeyInput shape
@@ -15,23 +16,19 @@ export interface DescribeKeyInput {
     GrantTokens?: Array<string>|Iterable<string>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/DescribeKeyOutput.ts
+++ b/packages/sdk-kms-node/types/DescribeKeyOutput.ts
@@ -1,5 +1,5 @@
 import {_UnmarshalledKeyMetadata} from './_KeyMetadata';
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DescribeKeyOutput shape
@@ -11,8 +11,7 @@ export interface DescribeKeyOutput {
     KeyMetadata?: _UnmarshalledKeyMetadata;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/DisableKeyInput.ts
+++ b/packages/sdk-kms-node/types/DisableKeyInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DisableKeyInput shape
@@ -10,23 +11,19 @@ export interface DisableKeyInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/DisableKeyOutput.ts
+++ b/packages/sdk-kms-node/types/DisableKeyOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DisableKeyOutput shape
  */
 export interface DisableKeyOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/DisableKeyRotationInput.ts
+++ b/packages/sdk-kms-node/types/DisableKeyRotationInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DisableKeyRotationInput shape
@@ -10,23 +11,19 @@ export interface DisableKeyRotationInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/DisableKeyRotationOutput.ts
+++ b/packages/sdk-kms-node/types/DisableKeyRotationOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * DisableKeyRotationOutput shape
  */
 export interface DisableKeyRotationOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/DisabledException.ts
+++ b/packages/sdk-kms-node/types/DisabledException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified CMK is not enabled.</p>

--- a/packages/sdk-kms-node/types/EnableKeyInput.ts
+++ b/packages/sdk-kms-node/types/EnableKeyInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * EnableKeyInput shape
@@ -10,23 +11,19 @@ export interface EnableKeyInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/EnableKeyOutput.ts
+++ b/packages/sdk-kms-node/types/EnableKeyOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * EnableKeyOutput shape
  */
 export interface EnableKeyOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/EnableKeyRotationInput.ts
+++ b/packages/sdk-kms-node/types/EnableKeyRotationInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * EnableKeyRotationInput shape
@@ -10,23 +11,19 @@ export interface EnableKeyRotationInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/EnableKeyRotationOutput.ts
+++ b/packages/sdk-kms-node/types/EnableKeyRotationOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * EnableKeyRotationOutput shape
  */
 export interface EnableKeyRotationOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/EncryptInput.ts
+++ b/packages/sdk-kms-node/types/EncryptInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * EncryptInput shape
@@ -25,23 +26,19 @@ export interface EncryptInput {
     GrantTokens?: Array<string>|Iterable<string>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/EncryptOutput.ts
+++ b/packages/sdk-kms-node/types/EncryptOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * EncryptOutput shape
@@ -15,8 +15,7 @@ export interface EncryptOutput {
     KeyId?: string;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ExpiredImportTokenException.ts
+++ b/packages/sdk-kms-node/types/ExpiredImportTokenException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the provided import token is expired. Use <a>GetParametersForImport</a> to get a new import token and public key, use the new public key to encrypt the key material, and then try the request again.</p>

--- a/packages/sdk-kms-node/types/GenerateDataKeyInput.ts
+++ b/packages/sdk-kms-node/types/GenerateDataKeyInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GenerateDataKeyInput shape
@@ -30,23 +31,19 @@ export interface GenerateDataKeyInput {
     GrantTokens?: Array<string>|Iterable<string>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/GenerateDataKeyOutput.ts
+++ b/packages/sdk-kms-node/types/GenerateDataKeyOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GenerateDataKeyOutput shape
@@ -20,8 +20,7 @@ export interface GenerateDataKeyOutput {
     KeyId?: string;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/GenerateDataKeyWithoutPlaintextInput.ts
+++ b/packages/sdk-kms-node/types/GenerateDataKeyWithoutPlaintextInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GenerateDataKeyWithoutPlaintextInput shape
@@ -30,23 +31,19 @@ export interface GenerateDataKeyWithoutPlaintextInput {
     GrantTokens?: Array<string>|Iterable<string>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/GenerateDataKeyWithoutPlaintextOutput.ts
+++ b/packages/sdk-kms-node/types/GenerateDataKeyWithoutPlaintextOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GenerateDataKeyWithoutPlaintextOutput shape
@@ -15,8 +15,7 @@ export interface GenerateDataKeyWithoutPlaintextOutput {
     KeyId?: string;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/GenerateRandomInput.ts
+++ b/packages/sdk-kms-node/types/GenerateRandomInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GenerateRandomInput shape
@@ -10,23 +11,19 @@ export interface GenerateRandomInput {
     NumberOfBytes?: number;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/GenerateRandomOutput.ts
+++ b/packages/sdk-kms-node/types/GenerateRandomOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GenerateRandomOutput shape
@@ -10,8 +10,7 @@ export interface GenerateRandomOutput {
     Plaintext?: Uint8Array;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/GetKeyPolicyInput.ts
+++ b/packages/sdk-kms-node/types/GetKeyPolicyInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GetKeyPolicyInput shape
@@ -15,23 +16,19 @@ export interface GetKeyPolicyInput {
     PolicyName: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/GetKeyPolicyOutput.ts
+++ b/packages/sdk-kms-node/types/GetKeyPolicyOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GetKeyPolicyOutput shape
@@ -10,8 +10,7 @@ export interface GetKeyPolicyOutput {
     Policy?: string;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/GetKeyRotationStatusInput.ts
+++ b/packages/sdk-kms-node/types/GetKeyRotationStatusInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GetKeyRotationStatusInput shape
@@ -10,23 +11,19 @@ export interface GetKeyRotationStatusInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/GetKeyRotationStatusOutput.ts
+++ b/packages/sdk-kms-node/types/GetKeyRotationStatusOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GetKeyRotationStatusOutput shape
@@ -10,8 +10,7 @@ export interface GetKeyRotationStatusOutput {
     KeyRotationEnabled?: boolean;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/GetParametersForImportInput.ts
+++ b/packages/sdk-kms-node/types/GetParametersForImportInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GetParametersForImportInput shape
@@ -20,23 +21,19 @@ export interface GetParametersForImportInput {
     WrappingKeySpec: 'RSA_2048'|string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/GetParametersForImportOutput.ts
+++ b/packages/sdk-kms-node/types/GetParametersForImportOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * GetParametersForImportOutput shape
@@ -25,8 +25,7 @@ export interface GetParametersForImportOutput {
     ParametersValidTo?: Date;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ImportKeyMaterialInput.ts
+++ b/packages/sdk-kms-node/types/ImportKeyMaterialInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ImportKeyMaterialInput shape
@@ -30,23 +31,19 @@ export interface ImportKeyMaterialInput {
     ExpirationModel?: 'KEY_MATERIAL_EXPIRES'|'KEY_MATERIAL_DOES_NOT_EXPIRE'|string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ImportKeyMaterialOutput.ts
+++ b/packages/sdk-kms-node/types/ImportKeyMaterialOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ImportKeyMaterialOutput shape
  */
 export interface ImportKeyMaterialOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/IncorrectKeyMaterialException.ts
+++ b/packages/sdk-kms-node/types/IncorrectKeyMaterialException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the provided key material is invalid or is not the same key material that was previously imported into this customer master key (CMK).</p>

--- a/packages/sdk-kms-node/types/InvalidAliasNameException.ts
+++ b/packages/sdk-kms-node/types/InvalidAliasNameException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified alias name is not valid.</p>

--- a/packages/sdk-kms-node/types/InvalidArnException.ts
+++ b/packages/sdk-kms-node/types/InvalidArnException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because a specified ARN was not valid.</p>

--- a/packages/sdk-kms-node/types/InvalidCiphertextException.ts
+++ b/packages/sdk-kms-node/types/InvalidCiphertextException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified ciphertext, or additional authenticated data incorporated into the ciphertext, such as the encryption context, is corrupted, missing, or otherwise invalid.</p>

--- a/packages/sdk-kms-node/types/InvalidGrantIdException.ts
+++ b/packages/sdk-kms-node/types/InvalidGrantIdException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified <code>GrantId</code> is not valid.</p>

--- a/packages/sdk-kms-node/types/InvalidGrantTokenException.ts
+++ b/packages/sdk-kms-node/types/InvalidGrantTokenException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified grant token is not valid.</p>

--- a/packages/sdk-kms-node/types/InvalidImportTokenException.ts
+++ b/packages/sdk-kms-node/types/InvalidImportTokenException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the provided import token is invalid or is associated with a different customer master key (CMK).</p>

--- a/packages/sdk-kms-node/types/InvalidKeyUsageException.ts
+++ b/packages/sdk-kms-node/types/InvalidKeyUsageException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified <code>KeySpec</code> value is not valid.</p>

--- a/packages/sdk-kms-node/types/InvalidMarkerException.ts
+++ b/packages/sdk-kms-node/types/InvalidMarkerException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the marker that specifies where pagination should next begin is not valid.</p>

--- a/packages/sdk-kms-node/types/KMSInternalException.ts
+++ b/packages/sdk-kms-node/types/KMSInternalException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because an internal exception occurred. The request can be retried.</p>

--- a/packages/sdk-kms-node/types/KMSInvalidStateException.ts
+++ b/packages/sdk-kms-node/types/KMSInvalidStateException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the state of the specified resource is not valid for this request.</p> <p>For more information about how key state affects the use of a CMK, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>

--- a/packages/sdk-kms-node/types/KeyUnavailableException.ts
+++ b/packages/sdk-kms-node/types/KeyUnavailableException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified CMK was not available. The request can be retried.</p>

--- a/packages/sdk-kms-node/types/LimitExceededException.ts
+++ b/packages/sdk-kms-node/types/LimitExceededException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because a limit was exceeded. For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/limits.html">Limits</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>

--- a/packages/sdk-kms-node/types/ListAliasesInput.ts
+++ b/packages/sdk-kms-node/types/ListAliasesInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListAliasesInput shape
@@ -15,23 +16,19 @@ export interface ListAliasesInput {
     Marker?: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ListAliasesOutput.ts
+++ b/packages/sdk-kms-node/types/ListAliasesOutput.ts
@@ -1,5 +1,5 @@
 import {_UnmarshalledAliasListEntry} from './_AliasListEntry';
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListAliasesOutput shape
@@ -21,8 +21,7 @@ export interface ListAliasesOutput {
     Truncated?: boolean;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ListGrantsInput.ts
+++ b/packages/sdk-kms-node/types/ListGrantsInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListGrantsInput shape
@@ -20,23 +21,19 @@ export interface ListGrantsInput {
     KeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ListGrantsOutput.ts
+++ b/packages/sdk-kms-node/types/ListGrantsOutput.ts
@@ -1,5 +1,5 @@
 import {_UnmarshalledGrantListEntry} from './_GrantListEntry';
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListGrantsOutput shape
@@ -21,8 +21,7 @@ export interface ListGrantsOutput {
     Truncated?: boolean;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ListKeyPoliciesInput.ts
+++ b/packages/sdk-kms-node/types/ListKeyPoliciesInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListKeyPoliciesInput shape
@@ -20,23 +21,19 @@ export interface ListKeyPoliciesInput {
     Marker?: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ListKeyPoliciesOutput.ts
+++ b/packages/sdk-kms-node/types/ListKeyPoliciesOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListKeyPoliciesOutput shape
@@ -20,8 +20,7 @@ export interface ListKeyPoliciesOutput {
     Truncated?: boolean;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ListKeysInput.ts
+++ b/packages/sdk-kms-node/types/ListKeysInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListKeysInput shape
@@ -15,23 +16,19 @@ export interface ListKeysInput {
     Marker?: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ListKeysOutput.ts
+++ b/packages/sdk-kms-node/types/ListKeysOutput.ts
@@ -1,5 +1,5 @@
 import {_UnmarshalledKeyListEntry} from './_KeyListEntry';
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListKeysOutput shape
@@ -21,8 +21,7 @@ export interface ListKeysOutput {
     Truncated?: boolean;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ListResourceTagsInput.ts
+++ b/packages/sdk-kms-node/types/ListResourceTagsInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListResourceTagsInput shape
@@ -20,23 +21,19 @@ export interface ListResourceTagsInput {
     Marker?: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ListResourceTagsOutput.ts
+++ b/packages/sdk-kms-node/types/ListResourceTagsOutput.ts
@@ -1,5 +1,5 @@
 import {_UnmarshalledTag} from './_Tag';
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListResourceTagsOutput shape
@@ -21,8 +21,7 @@ export interface ListResourceTagsOutput {
     Truncated?: boolean;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ListRetirableGrantsInput.ts
+++ b/packages/sdk-kms-node/types/ListRetirableGrantsInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListRetirableGrantsInput shape
@@ -20,23 +21,19 @@ export interface ListRetirableGrantsInput {
     RetiringPrincipal: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ListRetirableGrantsOutput.ts
+++ b/packages/sdk-kms-node/types/ListRetirableGrantsOutput.ts
@@ -1,5 +1,5 @@
 import {_UnmarshalledGrantListEntry} from './_GrantListEntry';
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ListRetirableGrantsOutput shape
@@ -21,8 +21,7 @@ export interface ListRetirableGrantsOutput {
     Truncated?: boolean;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/MalformedPolicyDocumentException.ts
+++ b/packages/sdk-kms-node/types/MalformedPolicyDocumentException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified policy is not syntactically or semantically correct.</p>

--- a/packages/sdk-kms-node/types/NotFoundException.ts
+++ b/packages/sdk-kms-node/types/NotFoundException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because the specified entity or resource could not be found.</p>

--- a/packages/sdk-kms-node/types/PutKeyPolicyInput.ts
+++ b/packages/sdk-kms-node/types/PutKeyPolicyInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * PutKeyPolicyInput shape
@@ -25,23 +26,19 @@ export interface PutKeyPolicyInput {
     BypassPolicyLockoutSafetyCheck?: boolean;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/PutKeyPolicyOutput.ts
+++ b/packages/sdk-kms-node/types/PutKeyPolicyOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * PutKeyPolicyOutput shape
  */
 export interface PutKeyPolicyOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ReEncryptInput.ts
+++ b/packages/sdk-kms-node/types/ReEncryptInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ReEncryptInput shape
@@ -30,23 +31,19 @@ export interface ReEncryptInput {
     GrantTokens?: Array<string>|Iterable<string>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ReEncryptOutput.ts
+++ b/packages/sdk-kms-node/types/ReEncryptOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ReEncryptOutput shape
@@ -20,8 +20,7 @@ export interface ReEncryptOutput {
     KeyId?: string;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/RetireGrantExceptionsUnion.ts
+++ b/packages/sdk-kms-node/types/RetireGrantExceptionsUnion.ts
@@ -1,10 +1,12 @@
+import {InvalidArnException} from './InvalidArnException';
 import {InvalidGrantTokenException} from './InvalidGrantTokenException';
 import {InvalidGrantIdException} from './InvalidGrantIdException';
 import {NotFoundException} from './NotFoundException';
 import {DependencyTimeoutException} from './DependencyTimeoutException';
 import {KMSInternalException} from './KMSInternalException';
 import {KMSInvalidStateException} from './KMSInvalidStateException';
-export type RetireGrantExceptionsUnion = InvalidGrantTokenException |
+export type RetireGrantExceptionsUnion = InvalidArnException |
+    InvalidGrantTokenException |
     InvalidGrantIdException |
     NotFoundException |
     DependencyTimeoutException |

--- a/packages/sdk-kms-node/types/RetireGrantInput.ts
+++ b/packages/sdk-kms-node/types/RetireGrantInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * RetireGrantInput shape
@@ -20,23 +21,19 @@ export interface RetireGrantInput {
     GrantId?: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/RetireGrantOutput.ts
+++ b/packages/sdk-kms-node/types/RetireGrantOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * RetireGrantOutput shape
  */
 export interface RetireGrantOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/RevokeGrantInput.ts
+++ b/packages/sdk-kms-node/types/RevokeGrantInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * RevokeGrantInput shape
@@ -15,23 +16,19 @@ export interface RevokeGrantInput {
     GrantId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/RevokeGrantOutput.ts
+++ b/packages/sdk-kms-node/types/RevokeGrantOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * RevokeGrantOutput shape
  */
 export interface RevokeGrantOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/ScheduleKeyDeletionInput.ts
+++ b/packages/sdk-kms-node/types/ScheduleKeyDeletionInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ScheduleKeyDeletionInput shape
@@ -15,23 +16,19 @@ export interface ScheduleKeyDeletionInput {
     PendingWindowInDays?: number;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/ScheduleKeyDeletionOutput.ts
+++ b/packages/sdk-kms-node/types/ScheduleKeyDeletionOutput.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * ScheduleKeyDeletionOutput shape
@@ -15,8 +15,7 @@ export interface ScheduleKeyDeletionOutput {
     DeletionDate?: Date;
 
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/TagException.ts
+++ b/packages/sdk-kms-node/types/TagException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because one or more tags are not valid.</p>

--- a/packages/sdk-kms-node/types/TagResourceInput.ts
+++ b/packages/sdk-kms-node/types/TagResourceInput.ts
@@ -1,5 +1,6 @@
 import {_Tag} from './_Tag';
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * TagResourceInput shape
@@ -16,23 +17,19 @@ export interface TagResourceInput {
     Tags: Array<_Tag>|Iterable<_Tag>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/TagResourceOutput.ts
+++ b/packages/sdk-kms-node/types/TagResourceOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * TagResourceOutput shape
  */
 export interface TagResourceOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/UnsupportedOperationException.ts
+++ b/packages/sdk-kms-node/types/UnsupportedOperationException.ts
@@ -1,4 +1,4 @@
-import {ResponseMetadata as __ResponseMetadata__, ServiceException as __ServiceException__} from '@aws/types';
+import {ServiceException as __ServiceException__} from '@aws/types';
 
 /**
  * <p>The request was rejected because a specified parameter is not supported or a specified resource is not valid for this operation.</p>

--- a/packages/sdk-kms-node/types/UntagResourceInput.ts
+++ b/packages/sdk-kms-node/types/UntagResourceInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * UntagResourceInput shape
@@ -15,23 +16,19 @@ export interface UntagResourceInput {
     TagKeys: Array<string>|Iterable<string>;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/UntagResourceOutput.ts
+++ b/packages/sdk-kms-node/types/UntagResourceOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * UntagResourceOutput shape
  */
 export interface UntagResourceOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/UpdateAliasInput.ts
+++ b/packages/sdk-kms-node/types/UpdateAliasInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * UpdateAliasInput shape
@@ -15,23 +16,19 @@ export interface UpdateAliasInput {
     TargetKeyId: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/UpdateAliasOutput.ts
+++ b/packages/sdk-kms-node/types/UpdateAliasOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * UpdateAliasOutput shape
  */
 export interface UpdateAliasOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/sdk-kms-node/types/UpdateKeyDescriptionInput.ts
+++ b/packages/sdk-kms-node/types/UpdateKeyDescriptionInput.ts
@@ -1,4 +1,5 @@
-import {AbortSignal as __AbortSignal__, NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import {NodeHttpOptions as __HttpOptions__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * UpdateKeyDescriptionInput shape
@@ -15,23 +16,19 @@ export interface UpdateKeyDescriptionInput {
     Description: string;
 
     /**
-     * The maximum number of times this operation should be retried. If set, this
-     * value will override the `maxRetries` configuration set on the client for
-     * this command.
+     * The maximum number of times this operation should be retried. If set, this value will override the `maxRetries` configuration set on the client for this command.
      */
     $maxRetries?: number;
 
     /**
-     * An object that may be queried to determine if the underlying operation
-     * has been aborted.
+     * An object that may be queried to determine if the underlying operation has been aborted.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
      */
-    $abortSignal?: __AbortSignal__
+    $abortSignal?: __aws_types.AbortSignal;
 
     /**
-     * Per-request HTTP configuration options. If set, any options specified will
-     * override the corresponding HTTP option set on the client for this command.
+     * Per-request HTTP configuration options. If set, any options specified will override the corresponding HTTP option set on the client for this command.
      */
-    $httpOptions?: __HttpOptions__
+    $httpOptions?: __HttpOptions__;
 }

--- a/packages/sdk-kms-node/types/UpdateKeyDescriptionOutput.ts
+++ b/packages/sdk-kms-node/types/UpdateKeyDescriptionOutput.ts
@@ -1,12 +1,11 @@
-import {ResponseMetadata as __ResponseMetadata__} from '@aws/types';
+import * as __aws_types from '@aws/types';
 
 /**
  * UpdateKeyDescriptionOutput shape
  */
 export interface UpdateKeyDescriptionOutput {
     /**
-     * Metadata about the response received, including the HTTP status code, HTTP
-     * headers, and any request identifiers recognized by the SDK.
+     * Metadata about the response received, including the HTTP status code, HTTP headers, and any request identifiers recognized by the SDK.
      */
-    $metadata: __ResponseMetadata__;
+    $metadata: __aws_types.ResponseMetadata;
 }

--- a/packages/service-types-generator/src/Components/Client/Client.ts
+++ b/packages/service-types-generator/src/Components/Client/Client.ts
@@ -72,9 +72,9 @@ export class ${this.className} {
         ${streamType(this.target)}
     >();
 
-    constructor(configuration: ${this.prefix}Configuration) {
-        this.config = ${packageNameToVariable('@aws/config-resolver')}.resolveConfiguration(
-            configuration,
+    constructor(options: ${this.prefix}Configuration) {
+        const configuration = this.config = ${packageNameToVariable('@aws/config-resolver')}.resolveConfiguration(
+            options,
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/httpConfigurationProperties.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/httpConfigurationProperties.ts
@@ -51,12 +51,14 @@ function httpHandlerProperty(
     configuration: {
         connectionTimeout: number,
         keepAlive: boolean,
-        socketTimeout: number,
+        maxConcurrencyPerHost: number,
+        timeout: number,
     }
 ) => new ${packageNameToVariable('@aws/node-http-handler')}.NodeHttpHandler({
     connectionTimeout: configuration.connectionTimeout,
     keepAlive: configuration.keepAlive,
-    socketTimeout: configuration.socketTimeout,
+    maxConcurrencyPerHost: configuration.maxConcurrencyPerHost,
+    timeout: configuration.timeout,
 })`
             }
         },
@@ -118,8 +120,8 @@ function runtimeHttpConfigurationProperties(
             return {
                 connectionTimeout,
                 keepAlive,
-                maxSockets,
-                socketTimeout,
+                maxConcurrencyPerHost,
+                timeout,
             };
         case 'browser':
             return {
@@ -155,7 +157,7 @@ const connectionTimeout: ConfigurationPropertyDefinition = {
     documentation: 'The maximum time in milliseconds that the connection phase of a request may take before the connection attempt is abandoned. Defaults to 20000 (20 seconds).'
 };
 
-const maxSockets: ConfigurationPropertyDefinition = {
+const maxConcurrencyPerHost: ConfigurationPropertyDefinition = {
     type: 'unified',
     inputType: 'number',
     required: false,
@@ -163,7 +165,7 @@ const maxSockets: ConfigurationPropertyDefinition = {
         type: 'value',
         expression: '50',
     },
-    documentation: 'The maximum number of concurrent sockets the HTTP handler can have open per origin. Defaults to 50.'
+    documentation: 'The maximum number of concurrent connections (either logical or physical) allowed per remote host. Defaults to 50.'
 };
 
 const keepAlive: ConfigurationPropertyDefinition = {
@@ -184,7 +186,7 @@ const requestTimeout: ConfigurationPropertyDefinition = {
     documentation: 'The number of milliseconds a request can take before being automatically terminated.'
 };
 
-const socketTimeout: ConfigurationPropertyDefinition = {
+const timeout: ConfigurationPropertyDefinition = {
     type: 'unified',
     inputType: 'number',
     required: false,
@@ -192,5 +194,5 @@ const socketTimeout: ConfigurationPropertyDefinition = {
         type: 'value',
         expression: '30000',
     },
-    documentation: 'The maximum time in milliseconds that a socket may remain idle before it is closed. Defaults to 30000 (30 seconds).'
+    documentation: 'The maximum time in milliseconds that an open connection may remain idle before it is closed. Defaults to 30000 (30 seconds).'
 };

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/index.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/index.ts
@@ -44,7 +44,7 @@ export function customizationsFromModel(
         sslEnabled,
         ...endpointConfigurationProperties(model.metadata),
         ...serializerConfigurationProperties(model.metadata, streamTypeParam),
-        ...httpConfigurationProperties('any', 'any', streamTypeParam)
+        ...httpConfigurationProperties(target, 'any', 'any')
     };
 
     return mergeCustomizationDefinitions(

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
@@ -165,7 +165,7 @@ function customizationsForAuthType(
             imports: [ IMPORTS['signing-middleware'] ],
             expression:`${
                 packageNameToVariable('@aws/signing-middleware')
-            }.signingMiddleware<InputTypesUnion, OutputTypesUnion, ${streamType(runtime)}>(this.config.signer)`
+            }.signingMiddleware<${streamType(runtime)}>(configuration.signer)`
         });
     }
 

--- a/packages/signing-middleware/src/index.ts
+++ b/packages/signing-middleware/src/index.ts
@@ -5,15 +5,13 @@ import {
     RequestSigner,
 } from '@aws/types';
 
-export function signingMiddleware<
-    Input extends object,
-    Output extends object,
-    Stream = Uint8Array
->(signer: RequestSigner): FinalizeMiddleware<Input, Output, Stream> {
-    return (
-        next: FinalizeHandler<Input, Output, Stream>
-    ): FinalizeHandler<Input, Output, Stream> => async (
-        args: FinalizeHandlerArguments<Input, Stream>
+export function signingMiddleware<StreamType>(
+    signer: RequestSigner
+): FinalizeMiddleware<any, any, StreamType> {
+    return <Output extends object>(
+        next: FinalizeHandler<any, Output, StreamType>
+    ): FinalizeHandler<any, Output, StreamType> => async (
+        args: FinalizeHandlerArguments<any, StreamType>
     ): Promise<Output> => next({
         ...args,
         request: await signer.sign(args.request),

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -142,6 +142,10 @@ export interface HttpOptions {}
  * Represents the http options that can be passed to a browser http client.
  */
 export interface BrowserHttpOptions extends HttpOptions {
+    /**
+     * The number of milliseconds a request can take before being automatically
+     * terminated.
+     */
     requestTimeout?: number;
 }
 
@@ -149,6 +153,28 @@ export interface BrowserHttpOptions extends HttpOptions {
  * Represents the http options that can be passed to a node http client.
  */
 export interface NodeHttpOptions extends HttpOptions {
+    /**
+     * The maximum time in milliseconds that the connection phase of a request
+     * may take before the connection attempt is abandoned.
+     */
     connectionTimeout?: number;
+
+    /**
+     * Whether sockets should be kept open even when there are no outstanding
+     * requests so that future requests can forgo having to reestablish a TCP or
+     * TLS connection.
+     */
+    keepAlive?: boolean;
+
+    /**
+     * The maximum number of concurrent sockets the HTTP handler can have open
+     * per origin.
+     */
+    maxSockets?: number;
+
+    /**
+     * The maximum time in milliseconds that a socket may remain idle before it
+     * is closed.
+     */
     socketTimeout?: number;
 }

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -167,14 +167,14 @@ export interface NodeHttpOptions extends HttpOptions {
     keepAlive?: boolean;
 
     /**
-     * The maximum number of concurrent sockets the HTTP handler can have open
-     * per origin.
+     * The maximum number of concurrent connections (either logical or physical)
+     * allowed per remote host.
      */
-    maxSockets?: number;
+    maxConcurrencyPerHost?: number;
 
     /**
-     * The maximum time in milliseconds that a socket may remain idle before it
-     * is closed.
+     * The maximum time in milliseconds that an open connection may remain idle
+     * before it is closed.
      */
-    socketTimeout?: number;
+    timeout?: number;
 }


### PR DESCRIPTION
The biggest change here is that `keepAlive` is enabled by default. Timeout values are shortened but still pretty large.