### PR TITLE
feat: throw error when bucket name contains "/"

### DIFF
--- a/packages/client-s3-browser/S3Client.ts
+++ b/packages/client-s3-browser/S3Client.ts
@@ -6,6 +6,7 @@ import * as __aws_sdk_hash_blob_browser from "@aws-sdk/hash-blob-browser";
 import * as __aws_sdk_md5_js from "@aws-sdk/md5-js";
 import * as __aws_sdk_middleware_content_length from "@aws-sdk/middleware-content-length";
 import * as __aws_sdk_middleware_header_default from "@aws-sdk/middleware-header-default";
+import * as __aws_sdk_middleware_sdk_s3 from "@aws-sdk/middleware-sdk-s3";
 import * as __aws_sdk_middleware_serializer from "@aws-sdk/middleware-serializer";
 import * as __aws_sdk_middleware_stack from "@aws-sdk/middleware-stack";
 import * as __aws_sdk_protocol_rest from "@aws-sdk/protocol-rest";
@@ -108,6 +109,11 @@ export class S3Client
         tags: { SET_USER_AGENT: true }
       }
     );
+    this.middlewareStack.add(__aws_sdk_middleware_sdk_s3.validateBucketName, {
+      step: "initialize",
+      priority: 0,
+      tags: { VALIDATE_BUCKET_NAME: true }
+    });
   }
 
   destroy(): void {

--- a/packages/client-s3-browser/model/ServiceMetadata.ts
+++ b/packages/client-s3-browser/model/ServiceMetadata.ts
@@ -10,4 +10,4 @@ export const ServiceMetadata: _ServiceMetadata_ = {
   signatureVersion: "s3",
   uid: "s3-2006-03-01"
 };
-export const clientVersion: string = "0.1.0-preview.1";
+export const clientVersion: string = "0.1.0-preview.2";

--- a/packages/client-s3-browser/package.json
+++ b/packages/client-s3-browser/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/md5-js": "^0.1.0-preview.4",
     "@aws-sdk/middleware-content-length": "^0.1.0-preview.4",
     "@aws-sdk/middleware-header-default": "^0.1.0-preview.4",
+    "@aws-sdk/middleware-sdk-s3": "^0.1.0-preview.1",
     "@aws-sdk/middleware-serializer": "^0.1.0-preview.4",
     "@aws-sdk/middleware-stack": "^0.1.0-preview.5",
     "@aws-sdk/protocol-rest": "^0.1.0-preview.6",

--- a/packages/client-s3-node/S3Client.ts
+++ b/packages/client-s3-node/S3Client.ts
@@ -6,6 +6,7 @@ import * as __aws_sdk_hash_stream_node from "@aws-sdk/hash-stream-node";
 import * as __aws_sdk_middleware_content_length from "@aws-sdk/middleware-content-length";
 import * as __aws_sdk_middleware_expect_continue from "@aws-sdk/middleware-expect-continue";
 import * as __aws_sdk_middleware_header_default from "@aws-sdk/middleware-header-default";
+import * as __aws_sdk_middleware_sdk_s3 from "@aws-sdk/middleware-sdk-s3";
 import * as __aws_sdk_middleware_serializer from "@aws-sdk/middleware-serializer";
 import * as __aws_sdk_middleware_stack from "@aws-sdk/middleware-stack";
 import * as __aws_sdk_node_http_handler from "@aws-sdk/node-http-handler";
@@ -115,6 +116,11 @@ export class S3Client
         tags: { SET_USER_AGENT: true }
       }
     );
+    this.middlewareStack.add(__aws_sdk_middleware_sdk_s3.validateBucketName, {
+      step: "initialize",
+      priority: 0,
+      tags: { VALIDATE_BUCKET_NAME: true }
+    });
     this.middlewareStack.add(
       __aws_sdk_middleware_expect_continue.addExpectContinue,
       {

--- a/packages/client-s3-node/package.json
+++ b/packages/client-s3-node/package.json
@@ -58,12 +58,12 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-documentation-generator": "^0.1.0-preview.1",
+    "@aws-sdk/client-documentation-generator": "^0.1.0-preview.2",
     "@types/jest": "^24.0.12",
-    "@types/node": "^8.10.29",
+    "@types/node": "^10.0.0",
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
-    "typedoc": "^0.10.0",
+    "typedoc": "^0.14.2",
     "typescript": "~3.4.0"
   }
 }

