### PR TITLE
fix(client-documentation-generator): make package public

### DIFF
--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@aws-sdk/client-documentation-generator",
   "version": "0.1.0-preview.2",
-  "private": true,
   "scripts": {
     "prepublishOnly": "tsc",
     "pretest": "tsc",


### PR DESCRIPTION
This package is marked as private in #238. But it is a dev dependency of all service clients. It's now preventing users from building docs locally. This PR publish the package again.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
