### PR TITLE
 feat: allow undefined argument in client constructor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,9 @@ Please be aware of the following notes prior to opening a pull request:
    a breaking change, the commit message must end with a single paragraph: `BREAKING 
    CHANGE: a description of what broke` 
 
-5. After getting ready to open a pull request, make sure to run the `scripts/
-   rebuildClients.js` to re-generate all the service clients, and commit the 
-   change(if any) to a standalone commit following the guide above.
+5. After getting ready to open a pull request, make sure to run the `npm run generate-clients`
+   to re-generate all the service clients, and commit the change(if any) to a
+   standalone commit following the guide above.
 
 ### Setup and Testing
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean": "npm run clear-build-cache && lerna clean",
     "clear-build-cache": "rimraf ./packages/*/build/*",
     "copy-models": "node ./scripts/copyModels.js",
+    "generate-clients": "node ./scripts/rebuildClients.js",
     "pretest": "lerna run pretest",
     "test": "jest --coverage"
   },

--- a/packages/client-codecommit-node/CodeCommitClient.ts
+++ b/packages/client-codecommit-node/CodeCommitClient.ts
@@ -37,9 +37,9 @@ export class CodeCommitClient {
         _stream.Readable
     >();
 
-    constructor(configuration: CodeCommitConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<CodeCommitConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
-            configuration,
+            configuration = {},
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/client-cognito-identity-browser/CognitoIdentityClient.ts
+++ b/packages/client-cognito-identity-browser/CognitoIdentityClient.ts
@@ -34,7 +34,7 @@ export class CognitoIdentityClient {
         Blob
     >();
 
-    constructor(configuration: CognitoIdentityConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<CognitoIdentityConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
             configuration,
             configurationProperties,

--- a/packages/client-dynamodb-browser/DynamoDBClient.ts
+++ b/packages/client-dynamodb-browser/DynamoDBClient.ts
@@ -34,7 +34,7 @@ export class DynamoDBClient {
         Blob
     >();
 
-    constructor(configuration: DynamoDBConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<DynamoDBConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
             configuration,
             configurationProperties,

--- a/packages/client-dynamodb-node/DynamoDBClient.ts
+++ b/packages/client-dynamodb-node/DynamoDBClient.ts
@@ -37,9 +37,9 @@ export class DynamoDBClient {
         _stream.Readable
     >();
 
-    constructor(configuration: DynamoDBConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<DynamoDBConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
-            configuration,
+            configuration = {},
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/client-glacier-node/GlacierClient.ts
+++ b/packages/client-glacier-node/GlacierClient.ts
@@ -40,9 +40,9 @@ export class GlacierClient {
         _stream.Readable
     >();
 
-    constructor(configuration: GlacierConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<GlacierConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
-            configuration,
+            configuration = {},
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/client-kinesis-browser/KinesisClient.ts
+++ b/packages/client-kinesis-browser/KinesisClient.ts
@@ -34,7 +34,7 @@ export class KinesisClient {
         Blob
     >();
 
-    constructor(configuration: KinesisConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<KinesisConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
             configuration,
             configurationProperties,

--- a/packages/client-lambda-node/LambdaClient.ts
+++ b/packages/client-lambda-node/LambdaClient.ts
@@ -37,9 +37,9 @@ export class LambdaClient {
         _stream.Readable
     >();
 
-    constructor(configuration: LambdaConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<LambdaConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
-            configuration,
+            configuration = {},
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/client-pinpoint-browser/PinpointClient.ts
+++ b/packages/client-pinpoint-browser/PinpointClient.ts
@@ -34,7 +34,7 @@ export class PinpointClient {
         Blob
     >();
 
-    constructor(configuration: PinpointConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<PinpointConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
             configuration,
             configurationProperties,

--- a/packages/client-sqs-node/SQSClient.ts
+++ b/packages/client-sqs-node/SQSClient.ts
@@ -37,9 +37,9 @@ export class SQSClient {
         _stream.Readable
     >();
 
-    constructor(configuration: SQSConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<SQSConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
-            configuration,
+            configuration = {},
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/client-xray-node/XRayClient.ts
+++ b/packages/client-xray-node/XRayClient.ts
@@ -37,9 +37,9 @@ export class XRayClient {
         _stream.Readable
     >();
 
-    constructor(configuration: XRayConfiguration) {
+    constructor(configuration: __aws_sdk_types.Undefinable<XRayConfiguration>) {
         this.config = __aws_sdk_config_resolver.resolveConfiguration(
-            configuration,
+            configuration = {},
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/service-types-generator/src/Components/Client/Client.ts
+++ b/packages/service-types-generator/src/Components/Client/Client.ts
@@ -73,9 +73,9 @@ export class ${this.className} {
         ${streamType(this.target)}
     >();
 
-    constructor(configuration: ${this.prefix}Configuration) {
+    constructor(configuration: ${typesPackage}.Undefinable<${this.prefix}Configuration>) {
         this.config = ${packageNameToVariable('@aws-sdk/config-resolver')}.resolveConfiguration(
-            configuration,
+            configuration${this.target === 'node' ? ' = {}' : ''},
             configurationProperties,
             this.middlewareStack
         );

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -62,3 +62,15 @@ export type ConfigurationDefinition<
         ResolvedConfiguration
     >;
 };
+
+/**
+ * A type makes interfaces with all optional properties to be optional as a whole.
+ * This is useful for client configuration interface. If there's no required
+ * property in the client configuration, `undefined` should be allowed instead
+ * off always supplying empty objects `{}`
+ * 
+ * For example if `interface A {a?: string, b?: string}`, then `Undefinable<A>`
+ * equals `A|undefined`.
+ */
+type RequiredKeys<T> = { [K in keyof T]-?: {} extends Pick<T, K> ? never : K }[keyof T];
+export type Undefinable<T extends object> = RequiredKeys<T> extends never|null|undefined ? T|undefined : T;


### PR DESCRIPTION
*Description of changes:*
Currently client constructor requires users supply empty object for configuration even if you have configuration to set. This feature allows users to supply undefined client constructor parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
