### PR TITLE
chore: add vscode extension recommendation for prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ lerna-debug.log
 package-lock.json
 
 !serviceModels/logs
-.vscode
 build

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": ["esbenp.prettier-vscode"],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
default workspace settings:
* editor.tabSize: 2
* editor.formatOnSave: true

*Issue #, if available:*
N/A

*Description of changes:*
add vscode extension recommendation for prettier along with default workspace settings

The below modal will be shown to the developer when the workspace is opened in VSCode:
![workspace-recommendations](https://user-images.githubusercontent.com/16024985/56995612-175fec80-6b57-11e9-85f7-8dfcb688c99c.png)

On clicking "Show recommendations", Prettier code formatter will be shown:
![workspace-recommendations-prettier](https://user-images.githubusercontent.com/16024985/56995641-29da2600-6b57-11e9-8afe-26d2b6bec01c.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
