### PR TITLE
Export more interfaces from command

### DIFF
--- a/packages/client-sqs-node/README.md
+++ b/packages/client-sqs-node/README.md
@@ -21,7 +21,7 @@ The AWS SDK is modulized by clients and commends in CommonJS modules. To send a 
 ```javascript
 //javascript
 const { SQSClient } = require('@aws-sdk/client-sqs-node/SQSClient');
-const { AddPermissionCommand } = require('@aws-sdk/client-sqs-node/AddPermissionCommand');
+const { AddPermissionCommand } = require('@aws-sdk/client-sqs-node/commands/AddPermissionCommand');
 ```
 
 ```javascript
@@ -114,7 +114,7 @@ The keys within exceptions are also parsed, you can access them by specifying ex
 
 Please use these community resources for getting help. We use the GitHub issues for tracking bugs and feature requests and have limited bandwidth to address them.
 
- * Ask a question on [StackOverflow](https://stackoverflow.com/) and tag it with `aws-sdk-js`
+ * Ask a question on [StackOverflow](https://stackoverflow.com/questions/tagged/aws-sdk-js) and tag it with `aws-sdk-js`
  * Come join the AWS JavaScript community on [gitter](https://gitter.im/aws/aws-sdk-js-v3)
  * If it turns out that you may have found a bug, please [open an issue](https://github.com/aws/aws-sdk-js-v3/issues)
 

--- a/packages/client-sqs-node/commands/AddPermissionCommand.ts
+++ b/packages/client-sqs-node/commands/AddPermissionCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {AddPermissionInput} from '../types/AddPermissionInput';
 import {AddPermissionOutput} from '../types/AddPermissionOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/AddPermissionInput';
+export * from '../types/AddPermissionOutput';
+export * from '../types/AddPermissionExceptionsUnion';
 
 export class AddPermissionCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/ChangeMessageVisibilityBatchCommand.ts
+++ b/packages/client-sqs-node/commands/ChangeMessageVisibilityBatchCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {ChangeMessageVisibilityBatchInput} from '../types/ChangeMessageVisibilityBatchInput';
 import {ChangeMessageVisibilityBatchOutput} from '../types/ChangeMessageVisibilityBatchOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/ChangeMessageVisibilityBatchInput';
+export * from '../types/ChangeMessageVisibilityBatchOutput';
+export * from '../types/ChangeMessageVisibilityBatchExceptionsUnion';
 
 export class ChangeMessageVisibilityBatchCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/ChangeMessageVisibilityCommand.ts
+++ b/packages/client-sqs-node/commands/ChangeMessageVisibilityCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {ChangeMessageVisibilityInput} from '../types/ChangeMessageVisibilityInput';
 import {ChangeMessageVisibilityOutput} from '../types/ChangeMessageVisibilityOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/ChangeMessageVisibilityInput';
+export * from '../types/ChangeMessageVisibilityOutput';
+export * from '../types/ChangeMessageVisibilityExceptionsUnion';
 
 export class ChangeMessageVisibilityCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/CreateQueueCommand.ts
+++ b/packages/client-sqs-node/commands/CreateQueueCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {CreateQueueInput} from '../types/CreateQueueInput';
 import {CreateQueueOutput} from '../types/CreateQueueOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/CreateQueueInput';
+export * from '../types/CreateQueueOutput';
+export * from '../types/CreateQueueExceptionsUnion';
 
 export class CreateQueueCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/DeleteMessageBatchCommand.ts
+++ b/packages/client-sqs-node/commands/DeleteMessageBatchCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {DeleteMessageBatchInput} from '../types/DeleteMessageBatchInput';
 import {DeleteMessageBatchOutput} from '../types/DeleteMessageBatchOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/DeleteMessageBatchInput';
+export * from '../types/DeleteMessageBatchOutput';
+export * from '../types/DeleteMessageBatchExceptionsUnion';
 
 export class DeleteMessageBatchCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/DeleteMessageCommand.ts
+++ b/packages/client-sqs-node/commands/DeleteMessageCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {DeleteMessageInput} from '../types/DeleteMessageInput';
 import {DeleteMessageOutput} from '../types/DeleteMessageOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/DeleteMessageInput';
+export * from '../types/DeleteMessageOutput';
+export * from '../types/DeleteMessageExceptionsUnion';
 
 export class DeleteMessageCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/DeleteQueueCommand.ts
+++ b/packages/client-sqs-node/commands/DeleteQueueCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {DeleteQueueInput} from '../types/DeleteQueueInput';
 import {DeleteQueueOutput} from '../types/DeleteQueueOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/DeleteQueueInput';
+export * from '../types/DeleteQueueOutput';
+export * from '../types/DeleteQueueExceptionsUnion';
 
 export class DeleteQueueCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/GetQueueAttributesCommand.ts
+++ b/packages/client-sqs-node/commands/GetQueueAttributesCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {GetQueueAttributesInput} from '../types/GetQueueAttributesInput';
 import {GetQueueAttributesOutput} from '../types/GetQueueAttributesOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/GetQueueAttributesInput';
+export * from '../types/GetQueueAttributesOutput';
+export * from '../types/GetQueueAttributesExceptionsUnion';
 
 export class GetQueueAttributesCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/GetQueueUrlCommand.ts
+++ b/packages/client-sqs-node/commands/GetQueueUrlCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {GetQueueUrlInput} from '../types/GetQueueUrlInput';
 import {GetQueueUrlOutput} from '../types/GetQueueUrlOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/GetQueueUrlInput';
+export * from '../types/GetQueueUrlOutput';
+export * from '../types/GetQueueUrlExceptionsUnion';
 
 export class GetQueueUrlCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/ListDeadLetterSourceQueuesCommand.ts
+++ b/packages/client-sqs-node/commands/ListDeadLetterSourceQueuesCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {ListDeadLetterSourceQueuesInput} from '../types/ListDeadLetterSourceQueuesInput';
 import {ListDeadLetterSourceQueuesOutput} from '../types/ListDeadLetterSourceQueuesOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/ListDeadLetterSourceQueuesInput';
+export * from '../types/ListDeadLetterSourceQueuesOutput';
+export * from '../types/ListDeadLetterSourceQueuesExceptionsUnion';
 
 export class ListDeadLetterSourceQueuesCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/ListQueueTagsCommand.ts
+++ b/packages/client-sqs-node/commands/ListQueueTagsCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {ListQueueTagsInput} from '../types/ListQueueTagsInput';
 import {ListQueueTagsOutput} from '../types/ListQueueTagsOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/ListQueueTagsInput';
+export * from '../types/ListQueueTagsOutput';
+export * from '../types/ListQueueTagsExceptionsUnion';
 
 export class ListQueueTagsCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/ListQueuesCommand.ts
+++ b/packages/client-sqs-node/commands/ListQueuesCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {ListQueuesInput} from '../types/ListQueuesInput';
 import {ListQueuesOutput} from '../types/ListQueuesOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/ListQueuesInput';
+export * from '../types/ListQueuesOutput';
+export * from '../types/ListQueuesExceptionsUnion';
 
 export class ListQueuesCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/PurgeQueueCommand.ts
+++ b/packages/client-sqs-node/commands/PurgeQueueCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {PurgeQueueInput} from '../types/PurgeQueueInput';
 import {PurgeQueueOutput} from '../types/PurgeQueueOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/PurgeQueueInput';
+export * from '../types/PurgeQueueOutput';
+export * from '../types/PurgeQueueExceptionsUnion';
 
 export class PurgeQueueCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/ReceiveMessageCommand.ts
+++ b/packages/client-sqs-node/commands/ReceiveMessageCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {ReceiveMessageInput} from '../types/ReceiveMessageInput';
 import {ReceiveMessageOutput} from '../types/ReceiveMessageOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/ReceiveMessageInput';
+export * from '../types/ReceiveMessageOutput';
+export * from '../types/ReceiveMessageExceptionsUnion';
 
 export class ReceiveMessageCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/RemovePermissionCommand.ts
+++ b/packages/client-sqs-node/commands/RemovePermissionCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {RemovePermissionInput} from '../types/RemovePermissionInput';
 import {RemovePermissionOutput} from '../types/RemovePermissionOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/RemovePermissionInput';
+export * from '../types/RemovePermissionOutput';
+export * from '../types/RemovePermissionExceptionsUnion';
 
 export class RemovePermissionCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/SendMessageBatchCommand.ts
+++ b/packages/client-sqs-node/commands/SendMessageBatchCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {SendMessageBatchInput} from '../types/SendMessageBatchInput';
 import {SendMessageBatchOutput} from '../types/SendMessageBatchOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/SendMessageBatchInput';
+export * from '../types/SendMessageBatchOutput';
+export * from '../types/SendMessageBatchExceptionsUnion';
 
 export class SendMessageBatchCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/SendMessageCommand.ts
+++ b/packages/client-sqs-node/commands/SendMessageCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {SendMessageInput} from '../types/SendMessageInput';
 import {SendMessageOutput} from '../types/SendMessageOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/SendMessageInput';
+export * from '../types/SendMessageOutput';
+export * from '../types/SendMessageExceptionsUnion';
 
 export class SendMessageCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/SetQueueAttributesCommand.ts
+++ b/packages/client-sqs-node/commands/SetQueueAttributesCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {SetQueueAttributesInput} from '../types/SetQueueAttributesInput';
 import {SetQueueAttributesOutput} from '../types/SetQueueAttributesOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/SetQueueAttributesInput';
+export * from '../types/SetQueueAttributesOutput';
+export * from '../types/SetQueueAttributesExceptionsUnion';
 
 export class SetQueueAttributesCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/TagQueueCommand.ts
+++ b/packages/client-sqs-node/commands/TagQueueCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {TagQueueInput} from '../types/TagQueueInput';
 import {TagQueueOutput} from '../types/TagQueueOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/TagQueueInput';
+export * from '../types/TagQueueOutput';
+export * from '../types/TagQueueExceptionsUnion';
 
 export class TagQueueCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/commands/UntagQueueCommand.ts
+++ b/packages/client-sqs-node/commands/UntagQueueCommand.ts
@@ -7,6 +7,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {UntagQueueInput} from '../types/UntagQueueInput';
 import {UntagQueueOutput} from '../types/UntagQueueOutput';
 import {SQSResolvedConfiguration} from '../SQSConfiguration';
+export * from '../types/UntagQueueInput';
+export * from '../types/UntagQueueOutput';
+export * from '../types/UntagQueueExceptionsUnion';
 
 export class UntagQueueCommand implements __aws_sdk_types.Command<
     InputTypesUnion,

--- a/packages/client-sqs-node/model/ServiceMetadata.ts
+++ b/packages/client-sqs-node/model/ServiceMetadata.ts
@@ -11,4 +11,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
     uid: 'sqs-2012-11-05',
     xmlNamespace: '[object Object]'
 };
-export const clientVersion: string = '0.1.0-preview.1';
+export const clientVersion: string = '0.1.0-preview.2';

--- a/packages/service-types-generator/src/Components/Command/command.ts
+++ b/packages/service-types-generator/src/Components/Command/command.ts
@@ -49,6 +49,9 @@ import {OutputTypesUnion} from '../types/OutputTypesUnion';
 import {${inputType}} from '../types/${inputType}';
 import {${outputType}} from '../types/${outputType}';
 ${configurationImport.toString()}
+export * from '../types/${inputType}';
+export * from '../types/${outputType}';
+export * from '../types/${this.operation.name}ExceptionsUnion';
 
 export class ${this.className} implements ${typesPackage}.Command<
     InputTypesUnion,

--- a/packages/service-types-generator/src/SmokeTestGenerator.ts
+++ b/packages/service-types-generator/src/SmokeTestGenerator.ts
@@ -145,7 +145,8 @@ module.exports = function(config) {
             }
         },
         singleRun: true,
-        concurrency: Infinity
+        concurrency: Infinity,
+        exclude: ['**/*.d.ts']
     });
 };
 `.trim();

