### PR TITLE
fix: remove api version number in client identifier

### DIFF
--- a/packages/package-generator/src/clientModuleIdentifier.spec.ts
+++ b/packages/package-generator/src/clientModuleIdentifier.spec.ts
@@ -34,16 +34,6 @@ describe('clientModuleIdentifier', () => {
             .toBe('client-simple-foo-service');
     });
 
-    it('should apply known version identifiers', () => {
-        expect(
-            clientModuleIdentifier({
-                ...minimalMetadata,
-                serviceId: 'DynamoDB',
-                apiVersion: '2012-08-10',
-            })
-        ).toBe('client-dynamodb-v2');
-    });
-
     it('should append the runtime target', () => {
         expect(clientModuleIdentifier(minimalMetadata, 'node'))
             .toBe('client-simple-foo-service-node');

--- a/packages/package-generator/src/clientModuleIdentifier.ts
+++ b/packages/package-generator/src/clientModuleIdentifier.ts
@@ -7,10 +7,6 @@ export function clientModuleIdentifier(
 ): string {
 
     let name = `client-${getServiceId(metadata)}`;
-    const modelVersion = determineServiceVersion(metadata);
-    if (modelVersion > 1) {
-        name += `-v${modelVersion}`;
-    }
     if (runtime !== 'universal') {
         name += `-${runtime}`;
     }
@@ -35,28 +31,3 @@ function getServiceId(metadata: ServiceMetadata): string {
         .toLowerCase()
         .replace(/\s/g, '-');
 }
-
-// TODO use metadata.major_version when added to the model
-function determineServiceVersion(metadata: ServiceMetadata): number {
-    const serviceId = getServiceId(metadata);
-    if (
-        serviceMajorVersions[serviceId] &&
-        serviceMajorVersions[serviceId][metadata.apiVersion]
-    ) {
-        return serviceMajorVersions[serviceId][metadata.apiVersion];
-    }
-
-    return 1;
-}
-
-interface MajorVersionMatcher {
-    [serviceIdentifier: string]: {
-        [apiVersion: string]: number;
-    }
-}
-
-const serviceMajorVersions: MajorVersionMatcher = {
-    dynamodb: {
-        '2012-08-10': 2,
-    },
-};

--- a/packages/package-generator/src/commands/ImportModelsCommand.ts
+++ b/packages/package-generator/src/commands/ImportModelsCommand.ts
@@ -39,7 +39,15 @@ export const ImportModelsCommand: yargs.CommandModule = {
         for (const match of globSync(matching, {ignore})) {
             const model = fromModelJson(readFileSync(match, 'utf8'));
             const smoke = loadSmokeTestModel(dirname(match));
-            services.set(clientModuleIdentifier(model.metadata), {model, smoke});
+            const clientId = clientModuleIdentifier(model.metadata);
+            if (services.has(clientId)) {
+                const currentApiVersion = services.get(clientId)!.model.metadata.apiVersion;
+                if (model.metadata.apiVersion > currentApiVersion) {
+                    services.set(clientId, {model, smoke});
+                }
+            } else {
+                services.set(clientModuleIdentifier(model.metadata), {model, smoke});
+            }
         }
 
         console.log(`Generating ${services.size} SDK packages...`);


### PR DESCRIPTION
Currently, V3 SDK supports generating service client for all the major API versions. For example, DynamoDB model has to major versions: 2011-12-05 and 2012-08-10. The SDK will generate 2 service clients accordingly: client-dynamodb-node and client-dynamodb-v2-node. This change will make codegen to generate client only with the newest API version, which mean, there won’t be client-dynamodb-v2-node client but only client-dynamodb-node client. Here’s the rationale:
 
* Different major API versions are usually backward compatible. There’s no need to generate client for older API version. Other SDKs(like Ruby) never ship the older version, they never get customer requesting for older clients.
* Some services have excessive api versions(CloudFront has 9), that could make excessive number of packages we need to maintain.
* Customers need to update their dependencies to use the latest API. For example if ddb launch a new API version, customer will have to update there dependency from `client-dynamodb-v2-node` to v3 package.
* Keeping all packages will make release logic complexed