### PR TITLE
doc: remove greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/aws/aws-sdk-js-v3.svg?branch=master)](https://travis-ci.org/aws/aws-sdk-js-v3)
 [![codecov](https://codecov.io/gh/aws/aws-sdk-js-v3/branch/master/graph/badge.svg)](https://codecov.io/gh/aws/aws-sdk-js-v3)
-[![Greenkeeper badge](https://badges.greenkeeper.io/aws/aws-sdk-js-v3.svg)](https://greenkeeper.io/)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 The **AWS SDK for JavaScript V3 Developer Preview** is a rewrite of V2 with some great new features. As with version 2, it enables you to easily work with [Amazon Web Services](https://aws.amazon.com/), but has been written in TypeScript and adds several frequently requested features, like modularized packages.


### PR DESCRIPTION
GreenKeeper was removed in #331
we are now using dependabot

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
