### PR TITLE
Updates protocol-rest to serialize GET and HEAD requests as null

### DIFF
--- a/packages/protocol-rest/src/RestSerializer.spec.ts
+++ b/packages/protocol-rest/src/RestSerializer.spec.ts
@@ -1,14 +1,13 @@
 import {RestSerializer} from './RestSerializer';
-import {
-    HttpEndpoint,
-    OperationModel
-} from '@aws/types';
+import {HttpEndpoint} from '@aws/types';
 
 import {
     complexGetOperation,
     containsSubresourceGetOperation,
     minimalPostOperation,
-    streamingPostOperation
+    streamingPostOperation,
+    simpleGetOperation,
+    simpleHeadOperation
 } from './operations.fixture';
 
 describe('RestMarshaller', () => {
@@ -61,6 +60,18 @@ describe('RestMarshaller', () => {
             
             expect(serialized.method).toBe(minimalPostOperation.http.method);
             expect(serialized.path).toBe('/path/');
+        });
+
+        it('should set request body to null if HTTP method is GET', () => {
+            const serialized = restMarshaller.serialize(simpleGetOperation, {});
+            
+            expect(serialized.body).toBe(null);
+        });
+
+        it('should set request body to null if HTTP method is HEAD', () => {
+            const serialized = restMarshaller.serialize(simpleHeadOperation, {});
+            
+            expect(serialized.body).toBe(null);
         });
     
         describe('uri', () => {

--- a/packages/protocol-rest/src/RestSerializer.ts
+++ b/packages/protocol-rest/src/RestSerializer.ts
@@ -8,7 +8,6 @@ import {
     HeaderBag,
     HttpEndpoint,
     HttpRequest,
-    HttpTrait,
     Member,
     OperationModel,
     QueryParameterBag,
@@ -71,8 +70,11 @@ export class RestSerializer<StreamType> implements
         let hasPayload: boolean = false;
         let memberName:string|undefined;
         let bodyInput: any = input;
-        let requestBody: any;
-
+        const method = operation.http.method;
+        if (method === 'GET' || method === 'HEAD') {
+            // GET and HEAD requests should not have a body
+            return null;
+        }
 
         const payloadName:string = inputModelShape.payload as string;
         if (payloadName) {

--- a/packages/protocol-rest/src/operations.fixture.ts
+++ b/packages/protocol-rest/src/operations.fixture.ts
@@ -395,3 +395,51 @@ export const getSimpleHeadersOperation: OperationModel = {
     },
     errors:[]
 }
+
+export const simpleGetOperation: OperationModel = {
+    metadata: minimumMetadata,
+    name: 'SimpleGetOperation',
+    http: {
+        method: 'GET',
+        requestUri: '/'
+    },
+    input: {
+        shape: {
+            type: 'structure',
+            required: [],
+            members: {}
+        },
+    },
+    output: {
+        shape: {
+            type: 'structure',
+            required: [],
+            members: {}
+        },
+    },
+    errors:[]
+}
+
+export const simpleHeadOperation: OperationModel = {
+    metadata: minimumMetadata,
+    name: 'SimpleHeadOperation',
+    http: {
+        method: 'HEAD',
+        requestUri: '/'
+    },
+    input: {
+        shape: {
+            type: 'structure',
+            required: [],
+            members: {}
+        },
+    },
+    output: {
+        shape: {
+            type: 'structure',
+            required: [],
+            members: {}
+        },
+    },
+    errors:[]
+}

--- a/packages/test-protocol-rest-xml/src/serializer.spec.ts
+++ b/packages/test-protocol-rest-xml/src/serializer.spec.ts
@@ -147,7 +147,7 @@ describe('Rest-XML serialization', () => {
             const result = restSerializer.serialize(operation, {});
     
             expect(result.method).toBe('GET');
-            expect(result.body).toBe('');
+            expect(result.body).toBe(null);
             expect(result.path).toBe('/2014-01-01/hostedzone');
         });
     });
@@ -668,7 +668,7 @@ describe('Rest-XML serialization', () => {
             });
     
             expect(result.method).toBe('GET');
-            expect(result.body).toBe('');
+            expect(result.body).toBe(null);
             expect(result.path).toBe('/path');
             expect(result.query).toEqual({
                 'item': ['value1', 'value2']
@@ -719,7 +719,7 @@ describe('Rest-XML serialization', () => {
             });
     
             expect(result.method).toBe('GET');
-            expect(result.body).toBe('');
+            expect(result.body).toBe(null);
             expect(result.path).toBe('/2014-01-01/jobsByPipeline/foo');
             expect(result.query).toEqual({
                 'bar': 'baz',
@@ -776,7 +776,7 @@ describe('Rest-XML serialization', () => {
             });
     
             expect(result.method).toBe('GET');
-            expect(result.body).toBe('');
+            expect(result.body).toBe(null);
             expect(result.path).toBe('/2014-01-01/jobsByPipeline/id');
             expect(result.query).toEqual({
                 'foo': ['bar', 'baz'],
@@ -817,7 +817,7 @@ describe('Rest-XML serialization', () => {
             expect(result.query).toEqual({
                 'bool-query': 'true'
             });
-            expect(result.body).toBe('');
+            expect(result.body).toBe(null);
         });
 
         it('case 19', () => {
@@ -835,7 +835,7 @@ describe('Rest-XML serialization', () => {
             expect(result.query).toEqual({
                 'bool-query': 'false'
             });
-            expect(result.body).toBe('');
+            expect(result.body).toBe(null);
         });
     });
 
@@ -1107,7 +1107,7 @@ describe('Rest-XML serialization', () => {
             expect(result.method).toBe('GET');
             expect(result.path).toBe('/my%2Fbucket/testing%20/123');
             expect(result.query).toEqual({});
-            expect(result.body).toBe('');
+            expect(result.body).toBe(null);
         });
     });
 


### PR DESCRIPTION
The fetch API doesn't allow a request body to be specified for GET or HEAD requests. In V2, we serialized empty bodies as empty strings and neither node.js or XmlHttpRequest complained.

Fetch does care if you set your body to an empty string. I only modified the protocol-rest package because only the rest protocol services support those http methods.