### PR TITLE
 feat(middleware-stack): add filter() function to middleware stack

### DIFF
--- a/packages/middleware-stack/src/index.ts
+++ b/packages/middleware-stack/src/index.ts
@@ -98,6 +98,26 @@ export class MiddlewareStack<
     return this.entries.length < length;
   }
 
+  filter(
+    callbackfn: (handlerOptions: HandlerOptions) => boolean
+  ): MiddlewareStack<Input, Output, Stream> {
+    const filtered = new MiddlewareStack<Input, Output, Stream>();
+    for (const entry of this.entries) {
+      const options: HandlerOptions = {
+        step: entry.step,
+        priority: entry.priority,
+        tags: {
+          ...entry.tags
+        }
+      };
+      if (callbackfn(options)) {
+        filtered.entries.push(entry);
+      }
+    }
+    filtered.sorted = this.sorted;
+    return filtered;
+  }
+
   resolve<InputType extends Input, OutputType extends Output>(
     handler: FinalizeHandler<InputType, OutputType, Stream>,
     context: HandlerExecutionContext

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -289,6 +289,16 @@ export interface MiddlewareStack<
   remove(toRemove: Middleware<Input, Output> | string): boolean;
 
   /**
+   * Creates a clone of middleware stack with all middlewares that pass the test
+   * implemented by the provided callback function.
+   *
+   * @param callbackfn
+   */
+  filter(
+    callbackfn: (stats: HandlerOptions) => boolean
+  ): MiddlewareStack<Input, Output>;
+
+  /**
    * Builds a single handler function from zero or more middleware classes and
    * a core handler. The core handler is meant to send command objects to AWS
    * services and return promises that will resolve with the operation result

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -289,16 +289,6 @@ export interface MiddlewareStack<
   remove(toRemove: Middleware<Input, Output> | string): boolean;
 
   /**
-   * Creates a clone of middleware stack with all middlewares that pass the test
-   * implemented by the provided callback function.
-   *
-   * @param callbackfn
-   */
-  filter(
-    callbackfn: (stats: HandlerOptions) => boolean
-  ): MiddlewareStack<Input, Output>;
-
-  /**
    * Builds a single handler function from zero or more middleware classes and
    * a core handler. The core handler is meant to send command objects to AWS
    * services and return promises that will resolve with the operation result


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a filter function to middleware stack class. This enables you to make copy of middleware stack with specific stats(priority, step, tags). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
