### PR TITLE
fix(service-types-generator): correct readme import examples

### DIFF
--- a/packages/service-types-generator/src/clientReadme.ts
+++ b/packages/service-types-generator/src/clientReadme.ts
@@ -57,7 +57,7 @@ The AWS SDK is modulized by clients and commands in CommonJS modules. To send a 
   }Command\`:
 
 \`\`\`javascript
-//javascript
+//JavaScript
 const { ${serviceId}Client } = require('${packageName}/${serviceId}Client');
 const { ${exampleCommand.name}Command } = require('${packageName}/commands/${
     exampleCommand.name
@@ -65,9 +65,9 @@ const { ${exampleCommand.name}Command } = require('${packageName}/commands/${
 \`\`\`
 
 \`\`\`javascript
-//typescript
-const { ${serviceId}Client } = import '${packageName}/${serviceId}Client';
-const { ${exampleCommand.name}Command } = import '${packageName}/commands/${
+//TypeScript
+import { ${serviceId}Client } from '${packageName}/${serviceId}Client';
+import { ${exampleCommand.name}Command } from '${packageName}/commands/${
     exampleCommand.name
   }Command';
 \`\`\`


### PR DESCRIPTION
Corrects TypeScript import example in client readme

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
