### PR TITLE
feat: node-http-handler set default keep-alive to true

### DIFF
--- a/packages/client-codecommit-node/CodeCommitConfiguration.ts
+++ b/packages/client-codecommit-node/CodeCommitConfiguration.ts
@@ -68,6 +68,11 @@ export interface CodeCommitConfiguration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -181,6 +186,8 @@ export interface CodeCommitResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -335,12 +342,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.utf8Encoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-codecommit-node/model/ServiceMetadata.ts
+++ b/packages/client-codecommit-node/model/ServiceMetadata.ts
@@ -12,4 +12,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   targetPrefix: "CodeCommit_20150413",
   uid: "codecommit-2015-04-13"
 };
-export const clientVersion: string = "0.1.0-preview.4";
+export const clientVersion: string = "0.1.0-preview.5";

--- a/packages/client-dynamodb-node/DynamoDBConfiguration.ts
+++ b/packages/client-dynamodb-node/DynamoDBConfiguration.ts
@@ -68,6 +68,11 @@ export interface DynamoDBConfiguration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -180,6 +185,8 @@ export interface DynamoDBResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -334,12 +341,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.utf8Encoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-dynamodb-node/model/ServiceMetadata.ts
+++ b/packages/client-dynamodb-node/model/ServiceMetadata.ts
@@ -12,4 +12,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   targetPrefix: "DynamoDB_20120810",
   uid: "dynamodb-2012-08-10"
 };
-export const clientVersion: string = "0.1.0-preview.3";
+export const clientVersion: string = "0.1.0-preview.4";

--- a/packages/client-glacier-node/GlacierConfiguration.ts
+++ b/packages/client-glacier-node/GlacierConfiguration.ts
@@ -68,6 +68,11 @@ export interface GlacierConfiguration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -180,6 +185,8 @@ export interface GlacierResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -337,12 +344,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.base64Decoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-glacier-node/model/ServiceMetadata.ts
+++ b/packages/client-glacier-node/model/ServiceMetadata.ts
@@ -9,4 +9,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   signatureVersion: "v4",
   uid: "glacier-2012-06-01"
 };
-export const clientVersion: string = "0.1.0-preview.5";
+export const clientVersion: string = "0.1.0-preview.6";

--- a/packages/client-kms-node/KMSConfiguration.ts
+++ b/packages/client-kms-node/KMSConfiguration.ts
@@ -68,6 +68,11 @@ export interface KMSConfiguration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -180,6 +185,8 @@ export interface KMSResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -334,12 +341,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.utf8Encoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-kms-node/model/ServiceMetadata.ts
+++ b/packages/client-kms-node/model/ServiceMetadata.ts
@@ -12,4 +12,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   targetPrefix: "TrentService",
   uid: "kms-2014-11-01"
 };
-export const clientVersion: string = "0.1.0-preview.3";
+export const clientVersion: string = "0.1.0-preview.4";

--- a/packages/client-lambda-node/LambdaConfiguration.ts
+++ b/packages/client-lambda-node/LambdaConfiguration.ts
@@ -68,6 +68,11 @@ export interface LambdaConfiguration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -180,6 +185,8 @@ export interface LambdaResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -337,12 +344,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.base64Decoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-lambda-node/model/ServiceMetadata.ts
+++ b/packages/client-lambda-node/model/ServiceMetadata.ts
@@ -9,4 +9,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   signatureVersion: "v4",
   uid: "lambda-2015-03-31"
 };
-export const clientVersion: string = "0.1.0-preview.5";
+export const clientVersion: string = "0.1.0-preview.6";

--- a/packages/client-s3-node/S3Configuration.ts
+++ b/packages/client-s3-node/S3Configuration.ts
@@ -84,6 +84,11 @@ export interface S3Configuration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -222,6 +227,8 @@ export interface S3ResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -389,12 +396,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.base64Decoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-s3-node/model/ServiceMetadata.ts
+++ b/packages/client-s3-node/model/ServiceMetadata.ts
@@ -10,4 +10,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   signatureVersion: "s3",
   uid: "s3-2006-03-01"
 };
-export const clientVersion: string = "0.1.0-preview.1";
+export const clientVersion: string = "0.1.0-preview.2";

--- a/packages/client-sqs-node/SQSConfiguration.ts
+++ b/packages/client-sqs-node/SQSConfiguration.ts
@@ -68,6 +68,11 @@ export interface SQSConfiguration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -180,6 +185,8 @@ export interface SQSResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -337,12 +344,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.utf8Encoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-sqs-node/model/ServiceMetadata.ts
+++ b/packages/client-sqs-node/model/ServiceMetadata.ts
@@ -11,4 +11,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   uid: "sqs-2012-11-05",
   xmlNamespace: { uri: "http://queue.amazonaws.com/doc/2012-11-05/" }
 };
-export const clientVersion: string = "0.1.0-preview.5";
+export const clientVersion: string = "0.1.0-preview.6";

--- a/packages/client-xray-node/XRayConfiguration.ts
+++ b/packages/client-xray-node/XRayConfiguration.ts
@@ -68,6 +68,11 @@ export interface XRayConfiguration {
   httpHandler?: __aws_sdk_types.HttpHandler<_stream.Readable>;
 
   /**
+   * Whether sockets should be kept open even when there are no outstanding requests so that future requests can forgo having to reestablish a TCP or TLS connection. Defaults to true.
+   */
+  keepAlive?: boolean;
+
+  /**
    * The maximum number of redirects to follow for a service request. Set to `0` to disable retries.
    */
   maxRedirects?: number;
@@ -180,6 +185,8 @@ export interface XRayResolvedConfiguration
   handler: __aws_sdk_types.Terminalware<any, _stream.Readable>;
 
   httpHandler: __aws_sdk_types.HttpHandler<_stream.Readable>;
+
+  keepAlive: boolean;
 
   maxRedirects: number;
 
@@ -337,12 +344,16 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         configuration.base64Decoder
       )
   },
