### PR TITLE
fix: generate model metadata xmlNamespace properly

### DIFF
--- a/packages/client-sqs-node/model/ServiceMetadata.ts
+++ b/packages/client-sqs-node/model/ServiceMetadata.ts
@@ -9,6 +9,6 @@ export const ServiceMetadata: _ServiceMetadata_ = {
     serviceId: 'SQS',
     signatureVersion: 'v4',
     uid: 'sqs-2012-11-05',
-    xmlNamespace: '[object Object]'
+    xmlNamespace: {"uri":"http://queue.amazonaws.com/doc/2012-11-05/"}
 };
 export const clientVersion: string = '0.1.0-preview.2';

--- a/packages/service-types-generator/src/Components/Model/ServiceMetadata.ts
+++ b/packages/service-types-generator/src/Components/Model/ServiceMetadata.ts
@@ -8,6 +8,7 @@ export class ServiceMetadata {
         let metadata = Object.keys(this.metadata)
             .sort()
             .map((key) => {
+                if (key === 'xmlNamespace') return `${key}: ${JSON.stringify(this.metadata[key])}`;
                 return `${key}: '${(this.metadata as any)[key]}'`;
             }).join(',\n');
         return `

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -125,5 +125,5 @@ export interface ServiceMetadata {
     /**
      * Required for query services.
      */
-    xmlNamespace?: string;
+    xmlNamespace?: XmlNamespace;
 }


### PR DESCRIPTION
Fix the type discrepency of xmlNamespace. Currently services like ec2 will generate xmlNamespace like `[object Object]`. 