### PR TITLE
Fixes signing middleware and interface generation in node when using streams

### DIFF
--- a/packages/service-types-generator/src/Components/Type/Output.spec.ts
+++ b/packages/service-types-generator/src/Components/Type/Output.spec.ts
@@ -121,6 +121,42 @@ ${new IndentedSection(metadataProp)}
         }
     );
 
+    it(
+        'should import the streams module if the shape has a streaming body and the environment is node',
+        () => {
+            const name = 'OperationOutput';
+            const output = new Output({
+                name,
+                type: 'structure',
+                documentation: 'Operation output',
+                required: [],
+                members: {
+                    data: {
+                        shape: StreamingBlob,
+                    }
+                },
+            }, 'node');
+
+            expect(output.toString()).toEqual(
+`import * as _stream from 'stream';
+import * as __aws_types from '@aws/types';
+
+/**
+ * Operation output
+ */
+export interface ${name}<StreamType = _stream.Readable> {
+    /**
+     * ${StreamingBlob.documentation}
+     */
+    data?: ${getMemberType(StreamingBlob)};
+
+${new IndentedSection(metadataProp)}
+}
+`
+            );
+        }
+    );
+
     it('should import structure shapes', () => {
         const name = 'OperationOutput';
         const structure: TreeModelStructure = {

--- a/packages/service-types-generator/src/Components/Type/Output.ts
+++ b/packages/service-types-generator/src/Components/Type/Output.ts
@@ -12,6 +12,7 @@ import {
     TreeModelStructure,
 } from '@aws/build-types';
 import { streamType } from '../../streamType';
+import { FullPackageImport } from '../Client/FullPackageImport';
 
 export class Output extends Structure {
     constructor(
@@ -59,10 +60,10 @@ ${new IndentedSection(
             .join('\n');
     }
 
-    private environmentImports(): Import[] {
+    private environmentImports(): FullPackageImport[] {
         const toImport = [];
         if (this.runtime === 'node' && hasStreamingBody(this.shape)) {
-            toImport.push(new Import('stream', 'Readable'));
+            toImport.push(new FullPackageImport('stream'));
         }
         return toImport;
     }

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/index.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/index.ts
@@ -59,6 +59,6 @@ export function customizationsFromModel(
             ],
             commands: {},
         },
-        signatureCustomizations(model)
+        signatureCustomizations(model, target)
     );
 }

--- a/packages/signing-middleware/src/index.ts
+++ b/packages/signing-middleware/src/index.ts
@@ -8,7 +8,7 @@ import {
 export function signingMiddleware<
     Input extends object,
     Output extends object,
-    Stream
+    Stream = Uint8Array
 >(signer: RequestSigner): FinalizeMiddleware<Input, Output, Stream> {
     return (
         next: FinalizeHandler<Input, Output, Stream>


### PR DESCRIPTION
Fixes a few issues:
1. Any interface that had a streaming member was incorrectly importing Readable from streams.
2. The signing middleware was using an undefined signer.
3. The SignatureHasher always had a stream type of `Blob` and the default value was a `StreamCollector` instead of a `SignatureHasher`.

I've tested these changes and was able to compile the node.js and browser clients. The universal client only complained about missing a universal http handler.