### PR TITLE
Move jest, lerna and ts to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "license": "UNLICENSED",
   "dependencies": {
     "glob": "^7.1.2",
+    "rimraf": "^2.6.2",
+    "yargs": "^8.0.2"
+  },
+  "devDependencies": {
     "jest": "^20.0.4",
     "lerna": "2.11.0",
-    "rimraf": "^2.6.2",
-    "typescript": "^3.0.0",
-    "yargs": "^8.0.2"
+    "typescript": "^3.0.0"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Moving jest, lerna and typescript under devDependencies where they belong.

As described in Contributing.md, the following commands were successfully run:
* npm install
* npm run bootstrap
* npm test 