### PR TITLE
feat: mark code generator packages as private

### DIFF
--- a/packages/build-types/package.json
+++ b/packages/build-types/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aws-sdk/build-types",
+  "private": true,
   "version": "0.1.0-preview.3",
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/package-generator/package.json
+++ b/packages/package-generator/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aws-sdk/package-generator",
+  "private": true,
   "version": "0.1.0-preview.6",
   "description": "Provides a command-line tool for generating the various types of packages that constitute the AWS SDK for JavaScript",
   "scripts": {

--- a/packages/service-model/package.json
+++ b/packages/service-model/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aws-sdk/service-model",
+  "private": true,
   "version": "0.1.0-preview.5",
   "description": "A service model parser and validator",
   "main": "./build/index.js",

--- a/packages/service-types-generator/package.json
+++ b/packages/service-types-generator/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aws-sdk/service-types-generator",
+  "private": true,
   "version": "0.1.0-preview.6",
   "description": "Code generator for the AWS SDK",
   "dependencies": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes*
We shouldn't publish code generator packages to NPM. So mark them private. Each of the 4 packages only have dependents within the 4 packages. In other word, the 4 packages are self contained. So marking them as private should break any other packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 
