### PR TITLE
chore: remove installation of yarn from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js:
   - "10.9.0"
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.17.3
-  - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - yarn
 script:


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/340

*Description of changes:*
As per build log yarn is already present before before_install is run
Example log: https://travis-ci.org/aws/aws-sdk-js-v3/builds/575606372#L203-L243

Also, Travis CI supports yarn
Announcement: https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