--- a/packages/client-s3-node/package.json
+++ b/packages/client-s3-node/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/middleware-content-length": "^0.1.0-preview.4",
     "@aws-sdk/middleware-expect-continue": "^0.1.0-preview.4",
     "@aws-sdk/middleware-header-default": "^0.1.0-preview.4",
+    "@aws-sdk/middleware-sdk-s3": "^0.1.0-preview.1",
     "@aws-sdk/middleware-serializer": "^0.1.0-preview.4",
     "@aws-sdk/middleware-stack": "^0.1.0-preview.5",
     "@aws-sdk/node-http-handler": "^0.1.0-preview.5",
@@ -57,12 +58,12 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-documentation-generator": "^0.1.0-preview.2",
+    "@aws-sdk/client-documentation-generator": "^0.1.0-preview.1",
     "@types/jest": "^24.0.12",
-    "@types/node": "^10.0.0",
+    "@types/node": "^8.10.29",
     "jest": "^24.7.1",
     "rimraf": "^2.6.2",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.10.0",
     "typescript": "~3.4.0"
   }
 }

--- a/packages/middleware-sdk-s3/.gitignore
+++ b/packages/middleware-sdk-s3/.gitignore
@@ -1,0 +1,7 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tgz
+*.log
+package-lock.json

--- a/packages/middleware-sdk-s3/.npmignore
+++ b/packages/middleware-sdk-s3/.npmignore
@@ -1,0 +1,12 @@
+/src/
+/coverage/
+/docs/
+tsconfig.test.json
+
+*.spec.js
+*.spec.d.ts
+*.spec.js.map
+
+*.fixture.js
+*.fixture.d.ts
+*.fixture.js.map

--- a/packages/middleware-sdk-s3/LICENSE
+++ b/packages/middleware-sdk-s3/LICENSE
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-sdk-s3/README.md
+++ b/packages/middleware-sdk-s3/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/@aws-sdk/middleware-sdk-s3
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/middleware-sdk-s3/preview.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-s3)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/middleware-sdk-s3.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-s3)

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@aws-sdk/middleware-sdk-s3",
+  "version": "0.1.0-preview.1",
+  "scripts": {
+    "prepublishOnly": "tsc",
+    "pretest": "tsc -p tsconfig.test.json",
+    "test": "jest"
+  },
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "email": "",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "tslib": "^1.8.0"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "^0.1.0-preview.4",
+    "@types/jest": "^24.0.12",
+    "jest": "^24.7.1",
+    "typescript": "~3.4.0"
+  }
+}

--- a/packages/middleware-sdk-s3/src/index.ts
+++ b/packages/middleware-sdk-s3/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./validate-bucket-name";

--- a/packages/middleware-sdk-s3/src/validate-bucket-name.spec.ts
+++ b/packages/middleware-sdk-s3/src/validate-bucket-name.spec.ts
@@ -1,0 +1,32 @@
+import { validateBucketName } from "./validate-bucket-name";
+import { SerializeHandler } from "@aws-sdk/types";
+
+describe("validateBucketName", () => {
+  const mockNextHandler = jest.fn();
+  const composedHandler: SerializeHandler<any, any> = validateBucketName(
+    mockNextHandler
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws error if Bucket parameter contains '/'", async () => {
+    const bucket = "bucket/part/of/key";
+    let error;
+    try {
+      await composedHandler({
+        input: {
+          Bucket: bucket
+        }
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.message).toEqual(
+      `Bucket name shouldn't contain '/', received '${bucket}'`
+    );
+    expect(error.name).toEqual("InvalidBucketName");
+  });
+});

--- a/packages/middleware-sdk-s3/src/validate-bucket-name.spec.ts
+++ b/packages/middleware-sdk-s3/src/validate-bucket-name.spec.ts
@@ -29,4 +29,15 @@ describe("validateBucketName", () => {
     );
     expect(error.name).toEqual("InvalidBucketName");
   });
