### PR TITLE
Support Typescript 3.2 and enable Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "10.9.0"
+install:
+  - npm install
+  - npm run bootstrap
+script:
+  - npm run test

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -27,8 +27,8 @@ afterEach(() => {
 });
 
 describe('NodeHttpHandler', () => {
-    let mockHttpServer: HttpServer = createMockHttpServer().listen(5432);
-    let mockHttpsServer: HttpsServer = createMockHttpsServer().listen(5433);
+    let mockHttpServer: HttpServer = createMockHttpServer().listen(54321);
+    let mockHttpsServer: HttpsServer = createMockHttpsServer().listen(54322);
 
     afterEach(() => {
         mockHttpServer.removeAllListeners('request');

--- a/packages/service-model/src/TreeModel/deepCopy.fixture.ts
+++ b/packages/service-model/src/TreeModel/deepCopy.fixture.ts
@@ -9,10 +9,10 @@ export function deepCopy<T>(arg: T): T {
     }
 
     if (typeof arg === 'object') {
-        return (Object.keys(arg) as Array<keyof T>).reduce((
+        return (Object.keys(arg) as Array<keyof T>).reduce<T>((
             carry: T,
             item: keyof T
-        ) => ({...carry as any, [item]: deepCopy(arg[item])}), {});
+        ) => ({...carry as any, [item]: deepCopy(arg[item])}), <T>{});
     }
 
     return arg;


### PR DESCRIPTION
fix #154 
* remove [type-unsafe-ly](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#caveats) using of `.bind()`;
* fix a generic issue with `deepCopy()`;

Could ping the `typescript` dependency version of `middleware-stack` package, but It's better to update the test