### PR TITLE
chore: lock all inactive past issues

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -5,7 +5,7 @@ daysUntilLock: 7
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
-skipCreatedBefore: 2019-02-01
+skipCreatedBefore: false
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
 exemptLabels: []


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This will lock all 14 inactive closed issues before 2019-02-01 ([search link](https://github.com/aws/aws-sdk-js-v3/issues?utf8=%E2%9C%93&q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed+closed%3A%3C2019-02-01))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