+  keepAlive: {
+    defaultValue: true
+  },
   _user_injected_http_handler: {
     defaultProvider: (configuration: { httpHandler?: any }) =>
       !configuration.httpHandler
   },
   httpHandler: {
-    defaultProvider: () => new __aws_sdk_node_http_handler.NodeHttpHandler()
+    defaultProvider: (configuration: { keepAlive: boolean }) =>
+      new __aws_sdk_node_http_handler.NodeHttpHandler(configuration)
   },
   handler: {
     defaultProvider: (configuration: {

--- a/packages/client-xray-node/model/ServiceMetadata.ts
+++ b/packages/client-xray-node/model/ServiceMetadata.ts
@@ -9,4 +9,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   signatureVersion: "v4",
   uid: "xray-2016-04-12"
 };
-export const clientVersion: string = "0.1.0-preview.5";
+export const clientVersion: string = "0.1.0-preview.6";

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -35,7 +35,7 @@ describe("NodeHttpHandler", () => {
         "request",
         createResponseFunction(mockResponse)
       );
-      const nodeHttpHandler = new NodeHttpHandler();
+      const nodeHttpHandler = new NodeHttpHandler({});
 
       let response = await nodeHttpHandler.handle(
         {

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -35,7 +35,7 @@ describe("NodeHttpHandler", () => {
         "request",
         createResponseFunction(mockResponse)
       );
-      const nodeHttpHandler = new NodeHttpHandler({});
+      const nodeHttpHandler = new NodeHttpHandler();
 
       let response = await nodeHttpHandler.handle(
         {

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -15,11 +15,18 @@ import { setSocketTimeout } from "./set-socket-timeout";
 import { writeRequestBody } from "./write-request-body";
 
 export class NodeHttpHandler implements HttpHandler<Readable, NodeHttpOptions> {
-  constructor(private readonly httpOptions: NodeHttpOptions = {}) {}
+  private readonly httpAgent: http.Agent;
+  private readonly httpsAgent: https.Agent;
+
+  constructor(private readonly httpOptions: NodeHttpOptions = {}) {
+    const { keepAlive } = httpOptions;
+    this.httpAgent = new http.Agent({ keepAlive });
+    this.httpsAgent = new https.Agent({ keepAlive });
+  }
 
   destroy(): void {
-    // pass for now, but this may destroy the underlying agent in the future
-    // if we decide to enable keep-alive by default.
+    this.httpAgent.destroy();
+    this.httpsAgent.destroy();
   }
 
   handle(
@@ -43,7 +50,8 @@ export class NodeHttpHandler implements HttpHandler<Readable, NodeHttpOptions> {
       host: request.hostname,
       method: request.method,
       path: path,
-      port: request.port
+      port: request.port,
+      agent: isSSL ? this.httpsAgent : this.httpAgent
     };
 
     return new Promise((resolve, reject) => {

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/httpConfigurationProperties.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/httpConfigurationProperties.ts
@@ -38,9 +38,9 @@ function httpHandlerProperty(
       imports: [IMPORTS["node-http-handler"]],
       default: {
         type: "provider",
-        expression: `() => new ${packageNameToVariable(
+        expression: `(configuration: ${typesPackage}.NodeHttpOptions) => new ${packageNameToVariable(
           "@aws-sdk/node-http-handler"
-        )}.NodeHttpHandler()`
+        )}.NodeHttpHandler(configuration)`
       }
     },
     browser: {

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/index.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/index.ts
@@ -42,7 +42,7 @@ export function customizationsFromModel(
     sslEnabled,
     ...endpointConfigurationProperties(model.metadata),
     ...serializerConfigurationProperties(model.metadata, streamTypeParam),
-    ...httpConfigurationProperties("any", "any", streamTypeParam)
+    ...httpConfigurationProperties(target, "any", "any")
   };
 
   return mergeCustomizationDefinitions(

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -145,6 +145,10 @@ export interface HttpOptions {}
  * Represents the http options that can be passed to a browser http client.
  */
 export interface BrowserHttpOptions extends HttpOptions {
+  /**
+   * The number of milliseconds a request can take before being automatically
+   * terminated.
+   */
   requestTimeout?: number;
 }
 
@@ -152,6 +156,22 @@ export interface BrowserHttpOptions extends HttpOptions {
  * Represents the http options that can be passed to a node http client.
  */
 export interface NodeHttpOptions extends HttpOptions {
+  /**
+   * The maximum time in milliseconds that the connection phase of a request
+   * may take before the connection attempt is abandoned.
+   */
   connectionTimeout?: number;
+
+  /**
+   * Whether sockets should be kept open even when there are no outstanding
+   * requests so that future requests can forgo having to reestablish a TCP or
+   * TLS connection.
+   */
+  keepAlive?: boolean;
+
+  /**
+   * The maximum time in milliseconds that a socket may remain idle before it
+   * is closed.
+   */
   socketTimeout?: number;
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js/issues/2571

*Description of changes:*
* added keepAlive in NodeHttpOptions
* modified node-http-handler to accept keepAlive
* set default keepAlive to true
* ran `node scripts/rebuildClients.ts` to update node clients

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
