### PR TITLE
chore: update dependencies in CodeGen

### DIFF
--- a/packages/package-generator/src/ClientModuleGenerator.ts
+++ b/packages/package-generator/src/ClientModuleGenerator.ts
@@ -270,14 +270,14 @@ tsconfig.test.json
 
   private devDependencies(): { [key: string]: string } {
     const devDependencies: { [key: string]: string } = {
-      "@aws-sdk/client-documentation-generator": "^0.1.0-preview.1",
+      "@aws-sdk/client-documentation-generator": "^0.1.0-preview.2",
       rimraf: "^2.6.2",
-      typedoc: "^0.10.0",
+      typedoc: "^0.14.2",
       typescript: "~3.4.0"
     };
 
     if (this.target === "node" || this.target === "universal") {
-      devDependencies["@types/node"] = "^8.10.29";
+      devDependencies["@types/node"] = "^10.0.0";
     }
 
     if (this.smokeTestGenerator) {
@@ -318,9 +318,7 @@ tsconfig.test.json
       this.circularDependencies
     )) {
       if (file === "ServiceMetadata") {
-        generated += `\nexport const clientVersion: string = "${
-          this.version
-        }";`;
+        generated += `\nexport const clientVersion: string = "${this.version}";`;
       }
       yield [file, generated];
     }

--- a/packages/service-types-generator/src/SmokeTestGenerator.ts
+++ b/packages/service-types-generator/src/SmokeTestGenerator.ts
@@ -75,12 +75,12 @@ export class SmokeTestGenerator {
     if (this.runtime === "browser") {
       dependencies["@aws-sdk/karma-credential-loader"] =
         IMPORTS["karma-credential-loader"].version;
-      dependencies["jasmine-core"] = "^2.8.0";
-      dependencies["karma"] = "^2.0.0";
-      dependencies["karma-chrome-launcher"] = "^2.2.0";
+      dependencies["jasmine-core"] = "^3.4.0";
+      dependencies["karma"] = "^4.1.0";
+      dependencies["karma-chrome-launcher"] = "^3.0.0";
       dependencies["karma-coverage"] = "^1.1.1";
-      dependencies["karma-jasmine"] = "^1.1.1";
-      dependencies["karma-typescript"] = "^3.0.12";
+      dependencies["karma-jasmine"] = "^2.0.1";
+      dependencies["karma-typescript"] = "^4.0.0";
       dependencies["puppeteer"] = "^1.0.0";
     }
 


### PR DESCRIPTION
This is will be caught when we reintroduce client generation scripts in CI
They were removed in https://github.com/aws/aws-sdk-js-v3/pull/231
The CodeGen will be updated along with dependencies when CI fails

*Issue #, if available:*
N/A

*Description of changes:*
Updates dependencies in CodeGen
Confirmed that package.json is not updated when `node scripts/rebuildClients.js` is run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
