### PR TITLE
fix: do not append to undefined/null header values

### DIFF
--- a/packages/util-user-agent-browser/src/index.spec.ts
+++ b/packages/util-user-agent-browser/src/index.spec.ts
@@ -27,3 +27,15 @@ it("append to user agent", () => {
   appendToUserAgent(request, "http/2.0");
   expect(request.headers["X-Amz-User-Agent"]).toBe(`${defaultValue} http/2.0`);
 });
+
+it("append custom user agent when existing user agent was undefined", () => {
+  const request = {
+    headers: { "X-Amz-User-Agent": undefined as any },
+    method: "GET",
+    protocol: "json",
+    hostname: "foo.amazonaws.com",
+    path: "/"
+  };
+  appendToUserAgent(request, "http/2.0");
+  expect(request.headers["X-Amz-User-Agent"]).toBe("http/2.0");
+});

--- a/packages/util-user-agent-browser/src/index.ts
+++ b/packages/util-user-agent-browser/src/index.ts
@@ -15,5 +15,9 @@ export function appendToUserAgent(
   request: HttpRequest,
   userAgentPartial: string
 ): void {
-  request.headers["X-Amz-User-Agent"] += ` ${userAgentPartial}`;
+  if(request.headers["X-Amz-User-Agent"]) {
+    request.headers["X-Amz-User-Agent"] += ` ${userAgentPartial}`;
+  } else {
+    request.headers["X-Amz-User-Agent"] = `${userAgentPartial}`;
+  }
 }

--- a/packages/util-user-agent-browser/src/index.ts
+++ b/packages/util-user-agent-browser/src/index.ts
@@ -18,6 +18,6 @@ export function appendToUserAgent(
   if(request.headers["X-Amz-User-Agent"]) {
     request.headers["X-Amz-User-Agent"] += ` ${userAgentPartial}`;
   } else {
-    request.headers["X-Amz-User-Agent"] = `${userAgentPartial}`;
+    request.headers["X-Amz-User-Agent"] = userAgentPartial;
   }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Avoid appending to user agent header when the existing value is undefined or null to avoid getting header values as "undefined myUserAgent"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
