### PR TITLE
feat: make client changelog preservable

### DIFF
--- a/models/importexport/2010-06-01/service-2.json
+++ b/models/importexport/2010-06-01/service-2.json
@@ -6,6 +6,7 @@
     "endpointPrefix":"importexport",
     "globalEndpoint":"importexport.amazonaws.com",
     "serviceFullName":"AWS Import/Export",
+    "serviceId":"ImportExport",
     "signatureVersion":"v2",
     "xmlNamespace":"http://importexport.amazonaws.com/doc/2010-06-01/",
     "protocol":"query"

--- a/packages/package-generator/src/ModuleGenerator.spec.ts
+++ b/packages/package-generator/src/ModuleGenerator.spec.ts
@@ -1,4 +1,5 @@
 import {ModuleGenerator} from "./ModuleGenerator";
+import * as fs from 'fs';
 
 describe('ModuleGenerator', () => {
     describe('expected files', () => {
@@ -148,4 +149,11 @@ ${description}`
             }
         );
     });
+
+    describe('CHANGELOG.md', () => {
+        it('should inherit previous change log if exists', () => {
+            jest.mock('fs');
+
+        });
+    })
 });

--- a/packages/package-generator/src/ModuleGenerator.spec.ts
+++ b/packages/package-generator/src/ModuleGenerator.spec.ts
@@ -1,5 +1,6 @@
 import {ModuleGenerator} from "./ModuleGenerator";
 import * as fs from 'fs';
+import * as path from 'path';
 
 describe('ModuleGenerator', () => {
     describe('expected files', () => {
@@ -152,8 +153,30 @@ ${description}`
 
     describe('CHANGELOG.md', () => {
         it('should inherit previous change log if exists', () => {
-            jest.mock('fs');
-
+            jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => '###changelog###');
+            const name = 'name';
+            const generator = new ModuleGenerator({name});
+            let generated = false;
+            for (const [filename, contents] of generator) {
+                if (filename === 'CHANGELOG.md') {
+                    generated = true;
+                    expect(contents).toBe('###changelog###');
+                }
+            }
+            expect(generated).toBe(true);
         });
-    })
+
+        it('should not add changelog if no changelog exists previously', () => {
+            jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {throw new Error('ENOENT')});
+            const name = 'name';
+            const generator = new ModuleGenerator({name});
+            let generated = false;
+            for (const [filename, contents] of generator) {
+                if (filename === 'CHANGELOG.md') {
+                    generated = true;
+                }
+            }
+            expect(generated).toBe(false);
+        })
+    });
 });

--- a/packages/package-generator/src/ModuleGenerator.spec.ts
+++ b/packages/package-generator/src/ModuleGenerator.spec.ts
@@ -1,6 +1,5 @@
 import {ModuleGenerator} from "./ModuleGenerator";
 import * as fs from 'fs';
-import * as path from 'path';
 
 describe('ModuleGenerator', () => {
     describe('expected files', () => {

--- a/packages/package-generator/src/ModuleGenerator.ts
+++ b/packages/package-generator/src/ModuleGenerator.ts
@@ -7,7 +7,7 @@ import {
     JsonDocument,
 } from './constants';
 import { join, dirname } from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync, statSync } from 'fs';
 
 export interface CustomModuleInit {
     name: string;
@@ -38,7 +38,8 @@ export class ModuleGenerator {
         yield ['LICENSE', APACHE_2_LICENSE];
         yield ['tsconfig.json', JSON.stringify(this.tsconfig(), null, 4)];
         yield ['tsconfig.test.json', JSON.stringify(this.testTsconfig(), null, 4)];
-        if (this.changelog()) yield ['CHANGELOG.md', this.changelog()!];
+        const changelog = this.changelog();
+        if (changelog) yield ['CHANGELOG.md', changelog];
     }
 
     protected gitignore(): string {
@@ -102,7 +103,7 @@ ${this.description || ''}
         );
         try {
             return readFileSync(previousChangelog).toString();
-        } catch (e) {
+        } catch(e) {
             return undefined;
         }
     }

--- a/packages/package-generator/src/ModuleGenerator.ts
+++ b/packages/package-generator/src/ModuleGenerator.ts
@@ -7,7 +7,7 @@ import {
     JsonDocument,
 } from './constants';
 import { join, dirname } from 'path';
-import { readFileSync, existsSync, statSync } from 'fs';
+import { readFileSync } from 'fs';
 
 export interface CustomModuleInit {
     name: string;

--- a/packages/package-generator/src/ModuleGenerator.ts
+++ b/packages/package-generator/src/ModuleGenerator.ts
@@ -6,6 +6,8 @@ import {
     DEFAULT_TSCONFIG,
     JsonDocument,
 } from './constants';
+import { join, dirname } from 'path';
+import { readFileSync } from 'fs';
 
 export interface CustomModuleInit {
     name: string;
@@ -36,6 +38,7 @@ export class ModuleGenerator {
         yield ['LICENSE', APACHE_2_LICENSE];
         yield ['tsconfig.json', JSON.stringify(this.tsconfig(), null, 4)];
         yield ['tsconfig.test.json', JSON.stringify(this.testTsconfig(), null, 4)];
+        if (this.changelog()) yield ['CHANGELOG.md', this.changelog()!];
     }
 
     protected gitignore(): string {
@@ -89,5 +92,18 @@ ${this.description || ''}
 
     protected tsconfig(): {[key: string]: any} {
         return DEFAULT_TSCONFIG;
+    }
+
+    protected changelog(): string | undefined {
+        const previousChangelog = join(
+            dirname(dirname(__dirname)),
+            this.name.replace(/^@aws-sdk\//, ''),
+            'CHANGELOG.md'   
+        );
+        try {
+            return readFileSync(previousChangelog).toString();
+        } catch (e) {
+            return undefined;
+        }
     }
 }

--- a/packages/package-generator/src/commands/ImportModelsCommand.ts
+++ b/packages/package-generator/src/commands/ImportModelsCommand.ts
@@ -45,7 +45,7 @@ export const ImportModelsCommand: yargs.CommandModule = {
         console.log(`Generating ${services.size} SDK packages...`);
 
         for (const [identifier, {model, smoke}] of services) {
-            for (const runtime of ['node', 'browser', 'universal']) {
+            for (const runtime of ['node', 'browser']) {
                 console.log(`Generating ${runtime} ${clientModuleIdentifier(model.metadata)} SDK`);
                 ImportClientPackageCommand.handler({ model, runtime, smoke });
             }

--- a/packages/package-generator/src/importModule.ts
+++ b/packages/package-generator/src/importModule.ts
@@ -1,5 +1,6 @@
 import {ModuleGenerator} from "./ModuleGenerator";
 import {ok} from 'assert';
+import {GlobSync} from 'glob';
 import {
     existsSync,
     mkdirSync,

--- a/packages/package-generator/src/importModule.ts
+++ b/packages/package-generator/src/importModule.ts
@@ -1,6 +1,5 @@
 import {ModuleGenerator} from "./ModuleGenerator";
 import {ok} from 'assert';
-import {GlobSync} from 'glob';
 import {
     existsSync,
     mkdirSync,


### PR DESCRIPTION
When generating any model, the changelog within to model shouldn't be reset. This change will preserve the CHANGELOG.md when regenerating the package.