### PR TITLE
chore: limit Typescript to minor version v3.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lerna": "3.14.1",
     "lint-staged": "^8.1.5",
     "prettier": "1.17.0",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "workspaces": [
     "packages/*"

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/add-glacier-checksum-headers-browser/package.json
+++ b/packages/add-glacier-checksum-headers-browser/package.json
@@ -34,6 +34,6 @@
     "karma-jasmine": "^2.0.1",
     "karma-typescript": "^4.0.0",
     "puppeteer": "^1.0.0",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/add-glacier-checksum-headers-node/package.json
+++ b/packages/add-glacier-checksum-headers-node/package.json
@@ -28,6 +28,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/add-glacier-checksum-headers-universal/package.json
+++ b/packages/add-glacier-checksum-headers-universal/package.json
@@ -25,6 +25,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/apply-body-checksum-middleware/package.json
+++ b/packages/apply-body-checksum-middleware/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/bucket-endpoint-middleware/package.json
+++ b/packages/bucket-endpoint-middleware/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/build-types/package.json
+++ b/packages/build-types/package.json
@@ -19,6 +19,6 @@
     "@aws-sdk/types": "^0.1.0-preview.3"
   },
   "devDependencies": {
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -21,6 +21,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-codecommit-node/package.json
+++ b/packages/client-codecommit-node/package.json
@@ -56,6 +56,6 @@
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-cognito-identity-browser/package.json
+++ b/packages/client-cognito-identity-browser/package.json
@@ -51,6 +51,6 @@
     "@aws-sdk/client-documentation-generator": "^0.1.0-preview.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -26,6 +26,6 @@
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-dynamodb-browser/package.json
+++ b/packages/client-dynamodb-browser/package.json
@@ -61,6 +61,6 @@
     "puppeteer": "^1.0.0",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-dynamodb-node/package.json
+++ b/packages/client-dynamodb-node/package.json
@@ -56,6 +56,6 @@
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-glacier-node/package.json
+++ b/packages/client-glacier-node/package.json
@@ -59,6 +59,6 @@
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-kinesis-browser/package.json
+++ b/packages/client-kinesis-browser/package.json
@@ -61,6 +61,6 @@
     "puppeteer": "^1.0.0",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-kms-browser/package.json
+++ b/packages/client-kms-browser/package.json
@@ -61,6 +61,6 @@
     "puppeteer": "^1.0.0",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-kms-node/package.json
+++ b/packages/client-kms-node/package.json
@@ -56,6 +56,6 @@
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-lambda-node/package.json
+++ b/packages/client-lambda-node/package.json
@@ -56,6 +56,6 @@
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-pinpoint-browser/package.json
+++ b/packages/client-pinpoint-browser/package.json
@@ -61,6 +61,6 @@
     "puppeteer": "^1.0.0",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-s3-browser/package.json
+++ b/packages/client-s3-browser/package.json
@@ -67,6 +67,6 @@
     "puppeteer": "^1.0.0",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-s3-node/package.json
+++ b/packages/client-s3-node/package.json
@@ -62,6 +62,6 @@
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-sqs-node/package.json
+++ b/packages/client-sqs-node/package.json
@@ -56,6 +56,6 @@
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/client-xray-node/package.json
+++ b/packages/client-xray-node/package.json
@@ -54,6 +54,6 @@
     "@types/node": "^10.0.0",
     "rimraf": "^2.6.2",
     "typedoc": "^0.14.2",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
     "tslib": "^1.8.0",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "@aws-sdk/types": "^0.1.0-preview.3",

--- a/packages/core-handler/package.json
+++ b/packages/core-handler/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/ec2-error-unmarshaller/package.json
+++ b/packages/ec2-error-unmarshaller/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -25,6 +25,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -25,6 +25,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -30,6 +30,6 @@
     "karma-jasmine": "^2.0.1",
     "karma-typescript": "^4.0.0",
     "puppeteer": "^1.0.0",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "@aws-sdk/types": "^0.1.0-preview.3",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -24,6 +24,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/http-headers/package.json
+++ b/packages/http-headers/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/http-serialization/package.json
+++ b/packages/http-serialization/package.json
@@ -23,6 +23,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts",
   "dependencies": {

--- a/packages/is-iterable/package.json
+++ b/packages/is-iterable/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts",
   "dependencies": {

--- a/packages/is-node/package.json
+++ b/packages/is-node/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts",
   "dependencies": {

--- a/packages/json-builder/package.json
+++ b/packages/json-builder/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/json-error-unmarshaller/package.json
+++ b/packages/json-error-unmarshaller/package.json
@@ -23,6 +23,6 @@
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
     "tslib": "^1.8.0",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/json-parser/package.json
+++ b/packages/json-parser/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -22,6 +22,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/location-constraint-middleware/package.json
+++ b/packages/location-constraint-middleware/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "@aws-sdk/types": "^0.1.0-preview.3",

--- a/packages/md5-universal/package.json
+++ b/packages/md5-universal/package.json
@@ -28,6 +28,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-ec2-copysnapshot/package.json
+++ b/packages/middleware-ec2-copysnapshot/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-input-default/package.json
+++ b/packages/middleware-input-default/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-operation-logging/package.json
+++ b/packages/middleware-operation-logging/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/middleware-rds-presignedurl/package.json
+++ b/packages/middleware-rds-presignedurl/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -21,7 +21,7 @@
     "@aws-sdk/util-utf8-node": "^0.1.0-preview.1",
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "@aws-sdk/middleware-header-default": "^0.1.0-preview.3",

--- a/packages/middleware-serializer/package.json
+++ b/packages/middleware-serializer/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/modeled-endpoint-middleware/package.json
+++ b/packages/modeled-endpoint-middleware/package.json
@@ -22,6 +22,6 @@
     "@aws-sdk/url-parser-universal": "^0.1.0-preview.3",
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -25,7 +25,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "jest": {
     "coveragePathIgnorePatterns": [

--- a/packages/package-generator/package.json
+++ b/packages/package-generator/package.json
@@ -43,6 +43,6 @@
     "@types/yargs": "^8.0",
     "@types/prettier": "1.16.3",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/package-generator/src/ClientModuleGenerator.ts
+++ b/packages/package-generator/src/ClientModuleGenerator.ts
@@ -273,7 +273,7 @@ tsconfig.test.json
       "@aws-sdk/client-documentation-generator": "^0.1.0-preview.1",
       rimraf: "^2.6.2",
       typedoc: "^0.10.0",
-      typescript: "^3.0.0"
+      typescript: "~3.4.0"
     };
 
     if (this.target === "node" || this.target === "universal") {

--- a/packages/package-generator/src/ModuleGenerator.ts
+++ b/packages/package-generator/src/ModuleGenerator.ts
@@ -89,7 +89,7 @@ export class ModuleGenerator {
       },
       devDependencies: {
         "@types/jest": "^24.0.12",
-        typescript: "^3.0.0",
+        typescript: "~3.4.0",
         jest: "^24.7.1"
       }
     };

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/protocol-json-rpc/package.json
+++ b/packages/protocol-json-rpc/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/protocol-query/package.json
+++ b/packages/protocol-query/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/xml-body-parser": "^0.1.0-preview.4",
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts",
   "author": {

--- a/packages/protocol-rest/package.json
+++ b/packages/protocol-rest/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/protocol-timestamp/package.json
+++ b/packages/protocol-timestamp/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/query-builder/package.json
+++ b/packages/query-builder/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/query-error-unmarshaller/package.json
+++ b/packages/query-error-unmarshaller/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/query-request-presigner/package.json
+++ b/packages/query-request-presigner/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -29,6 +29,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/remove-sensitive-logs/package.json
+++ b/packages/remove-sensitive-logs/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/response-metadata-extractor/package.json
+++ b/packages/response-metadata-extractor/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/retry-middleware/package.json
+++ b/packages/retry-middleware/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/route53-id-normalizer-middleware/package.json
+++ b/packages/route53-id-normalizer-middleware/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/service-model/package.json
+++ b/packages/service-model/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/service-types-generator/package.json
+++ b/packages/service-types-generator/package.json
@@ -14,7 +14,7 @@
     "@types/node": "^10.0.0",
     "@types/prettier": "1.16.3",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "scripts": {
     "build-internal-import-map": "node ./scripts/buildInternalImportMap.js",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -24,6 +24,6 @@
     "@aws-sdk/util-utf8-node": "^0.1.0-preview.1",
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/signature-v4-browser/package.json
+++ b/packages/signature-v4-browser/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/signature-v4-node/package.json
+++ b/packages/signature-v4-node/package.json
@@ -24,6 +24,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/signature-v4-universal/package.json
+++ b/packages/signature-v4-universal/package.json
@@ -24,6 +24,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/util-buffer-from": "^0.1.0-preview.1",
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/signing-middleware/package.json
+++ b/packages/signing-middleware/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "@aws-sdk/signature-v4": "^0.1.0-preview.4",

--- a/packages/ssec-middleware/package.json
+++ b/packages/ssec-middleware/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/stream-collector-browser/package.json
+++ b/packages/stream-collector-browser/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/stream-collector-node/package.json
+++ b/packages/stream-collector-node/package.json
@@ -23,6 +23,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/test-protocol-rest-json/package.json
+++ b/packages/test-protocol-rest-json/package.json
@@ -23,6 +23,6 @@
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
     "tslib": "^1.8.0",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/test-protocol-rest-xml/package.json
+++ b/packages/test-protocol-rest-xml/package.json
@@ -23,6 +23,6 @@
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
     "tslib": "^1.8.0",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "types": "./build/index.d.ts",
   "description": "Types for the AWS SDK",
   "devDependencies": {
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/url-parser-browser/package.json
+++ b/packages/url-parser-browser/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/url-parser-node/package.json
+++ b/packages/url-parser-node/package.json
@@ -23,6 +23,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/url-parser-universal/package.json
+++ b/packages/url-parser-universal/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -22,7 +22,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/util-base64-universal/package.json
+++ b/packages/util-base64-universal/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -20,7 +20,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts"

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -23,6 +23,6 @@
     "@types/jest": "^20.0.2",
     "@aws-sdk/middleware-stack": "^0.1.0-preview.4",
     "jest": "^20.0.4",
-    "typescript": "^3.4.5"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-error-constructor/package.json
+++ b/packages/util-error-constructor/package.json
@@ -22,6 +22,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "main": "./build/index.js",
   "types": "./build/index.d.ts"

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -22,6 +22,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   }
 }

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -22,7 +22,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/util-utf8-universal/package.json
+++ b/packages/util-utf8-universal/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "types": "./build/index.d.ts"
 }

--- a/packages/xml-body-builder/package.json
+++ b/packages/xml-body-builder/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "@aws-sdk/is-iterable": "^0.1.0-preview.1",

--- a/packages/xml-body-parser/package.json
+++ b/packages/xml-body-parser/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "@aws-sdk/protocol-timestamp": "^0.1.0-preview.3",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "^3.0.0"
+    "typescript": "~3.4.0"
   },
   "scripts": {
     "prepublishOnly": "tsc",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Limiting TypeScript version to minor version v3.4.x, as CI is failing because of v3.5.x
* https://travis-ci.org/aws/aws-sdk-js-v3/builds/539577881
* https://travis-ci.org/aws/aws-sdk-js-v3/builds/539588169

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
