### PR TITLE
Fix SigV4 signer configuration in service clients

### DIFF
--- a/packages/client-codecommit-node/CodeCommitConfiguration.ts
+++ b/packages/client-codecommit-node/CodeCommitConfiguration.ts
@@ -391,7 +391,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-cognito-identity-browser/CognitoIdentityConfiguration.ts
+++ b/packages/client-cognito-identity-browser/CognitoIdentityConfiguration.ts
@@ -378,7 +378,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-dynamodb-browser/DynamoDBConfiguration.ts
+++ b/packages/client-dynamodb-browser/DynamoDBConfiguration.ts
@@ -377,7 +377,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-dynamodb-node/DynamoDBConfiguration.ts
+++ b/packages/client-dynamodb-node/DynamoDBConfiguration.ts
@@ -390,7 +390,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-glacier-node/GlacierConfiguration.ts
+++ b/packages/client-glacier-node/GlacierConfiguration.ts
@@ -393,7 +393,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-kinesis-browser/KinesisConfiguration.ts
+++ b/packages/client-kinesis-browser/KinesisConfiguration.ts
@@ -377,7 +377,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-kms-browser/KMSConfiguration.ts
+++ b/packages/client-kms-browser/KMSConfiguration.ts
@@ -377,7 +377,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-kms-node/KMSConfiguration.ts
+++ b/packages/client-kms-node/KMSConfiguration.ts
@@ -390,7 +390,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-lambda-node/LambdaConfiguration.ts
+++ b/packages/client-lambda-node/LambdaConfiguration.ts
@@ -393,7 +393,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-pinpoint-browser/PinpointConfiguration.ts
+++ b/packages/client-pinpoint-browser/PinpointConfiguration.ts
@@ -380,7 +380,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-s3-browser/S3Configuration.ts
+++ b/packages/client-s3-browser/S3Configuration.ts
@@ -433,7 +433,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: true
+        uriEscapePath: false
       })
   },
   bucketEndpoint: {

--- a/packages/client-s3-node/S3Configuration.ts
+++ b/packages/client-s3-node/S3Configuration.ts
@@ -445,7 +445,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: true
+        uriEscapePath: false
       })
   },
   bucketEndpoint: {

--- a/packages/client-sqs-node/SQSConfiguration.ts
+++ b/packages/client-sqs-node/SQSConfiguration.ts
@@ -393,7 +393,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/client-xray-node/XRayConfiguration.ts
+++ b/packages/client-xray-node/XRayConfiguration.ts
@@ -393,7 +393,7 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         region: configuration.region,
         service: configuration.signingName,
         sha256: configuration.sha256,
-        uriEscapePath: false
+        uriEscapePath: true
       })
   }
 };

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
@@ -197,7 +197,8 @@ function signerProperty(
   metadata: ServiceMetadata
 ): ConfigurationPropertyDefinition {
   const typesPackage = packageNameToVariable("@aws-sdk/types");
-
+  const uriEscapePath = ["s3", "s3v4"].indexOf(metadata.signatureVersion) < 0;
+  //for sig version not 's3' or 's3v4', the uriEscapePath should be true
   return {
     type: "unified",
     inputType: `${typesPackage}.RequestSigner`,
@@ -222,8 +223,8 @@ function signerProperty(
     region: configuration.region,
     service: configuration.signingName,
     sha256: configuration.sha256,
-    uriEscapePath: ${["s3", "s3v4"].indexOf(metadata.signatureVersion) < 0},
-})` //for sig version not 's3' or 's3v4', the uriEscapePath should be true
+    uriEscapePath: ${uriEscapePath},
+})`
     }
   };
 }

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
@@ -222,8 +222,8 @@ function signerProperty(
     region: configuration.region,
     service: configuration.signingName,
     sha256: configuration.sha256,
-    uriEscapePath: ${["s3", "s3v4"].indexOf(metadata.signatureVersion) > -1},
-})`
+    uriEscapePath: ${["s3", "s3v4"].indexOf(metadata.signatureVersion) < 0},
+})` //for sig version not 's3' or 's3v4', the uriEscapePath should be true
     }
   };
 }

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
@@ -197,8 +197,9 @@ function signerProperty(
   metadata: ServiceMetadata
 ): ConfigurationPropertyDefinition {
   const typesPackage = packageNameToVariable("@aws-sdk/types");
+  // for sig version not 's3' or 's3v4', the uriEscapePath should be true
   const uriEscapePath = ["s3", "s3v4"].indexOf(metadata.signatureVersion) < 0;
-  //for sig version not 's3' or 's3v4', the uriEscapePath should be true
+  
   return {
     type: "unified",
     inputType: `${typesPackage}.RequestSigner`,


### PR DESCRIPTION
*Issue #, if available:*
#283 

*Description of changes:*
Fix the wrong configuration in Service client config as well as in code generator. This bug can result in any request with path containing special characters results in `SignatureMismatch`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
