### PR TITLE
Endpoints resolver

### DIFF
--- a/packages/endpoint-resolver/LICENSE
+++ b/packages/endpoint-resolver/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/endpoint-resolver/README.md
+++ b/packages/endpoint-resolver/README.md
@@ -1,0 +1,3 @@
+# endpoints
+
+AWS Endpoints resolver

--- a/packages/endpoint-resolver/package.json
+++ b/packages/endpoint-resolver/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "@aws/endpoint-resolver",
+    "description": "AWS Endpoints resolver",
+    "version": "0.0.1",
+    "scripts": {
+        "prepublishOnly": "tsc",
+        "pretest": "tsc -p tsconfig.test.json",
+        "test": "jest --coverage"
+    },
+    "dependencies": {
+        "@aws/types": "^0.0.1"
+    },
+    "main": "./build/index.js",
+    "types": "./build/index.d.ts",
+    "author": "aws-sdk-js@amazon.com",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "@types/jest": "^20.0.8",
+        "jest": "^20.0.4",
+        "typescript": "^2.6.1"
+    },
+    "jest": {
+        "mapCoverage": true,
+        "coveragePathIgnorePatterns": [
+          "/node_modules/",
+          "<rootDir>/*.fixture.ts"
+        ]
+    }
+}

--- a/packages/endpoint-resolver/package.json
+++ b/packages/endpoint-resolver/package.json
@@ -17,7 +17,7 @@
     "devDependencies": {
         "@types/jest": "^20.0.8",
         "jest": "^20.0.4",
-        "typescript": "^2.6.1"
+        "typescript": "^3.0.0"
     },
     "jest": {
         "mapCoverage": true,

--- a/packages/endpoint-resolver/src/endpoint-resolver.spec.ts
+++ b/packages/endpoint-resolver/src/endpoint-resolver.spec.ts
@@ -1,0 +1,107 @@
+import {EndpointRules} from './endpoint-rules';
+import {EndpointResolver} from './endpoint-resolver';
+import {
+    fizzPartition,
+    fooPartition
+} from './partitions.fixture';
+
+describe('EndpointResolver', () => {
+    const mockRules: EndpointRules = {
+        partitions: [fooPartition, fizzPartition],
+        version: 1
+    };
+
+    const endpointResolver = new EndpointResolver(mockRules);
+
+    it('resolves an endpoint given a valid serviceId and region', () => {
+        const endpointProperties = endpointResolver.resolveEndpoint('bar', 'foo-north-1');
+        expect(endpointProperties.hostname).toBe('bar.foo-north-1.foo.com');
+    });
+
+    it('resolves an endpoint from correct partition', () => {
+        const endpointProperties = endpointResolver.resolveEndpoint('bar', 'fizz-north-1');
+        expect(endpointProperties.hostname).toBe('bar.fizz-north-1.fizz.com');
+    });
+
+    it(
+        'merges endpoint data, preferring endpoints over service defaults',
+        () => {
+            const endpointProperties = endpointResolver.resolveEndpoint('buzz', 'foo-north-2');
+            expect(endpointProperties.hostname).toBe('buzz.foo-north-2.foo.com');
+            expect(endpointProperties.signatureVersions).toEqual(['v2']);
+            expect(endpointProperties.protocols).toEqual(['https']);
+            expect(endpointProperties.sslCommonName).toEqual('ssl-buzz');
+        }
+    );
+
+    it(
+        'merges endpoint data, preferring service defaults over partition defaults',
+        () => {
+            const endpointProperties = endpointResolver.resolveEndpoint('buzz', 'foo-north-1');
+            expect(endpointProperties.hostname).toBe('buzz.foo-north-1.foo.com');
+            expect(endpointProperties.signatureVersions).toEqual(['v2', 's3']);
+            expect(endpointProperties.protocols).toEqual(['https']);
+            expect(endpointProperties.sslCommonName).toEqual('ssl-buzz');
+        }
+    );
+
+    it('substitutes hostname placeholders', () => {
+        const endpointProperties = endpointResolver.resolveEndpoint('buzz', 'fizz-north-2');
+        expect(endpointProperties.hostname).toBe('fizz-north-2-buzz.fizz.com');
+    });
+
+    it('will resolve using partition endpoint if service is not regionalized', () => {
+        const endpointProperties = endpointResolver.resolveEndpoint('baz', 'foo-north-1');
+        expect(endpointProperties.hostname).toBe('baz.foo.com');
+        expect(endpointProperties.credentialScope).toEqual({
+            region: 'foo-north-1'
+        });
+    });
+
+    it('will validate region against regex if it is not found in a partition', () => {
+        expect(fooPartition.regions['foo-south-1']).toBeUndefined();
+        const endpointProperties = endpointResolver.resolveEndpoint('bar', 'foo-south-1');
+        expect(endpointProperties.hostname).toBe('bar.foo-south-1.foo.com');
+    });
+
+    it('will use partition defaults if service not found', () => {
+        expect(fooPartition.services['xyz']).toBeUndefined();
+        expect(fizzPartition.services['xyz']).toBeUndefined();
+        
+        const endpointProperties = endpointResolver.resolveEndpoint('xyz', 'foo-north-1');
+        expect(endpointProperties.hostname).toBe('xyz.foo-north-1.foo.com');
+    });
+
+    describe('throws', () => {
+        it('if serviceId is not provided', () => {
+            expect(() => {
+                endpointResolver.resolveEndpoint('', 'foo-north-1');
+            }).toThrow();
+        });
+
+        it('if region is not provided', () => {
+            expect(() => {
+                endpointResolver.resolveEndpoint('bar', '');
+            }).toThrow();
+        });
+
+        it('if region is not found', () => {
+            expect(fooPartition.regions['xyz-south-1']).toBeUndefined();
+            expect(fizzPartition.regions['xyz-south-1']).toBeUndefined();
+
+            expect(() => {
+                endpointResolver.resolveEndpoint('bar', 'xyz-south-1');
+            }).toThrow();
+        });
+
+        it('if hostname is not found', () => {
+            expect((fizzPartition.services['blarg'] as any).endpoints['fizz-north-1'].hostname).toBeUndefined();
+            expect(fizzPartition.services['blarg'].defaults).toBeUndefined();
+            expect((fizzPartition.defaults as any).hostname).toBeUndefined();
+
+            expect(() => {
+                endpointResolver.resolveEndpoint('blarg', 'fizz-north-1');
+            }).toThrow();
+        });
+    });
+});

--- a/packages/endpoint-resolver/src/endpoint-resolver.ts
+++ b/packages/endpoint-resolver/src/endpoint-resolver.ts
@@ -1,0 +1,97 @@
+import {
+    HttpEndpoint
+} from '@aws/types';
+
+import {
+    EndpointProperties,
+    EndpointRules,
+    ResolvedEndpointProperties
+} from './endpoint-rules';
+
+
+export class EndpointResolver {
+    constructor(private readonly rules: EndpointRules) {}
+
+    public resolveEndpoint(serviceId: string, region: string): ResolvedEndpointProperties {
+        if (!serviceId || !region) {
+            throw new Error(
+                `Unable to resolve endpoint for serviceId ${serviceId} and region ${region}`
+            );
+        }
+        // iterate over each partition
+        const partitions = this.rules.partitions;
+        const partitionsLength = partitions.length;
+
+        for (let i = 0; i < partitionsLength; i++) {
+            const partition = partitions[i];
+            // determine the correct partition by making sure the region is valid (or reg-ex)
+            let isValidRegion = partition.regions.hasOwnProperty(region);
+            if (!isValidRegion && partition.regionRegex) {
+                isValidRegion = new RegExp(partition.regionRegex).test(region);
+            }
+
+            if (!isValidRegion) {
+                // can not resolve endpoint using this partition
+                continue;
+            }
+
+            let endpointProperties: EndpointProperties = {};
+
+            // determine the service's endpoint rules
+            const service = partition.services[serviceId];
+            if (service) {
+                // check if the service is regionalized
+                if (service.isRegionalized === false && service.partitionEndpoint) {
+                    region = service.partitionEndpoint;
+                }
+                if (service.endpoints && service.endpoints[region]) {
+                    this.mergeEndpointProperties(endpointProperties, service.endpoints[region]);
+                }
+                // merge in service defaults
+                if (service.defaults) {
+                    this.mergeEndpointProperties(endpointProperties, service.defaults);
+                }
+            }
+
+            // merge partition defaults is present
+            if (partition.defaults) {
+                this.mergeEndpointProperties(endpointProperties, partition.defaults);
+            }
+
+            // expand the hostname
+            if (!endpointProperties.hostname) {
+                throw new Error(`Unable to resolve hostname for ${serviceId}, ${region}`);
+            }
+
+            endpointProperties.hostname = this.expandHostname(endpointProperties.hostname, serviceId, region, partition.dnsSuffix);
+            return endpointProperties as ResolvedEndpointProperties;
+        }
+
+        throw new Error(`Unable to resolve endpoint for ${serviceId}, ${region}`);
+    }
+
+    private mergeEndpointProperties(base: EndpointProperties, additional: EndpointProperties): void {
+        for (let key of Object.keys(additional)) {
+            if (!base.hasOwnProperty(key)) {
+                base[key] = additional[key];
+            }
+        }
+    }
+
+    private expandHostname(hostname: string, serviceId: string, region: string, dnsSuffix: string) {
+        hostname = this.replace(hostname, '{service}', serviceId);
+        hostname = this.replace(hostname, '{region}', region);
+        hostname = this.replace(hostname, '{dnsSuffix}', dnsSuffix);
+        return hostname;
+    }
+
+    private replace(source: string, pattern: string, replacement: string) {
+        const index = source.search(pattern);
+        if (index === -1) {
+            return source;
+        }
+        const pLen = pattern.length;
+        return source.substr(0, index) + replacement + source.substr(index + pLen);
+    }
+}
+

--- a/packages/endpoint-resolver/src/endpoint-rules.ts
+++ b/packages/endpoint-resolver/src/endpoint-rules.ts
@@ -1,0 +1,126 @@
+export interface EndpointRules {
+    /**
+     * list of partition metadata.
+     */
+    partitions: Partition[];
+    /**
+     * Schema version number.
+     */
+    version: number;
+}
+
+export interface EndpointProperties {
+    /**
+     * Signature version 4 credential scope information.
+     */
+    credentialScope?: {
+        /**
+         * Region signing name.
+         */
+        region?: string;
+        /**
+         * Service signing name.
+         */
+        service?: string;
+    }
+    /**
+     * URI template containing the hostname to connect to.
+     */
+    hostname?: string;
+    /**
+     * List of acceptable protocols to connect with.
+     */
+    protocols?: Protocols
+    /**
+     * List of acceptable signature versions.
+     */
+    signatureVersions?: SignatureVersions[];
+    /**
+     * Used in some tools to determine the endpoint.
+     */
+    sslCommonName?: string;
+
+    [key: string]: any;
+}
+
+export interface Partition {
+    /**
+     * Default values to merge into each endpoint of the partition.
+     */
+    defaults?: EndpointProperties;
+    /**
+     * Suffix used as a varspec in the hostname.
+     */
+    dnsSuffix: string;
+    /**
+     * Partition identifier.
+     */
+    partition: string;
+    /**
+     * Descriptive partition name.
+     */
+    partitionName?: string;
+    /**
+     * Regular expression that should match all regions in the partition.
+     */
+    regionRegex?: string;
+    /**
+     * Map of region name to region data.
+     */
+    regions: {
+        [region: string]: Region|undefined;
+    }
+    /**
+     * Map of service identifier to service configuration.
+     */
+    services: {
+        [service: string]: Service;
+    }
+}
+
+/**
+ * List of acceptable protocols to connect with.
+ */
+export type Protocols = string[];
+
+export interface Region {
+    /**
+     * Short, human readable, name of the region.
+     */
+    description: string;
+}
+
+export interface ResolvedEndpointProperties extends EndpointProperties {
+    hostname: string;
+}
+
+export interface Service {
+    /**
+     * Default values to merge into each endpoint of the service.
+     */
+    defaults?: EndpointProperties;
+    /**
+     * Map of endpoint name (e.g., region) to endpoint data.
+     */
+    endpoints?: {
+        [region: string]: EndpointProperties;
+    }
+    /**
+     * Specifies whether or not the service is regionalized in the partition.
+     * Default: true
+     */
+    isRegionalized?: boolean;
+    /**
+     * Specifies the endpoint name to use as a partition-global endpoint.
+     */
+    partitionEndpoint?: string;
+    /**
+     * List of acceptable protocols to connect with.
+     */
+    protocols?: Protocols;
+}
+
+/**
+ * List of acceptable signature versions.
+ */
+export type SignatureVersions = 'v2'|'v4'|'s3'|'s3v4'|'v3'|'v3https';

--- a/packages/endpoint-resolver/src/index.ts
+++ b/packages/endpoint-resolver/src/index.ts
@@ -1,0 +1,2 @@
+export * from './endpoint-resolver';
+export * from './endpoint-rules';

--- a/packages/endpoint-resolver/src/partitions.fixture.ts
+++ b/packages/endpoint-resolver/src/partitions.fixture.ts
@@ -1,0 +1,109 @@
+import {
+    EndpointRules,
+    Partition
+} from './endpoint-rules';
+
+export const fooPartition: Partition = {
+    defaults: {
+        hostname: '{service}.{region}.{dnsSuffix}',
+        protocols: ['https'],
+        signatureVersions: ['v4'],
+    },
+    dnsSuffix: 'foo.com',
+    partition: 'foo',
+    regionRegex: '^(foo)\\-\\w+\\-\\d+$',
+    regions: {
+        'foo-north-1': {
+            description: 'The Foo North'
+        },
+        'foo-north-2': {
+            description: 'Foo North: The Sequel'
+        }
+    },
+    services: {
+        bar: {
+            endpoints: {
+                'foo-north-1': {}
+            }
+        },
+        baz: {
+            endpoints: {
+                'aws-global': {
+                    credentialScope: {
+                        region: 'foo-north-1'
+                    },
+                    hostname: 'baz.foo.com'
+                }
+            },
+            isRegionalized: false,
+            partitionEndpoint: 'aws-global'
+        },
+        buzz: {
+            endpoints: {
+                'foo-north-1': {},
+                'foo-north-2': {
+                    signatureVersions: ['v2']
+                },
+                
+            },
+            defaults: {
+                sslCommonName: 'ssl-buzz',
+                signatureVersions: ['v2', 's3']
+            }
+        }
+    }
+};
+
+export const fizzPartition: Partition = {
+    defaults: {
+        protocols: ['https'],
+        signatureVersions: ['v4']
+    },
+    dnsSuffix: 'fizz.com',
+    partition: 'fizz',
+    regionRegex: '^(fizz)\\-\\w+\\-\\d+$',
+    regions: {
+        'fizz-north-1': {
+            description: 'The Fizzy North'
+        },
+        'fizz-north-2': {
+            description: 'Fizzy North: The Sequel'
+        }
+    },
+    services: {
+        bar: {
+            endpoints: {
+                'fizz-north-1': {
+                    hostname: 'bar.fizz-north-1.fizz.com'
+                }
+            }
+        },
+        baz: {
+            endpoints: {
+                'aws-global': {
+                    credentialScope: {
+                        region: 'fizz-north-1'
+                    },
+                    hostname: 'baz.fizz.com'
+                }
+            },
+            isRegionalized: false,
+            partitionEndpoint: 'aws-global'
+        },
+        buzz: {
+            endpoints: {
+                'fizz-north-2': {}
+            },
+            defaults: {
+                protocols: ['http'],
+                signatureVersions: ['v2'],
+                hostname: '{region}-{service}.{dnsSuffix}'
+            }
+        },
+        blarg: {
+            endpoints: {
+                'fizz-north-1': {}
+            }
+        }
+    }
+};

--- a/packages/endpoint-resolver/tsconfig.json
+++ b/packages/endpoint-resolver/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": true,
+        "strict": true,
+        "sourceMap": true,
+        "downlevelIteration": true,
+        "lib": [
+            "es5",
+            "es2015.promise",
+            "es2015.collection",
+            "es2015.iterable",
+            "es2015.symbol.wellknown"
+        ],
+        "rootDir": "./src",
+        "outDir": "./build"
+    }
+}

--- a/packages/endpoint-resolver/tsconfig.test.json
+++ b/packages/endpoint-resolver/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "sourceMap": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "rootDir": "./src",
+        "outDir": "./build"
+    }
+}


### PR DESCRIPTION
Replaces #67 

Needs to move interfaces to `@aws/types packages` before merging.

Also potentially needs to be updated to use heuristics by default, with services providing 'custom' endpoints if they are detected when generating the service clients. This should be a minor change.