### PR TITLE
test: only include packages updates since master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ before_install:
 install:
   - yarn
 script:
-  - yarn test-ci
+  - yarn test
 after_success:
   - ./node_modules/.bin/codecov -f coverage/*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ before_install:
 install:
   - yarn
 script:
-  - yarn test
+  - yarn test-ci
 after_success:
   - ./node_modules/.bin/codecov -f coverage/*.json

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clear-build-info": "rimraf ./packages/*/*.tsbuildinfo ./clients/*/*/*.tsbuildinfo",
     "copy-models": "node ./scripts/copyModels.js",
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
-    "pretest": "lerna run pretest --since --include-filtered-dependents --include-filtered-dependencies",
+    "pretest": "lerna run pretest --since master --include-filtered-dependents --include-filtered-dependencies",
     "test": "jest --coverage",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "clear-build-info": "rimraf ./packages/*/*.tsbuildinfo ./clients/*/*/*.tsbuildinfo",
     "copy-models": "node ./scripts/copyModels.js",
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
-    "pretest": "lerna run pretest --since master --include-filtered-dependents --include-filtered-dependencies",
-    "test": "jest --coverage",
-    "test-ci": "yarn pretest && yarn test -- --passWithNoTests",
+    "pretest": "lerna run pretest --since master --include-filtered-dependencies",
+    "test": "jest --coverage --passWithNoTests",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clear-build-info": "rimraf ./packages/*/*.tsbuildinfo ./clients/*/*/*.tsbuildinfo",
     "copy-models": "node ./scripts/copyModels.js",
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
-    "pretest": "lerna run pretest --since master --include-filtered-dependencies",
+    "pretest": "lerna run pretest --since master --include-filtered-dependents --include-filtered-dependencies",
     "test": "jest --coverage --passWithNoTests",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
     "pretest": "lerna run pretest --since master --include-filtered-dependents --include-filtered-dependencies",
     "test": "jest --coverage",
+    "test-ci": "yarn pretest && yarn test -- --passWithNoTests",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"
   },


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/335

*Description of changes:*
While running tests, only include packages that have been updated since master
Doc: https://github.com/lerna/lerna/tree/master/core/filter-options#--since-ref
If there are no changes, it takes less than 1 min to run `yarn test` ([yarn-test.log](https://github.com/aws/aws-sdk-js-v3/files/3531549/yarn-test.log))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
