### PR TITLE
chore: make prettier ignore changelog

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+**/*/CHANGELOG.md

--- a/packages/abort-controller/CHANGELOG.md
+++ b/packages/abort-controller/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/abort-controller@0.1.0-preview.2...@aws-sdk/abort-controller@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/abort-controller@0.1.0-preview.2...@aws-sdk/abort-controller@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/add-glacier-checksum-headers-browser/CHANGELOG.md
+++ b/packages/add-glacier-checksum-headers-browser/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/add-glacier-checksum-headers-browser@0.1.0-preview.3...@aws-sdk/add-glacier-checksum-headers-browser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/add-glacier-checksum-headers-browser@0.1.0-preview.3...@aws-sdk/add-glacier-checksum-headers-browser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/add-glacier-checksum-headers-node/CHANGELOG.md
+++ b/packages/add-glacier-checksum-headers-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/add-glacier-checksum-headers-node@0.1.0-preview.3...@aws-sdk/add-glacier-checksum-headers-node@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/add-glacier-checksum-headers-node@0.1.0-preview.3...@aws-sdk/add-glacier-checksum-headers-node@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/add-glacier-checksum-headers-universal/CHANGELOG.md
+++ b/packages/add-glacier-checksum-headers-universal/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/add-glacier-checksum-headers-universal@0.1.0-preview.3...@aws-sdk/add-glacier-checksum-headers-universal@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/add-glacier-checksum-headers-universal@0.1.0-preview.3...@aws-sdk/add-glacier-checksum-headers-universal@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/apply-body-checksum-middleware/CHANGELOG.md
+++ b/packages/apply-body-checksum-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/apply-body-checksum-middleware@0.1.0-preview.2...@aws-sdk/apply-body-checksum-middleware@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/apply-body-checksum-middleware@0.1.0-preview.2...@aws-sdk/apply-body-checksum-middleware@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/bucket-endpoint-middleware/CHANGELOG.md
+++ b/packages/bucket-endpoint-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/bucket-endpoint-middleware@0.1.0-preview.2...@aws-sdk/bucket-endpoint-middleware@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/bucket-endpoint-middleware@0.1.0-preview.2...@aws-sdk/bucket-endpoint-middleware@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/build-types/CHANGELOG.md
+++ b/packages/build-types/CHANGELOG.md
@@ -5,13 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/build-types@0.1.0-preview.2...@aws-sdk/build-types@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/build-types@0.1.0-preview.2...@aws-sdk/build-types@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/chunked-blob-reader/CHANGELOG.md
+++ b/packages/chunked-blob-reader/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/chunked-blob-reader@0.1.0-preview.1...@aws-sdk/chunked-blob-reader@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/chunked-stream-reader-node/CHANGELOG.md
+++ b/packages/chunked-stream-reader-node/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/chunked-stream-reader-node@0.1.0-preview.1...@aws-sdk/chunked-stream-reader-node@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/client-codecommit-node/CHANGELOG.md
+++ b/packages/client-codecommit-node/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-codecommit-node@0.1.0-preview.3...@aws-sdk/client-codecommit-node@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-codecommit-node@0.1.0-preview.3...@aws-sdk/client-codecommit-node@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/client-cognito-identity-browser/CHANGELOG.md
+++ b/packages/client-cognito-identity-browser/CHANGELOG.md
@@ -5,13 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-cognito-identity-browser@0.1.0-preview.3...@aws-sdk/client-cognito-identity-browser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-cognito-identity-browser@0.1.0-preview.3...@aws-sdk/client-cognito-identity-browser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/client-documentation-generator/CHANGELOG.md
+++ b/packages/client-documentation-generator/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-documentation-generator@0.1.0-preview.1...@aws-sdk/client-documentation-generator@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/client-dynamodb-browser/CHANGELOG.md
+++ b/packages/client-dynamodb-browser/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-dynamodb-browser@0.1.0-preview.2...@aws-sdk/client-dynamodb-browser@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-dynamodb-browser@0.1.0-preview.2...@aws-sdk/client-dynamodb-browser@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/client-dynamodb-node/CHANGELOG.md
+++ b/packages/client-dynamodb-node/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-dynamodb-node@0.1.0-preview.2...@aws-sdk/client-dynamodb-node@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-dynamodb-node@0.1.0-preview.2...@aws-sdk/client-dynamodb-node@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/client-glacier-node/CHANGELOG.md
+++ b/packages/client-glacier-node/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-glacier-node@0.1.0-preview.4...@aws-sdk/client-glacier-node@0.1.0-preview.6) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-glacier-node@0.1.0-preview.4...@aws-sdk/client-glacier-node@0.1.0-preview.5) (2019-04-19)
 

--- a/packages/client-kinesis-browser/CHANGELOG.md
+++ b/packages/client-kinesis-browser/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-kinesis-browser@0.1.0-preview.3...@aws-sdk/client-kinesis-browser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-kinesis-browser@0.1.0-preview.3...@aws-sdk/client-kinesis-browser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/client-kms-browser/CHANGELOG.md
+++ b/packages/client-kms-browser/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-kms-browser@0.1.0-preview.2...@aws-sdk/client-kms-browser@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-kms-browser@0.1.0-preview.2...@aws-sdk/client-kms-browser@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/client-kms-node/CHANGELOG.md
+++ b/packages/client-kms-node/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-kms-node@0.1.0-preview.2...@aws-sdk/client-kms-node@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-kms-node@0.1.0-preview.2...@aws-sdk/client-kms-node@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/client-lambda-node/CHANGELOG.md
+++ b/packages/client-lambda-node/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-lambda-node@0.1.0-preview.4...@aws-sdk/client-lambda-node@0.1.0-preview.6) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-lambda-node@0.1.0-preview.4...@aws-sdk/client-lambda-node@0.1.0-preview.5) (2019-04-19)
 

--- a/packages/client-pinpoint-browser/CHANGELOG.md
+++ b/packages/client-pinpoint-browser/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-pinpoint-browser@0.1.0-preview.3...@aws-sdk/client-pinpoint-browser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-pinpoint-browser@0.1.0-preview.3...@aws-sdk/client-pinpoint-browser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/client-s3-browser/CHANGELOG.md
+++ b/packages/client-s3-browser/CHANGELOG.md
@@ -5,10 +5,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.1.0-preview.2 (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
-- **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))

--- a/packages/client-s3-node/CHANGELOG.md
+++ b/packages/client-s3-node/CHANGELOG.md
@@ -5,10 +5,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.1.0-preview.2 (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
-- **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))

--- a/packages/client-sqs-node/CHANGELOG.md
+++ b/packages/client-sqs-node/CHANGELOG.md
@@ -5,14 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-sqs-node@0.1.0-preview.4...@aws-sdk/client-sqs-node@0.1.0-preview.6) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-sqs-node@0.1.0-preview.4...@aws-sdk/client-sqs-node@0.1.0-preview.5) (2019-04-19)
 

--- a/packages/client-xray-node/CHANGELOG.md
+++ b/packages/client-xray-node/CHANGELOG.md
@@ -5,13 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-xray-node@0.1.0-preview.4...@aws-sdk/client-xray-node@0.1.0-preview.6) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/client-xray-node@0.1.0-preview.4...@aws-sdk/client-xray-node@0.1.0-preview.5) (2019-04-19)
 

--- a/packages/config-resolver/CHANGELOG.md
+++ b/packages/config-resolver/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/config-resolver@0.1.0-preview.2...@aws-sdk/config-resolver@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/config-resolver@0.1.0-preview.2...@aws-sdk/config-resolver@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/core-handler/CHANGELOG.md
+++ b/packages/core-handler/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/core-handler@0.1.0-preview.2...@aws-sdk/core-handler@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/core-handler@0.1.0-preview.2...@aws-sdk/core-handler@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/credential-provider-cognito-identity/CHANGELOG.md
+++ b/packages/credential-provider-cognito-identity/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-cognito-identity@0.1.0-preview.3...@aws-sdk/credential-provider-cognito-identity@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-cognito-identity@0.1.0-preview.3...@aws-sdk/credential-provider-cognito-identity@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/credential-provider-env/CHANGELOG.md
+++ b/packages/credential-provider-env/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-env@0.1.0-preview.3...@aws-sdk/credential-provider-env@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-env@0.1.0-preview.3...@aws-sdk/credential-provider-env@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/credential-provider-imds/CHANGELOG.md
+++ b/packages/credential-provider-imds/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-imds@0.1.0-preview.2...@aws-sdk/credential-provider-imds@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-imds@0.1.0-preview.2...@aws-sdk/credential-provider-imds@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/credential-provider-ini/CHANGELOG.md
+++ b/packages/credential-provider-ini/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-ini@0.1.0-preview.2...@aws-sdk/credential-provider-ini@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-ini@0.1.0-preview.2...@aws-sdk/credential-provider-ini@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/credential-provider-node/CHANGELOG.md
+++ b/packages/credential-provider-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-node@0.1.0-preview.3...@aws-sdk/credential-provider-node@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/credential-provider-node@0.1.0-preview.3...@aws-sdk/credential-provider-node@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/credential-provider-process/CHANGELOG.md
+++ b/packages/credential-provider-process/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.1.0-preview.2 (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/ec2-error-unmarshaller/CHANGELOG.md
+++ b/packages/ec2-error-unmarshaller/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/ec2-error-unmarshaller@0.1.0-preview.3...@aws-sdk/ec2-error-unmarshaller@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/ec2-error-unmarshaller@0.1.0-preview.3...@aws-sdk/ec2-error-unmarshaller@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/eventstream-marshaller/CHANGELOG.md
+++ b/packages/eventstream-marshaller/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/eventstream-marshaller@0.1.0-preview.3...@aws-sdk/eventstream-marshaller@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/eventstream-marshaller@0.1.0-preview.3...@aws-sdk/eventstream-marshaller@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/fetch-http-handler/CHANGELOG.md
+++ b/packages/fetch-http-handler/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/fetch-http-handler@0.1.0-preview.2...@aws-sdk/fetch-http-handler@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/fetch-http-handler@0.1.0-preview.2...@aws-sdk/fetch-http-handler@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/hash-blob-browser/CHANGELOG.md
+++ b/packages/hash-blob-browser/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/hash-blob-browser@0.1.0-preview.3...@aws-sdk/hash-blob-browser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/hash-blob-browser@0.1.0-preview.3...@aws-sdk/hash-blob-browser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/hash-node/CHANGELOG.md
+++ b/packages/hash-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/hash-node@0.1.0-preview.2...@aws-sdk/hash-node@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/hash-node@0.1.0-preview.2...@aws-sdk/hash-node@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/hash-stream-node/CHANGELOG.md
+++ b/packages/hash-stream-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/hash-stream-node@0.1.0-preview.3...@aws-sdk/hash-stream-node@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/hash-stream-node@0.1.0-preview.3...@aws-sdk/hash-stream-node@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/http-headers/CHANGELOG.md
+++ b/packages/http-headers/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/http-headers@0.1.0-preview.2...@aws-sdk/http-headers@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/http-headers@0.1.0-preview.2...@aws-sdk/http-headers@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/http-serialization/CHANGELOG.md
+++ b/packages/http-serialization/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/http-serialization@0.1.0-preview.2...@aws-sdk/http-serialization@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/http-serialization@0.1.0-preview.2...@aws-sdk/http-serialization@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/is-array-buffer/CHANGELOG.md
+++ b/packages/is-array-buffer/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/is-array-buffer@0.1.0-preview.1...@aws-sdk/is-array-buffer@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/is-iterable/CHANGELOG.md
+++ b/packages/is-iterable/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/is-iterable@0.1.0-preview.1...@aws-sdk/is-iterable@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/is-node/CHANGELOG.md
+++ b/packages/is-node/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/is-node@0.1.0-preview.1...@aws-sdk/is-node@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/json-builder/CHANGELOG.md
+++ b/packages/json-builder/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/json-builder@0.1.0-preview.2...@aws-sdk/json-builder@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/json-builder@0.1.0-preview.2...@aws-sdk/json-builder@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/json-error-unmarshaller/CHANGELOG.md
+++ b/packages/json-error-unmarshaller/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/json-error-unmarshaller@0.1.0-preview.3...@aws-sdk/json-error-unmarshaller@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/json-error-unmarshaller@0.1.0-preview.3...@aws-sdk/json-error-unmarshaller@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/json-parser/CHANGELOG.md
+++ b/packages/json-parser/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/json-parser@0.1.0-preview.2...@aws-sdk/json-parser@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/json-parser@0.1.0-preview.2...@aws-sdk/json-parser@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/karma-credential-loader/CHANGELOG.md
+++ b/packages/karma-credential-loader/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/karma-credential-loader@0.1.0-preview.3...@aws-sdk/karma-credential-loader@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/karma-credential-loader@0.1.0-preview.3...@aws-sdk/karma-credential-loader@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/location-constraint-middleware/CHANGELOG.md
+++ b/packages/location-constraint-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/location-constraint-middleware@0.1.0-preview.2...@aws-sdk/location-constraint-middleware@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/location-constraint-middleware@0.1.0-preview.2...@aws-sdk/location-constraint-middleware@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/logger@0.1.0-preview.2...@aws-sdk/logger@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/logger@0.1.0-preview.2...@aws-sdk/logger@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/md5-js/CHANGELOG.md
+++ b/packages/md5-js/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/md5-js@0.1.0-preview.2...@aws-sdk/md5-js@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/md5-js@0.1.0-preview.2...@aws-sdk/md5-js@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/md5-universal/CHANGELOG.md
+++ b/packages/md5-universal/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/md5-universal@0.1.0-preview.2...@aws-sdk/md5-universal@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/md5-universal@0.1.0-preview.2...@aws-sdk/md5-universal@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-content-length/CHANGELOG.md
+++ b/packages/middleware-content-length/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-content-length@0.1.0-preview.2...@aws-sdk/middleware-content-length@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-content-length@0.1.0-preview.2...@aws-sdk/middleware-content-length@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-ec2-copysnapshot/CHANGELOG.md
+++ b/packages/middleware-ec2-copysnapshot/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.3...@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.3...@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/middleware-expect-continue/CHANGELOG.md
+++ b/packages/middleware-expect-continue/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-expect-continue@0.1.0-preview.2...@aws-sdk/middleware-expect-continue@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-expect-continue@0.1.0-preview.2...@aws-sdk/middleware-expect-continue@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-header-default/CHANGELOG.md
+++ b/packages/middleware-header-default/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-header-default@0.1.0-preview.2...@aws-sdk/middleware-header-default@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-header-default@0.1.0-preview.2...@aws-sdk/middleware-header-default@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-input-default/CHANGELOG.md
+++ b/packages/middleware-input-default/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-input-default@0.1.0-preview.2...@aws-sdk/middleware-input-default@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-input-default@0.1.0-preview.2...@aws-sdk/middleware-input-default@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-operation-logging/CHANGELOG.md
+++ b/packages/middleware-operation-logging/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-operation-logging@0.1.0-preview.2...@aws-sdk/middleware-operation-logging@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-operation-logging@0.1.0-preview.2...@aws-sdk/middleware-operation-logging@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-rds-presignedurl/CHANGELOG.md
+++ b/packages/middleware-rds-presignedurl/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-rds-presignedurl@0.1.0-preview.3...@aws-sdk/middleware-rds-presignedurl@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-rds-presignedurl@0.1.0-preview.3...@aws-sdk/middleware-rds-presignedurl@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/middleware-sdk-api-gateway/CHANGELOG.md
+++ b/packages/middleware-sdk-api-gateway/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-sdk-api-gateway@0.1.0-preview.2...@aws-sdk/middleware-sdk-api-gateway@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-sdk-api-gateway@0.1.0-preview.2...@aws-sdk/middleware-sdk-api-gateway@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-sdk-glacier/CHANGELOG.md
+++ b/packages/middleware-sdk-glacier/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-sdk-glacier@0.1.0-preview.3...@aws-sdk/middleware-sdk-glacier@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-sdk-glacier@0.1.0-preview.3...@aws-sdk/middleware-sdk-glacier@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/middleware-serializer/CHANGELOG.md
+++ b/packages/middleware-serializer/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-serializer@0.1.0-preview.2...@aws-sdk/middleware-serializer@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-serializer@0.1.0-preview.2...@aws-sdk/middleware-serializer@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/middleware-stack/CHANGELOG.md
+++ b/packages/middleware-stack/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-stack@0.1.0-preview.3...@aws-sdk/middleware-stack@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-stack@0.1.0-preview.3...@aws-sdk/middleware-stack@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/modeled-endpoint-middleware/CHANGELOG.md
+++ b/packages/modeled-endpoint-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/modeled-endpoint-middleware@0.1.0-preview.2...@aws-sdk/modeled-endpoint-middleware@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/modeled-endpoint-middleware@0.1.0-preview.2...@aws-sdk/modeled-endpoint-middleware@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/node-http-handler/CHANGELOG.md
+++ b/packages/node-http-handler/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/node-http-handler@0.1.0-preview.3...@aws-sdk/node-http-handler@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/node-http-handler@0.1.0-preview.3...@aws-sdk/node-http-handler@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/package-generator/CHANGELOG.md
+++ b/packages/package-generator/CHANGELOG.md
@@ -5,13 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.7](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/package-generator@0.1.0-preview.5...@aws-sdk/package-generator@0.1.0-preview.7) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/package-generator@0.1.0-preview.5...@aws-sdk/package-generator@0.1.0-preview.6) (2019-04-19)
 

--- a/packages/package-generator/src/ModuleGenerator.spec.ts
+++ b/packages/package-generator/src/ModuleGenerator.spec.ts
@@ -152,7 +152,7 @@ describe("ModuleGenerator", () => {
       for (const [filename, contents] of generator) {
         if (filename === "CHANGELOG.md") {
           generated = true;
-          expect(contents).toBe(`###changelog###\n`);
+          expect(contents).toBe(`###changelog###`);
         }
       }
       expect(generated).toBe(true);

--- a/packages/package-generator/src/ModuleGenerator.ts
+++ b/packages/package-generator/src/ModuleGenerator.ts
@@ -51,11 +51,7 @@ export class ModuleGenerator {
       })
     ];
     const changelog = this.changelog();
-    if (changelog)
-      yield [
-        "CHANGELOG.md",
-        prettier.format(changelog, { parser: "markdown" })
-      ];
+    if (changelog) yield ["CHANGELOG.md", changelog];
   }
 
   protected gitignore(): string {

--- a/packages/property-provider/CHANGELOG.md
+++ b/packages/property-provider/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/property-provider@0.1.0-preview.2...@aws-sdk/property-provider@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/property-provider@0.1.0-preview.2...@aws-sdk/property-provider@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/protocol-json-rpc/CHANGELOG.md
+++ b/packages/protocol-json-rpc/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-json-rpc@0.1.0-preview.3...@aws-sdk/protocol-json-rpc@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-json-rpc@0.1.0-preview.3...@aws-sdk/protocol-json-rpc@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/protocol-query/CHANGELOG.md
+++ b/packages/protocol-query/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-query@0.1.0-preview.3...@aws-sdk/protocol-query@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-query@0.1.0-preview.3...@aws-sdk/protocol-query@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/protocol-rest/CHANGELOG.md
+++ b/packages/protocol-rest/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-rest@0.1.0-preview.4...@aws-sdk/protocol-rest@0.1.0-preview.6) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-rest@0.1.0-preview.4...@aws-sdk/protocol-rest@0.1.0-preview.5) (2019-04-19)
 

--- a/packages/protocol-timestamp/CHANGELOG.md
+++ b/packages/protocol-timestamp/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-timestamp@0.1.0-preview.2...@aws-sdk/protocol-timestamp@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/protocol-timestamp@0.1.0-preview.2...@aws-sdk/protocol-timestamp@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/query-builder/CHANGELOG.md
+++ b/packages/query-builder/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/query-builder@0.1.0-preview.2...@aws-sdk/query-builder@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/query-builder@0.1.0-preview.2...@aws-sdk/query-builder@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/query-error-unmarshaller/CHANGELOG.md
+++ b/packages/query-error-unmarshaller/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/query-error-unmarshaller@0.1.0-preview.3...@aws-sdk/query-error-unmarshaller@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/query-error-unmarshaller@0.1.0-preview.3...@aws-sdk/query-error-unmarshaller@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/query-request-presigner/CHANGELOG.md
+++ b/packages/query-request-presigner/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/query-request-presigner@0.1.0-preview.3...@aws-sdk/query-request-presigner@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/query-request-presigner@0.1.0-preview.3...@aws-sdk/query-request-presigner@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/querystring-builder/CHANGELOG.md
+++ b/packages/querystring-builder/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/querystring-builder@0.1.0-preview.2...@aws-sdk/querystring-builder@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/querystring-builder@0.1.0-preview.2...@aws-sdk/querystring-builder@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/querystring-parser/CHANGELOG.md
+++ b/packages/querystring-parser/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/querystring-parser@0.1.0-preview.2...@aws-sdk/querystring-parser@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/querystring-parser@0.1.0-preview.2...@aws-sdk/querystring-parser@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/region-provider/CHANGELOG.md
+++ b/packages/region-provider/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/region-provider@0.1.0-preview.2...@aws-sdk/region-provider@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/region-provider@0.1.0-preview.2...@aws-sdk/region-provider@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/remove-sensitive-logs/CHANGELOG.md
+++ b/packages/remove-sensitive-logs/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/remove-sensitive-logs@0.1.0-preview.2...@aws-sdk/remove-sensitive-logs@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/remove-sensitive-logs@0.1.0-preview.2...@aws-sdk/remove-sensitive-logs@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/response-metadata-extractor/CHANGELOG.md
+++ b/packages/response-metadata-extractor/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/response-metadata-extractor@0.1.0-preview.3...@aws-sdk/response-metadata-extractor@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/response-metadata-extractor@0.1.0-preview.3...@aws-sdk/response-metadata-extractor@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/retry-middleware/CHANGELOG.md
+++ b/packages/retry-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/retry-middleware@0.1.0-preview.2...@aws-sdk/retry-middleware@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/retry-middleware@0.1.0-preview.2...@aws-sdk/retry-middleware@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/route53-id-normalizer-middleware/CHANGELOG.md
+++ b/packages/route53-id-normalizer-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/route53-id-normalizer-middleware@0.1.0-preview.2...@aws-sdk/route53-id-normalizer-middleware@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/route53-id-normalizer-middleware@0.1.0-preview.2...@aws-sdk/route53-id-normalizer-middleware@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/s3-error-unmarshaller/CHANGELOG.md
+++ b/packages/s3-error-unmarshaller/CHANGELOG.md
@@ -5,6 +5,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.1.0-preview.2 (2019-07-12)
 
+
 ### Features
 
-- **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))
+* **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))

--- a/packages/s3-request-presigner/CHANGELOG.md
+++ b/packages/s3-request-presigner/CHANGELOG.md
@@ -5,6 +5,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.1.0-preview.2 (2019-07-12)
 
+
 ### Features
 
-- **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))
+* **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))

--- a/packages/service-error-classification/CHANGELOG.md
+++ b/packages/service-error-classification/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/service-error-classification@0.1.0-preview.1...@aws-sdk/service-error-classification@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/service-model/CHANGELOG.md
+++ b/packages/service-model/CHANGELOG.md
@@ -5,13 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/service-model@0.1.0-preview.4...@aws-sdk/service-model@0.1.0-preview.6) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/service-model@0.1.0-preview.4...@aws-sdk/service-model@0.1.0-preview.5) (2019-04-19)
 

--- a/packages/service-types-generator/CHANGELOG.md
+++ b/packages/service-types-generator/CHANGELOG.md
@@ -5,22 +5,30 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.7](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/service-types-generator@0.1.0-preview.5...@aws-sdk/service-types-generator@0.1.0-preview.7) (2019-07-12)
 
+
 ### Features
 
-- **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
-- **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))
-- **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))
-- **util-create-request:** create request package ([#257](https://github.com/aws/aws-sdk-js-v3/issues/257)) ([9855d49](https://github.com/aws/aws-sdk-js-v3/commit/9855d49))
+* **s3:** commit s3 clients ([#220](https://github.com/aws/aws-sdk-js-v3/issues/220)) ([c4d1a61](https://github.com/aws/aws-sdk-js-v3/commit/c4d1a61))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* mark code generator packages as private ([#238](https://github.com/aws/aws-sdk-js-v3/issues/238)) ([2d729b6](https://github.com/aws/aws-sdk-js-v3/commit/2d729b6))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3-error-unmarshaller:** add s3 customization to parse exceptions properly ([cee0f13](https://github.com/aws/aws-sdk-js-v3/commit/cee0f13))
+* **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))
+* **util-create-request:** create request package ([#257](https://github.com/aws/aws-sdk-js-v3/issues/257)) ([9855d49](https://github.com/aws/aws-sdk-js-v3/commit/9855d49))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/service-types-generator@0.1.0-preview.5...@aws-sdk/service-types-generator@0.1.0-preview.6) (2019-04-19)
 

--- a/packages/sha256-tree-hash/CHANGELOG.md
+++ b/packages/sha256-tree-hash/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/sha256-tree-hash@0.1.0-preview.3...@aws-sdk/sha256-tree-hash@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/sha256-tree-hash@0.1.0-preview.3...@aws-sdk/sha256-tree-hash@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/shared-ini-file-loader/CHANGELOG.md
+++ b/packages/shared-ini-file-loader/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/shared-ini-file-loader@0.1.0-preview.1...@aws-sdk/shared-ini-file-loader@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/signature-v4-browser/CHANGELOG.md
+++ b/packages/signature-v4-browser/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4-browser@0.1.0-preview.3...@aws-sdk/signature-v4-browser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4-browser@0.1.0-preview.3...@aws-sdk/signature-v4-browser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/signature-v4-node/CHANGELOG.md
+++ b/packages/signature-v4-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4-node@0.1.0-preview.3...@aws-sdk/signature-v4-node@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4-node@0.1.0-preview.3...@aws-sdk/signature-v4-node@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/signature-v4-universal/CHANGELOG.md
+++ b/packages/signature-v4-universal/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4-universal@0.1.0-preview.3...@aws-sdk/signature-v4-universal@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4-universal@0.1.0-preview.3...@aws-sdk/signature-v4-universal@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/signature-v4/CHANGELOG.md
+++ b/packages/signature-v4/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4@0.1.0-preview.3...@aws-sdk/signature-v4@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signature-v4@0.1.0-preview.3...@aws-sdk/signature-v4@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/signing-middleware/CHANGELOG.md
+++ b/packages/signing-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signing-middleware@0.1.0-preview.3...@aws-sdk/signing-middleware@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/signing-middleware@0.1.0-preview.3...@aws-sdk/signing-middleware@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/ssec-middleware/CHANGELOG.md
+++ b/packages/ssec-middleware/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/ssec-middleware@0.1.0-preview.2...@aws-sdk/ssec-middleware@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/ssec-middleware@0.1.0-preview.2...@aws-sdk/ssec-middleware@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/stream-collector-browser/CHANGELOG.md
+++ b/packages/stream-collector-browser/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/stream-collector-browser@0.1.0-preview.2...@aws-sdk/stream-collector-browser@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/stream-collector-browser@0.1.0-preview.2...@aws-sdk/stream-collector-browser@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/stream-collector-node/CHANGELOG.md
+++ b/packages/stream-collector-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/stream-collector-node@0.1.0-preview.2...@aws-sdk/stream-collector-node@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/stream-collector-node@0.1.0-preview.2...@aws-sdk/stream-collector-node@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/test-protocol-rest-json/CHANGELOG.md
+++ b/packages/test-protocol-rest-json/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.1.0-preview.5 (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # 0.1.0-preview.4 (2019-04-19)
 

--- a/packages/test-protocol-rest-xml/CHANGELOG.md
+++ b/packages/test-protocol-rest-xml/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/test-protocol-rest-xml@0.1.0-preview.4...@aws-sdk/test-protocol-rest-xml@0.1.0-preview.6) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/test-protocol-rest-xml@0.1.0-preview.4...@aws-sdk/test-protocol-rest-xml@0.1.0-preview.5) (2019-04-19)
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,19 +5,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/types@0.1.0-preview.2...@aws-sdk/types@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
-- **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))
-- **util-create-request:** create request package ([#257](https://github.com/aws/aws-sdk-js-v3/issues/257)) ([9855d49](https://github.com/aws/aws-sdk-js-v3/commit/9855d49))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* make operation model accessible from commands ([#242](https://github.com/aws/aws-sdk-js-v3/issues/242)) ([8bf91e2](https://github.com/aws/aws-sdk-js-v3/commit/8bf91e2))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))
+* **util-create-request:** create request package ([#257](https://github.com/aws/aws-sdk-js-v3/issues/257)) ([9855d49](https://github.com/aws/aws-sdk-js-v3/commit/9855d49))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/types@0.1.0-preview.2...@aws-sdk/types@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/url-parser-browser/CHANGELOG.md
+++ b/packages/url-parser-browser/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/url-parser-browser@0.1.0-preview.2...@aws-sdk/url-parser-browser@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/url-parser-browser@0.1.0-preview.2...@aws-sdk/url-parser-browser@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/url-parser-node/CHANGELOG.md
+++ b/packages/url-parser-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/url-parser-node@0.1.0-preview.2...@aws-sdk/url-parser-node@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/url-parser-node@0.1.0-preview.2...@aws-sdk/url-parser-node@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/url-parser-universal/CHANGELOG.md
+++ b/packages/url-parser-universal/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/url-parser-universal@0.1.0-preview.2...@aws-sdk/url-parser-universal@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/url-parser-universal@0.1.0-preview.2...@aws-sdk/url-parser-universal@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/util-base64-browser/CHANGELOG.md
+++ b/packages/util-base64-browser/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-base64-browser@0.1.0-preview.1...@aws-sdk/util-base64-browser@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-base64-node/CHANGELOG.md
+++ b/packages/util-base64-node/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-base64-node@0.1.0-preview.1...@aws-sdk/util-base64-node@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-base64-universal/CHANGELOG.md
+++ b/packages/util-base64-universal/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-base64-universal@0.1.0-preview.1...@aws-sdk/util-base64-universal@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-body-length-browser/CHANGELOG.md
+++ b/packages/util-body-length-browser/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-body-length-browser@0.1.0-preview.1...@aws-sdk/util-body-length-browser@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-body-length-node/CHANGELOG.md
+++ b/packages/util-body-length-node/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-body-length-node@0.1.0-preview.2...@aws-sdk/util-body-length-node@0.1.0-preview.3) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-buffer-from/CHANGELOG.md
+++ b/packages/util-buffer-from/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-buffer-from@0.1.0-preview.1...@aws-sdk/util-buffer-from@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-create-request/CHANGELOG.md
+++ b/packages/util-create-request/CHANGELOG.md
@@ -5,10 +5,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.1.0-preview.2 (2019-07-12)
 
+
 ### Bug Fixes
 
-- add npm badge for @aws-sdk/util-create-request ([#259](https://github.com/aws/aws-sdk-js-v3/issues/259)) ([067f75b](https://github.com/aws/aws-sdk-js-v3/commit/067f75b))
+* add npm badge for @aws-sdk/util-create-request ([#259](https://github.com/aws/aws-sdk-js-v3/issues/259)) ([067f75b](https://github.com/aws/aws-sdk-js-v3/commit/067f75b))
+
 
 ### Features
 
-- **util-create-request:** create request package ([#257](https://github.com/aws/aws-sdk-js-v3/issues/257)) ([9855d49](https://github.com/aws/aws-sdk-js-v3/commit/9855d49))
+* **util-create-request:** create request package ([#257](https://github.com/aws/aws-sdk-js-v3/issues/257)) ([9855d49](https://github.com/aws/aws-sdk-js-v3/commit/9855d49))

--- a/packages/util-error-constructor/CHANGELOG.md
+++ b/packages/util-error-constructor/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-error-constructor@0.1.0-preview.2...@aws-sdk/util-error-constructor@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-error-constructor@0.1.0-preview.2...@aws-sdk/util-error-constructor@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/util-format-url/CHANGELOG.md
+++ b/packages/util-format-url/CHANGELOG.md
@@ -5,13 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-format-url@0.1.0-preview.2...@aws-sdk/util-format-url@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
-- **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* **s3-request-presigner:** provide a s3 request presigner ([#266](https://github.com/aws/aws-sdk-js-v3/issues/266)) ([3f00b99](https://github.com/aws/aws-sdk-js-v3/commit/3f00b99))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-format-url@0.1.0-preview.2...@aws-sdk/util-format-url@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/util-hex-encoding/CHANGELOG.md
+++ b/packages/util-hex-encoding/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-hex-encoding@0.1.0-preview.1...@aws-sdk/util-hex-encoding@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-locate-window/CHANGELOG.md
+++ b/packages/util-locate-window/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-locate-window@0.1.0-preview.1...@aws-sdk/util-locate-window@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-uri-escape/CHANGELOG.md
+++ b/packages/util-uri-escape/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-uri-escape@0.1.0-preview.1...@aws-sdk/util-uri-escape@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-user-agent-browser/CHANGELOG.md
+++ b/packages/util-user-agent-browser/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-user-agent-browser@0.1.0-preview.3...@aws-sdk/util-user-agent-browser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-user-agent-browser@0.1.0-preview.3...@aws-sdk/util-user-agent-browser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/util-user-agent-node/CHANGELOG.md
+++ b/packages/util-user-agent-node/CHANGELOG.md
@@ -5,12 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-user-agent-node@0.1.0-preview.3...@aws-sdk/util-user-agent-node@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-user-agent-node@0.1.0-preview.3...@aws-sdk/util-user-agent-node@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/util-utf8-browser/CHANGELOG.md
+++ b/packages/util-utf8-browser/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-utf8-browser@0.1.0-preview.1...@aws-sdk/util-utf8-browser@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-utf8-node/CHANGELOG.md
+++ b/packages/util-utf8-node/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-utf8-node@0.1.0-preview.1...@aws-sdk/util-utf8-node@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/util-utf8-universal/CHANGELOG.md
+++ b/packages/util-utf8-universal/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/util-utf8-universal@0.1.0-preview.1...@aws-sdk/util-utf8-universal@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))

--- a/packages/xml-body-builder/CHANGELOG.md
+++ b/packages/xml-body-builder/CHANGELOG.md
@@ -5,16 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/xml-body-builder@0.1.0-preview.2...@aws-sdk/xml-body-builder@0.1.0-preview.4) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/xml-body-builder@0.1.0-preview.2...@aws-sdk/xml-body-builder@0.1.0-preview.3) (2019-04-19)
 

--- a/packages/xml-body-parser/CHANGELOG.md
+++ b/packages/xml-body-parser/CHANGELOG.md
@@ -5,20 +5,29 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/xml-body-parser@0.1.0-preview.3...@aws-sdk/xml-body-parser@0.1.0-preview.5) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
 
 # 0.1.0 (2019-04-19)
 
+
 ### Bug Fixes
 
-- **xml-body-parser:** handle parsing flattened list ([#217](https://github.com/aws/aws-sdk-js-v3/issues/217)) ([a3d2c0a](https://github.com/aws/aws-sdk-js-v3/commit/a3d2c0a))
+* **xml-body-parser:** handle parsing flattened list ([#217](https://github.com/aws/aws-sdk-js-v3/issues/217)) ([a3d2c0a](https://github.com/aws/aws-sdk-js-v3/commit/a3d2c0a))
+
 
 ### Features
 
-- timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+* timestamp serializing and de-serializing ([#216](https://github.com/aws/aws-sdk-js-v3/issues/216)) ([0556c99](https://github.com/aws/aws-sdk-js-v3/commit/0556c99))
+
+
+
+
 
 # [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/xml-body-parser@0.1.0-preview.3...@aws-sdk/xml-body-parser@0.1.0-preview.4) (2019-04-19)
 

--- a/packages/xml-builder/CHANGELOG.md
+++ b/packages/xml-builder/CHANGELOG.md
@@ -5,7 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.1.0-preview.2](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/xml-builder@0.1.0-preview.1...@aws-sdk/xml-builder@0.1.0-preview.2) (2019-07-12)
 
+
 ### Features
 
-- add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
-- update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))


### PR DESCRIPTION
Currently the code generator creates `CHANGELOG.md` that doesn't comply with the prettier(e.g. use `*` instead of `-` for item mark). Since the changelogs under each package are [created by Lerna](https://github.com/lerna/lerna/tree/master/commands/version#--conventional-commits), we don't have control over its formatting. So it makes less sense to enforce Prettier formatting when updating changelogs maunally whereas auto-generated changelogs don't comply the Prettier. 

Since the changelog will be mainly created by Lerna so we should prefer Lerna's formatting. Ignore changelog in Prettier to allow creating changelog manually with same formatting as Lerna(e.g. use `*` instead of `-` for item mark)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
