### PR TITLE
chore: rename npm script and update package generation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,9 @@ Please be aware of the following notes prior to opening a pull request:
    a breaking change, the commit message must end with a single paragraph: `BREAKING 
    CHANGE: a description of what broke` 
 
-5. After getting ready to open a pull request, make sure to run the `scripts/
-   rebuildClients.js` to re-generate all the service clients, and commit the 
-   change(if any) to a standalone commit following the guide above.
+5. After getting ready to open a pull request, make sure to run the `npm run update-clients`
+   to re-generate all the service clients, and commit the change(if any) to a
+   standalone commit following the guide above.
 
 ### Setup and Testing
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean": "npm run clear-build-cache && lerna clean",
     "clear-build-cache": "rimraf ./packages/*/build/*",
     "copy-models": "node ./scripts/copyModels.js",
+    "update-clients": "node ./scripts/rebuildClients.js",
     "pretest": "lerna run pretest",
     "test": "jest --coverage"
   },

--- a/packages/package-generator/src/commands/ImportClientPackageCommand.ts
+++ b/packages/package-generator/src/commands/ImportClientPackageCommand.ts
@@ -23,7 +23,7 @@ export const ImportClientPackageCommand: yargs.CommandModule = {
         runtime: {
             alias: ['r'],
             type: 'string',
-            choices: ['node', 'browser', 'universal'],
+            choices: ['node', 'browser'],
             demandOption: true,
         },
         smoke: {

--- a/scripts/rebuildClients.js
+++ b/scripts/rebuildClients.js
@@ -34,9 +34,7 @@ for (const serviceClient of existingServiceClients) {
     console.info(`generating ${runtime} client from model at ${models.service}`)
     generateClient(models, runtime);
 }
-
 console.log('done!');
-
 
 function grabExistingClients() {
     const packagesDir = path.join(path.dirname(__dirname), 'packages');


### PR DESCRIPTION
I also updated the package generator's import-all command to make it able to specify the run time and version of generated clients; The removed imports are because of no reference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
