### PR TITLE
chore: add settings for lock bot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -17,7 +17,7 @@ lockLabel: false
 lockComment: >
   This thread has been automatically locked since there has not been
   any recent activity after it was closed. Please open a new issue for
-  related bugs.
+  related bugs and link to relevant comments in this thread.
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,37 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 14
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* This adds settings for [lock bot](https://github.com/apps/lock)
* Once this PR is merged, we'll enable the bot on this repo. It'll automatically lock closed issues and PRs after 14 days of inactivity.
* This change is done to avoid discussions on closed issue like https://github.com/aws/aws-sdk-js/issues/2553 or closed PRs like https://github.com/aws/aws-sdk-js/pull/1391, we plan to introduce it on v2 once it successfully works on v3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
