### PR TITLE
test: adds rest-xml parser protocol tests

### DIFF
--- a/packages/protocol-rest/src/RestParser.spec.ts
+++ b/packages/protocol-rest/src/RestParser.spec.ts
@@ -1023,7 +1023,7 @@ describe('RestParser', () => {
 
                 it('adds an empty map if no matching headers are found', async () => {
                     const headerMapName = 'testHeader';
-                    const headerMapLocationName = <string>headerMapCustomLocationMember.locationName;
+                    const headerMapLocationName = headerMapCustomLocationMember.locationName!;
                     const operation:OperationModel = {
                         ...minimalPostOperation,
                         output: {

--- a/packages/test-protocol-rest-xml/package.json
+++ b/packages/test-protocol-rest-xml/package.json
@@ -20,9 +20,17 @@
         "@aws-sdk/xml-body-builder": "^0.1.0-preview.1"
     },
     "devDependencies": {
-        "@types/jest": "^20.0.2",
+        "@aws-sdk/is-node": "^0.1.0-preview.1",
+        "@aws-sdk/protocol-rest": "^0.1.0-preview.3",
+        "@aws-sdk/query-error-unmarshaller": "^0.1.0-preview.2",
+        "@aws-sdk/types": "^0.1.0-preview.1",
+        "@aws-sdk/util-base64-universal": "^0.1.0-preview.1",
+        "@aws-sdk/util-utf8-universal": "^0.1.0-preview.1",
+        "@aws-sdk/xml-body-builder": "^0.1.0-preview.1",
+        "@aws-sdk/xml-body-parser": "^0.1.0-preview.1",
+        "@types/jest": "^20.0.4",
         "jest": "^20.0.4",
-        "tslib": "^1.8.0",
-        "typescript": "^3.0.0"
+        "typescript": "^3.0.0",
+        "tslib": "^1.8.0"
     }
 }

--- a/packages/test-protocol-rest-xml/src/parser.spec.ts
+++ b/packages/test-protocol-rest-xml/src/parser.spec.ts
@@ -1,0 +1,824 @@
+import {RestParser} from '@aws-sdk/protocol-rest';
+import {XmlBodyParser} from '@aws-sdk/xml-body-parser';
+import {OperationModel} from '@aws-sdk/types';
+import {fromBase64} from '@aws-sdk/util-base64-universal';
+import {toUtf8, fromUtf8} from '@aws-sdk/util-utf8-universal';
+import {queryErrorUnmarshaller} from '@aws-sdk/query-error-unmarshaller';
+import {ResponseMetadata} from '@aws-sdk/types';
+
+let mockOperation: OperationModel;
+const mockStreamCollector = jasmine.createSpy('streamCollector');
+const restParser = new RestParser(
+    new XmlBodyParser(fromBase64),
+    mockStreamCollector,
+    queryErrorUnmarshaller,
+    toUtf8,
+    fromBase64
+);
+
+interface GenerateMetadataOptions {
+    statusCode: number;
+    headers: {[header: string]: string}
+}
+
+function generateMetadata(options: GenerateMetadataOptions): ResponseMetadata {
+    const headers: {[header: string]: string} = {};
+    for (const header of Object.keys(options.headers)) {
+        headers[header.toLowerCase()] = options.headers[header];
+    }
+
+    return {
+        cfId: void 0,
+        extendedRequestId: void 0,
+        httpHeaders: headers,
+        httpStatusCode: options.statusCode,
+        requestId: void 0
+    };
+}
+
+describe('Rest-XML parsing', () => {
+    beforeEach(() => {
+        mockOperation = {
+            metadata: {
+                apiVersion: '2017-12-05',
+                endpointPrefix: 'foo',
+                protocol: 'rest-xml',
+                serviceFullName: 'AWS Foo Service',
+                signatureVersion: 'v4',
+                uid: 'foo-2017-12-05'
+            },
+            name: 'OperationName',
+            http: {
+                method: 'GET',
+                requestUri: '/'
+            },
+            input: {} as any,
+            output: {} as any,
+            errors: [],
+        };
+    });
+
+    let caseCount = 0;
+
+    describe('scalar members', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        ImaHeader: {
+                            shape: {
+                                type: 'string' 
+                            },
+                            location: 'header'
+                        },
+                        ImaHeaderLocation: {
+                            shape: {
+                                type: 'string'
+                            },
+                            location: 'header',
+                            locationName: 'X-Foo'
+                        },
+                        Str: {
+                            shape: {
+                                type: 'string'
+                            }
+                        },
+                        Num: {
+                            shape: {
+                                type: 'integer'
+                            },
+                            locationName: 'FooNum'
+                        },
+                        FalseBool: {
+                            shape: {
+                                type: 'boolean'
+                            }
+                        },
+                        TrueBool: {
+                            shape: {
+                                type: 'boolean'
+                            }
+                        },
+                        Float: {
+                            shape: {
+                                type: 'float'
+                            }
+                        },
+                        Double: {
+                            shape: {
+                                type: 'float'
+                            }
+                        },
+                        Long: {
+                            shape: {
+                                type: 'integer'
+                            }
+                        },
+                        Char: {
+                            shape: {
+                                type: 'string'
+                            }
+                        },
+                        Timestamp: {
+                            shape: {
+                                type: 'timestamp'
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {
+                    ImaHeader: 'test',
+                    'X-Foo': 'abc'
+                }
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResponse>
+                    <Str>myname</Str>
+                    <FooNum>123</FooNum>
+                    <FalseBool>false</FalseBool>
+                    <TrueBool>true</TrueBool>
+                    <Float>1.2</Float>
+                    <Double>1.3</Double>
+                    <Long>200</Long>
+                    <Char>a</Char>
+                    <Timestamp>2015-01-25T08:00:00Z</Timestamp>
+                </OperationNameResponse>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                "ImaHeader": "test",
+                "ImaHeaderLocation": "abc",
+                "Str": "myname",
+                "Num": 123,
+                "FalseBool": false,
+                "TrueBool": true,
+                "Float": 1.2,
+                "Double": 1.3,
+                "Long": 200,
+                "Char": "a",
+                "Timestamp": new Date(1422172800000)
+            } as any);
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {
+                    ImaHeader: 'test',
+                    'X-Foo': 'abc'
+                }
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResponse>
+                    <Str></Str>
+                    <FooNum>123</FooNum>
+                    <FalseBool>false</FalseBool>
+                    <TrueBool>true</TrueBool>
+                    <Float>1.2</Float>
+                    <Double>1.3</Double>
+                    <Long>200</Long>
+                    <Char>a</Char>
+                    <Timestamp>2015-01-25T08:00:00Z</Timestamp>
+                </OperationNameResponse>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                "ImaHeader": "test",
+                "ImaHeaderLocation": "abc",
+                "Str": "",
+                "Num": 123,
+                "FalseBool": false,
+                "TrueBool": true,
+                "Float": 1.2,
+                "Double": 1.3,
+                "Long": 200,
+                "Char": "a",
+                "Timestamp": new Date(1422172800000)
+            } as any);
+        });
+    });
+
+    describe('blob members', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Blob: {
+                            shape: {
+                                type: 'blob'
+                            }
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResult>
+                    <Blob>dmFsdWU=</Blob>
+                </OperationNameResult>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                Blob: fromUtf8('value')
+            } as any);
+        });
+    });
+
+    describe('lists', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        ListMember: {
+                            shape: {
+                                type: 'list',
+                                member: {
+                                    shape: {
+                                        type: 'string'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResult>
+                    <ListMember>
+                        <member>abc</member>
+                        <member>123</member>
+                    </ListMember>
+                </OperationNameResult>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                ListMember: ["abc", "123"]
+            } as any);
+        });
+    });
+
+    describe('lists with custom member name', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        ListMember: {
+                            shape: {
+                                type: 'list',
+                                member: {
+                                    shape: {
+                                        type: 'string'
+                                    },
+                                    locationName: 'item'
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResult>
+                    <ListMember>
+                        <item>abc</item>
+                        <item>123</item>
+                    </ListMember>
+                </OperationNameResult>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                ListMember: ["abc", "123"]
+            } as any);
+        });
+    });
+
+    describe('flattened list members', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        ListMember: {
+                            shape: {
+                                type: 'list',
+                                member: {
+                                    shape: {
+                                        type: 'string'
+                                    }
+                                }
+                            },
+                            flattened: true
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResult>
+                    <ListMember>abc</ListMember>
+                    <ListMember>123</ListMember>
+                </OperationNameResult>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                ListMember: ["abc", "123"]
+            } as any);
+        });
+    });
+
+    describe('normal map members', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Map: {
+                            shape: {
+                                type: 'map',
+                                key: {
+                                    shape: {
+                                        type: 'string'
+                                    }
+                                },
+                                value: {
+                                    shape: {
+                                        type: 'structure',
+                                        required: [],
+                                        members: {
+                                            foo: {
+                                                shape: {
+                                                    type: 'string'
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResult>
+                    <Map>
+                        <entry>
+                            <key>qux</key>
+                            <value>
+                                <foo>bar</foo>
+                            </value>
+                        </entry>
+                        <entry>
+                            <key>baz</key>
+                            <value>
+                                <foo>bam</foo>
+                            </value>
+                        </entry>
+                    </Map>
+                </OperationNameResult>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                "Map": {
+                    "qux": {
+                        "foo": "bar"
+                    },
+                    "baz": {
+                        "foo": "bam"
+                    }
+                }
+            } as any);
+        });
+    });
+
+    describe('flattened map members', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Map: {
+                            shape: {
+                                type: 'map',
+                                key: {
+                                    shape: {
+                                        type: 'string'
+                                    }
+                                },
+                                value: {
+                                    shape: {
+                                        type: 'string'
+                                    }
+                                }
+                            },
+                            flattened: true
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResult>
+                    <Map>
+                        <key>qux</key>
+                        <value>bar</value>
+                    </Map>
+                    <Map>
+                        <key>baz</key>
+                        <value>bam</value>
+                    </Map>
+                </OperationNameResult>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                "Map": {
+                    "qux": "bar",
+                    "baz": "bam"
+                }
+            } as any);
+        });
+    });
+
+    describe('named map members', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Map: {
+                            shape: {
+                                type: 'map',
+                                key: {
+                                    shape: {
+                                        type: 'string'
+                                    },
+                                    locationName: 'foo'
+                                },
+                                value: {
+                                    shape: {
+                                        type: 'string'
+                                    },
+                                    locationName: 'bar'
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResult>
+                    <Map>
+                        <entry>
+                            <foo>qux</foo>
+                            <bar>bar</bar>
+                        </entry>
+                        <entry>
+                            <foo>baz</foo>
+                            <bar>bam</bar>
+                        </entry>
+                    </Map>
+                </OperationNameResult>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                "Map": {
+                    "qux": "bar",
+                    "baz": "bam"
+                }
+            } as any);
+        });
+    });
+
+    describe('XML payload', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Header: {
+                            shape: {
+                                type: 'string'
+                            },
+                            location: 'header',
+                            locationName: 'X-Foo'
+                        },
+                        Data: {
+                            shape: {
+                                type: 'structure',
+                                required: [],
+                                members: {
+                                    Foo: {
+                                        shape: {
+                                            type: 'string'
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    payload: 'Data'
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {
+                    'X-Foo': 'baz'
+                }
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResponse>
+                    <Foo>abc</Foo>
+                </OperationNameResponse>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                "Header": "baz",
+                "Data": {
+                    "Foo": "abc"
+                }
+            } as any);
+        });
+    });
+
+    describe('streaming payload', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Stream: {
+                            shape: {
+                                type: 'blob'
+                            }
+                        }
+                    },
+                    payload: 'Stream'
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: 'abc'
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                Stream: 'abc'
+            } as any);
+        });
+    });
+
+    describe('scalar members in headers', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Str: {
+                            shape: {
+                                type: 'string'
+                            },
+                            location: 'header',
+                            locationName: 'x-str'
+                        },
+                        Integer: {
+                            shape: {
+                                type: 'integer'
+                            },
+                            location: 'header',
+                            locationName: 'x-int'
+                        },
+                        TrueBool: {
+                            shape: {
+                                type: 'boolean'
+                            },
+                            location: 'header',
+                            locationName: 'x-true-bool'
+                        },
+                        FalseBool: {
+                            shape: {
+                                type: 'boolean'
+                            },
+                            location: 'header',
+                            locationName: 'x-false-bool'
+                        },
+                        Float: {
+                            shape: {
+                                type: 'float'
+                            },
+                            location: 'header',
+                            locationName: 'x-float'
+                        },
+                        Double: {
+                            shape: {
+                                type: 'float'
+                            },
+                            location: 'header',
+                            locationName: 'x-double'
+                        },
+                        Long: {
+                            shape: {
+                                type: 'integer'
+                            },
+                            location: 'header',
+                            locationName: 'x-long'
+                        },
+                        Char: {
+                            shape: {
+                                type: 'string'
+                            },
+                            location: 'header',
+                            locationName: 'x-char'
+                        },
+                        Timestamp: {
+                            shape: {
+                                type: 'timestamp'
+                            },
+                            location: 'header',
+                            locationName: 'x-timestamp'
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {
+                    "x-str": "string",
+                    "x-int": "1",
+                    "x-true-bool": "true",
+                    "x-false-bool": "false",
+                    "x-float": "1.5",
+                    "x-double": "1.5",
+                    "x-long": "100",
+                    "x-char": "a",
+                    "x-timestamp": "Sun, 25 Jan 2015 08:00:00 GMT"
+                }
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: ''
+            });
+
+            expect(result).toEqual({
+                "$metadata": generateMetadata(mockResponseMetadata),
+                "Str": "string",
+                "Integer": 1,
+                "TrueBool": true,
+                "FalseBool": false,
+                "Float": 1.5,
+                "Double": 1.5,
+                "Long": 100,
+                "Char": "a",
+                "Timestamp": new Date(1422172800000)
+            } as any);
+        });
+    });
+
+    describe('empty strings', () => {
+        beforeEach(() => {
+            mockOperation.output = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Foo: {
+                            shape: {
+                                type: 'string'
+                            }
+                        }
+                    }
+                }
+            };
+        });
+
+        it(`case ${++caseCount}`, async () => {
+            const mockResponseMetadata = {
+                statusCode: 200,
+                headers: {}
+            };
+            const result = await restParser.parse(mockOperation, {
+                ...mockResponseMetadata,
+                body: fromUtf8(`
+                <OperationNameResponse>
+                    <Foo/>
+                    <RequestId>requestid</RequestId>
+                </OperationNameResponse>`)
+            });
+
+            expect(result).toEqual({
+                "$metadata": {
+                    ...generateMetadata(mockResponseMetadata),
+                    requestId: 'requestid'
+                },
+                Foo: ''
+            } as any);
+        });
+    });
+});