+
+  it("doesn't throw error if Bucket parameter has no '/'", async () => {
+    const args = {
+      input: {
+        Bucket: "bucket"
+      }
+    };
+    await composedHandler(args);
+    expect(mockNextHandler.mock.calls.length).toBe(1);
+    expect(mockNextHandler.mock.calls[0][0]).toEqual(args);
+  });
 });

--- a/packages/middleware-sdk-s3/src/validate-bucket-name.ts
+++ b/packages/middleware-sdk-s3/src/validate-bucket-name.ts
@@ -1,0 +1,15 @@
+import { Handler, SerializeHandlerArguments } from "@aws-sdk/types";
+
+export const validateBucketName = (
+  next: Handler<any, any>
+): Handler<any, any> => async (args: SerializeHandlerArguments<any, any>) => {
+  const { input } = args;
+  if (typeof input.Bucket === "string" && input.Bucket.indexOf("/") >= 0) {
+    const err = new Error(
+      `Bucket name shouldn't contain '/', received '${input.Bucket}'`
+    );
+    err.name = "InvalidBucketName";
+    throw err;
+  }
+  return next({ ...args });
+};

--- a/packages/middleware-sdk-s3/tsconfig.json
+++ b/packages/middleware-sdk-s3/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "declaration": true,
+    "strict": true,
+    "sourceMap": true,
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "noEmitHelpers": true,
+    "lib": [
+      "es5",
+      "es2015.promise",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.symbol.wellknown"
+    ],
+    "rootDir": "./src",
+    "outDir": "./build"
+  }
+}

--- a/packages/middleware-sdk-s3/tsconfig.test.json
+++ b/packages/middleware-sdk-s3/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "rootDir": "./src",
+    "outDir": "./build"
+  }
+}

--- a/packages/service-types-generator/src/ServiceCustomizations/s3/index.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/s3/index.ts
@@ -5,6 +5,7 @@ import { locationConstraintCustomization } from "./locationConstraint";
 import { defaultContentTypeCustomization } from "./contentType";
 import { ssecCustomizations } from "./ssec";
 import { parserCustomization } from "./parser";
+import { validateBucketNameMiddleware } from "./validateBucketName";
 import {
   CustomizationProvider,
   RuntimeTarget,
@@ -22,6 +23,7 @@ export const s3Customizations: CustomizationProvider = (
   };
 
   for (const { client, commands } of [
+    validateBucketNameMiddleware,
     bucketEndpointCustomizations(model, runtime),
     bodySigningCustomizations(model, runtime),
     locationConstraintCustomization,

--- a/packages/service-types-generator/src/ServiceCustomizations/s3/validateBucketName.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/s3/validateBucketName.ts
@@ -1,0 +1,19 @@
+import { ServiceCustomizationDefinition } from "@aws-sdk/build-types";
+import { packageNameToVariable } from "../../packageNameToVariable";
+import { IMPORTS } from "../../internalImports";
+
+export const validateBucketNameMiddleware: ServiceCustomizationDefinition = {
+  commands: {},
+  client: [
+    {
+      imports: [IMPORTS["middleware-sdk-s3"]],
+      step: "initialize",
+      priority: 0,
+      type: "Middleware",
+      tags: "{VALIDATE_BUCKET_NAME: true}",
+      expression: `${packageNameToVariable(
+        "@aws-sdk/middleware-sdk-s3"
+      )}.validateBucketName`
+    }
+  ]
+};

--- a/packages/service-types-generator/src/internalImports.ts
+++ b/packages/service-types-generator/src/internalImports.ts
@@ -244,6 +244,10 @@ export const IMPORTS: { [key: string]: Import } = {
     package: "@aws-sdk/middleware-sdk-glacier",
     version: "^0.1.0-preview.5"
   },
+  "middleware-sdk-s3": {
+    package: "@aws-sdk/middleware-sdk-s3",
+    version: "^0.1.0-preview.1"
+  },
   "middleware-serializer": {
     package: "@aws-sdk/middleware-serializer",
     version: "^0.1.0-preview.4"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js/issues/1046
https://github.com/aws/aws-sdk-js/issues/1035
https://github.com/aws/aws-sdk-js/issues/1572

*Description of changes:*
S3 client will throw error if the `Bucket` parameter contains `/` that would interfere the signature V4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
