### PR TITLE
fix: typo correction in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
   - npm run bootstrap
 script:
   - npm run test
-after_sucess:
+after_success:
   - ./node_modules/.bin/codecov -f coverage/*.json


### PR DESCRIPTION
after_sucess -> after_success
Travis docs: https://docs.travis-ci.com/user/job-lifecycle/

*Issue #, if available:*
N/A

*Description of changes:*
Correcting typo `after_sucess` -> `after_success`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
