### PR TITLE
fix: lerna pretest --since HEAD^

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clear-build-info": "rimraf ./packages/*/*.tsbuildinfo ./clients/*/*/*.tsbuildinfo",
     "copy-models": "node ./scripts/copyModels.js",
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
-    "pretest": "lerna run pretest --since master --include-filtered-dependents --include-filtered-dependencies",
+    "pretest": "lerna run pretest --since HEAD^ --include-filtered-dependents --include-filtered-dependencies",
     "test": "jest --coverage --passWithNoTests",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clear-build-info": "rimraf ./packages/*/*.tsbuildinfo ./clients/*/*/*.tsbuildinfo",
     "copy-models": "node ./scripts/copyModels.js",
     "update-clients": "node ./packages/package-generator/build/cli.js import-all --matching './models/*/*/service-2.json'",
-    "pretest": "lerna run pretest --since HEAD^ --include-filtered-dependents --include-filtered-dependencies",
+    "pretest": "lerna run pretest --since 'HEAD^' --include-filtered-dependents --include-filtered-dependencies",
     "test": "jest --coverage --passWithNoTests",
     "pretest-all": "lerna run pretest",
     "test-all": "jest --coverage"


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/342

*Description of changes:*
travis-ci/push fails with `fatal: bad revision 'master'`, so switching to `HEAD^` instead as per https://github.com/aws/aws-sdk-js-v3/issues/342#issuecomment-524439104

Testing done along with fix as follows:
* performed operations from travis-ci/push ([travis-ci-push-yarn-test.log](https://github.com/aws/aws-sdk-js-v3/files/3535983/travis-ci-push-yarn-test.log))
* performed operations from travis-ci/pr ([travis-ci-pr-yarn-test.log](https://github.com/aws/aws-sdk-js-v3/files/3535985/travis-ci-pr-yarn-test.log))
* confirmed that build succeeds in workspace ([workspace-yarn-test.log](https://github.com/aws/aws-sdk-js-v3/files/3535987/workspace-yarn-test.log))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
