### PR TITLE
fix typos in readme generator

### DIFF
--- a/packages/client-codecommit-node/README.md
+++ b/packages/client-codecommit-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-codecommit-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`CodeCommitClient`) and the commands you need, for example `BatchGetRepositoriesCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`CodeCommitClient`) and the commands you need, for example `BatchGetRepositoriesCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { BatchGetRepositoriesCommand } = import '@aws-sdk/client-codecommit-node/
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -53,7 +53,7 @@ codeCommit.send(batchGetRepositoriesCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -72,7 +72,7 @@ codeCommit.send(batchGetRepositoriesCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-codecommit-node/CodeCommit';
@@ -85,7 +85,7 @@ codeCommit.batchGetRepositories(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -99,7 +99,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-cognito-identity-browser/README.md
+++ b/packages/client-cognito-identity-browser/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-cognito-identity-browser
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`CognitoIdentityClient`) and the commands you need, for example `CreateIdentityPoolCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`CognitoIdentityClient`) and the commands you need, for example `CreateIdentityPoolCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { CreateIdentityPoolCommand } = import '@aws-sdk/client-cognito-identity-b
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -54,7 +54,7 @@ cognitoIdentity.send(createIdentityPoolCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -73,7 +73,7 @@ cognitoIdentity.send(createIdentityPoolCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-cognito-identity-browser/CognitoIdentity';
@@ -86,7 +86,7 @@ cognitoIdentity.createIdentityPool(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -100,7 +100,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-dynamodb-browser/README.md
+++ b/packages/client-dynamodb-browser/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-dynamodb-browser
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`DynamoDBClient`) and the commands you need, for example `BatchGetItemCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`DynamoDBClient`) and the commands you need, for example `BatchGetItemCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { BatchGetItemCommand } = import '@aws-sdk/client-dynamodb-browser/command
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -53,7 +53,7 @@ dynamoDB.send(batchGetItemCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -72,7 +72,7 @@ dynamoDB.send(batchGetItemCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-dynamodb-browser/DynamoDB';
@@ -85,7 +85,7 @@ dynamoDB.batchGetItem(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -99,7 +99,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-dynamodb-node/README.md
+++ b/packages/client-dynamodb-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-dynamodb-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`DynamoDBClient`) and the commands you need, for example `BatchGetItemCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`DynamoDBClient`) and the commands you need, for example `BatchGetItemCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { BatchGetItemCommand } = import '@aws-sdk/client-dynamodb-node/commands/B
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -53,7 +53,7 @@ dynamoDB.send(batchGetItemCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -72,7 +72,7 @@ dynamoDB.send(batchGetItemCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-dynamodb-node/DynamoDB';
@@ -85,7 +85,7 @@ dynamoDB.batchGetItem(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -99,7 +99,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-glacier-node/README.md
+++ b/packages/client-glacier-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-glacier-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`GlacierClient`) and the commands you need, for example `UploadArchiveCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`GlacierClient`) and the commands you need, for example `UploadArchiveCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { UploadArchiveCommand } = import '@aws-sdk/client-glacier-node/commands/U
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -56,7 +56,7 @@ glacier.send(uploadArchiveCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -75,7 +75,7 @@ glacier.send(uploadArchiveCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-glacier-node/Glacier';
@@ -90,7 +90,7 @@ For operations containing stream response like `GetJobOutput()`, you can get res
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -104,7 +104,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-kinesis-browser/README.md
+++ b/packages/client-kinesis-browser/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-kinesis-browser
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`KinesisClient`) and the commands you need, for example `AddTagsToStreamCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`KinesisClient`) and the commands you need, for example `AddTagsToStreamCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { AddTagsToStreamCommand } = import '@aws-sdk/client-kinesis-browser/comma
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -54,7 +54,7 @@ kinesis.send(addTagsToStreamCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -73,7 +73,7 @@ kinesis.send(addTagsToStreamCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-kinesis-browser/Kinesis';
@@ -86,7 +86,7 @@ kinesis.addTagsToStream(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -100,7 +100,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-kms-browser/README.md
+++ b/packages/client-kms-browser/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-kms-browser
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`KMSClient`) and the commands you need, for example `CancelKeyDeletionCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`KMSClient`) and the commands you need, for example `CancelKeyDeletionCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { CancelKeyDeletionCommand } = import '@aws-sdk/client-kms-browser/command
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -53,7 +53,7 @@ kMS.send(cancelKeyDeletionCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -72,7 +72,7 @@ kMS.send(cancelKeyDeletionCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-kms-browser/KMS';
@@ -85,7 +85,7 @@ kMS.cancelKeyDeletion(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -99,7 +99,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-kms-node/README.md
+++ b/packages/client-kms-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-kms-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`KMSClient`) and the commands you need, for example `CancelKeyDeletionCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`KMSClient`) and the commands you need, for example `CancelKeyDeletionCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { CancelKeyDeletionCommand } = import '@aws-sdk/client-kms-node/commands/C
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -53,7 +53,7 @@ kMS.send(cancelKeyDeletionCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -72,7 +72,7 @@ kMS.send(cancelKeyDeletionCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-kms-node/KMS';
@@ -85,7 +85,7 @@ kMS.cancelKeyDeletion(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -99,7 +99,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-lambda-node/README.md
+++ b/packages/client-lambda-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-lambda-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`LambdaClient`) and the commands you need, for example `InvokeAsyncCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`LambdaClient`) and the commands you need, for example `InvokeAsyncCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { InvokeAsyncCommand } = import '@aws-sdk/client-lambda-node/commands/Invo
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -55,7 +55,7 @@ lambda.send(invokeAsyncCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -74,7 +74,7 @@ lambda.send(invokeAsyncCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-lambda-node/Lambda';
@@ -87,7 +87,7 @@ lambda.invokeAsync(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -101,7 +101,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-pinpoint-browser/README.md
+++ b/packages/client-pinpoint-browser/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-pinpoint-browser
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`PinpointClient`) and the commands you need, for example `CreateAppCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`PinpointClient`) and the commands you need, for example `CreateAppCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { CreateAppCommand } = import '@aws-sdk/client-pinpoint-browser/commands/C
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -53,7 +53,7 @@ pinpoint.send(createAppCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -72,7 +72,7 @@ pinpoint.send(createAppCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-pinpoint-browser/Pinpoint';
@@ -85,7 +85,7 @@ pinpoint.createApp(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -99,7 +99,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-s3-browser/README.md
+++ b/packages/client-s3-browser/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-s3-browser
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`S3Client`) and the commands you need, for example `PutObjectCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`S3Client`) and the commands you need, for example `PutObjectCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { PutObjectCommand } = import '@aws-sdk/client-s3-browser/commands/PutObje
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -56,7 +56,7 @@ s3.send(putObjectCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -75,7 +75,7 @@ s3.send(putObjectCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-s3-browser/S3';
@@ -90,7 +90,7 @@ For operations containing stream response like `GetObject()`, you can get respon
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -104,7 +104,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-s3-node/README.md
+++ b/packages/client-s3-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-s3-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`S3Client`) and the commands you need, for example `PutObjectCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`S3Client`) and the commands you need, for example `PutObjectCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { PutObjectCommand } = import '@aws-sdk/client-s3-node/commands/PutObjectC
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -56,7 +56,7 @@ s3.send(putObjectCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -75,7 +75,7 @@ s3.send(putObjectCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-s3-node/S3';
@@ -90,7 +90,7 @@ For operations containing stream response like `GetObject()`, you can get respon
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -104,7 +104,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-sqs-node/README.md
+++ b/packages/client-sqs-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-sqs-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`SQSClient`) and the commands you need, for example `AddPermissionCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`SQSClient`) and the commands you need, for example `AddPermissionCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { AddPermissionCommand } = import '@aws-sdk/client-sqs-node/commands/AddPe
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -56,7 +56,7 @@ sQS.send(addPermissionCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -75,7 +75,7 @@ sQS.send(addPermissionCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-sqs-node/SQS';
@@ -88,7 +88,7 @@ sQS.addPermission(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -102,7 +102,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/client-xray-node/README.md
+++ b/packages/client-xray-node/README.md
@@ -16,7 +16,7 @@ npm install @aws-sdk/client-xray-node
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(`XRayClient`) and the commands you need, for example `BatchGetTracesCommand`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(`XRayClient`) and the commands you need, for example `BatchGetTracesCommand`:
 
 ```javascript
 //javascript
@@ -34,9 +34,9 @@ const { BatchGetTracesCommand } = import '@aws-sdk/client-xray-node/commands/Bat
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call `send` operation of client with command object as input.
+* Call `send` operation on client with command object as input.
 * If you are using a custom http handler, you may call `destroy()` to close open connections. 
 
 ```javascript
@@ -53,7 +53,7 @@ xRay.send(batchGetTracesCommand).then(data => {
 })
 ```
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 ```javascript
 // async/await
@@ -72,7 +72,7 @@ xRay.send(batchGetTracesCommand, (err, data) => {
 })
 ```
  
-Besides using `send()`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 ```javascript
 import * as AWS from '@aws-sdk/@aws-sdk/client-xray-node/XRay';
@@ -85,7 +85,7 @@ xRay.batchGetTraces(params, (err, data) => {
 
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 ```javascript
 try {
@@ -99,7 +99,7 @@ cfId: ${metadata.cfId}
 extendedRequestId: ${metadata.extendedRequestId}`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }

--- a/packages/service-types-generator/src/clientReadme.ts
+++ b/packages/service-types-generator/src/clientReadme.ts
@@ -40,7 +40,7 @@ npm install ${packageName}
 
 ### Import
 
-The AWS SDK is modulized by clients and commends in CommonJS modules. To send a request, you only need to import the client(\`${serviceId}Client\`) and the commands you need, for example \`${exampleCommand.name}Command\`:
+The AWS SDK is modulized by clients and commands in CommonJS modules. To send a request, you only need to import the client(\`${serviceId}Client\`) and the commands you need, for example \`${exampleCommand.name}Command\`:
 
 \`\`\`javascript
 //javascript
@@ -58,9 +58,9 @@ const { ${exampleCommand.name}Command } = import '${packageName}/commands/${exam
 
 To send a request, you:
 
-* Initiate client with configurations.(credentials, region). For more information you can refer to the [API reference][].
+* Initiate client with configuration (e.g. credentials, region). For more information you can refer to the [API reference][].
 * Initiate command with input parameters.
-* Call \`send\` operation of client with command object as input.
+* Call \`send\` operation on client with command object as input.
 * If you are using a custom http handler, you may call \`destroy()\` to close open connections. 
 
 \`\`\`javascript
@@ -75,7 +75,7 @@ ${lowerFirst(serviceId)}.send(${lowerFirst(exampleCommand.name)}Command).then(da
 })
 \`\`\`
 
-Besides using promise style, there are 2 other ways to send a request:
+In addition to using promises, there are 2 other ways to send a request:
 
 \`\`\`javascript
 // async/await
@@ -94,7 +94,7 @@ ${lowerFirst(serviceId)}.send(${lowerFirst(exampleCommand.name)}Command, (err, d
 })
 \`\`\`
  
-Besides using \`send()\`, the SDK can also send requests using the simplified callback style in version 2 of the SDK.
+The SDK can also send requests using the simplified callback style from version 2 of the SDK.
 
 \`\`\`javascript
 import * as AWS from '@aws-sdk/${packageName}/${serviceId}';
@@ -107,7 +107,7 @@ ${lowerFirst(serviceId)}.${lowerFirst(exampleCommand.name)}(params, (err, data) 
 ${commandNameWithOutputStream && commandNameWithOutputStream !== exampleCommandName ? `\n${outputStreamComment(model.operations[commandNameWithOutputStream], runtime)}\n` : ''}
 ### Troubleshooting 
 
-When the service returns an exception, inpecting the exceptions is always helpful. You can not only access the exception information but also response metadata(i.e request id).
+When the service returns an exception, the error will include the exception information, as well as response metadata (e.g. request id).
 
 \`\`\`javascript
 try {
@@ -121,7 +121,7 @@ cfId: \${metadata.cfId}
 extendedRequestId: \${metadata.extendedRequestId}\`
     );
 /*
-The keys within exceptions are also parsed, you can access them by specifying exception names like below:
+The keys within exceptions are also parsed. You can access them by specifying exception names:
     if(error.name === 'SomeServiceException') {
         const value = error.specialKeyInException;
     }


### PR DESCRIPTION
Fixes a few typo/wording issues in the client README generator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
