### PR TITLE
Enable running prettier on precommit using husky and lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "lint-staged": {
     "linters": {
-      "*": [
+      "packages/**/*.{ts,json}": [
         "prettier --write",
         "git add"
       ]

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
   },
   "devDependencies": {
     "generate-changelog": "^1.7.1",
+    "husky": "^2.1.0",
     "jest": "^20.0.4",
     "lerna": "3.11.0",
+    "lint-staged": "^8.1.5",
+    "prettier": "1.17.0",
     "typescript": "^3.0.0"
   },
   "workspaces": [
@@ -49,6 +52,22 @@
       "<rootDir>/packages/xml-body-parser/vendor/",
       "<rootDir>/packages/client-.*",
       "/__fixtures__/"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "linters": {
+      "*": [
+        "prettier --write",
+        "git add"
+      ]
+    },
+    "ignore": [
+      "package.json"
     ]
   }
 }


### PR DESCRIPTION
Docs:
* Prettier pre-commit hook https://prettier.io/docs/en/precommit.html
* Using lint-staged in a multi package monorepo http://bit.ly/2DFStRB

*Issue #, if available:*
N/A

*Description of changes:*
* PR for running prettier on existing files is posted at https://github.com/aws/aws-sdk-js-v3/pull/224
* This PR ensures that prettier is automatically run on pre-commit, as shown in the example below
![husky-lint-staged-prettier-example](https://user-images.githubusercontent.com/16024985/56935129-0904c880-6aa4-11e9-859b-af6e632041cf.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
