### PR TITLE
fix: lerna pretest --since HEAD

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clear-build-info": "rimraf ./packages/*/*.tsbuildinfo ./clients/*/*/*.tsbuildinfo",
     "copy-models": "node ./scripts/copyModels.js",
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
-    "pretest": "lerna run pretest --since master --include-filtered-dependents --include-filtered-dependencies",
+    "pretest": "lerna run pretest --since HEAD --include-filtered-dependents --include-filtered-dependencies",
     "test": "jest --coverage --passWithNoTests",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/342

*Description of changes:*
travis-ci/push fails with `fatal: bad revision 'master'`, so switching to HEAD instead.
Testing done as follows:
* Confirmed that travis-ci/push will succeed by following the steps from https://travis-ci.org/aws/aws-sdk-js-v3/builds/575606345 on dev machine
* Confirmed that travis-ci/pr will succeed by following the steps from https://travis-ci.org/aws/aws-sdk-js-v3/builds/575606372 on dev machine

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
