### PR TITLE
doc: reduce daysUntilLock from 14 to 7

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for Lock Threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 14
+daysUntilLock: 7
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable


### PR DESCRIPTION
As discussed internally

*Issue #, if available:*
N/A

*Description of changes:*
reduces daysUntilLock from 14 to 7 in lock bot settings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