--- a/packages/service-types-generator/src/internalImports.ts
+++ b/packages/service-types-generator/src/internalImports.ts
@@ -10,15 +10,15 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'add-glacier-checksum-headers-browser': {
         package: '@aws-sdk/add-glacier-checksum-headers-browser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'add-glacier-checksum-headers-node': {
         package: '@aws-sdk/add-glacier-checksum-headers-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'add-glacier-checksum-headers-universal': {
         package: '@aws-sdk/add-glacier-checksum-headers-universal',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'apply-body-checksum-middleware': {
         package: '@aws-sdk/apply-body-checksum-middleware',
@@ -42,11 +42,11 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'client-codecommit-node': {
         package: '@aws-sdk/client-codecommit-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'client-cognito-identity-browser': {
         package: '@aws-sdk/client-cognito-identity-browser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'client-documentation-generator': {
         package: '@aws-sdk/client-documentation-generator',
@@ -54,27 +54,31 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'client-dynamodb-v2-browser': {
         package: '@aws-sdk/client-dynamodb-v2-browser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'client-dynamodb-v2-node': {
         package: '@aws-sdk/client-dynamodb-v2-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'client-glacier-node': {
         package: '@aws-sdk/client-glacier-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'client-kinesis-browser': {
         package: '@aws-sdk/client-kinesis-browser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'client-lambda-node': {
         package: '@aws-sdk/client-lambda-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
+    },
+    'client-sqs-node': {
+        package: '@aws-sdk/client-sqs-node',
+        version: '^0.1.0-preview.2',
     },
     'client-xray-node': {
         package: '@aws-sdk/client-xray-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'config-resolver': {
         package: '@aws-sdk/config-resolver',
@@ -86,11 +90,11 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'credential-provider-cognito-identity': {
         package: '@aws-sdk/credential-provider-cognito-identity',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'credential-provider-env': {
         package: '@aws-sdk/credential-provider-env',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'credential-provider-imds': {
         package: '@aws-sdk/credential-provider-imds',
@@ -102,15 +106,15 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'credential-provider-node': {
         package: '@aws-sdk/credential-provider-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'ec2-error-unmarshaller': {
         package: '@aws-sdk/ec2-error-unmarshaller',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'eventstream-marshaller': {
         package: '@aws-sdk/eventstream-marshaller',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'fetch-http-handler': {
         package: '@aws-sdk/fetch-http-handler',
@@ -118,7 +122,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'hash-blob-browser': {
         package: '@aws-sdk/hash-blob-browser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'hash-node': {
         package: '@aws-sdk/hash-node',
@@ -126,7 +130,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'hash-stream-node': {
         package: '@aws-sdk/hash-stream-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'http-headers': {
         package: '@aws-sdk/http-headers',
@@ -154,7 +158,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'json-error-unmarshaller': {
         package: '@aws-sdk/json-error-unmarshaller',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'json-parser': {
         package: '@aws-sdk/json-parser',
@@ -162,7 +166,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'karma-credential-loader': {
         package: '@aws-sdk/karma-credential-loader',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'location-constraint-middleware': {
         package: '@aws-sdk/location-constraint-middleware',
@@ -186,7 +190,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'middleware-ec2-copysnapshot': {
         package: '@aws-sdk/middleware-ec2-copysnapshot',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'middleware-expect-continue': {
         package: '@aws-sdk/middleware-expect-continue',
@@ -206,7 +210,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'middleware-rds-presignedurl': {
         package: '@aws-sdk/middleware-rds-presignedurl',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'middleware-sdk-api-gateway': {
         package: '@aws-sdk/middleware-sdk-api-gateway',
@@ -214,7 +218,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'middleware-sdk-glacier': {
         package: '@aws-sdk/middleware-sdk-glacier',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'middleware-serializer': {
         package: '@aws-sdk/middleware-serializer',
@@ -222,7 +226,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'middleware-stack': {
         package: '@aws-sdk/middleware-stack',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'modeled-endpoint-middleware': {
         package: '@aws-sdk/modeled-endpoint-middleware',
@@ -230,11 +234,11 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'node-http-handler': {
         package: '@aws-sdk/node-http-handler',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'package-generator': {
         package: '@aws-sdk/package-generator',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'property-provider': {
         package: '@aws-sdk/property-provider',
@@ -242,15 +246,15 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'protocol-json-rpc': {
         package: '@aws-sdk/protocol-json-rpc',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'protocol-query': {
         package: '@aws-sdk/protocol-query',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'protocol-rest': {
         package: '@aws-sdk/protocol-rest',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'protocol-timestamp': {
         package: '@aws-sdk/protocol-timestamp',
@@ -262,11 +266,11 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'query-error-unmarshaller': {
         package: '@aws-sdk/query-error-unmarshaller',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'query-request-presigner': {
         package: '@aws-sdk/query-request-presigner',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'querystring-builder': {
         package: '@aws-sdk/querystring-builder',
@@ -286,7 +290,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'response-metadata-extractor': {
         package: '@aws-sdk/response-metadata-extractor',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'retry-middleware': {
         package: '@aws-sdk/retry-middleware',
@@ -302,15 +306,15 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'service-model': {
         package: '@aws-sdk/service-model',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'service-types-generator': {
         package: '@aws-sdk/service-types-generator',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'sha256-tree-hash': {
         package: '@aws-sdk/sha256-tree-hash',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'shared-ini-file-loader': {
         package: '@aws-sdk/shared-ini-file-loader',
@@ -318,23 +322,23 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'signature-v4': {
         package: '@aws-sdk/signature-v4',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'signature-v4-browser': {
         package: '@aws-sdk/signature-v4-browser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'signature-v4-node': {
         package: '@aws-sdk/signature-v4-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'signature-v4-universal': {
         package: '@aws-sdk/signature-v4-universal',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'signing-middleware': {
         package: '@aws-sdk/signing-middleware',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'ssec-middleware': {
         package: '@aws-sdk/ssec-middleware',
@@ -350,7 +354,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'test-protocol-rest-xml': {
         package: '@aws-sdk/test-protocol-rest-xml',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'types': {
         package: '@aws-sdk/types',
@@ -386,7 +390,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'util-body-length-node': {
         package: '@aws-sdk/util-body-length-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'util-buffer-from': {
         package: '@aws-sdk/util-buffer-from',
@@ -414,11 +418,11 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'util-user-agent-browser': {
         package: '@aws-sdk/util-user-agent-browser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'util-user-agent-node': {
         package: '@aws-sdk/util-user-agent-node',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'util-utf8-browser': {
         package: '@aws-sdk/util-utf8-browser',
@@ -438,7 +442,7 @@ export const IMPORTS: {[key: string]: Import} = {
     },
     'xml-body-parser': {
         package: '@aws-sdk/xml-body-parser',
-        version: '^0.1.0-preview.1',
+        version: '^0.1.0-preview.2',
     },
     'xml-builder': {
         package: '@aws-sdk/xml-builder',


### PR DESCRIPTION
You can now export useful interfaces from commands.
Previously you need to import interfaces else where
```javascript
import { AddPermissionCommand } from '@aws-sdk/client-sqs-client/commands/AddPermissionCommand';
import {AddPermissionInput, AddPermissionOutput, AddPermissionExceptionsUnion} from '@aws-sdk/client-sqs-client';
```

Now you can just:
```javascript
import { 
    AddPermissionCommand,
    AddPermissionInput, 
    AddPermissionOutput, 
    AddPermissionExceptionsUnion
 } from  '@aws-sdk/client-sqs-client/commands/AddPermissionCommand';
```

The first commit is the actual code change.
