### PR TITLE
chore: remove packages folder from lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,11 +1,5 @@
 {
   "lerna": "3.13.4",
-  "packages": [
-    "packages/*",
-    "clients/browser/*",
-    "clients/node/*",
-    "clients/universal/*"
-  ],
   "version": "independent",
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/packages/service-types-generator/scripts/buildInternalImportMap.js
+++ b/packages/service-types-generator/scripts/buildInternalImportMap.js
@@ -12,7 +12,7 @@ export const IMPORTS: {[key: string]: Import} = {`;
 
 const packageRoot = dirname(__dirname);
 const projectRoot = dirname(dirname(packageRoot));
-const { packages: packagesFolders } = JSON.parse(
+const { workspaces: packagesFolders } = JSON.parse(
   readFileSync(join(projectRoot, "lerna.json"))
 );
 const packages = [];

--- a/packages/service-types-generator/scripts/buildInternalImportMap.js
+++ b/packages/service-types-generator/scripts/buildInternalImportMap.js
@@ -13,7 +13,7 @@ export const IMPORTS: {[key: string]: Import} = {`;
 const packageRoot = dirname(__dirname);
 const projectRoot = dirname(dirname(packageRoot));
 const { workspaces: packagesFolders } = JSON.parse(
-  readFileSync(join(projectRoot, "lerna.json"))
+  readFileSync(join(projectRoot, "package.json"))
 );
 const packages = [];
 for (const folderPattern of packagesFolders) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When using yarn workspaces, packages in lerna.json are overridden by the value from package.json/workspaces ([doc](http://bit.ly/2MvPL7d))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
