### PR TITLE
Update lerna version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0",
+  "lerna": "2.11.0",
   "packages": [
     "packages/*"
   ],


### PR DESCRIPTION
Current Lerna 2.0.0 is too old to support bumping prerelease version.