### PR TITLE
fix: prettify markdown files on precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "lint-staged": {
     "linters": {
-      "packages/**/*.{ts,json}": [
+      "packages/**/*.{ts,md,json}": [
         "prettier --write",
         "git add"
       ]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Prettier was run on TS, MD and JSON files in packages folder in #227
* Support for running prettier on precommit was added in #225, but we MD files weren't added
* This PR adds MD extension for prettifying on precommit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
