### PR TITLE
fix(xml-body-parser): handle parsing flattened list

### DIFF
--- a/packages/xml-body-parser/src/index.spec.ts
+++ b/packages/xml-body-parser/src/index.spec.ts
@@ -295,6 +295,30 @@ describe('XmlBodyParser', () => {
             });
         });
 
+        it('should parse flattened list with only 1 item', () => {
+            let xml = '<xml><Items>Jack</Items></xml>';
+            let rules: Member = {
+                shape: {
+                    type: "structure",
+                    required: [],
+                    members: {
+                        Items: {
+                            shape: {
+                                type: "list",
+                                member: {
+                                    shape: {type: "string"},
+                                },
+                                flattened: true
+                            },
+                        }
+                    }
+                }
+            }
+            expect(parser.parse(rules, xml)).toEqual({
+                Items: ['Jack']
+            });
+        });
+
         it('should parse list with attributes in tags', () => {
             let xml = '<xml><Item xsi:name="Jon"><Age>20</Age></Item><Item xsi:name="Lee"><Age>18</Age></Item></xml>';
             let rules: Member = {
@@ -573,22 +597,6 @@ describe('XmlBodyParser', () => {
                 CreatedAt: new Date(isoString)
             });
         });
-
-        it('should parse rfc822 string', () => {
-            let rfcString = 'Tue, 29 Apr 2014 18:30:38 GMT';
-            let xml = `<xml><CreatedAt>${rfcString}</CreatedAt></xml>`;
-            expect(parser.parse(rules, xml)).toEqual({
-                CreatedAt: new Date(rfcString)
-            });
-        })
-
-        it('should parse unixTimestamp', () => {
-            let unixTime = 1398796238;
-            let xml = `<xml><CreatedAt>${unixTime}</CreatedAt></xml>`;
-            expect(parser.parse(rules, xml)).toEqual({
-                CreatedAt: new Date(unixTime * 1000)
-            });
-        })
     });
 
     describe('string', () => {

--- a/packages/xml-body-parser/src/index.spec.ts
+++ b/packages/xml-body-parser/src/index.spec.ts
@@ -6,14 +6,18 @@ describe('XmlBodyParser', () => {
         const rules: Member = {
             resultWrapper: 'OperationResult',
             shape: {
-                type: 'string'
+                type: 'structure',
+                required: [],
+                members: {
+                    Str: {shape: {type: 'string'}}
+                }
             }
         }
         const parser = new XmlBodyParser(jest.fn());
         it('should wrap the shap with a structure with wrapper name as member name', () => {
-            let xml = '<xml><OperationResult>foo</OperationResult></xml>';
+            let xml = '<xml><OperationResult><Str>foo</Str></OperationResult></xml>';
             expect(parser.parse(rules, xml)).toEqual({
-                OperationResult: 'foo'
+                Str: 'foo'
             });
         })
     });
@@ -597,6 +601,22 @@ describe('XmlBodyParser', () => {
                 CreatedAt: new Date(isoString)
             });
         });
+
+        it('should parse rfc822 string', () => {
+            let rfcString = 'Tue, 29 Apr 2014 18:30:38 GMT';
+            let xml = `<xml><CreatedAt>${rfcString}</CreatedAt></xml>`;
+            expect(parser.parse(rules, xml)).toEqual({
+                CreatedAt: new Date(rfcString)
+            });
+        });
+
+        it('should parse unixTimestamp', () => {
+            let unixTime = 1398796238;
+            let xml = `<xml><CreatedAt>${unixTime}</CreatedAt></xml>`;
+            expect(parser.parse(rules, xml)).toEqual({
+                CreatedAt: new Date(unixTime * 1000)
+            });
+        });
     });
 
     describe('string', () => {
@@ -805,20 +825,24 @@ describe('XmlBodyParser', () => {
         it('should extract requestId from non-EC2 response body', () => {
             let rules: Member = {
                 shape: {
-                    type: 'string'
+                    type: 'structure',
+                    required: [],
+                    members: {
+                        Str: {shape: {type: 'string'}}
+                    }
                 },
                 resultWrapper: 'QueryResult'
             }
             const xml = `
                 <OperationNameResponse>
-                    <QueryResult>foo</QueryResult>
+                    <QueryResult><Str>foo</Str></QueryResult>
                     <ResponseMetadata>
                     <RequestId>request-id</RequestId>
                     </ResponseMetadata>
                 </OperationNameResponse>
             `
             expect(parser.parse(rules, xml)).toEqual({
-                QueryResult: 'foo',
+                Str: 'foo',
                 $metadata: {
                     requestId: 'request-id'
                 }

--- a/packages/xml-body-parser/src/index.ts
+++ b/packages/xml-body-parser/src/index.ts
@@ -140,7 +140,7 @@ export class XmlBodyParser implements BodyParser {
         }
         if (!Array.isArray(xmlObj)) {
             const key = shape.member.locationName || 'member';
-            xmlList = xmlObj[key];
+            xmlList = shape.flattened ? xmlObj : xmlObj[key];
             if (!xmlList || Object.keys(xmlList).length === 0) {
                 return list;
             }

--- a/packages/xml-body-parser/src/index.ts
+++ b/packages/xml-body-parser/src/index.ts
@@ -53,6 +53,9 @@ export class XmlBodyParser implements BodyParser {
             }
         }
         let data: OutputType = this.unmarshall(wrappedShape, xmlObj);
+        if (member.resultWrapper) {
+            data = (data as any)[member.resultWrapper]
+        }
         //standard query
         if (xmlObj.ResponseMetadata && xmlObj.ResponseMetadata.RequestId) {
             (data as any).$metadata = {


### PR DESCRIPTION
*Description of changes:*
Now when there is only one item in a flattened list in an xml response, the parser will mistakenly give undefined result. This is because the xml body parser uses the wrong reference to refer the list entry in the parsed object from xml response. This fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
