### PR TITLE
chore: revert "fix: lerna pretest --since HEAD"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clear-build-info": "rimraf ./packages/*/*.tsbuildinfo ./clients/*/*/*.tsbuildinfo",
     "copy-models": "node ./scripts/copyModels.js",
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
-    "pretest": "lerna run pretest --since HEAD --include-filtered-dependents --include-filtered-dependencies",
+    "pretest": "lerna run pretest --since master --include-filtered-dependents --include-filtered-dependencies",
     "test": "jest --coverage --passWithNoTests",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"


### PR DESCRIPTION
Reverts aws/aws-sdk-js-v3#343

This is causing empty diff
Example build log https://travis-ci.org/aws/aws-sdk-js-v3/builds/575946746