### PR TITLE
chore: ignore jasmine and karma-* in greenkeeper

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -129,7 +129,13 @@
         "@types/jest",
         "@types/yargs",
         "prettier",
-        "@types/prettier"
+        "@types/prettier",
+        "jasmine-core",
+        "karma",
+        "karma-chrome-launcher",
+        "karma-coverage",
+        "karma-jasmine",
+        "karma-typescript"
       ]
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* This PR adds jasmine and karma-* to ignore array in greenkeeper
* This is done to avoid PRs like #301 temporarily to fix CodeGen
* These dependencies can be remove from ignored dependencies, when we reintroduce CodeGen script in CI or remove the dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