--- a/packages/test-protocol-rest-xml/src/serializer.spec.ts
+++ b/packages/test-protocol-rest-xml/src/serializer.spec.ts
@@ -1,12 +1,11 @@
 import {RestSerializer} from '@aws-sdk/protocol-rest';
 import {XmlBodyBuilder} from '@aws-sdk/xml-body-builder';
-import { OperationModel, Structure, Member } from '../../types/build/index';
+import {OperationModel} from '../../types/build/index';
 
 let operation: OperationModel;
 
 describe('Rest-XML serialization', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
         // reset operation in case it was mutated
         operation = {
             http: {
@@ -28,10 +27,8 @@ describe('Rest-XML serialization', () => {
         };
     });
     
-    const base64Encoder = jest.fn(() => {
-        return 'base64'
-    });
-    const utf8Decoder = jest.fn();
+    const base64Encoder = jasmine.createSpy('base64Encoder').and.returnValue('base64');
+    const utf8Decoder = jasmine.createSpy('utf8Decoder');
     const xmlBodyBuilder = new XmlBodyBuilder(base64Encoder, utf8Decoder);
     const restSerializer = new RestSerializer({
         hostname: 'foo.region.amazonaws.com',
@@ -625,7 +622,7 @@ describe('Rest-XML serialization', () => {
             expect(result.method).toBe('POST');
             expect(result.body).toBe('');
             expect(result.path).toBe('/');
-            expect(result.headers).toMatchObject({
+            expect(result.headers).toEqual({
                 'x-foo-a': 'b',
                 'x-foo-c': 'd'
             });
@@ -1395,7 +1392,7 @@ describe('Rest-XML serialization', () => {
     
             expect(result.method).toBe('POST');
             expect(result.path).toBe('/path');
-            expect(result.headers).toMatchObject({
+            expect(result.headers).toEqual({
                 'x-amz-timearg': 'Sun, 25 Jan 2015 08:00:00 GMT'
             });
             expect(result.body).toBe('');

--- a/packages/xml-body-parser/src/index.spec.ts
+++ b/packages/xml-body-parser/src/index.spec.ts
@@ -255,7 +255,7 @@ describe('XmlBodyParser', () => {
                                     locationName: "complexValue"
                                 },
                                 flattened: true
-                            },
+                            }
                         }
                     }
                 }
@@ -272,31 +272,65 @@ describe('XmlBodyParser', () => {
         });
 
         it('should parse flattened list', () => {
-            let xml = '<xml><Items>Jack</Items><Items>Rose</Items></xml>';
-            let rules: Member = {
+            const xml = `
+            <xml>
+                <person>
+                    <name>Unknown</name>
+                    <alias>John Doe</alias>
+                    <alias>Jane Doe</alias>
+                </person>
+            </xml>`;
+            const rules: Member = {
                 shape: {
                     type: "structure",
                     required: [],
                     members: {
-                        Items: {
+                        person: {
                             shape: {
-                                type: "list",
-                                member: {
-                                    shape: {type: "string"},
-                                },
-                                flattened: true
-                            },
+                                type: 'structure',
+                                required: [],
+                                members: {
+                                    name: {
+                                        shape: {
+                                            type: 'string'
+                                        }
+                                    },
+                                    aka: {
+                                        shape: {
+                                            type: 'list',
+                                            flattened: true,
+                                            member: {
+                                                shape: {
+                                                    type: 'string'
+                                                },
+                                                locationName: 'alias'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-            }
+            };
             expect(parser.parse(rules, xml)).toEqual({
-                Items: ['Jack', 'Rose']
+                person: {
+                    name: 'Unknown',
+                    aka: ['John Doe', 'Jane Doe']
+                }
             });
         });
 
         it('should parse list with attributes in tags', () => {
-            let xml = '<xml><Item xsi:name="Jon"><Age>20</Age></Item><Item xsi:name="Lee"><Age>18</Age></Item></xml>';
+            let xml = `
+            <xml>
+                <Item xsi:name="Jon">
+                    <Age>20</Age>
+                </Item>
+                <Item xsi:name="Lee">
+                    <Age>18</Age>
+                </Item>
+            </xml>`;
             let rules: Member = {
                 shape: {
                     type: "structure",

--- a/packages/xml-body-parser/src/index.ts
+++ b/packages/xml-body-parser/src/index.ts
@@ -29,7 +29,6 @@ interface ParsedResponse extends XMLParseOutput {
 }
 
 interface ObjectTypeArray extends Array<ObjectType|Scalar|ObjectTypeArray> {}
-
 export class XmlBodyParser implements BodyParser {
     constructor(private readonly base64Decoder: Decoder) {}
 
@@ -39,20 +38,23 @@ export class XmlBodyParser implements BodyParser {
     ): OutputType {
         let xmlObj = <ParsedResponse>pixlParse(input, {
             preserveAttributes: true,
+            //preserveDocumentNode: true
         });
-        let wrappedShape: SerializationModel = member.shape;
+        let wrappedMember: Member = member;
         if (member.resultWrapper) {
-            wrappedShape = {
-                type: 'structure',
-                required: [],
-                members: {
-                    [member.resultWrapper]: {
-                        shape: member.shape
+            wrappedMember = {
+                shape: {
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        [member.resultWrapper]: {
+                            shape: member.shape
+                        }
                     }
                 }
-            }
+            };
         }
-        let data: OutputType = this.unmarshall(wrappedShape, xmlObj);
+        let data: OutputType = this.unmarshall(wrappedMember, xmlObj);
         //standard query
         if (xmlObj.ResponseMetadata && xmlObj.ResponseMetadata.RequestId) {
             (data as any).$metadata = {
@@ -74,49 +76,51 @@ export class XmlBodyParser implements BodyParser {
         return data as OutputType;
     }
 
-    private unmarshall(shape: SerializationModel, xmlObj: any): any {
-        if (shape.type === 'structure') {
-            return this.parseStructure(shape, xmlObj);
-        } else if (shape.type === 'list') {
-            return this.parseList(shape, xmlObj);
-        } else if (shape.type === 'map') {
-            return this.parseMap(shape, xmlObj);
-        } else if (shape.type === 'timestamp') {
-            return this.parseTimeStamp(shape, xmlObj);
-        } else if (shape.type === 'blob') {
+    private unmarshall(member: Member, xmlObj: any): any {
+        const type = member.shape.type;
+        if (type === 'structure') {
+            return this.parseStructure(member, xmlObj);
+        } else if (type === 'list') {
+            return this.parseList(member, xmlObj);
+        } else if (type === 'map') {
+            return this.parseMap(member, xmlObj);
+        } else if (type === 'timestamp') {
+            return this.parseTimeStamp(member, xmlObj);
+        } else if (type === 'blob') {
             return (typeof xmlObj) === 'string' ? this.base64Decoder(xmlObj) : undefined;
-        } else if (shape.type === 'boolean') {
+        } else if (type === 'boolean') {
             if (!xmlObj) return undefined;
             return xmlObj === 'true';
-        } else if (shape.type === 'float' || shape.type === 'integer') {
+        } else if (type === 'float' || type === 'integer') {
             if (!xmlObj) {
                 return undefined;
             }
             const num = Number(xmlObj);
             return isFinite(num) ? num : undefined;
-        } else if (shape.type === 'string') {
+        } else if (type === 'string') {
             if (xmlObj === '') {
                 return xmlObj
             }
             return xmlObj ? xmlObj.toString() : undefined;
         } else {
-            throw new Error(`${(shape as any).type} can not be parsed`);
+            throw new Error(`${type} can not be parsed`);
         }
     }
 
-    private parseStructure(shape: Structure, xmlObj: any): ObjectType|undefined {
+    private parseStructure(member: Member, xmlObj: any): ObjectType|undefined {
         if (xmlObj === undefined) {
             return undefined;
         }
+        const shape = member.shape as Structure;
         let obj: ObjectType = {};
         for (const memberName of Object.keys(shape.members)) {
-            const member: Member = shape.members[memberName];
-            const xmlKey = this.mapToXMLKey(member, memberName)
+            const structureMember = shape.members[memberName];
+            const xmlKey = this.mapToXMLKey(structureMember, memberName)
             let subXmlObj = xmlObj;
-            if (member.xmlAttribute) {
+            if (structureMember.xmlAttribute) {
                 subXmlObj = xmlObj['_Attribs'];
             }
-            obj[memberName] = this.unmarshall(member.shape, subXmlObj[xmlKey]);
+            obj[memberName] = this.unmarshall(structureMember, subXmlObj[xmlKey]);
         }
         return obj;
     }
@@ -125,19 +129,21 @@ export class XmlBodyParser implements BodyParser {
         let keyName = member.locationName || name,
             membershape = member.shape;
         if (membershape.type === 'list') {
-            keyName = membershape.flattened ? (
-                membershape.member.locationName || keyName
+            const isFlattened = Boolean(member.flattened || membershape.flattened);
+            keyName = isFlattened ? (
+                membershape.member.locationName || name
                 ) : keyName;
         }
         return keyName;
     }
 
-    private parseList(shape: List, xmlObj: any): ObjectTypeArray {
+    private parseList(member: Member, xmlObj: any): ObjectTypeArray {
         let list: ObjectType[] = [],
             xmlList = xmlObj;
         if (!xmlObj || Object.keys(xmlObj).length === 0) {
             return list;
         }
+        const shape = member.shape as List;
         if (!Array.isArray(xmlObj)) {
             const key = shape.member.locationName || 'member';
             xmlList = xmlObj[key];
@@ -149,15 +155,18 @@ export class XmlBodyParser implements BodyParser {
             }
         }
         for (let xmlObjEntry of xmlList) {
-            list.push(this.unmarshall(shape.member.shape, xmlObjEntry))
+            list.push(this.unmarshall(shape.member, xmlObjEntry))
         }
         return list;
     }
 
-    private parseMap(shape: Map, xmlObj: any): ObjectType {
+    private parseMap(member: Member, xmlObj: any): ObjectType {
         let obj: ObjectType = {},
             mapEntryList = xmlObj;
-        if (!shape.flattened) {
+        const shape = member.shape as Map;
+        const isFlattened = Boolean(member.flattened || shape.flattened);
+
+        if (!isFlattened) {
             mapEntryList = xmlObj["entry"];
         }
         if (!mapEntryList || Object.keys(mapEntryList).length === 0) {
@@ -169,12 +178,12 @@ export class XmlBodyParser implements BodyParser {
         for (let mapEntry of mapEntryList) {
             let keyName = shape.key.locationName || "key";
             let valueName = shape.value.locationName || "value";
-            obj[mapEntry[keyName]] = this.unmarshall(shape.value.shape, mapEntry[valueName]);
+            obj[mapEntry[keyName]] = this.unmarshall(shape.value, mapEntry[valueName]);
         }
         return obj;
     }
 
-    private parseTimeStamp(shape: Timestamp, xmlObj: any): Date|undefined|null {
+    private parseTimeStamp(member: Member, xmlObj: any): Date|undefined {
         if (!xmlObj) {
             return undefined;
         }


### PR DESCRIPTION
adds rest-xml parser protocol tests, fixes rest error handling, and rest-xml flattened list parsing

replacing #137 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
