### PR TITLE
feat: add RetryStrategy class and retryMiddleware implementation

### DIFF
--- a/packages/retry-middleware/src/defaultStrategy.ts
+++ b/packages/retry-middleware/src/defaultStrategy.ts
@@ -43,14 +43,6 @@ export class ExponentialBackOffStrategy implements RetryStrategy {
     return retryAttempted < this.maxRetries && this.retryDecider(error);
   }
 
-  set setRetryDecider(retryDecider: RetryDecider) {
-    this.retryDecider = retryDecider;
-  }
-
-  set setDelayDecider(delayDecider: DelayDecider) {
-    this.delayDecider = delayDecider;
-  }
-
   async retry<Input extends object, Ouput extends MetadataBearer>(
     next: FinalizeHandler<Input, Ouput>,
     args: FinalizeHandlerArguments<Input>

--- a/packages/retry-middleware/src/defaultStrategy.ts
+++ b/packages/retry-middleware/src/defaultStrategy.ts
@@ -5,19 +5,87 @@ import {
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
 import { isThrottlingError } from "@aws-sdk/service-error-classification";
-import { RetryStrategy, SdkError } from "@aws-sdk/types";
+import {
+  SdkError,
+  FinalizeHandler,
+  MetadataBearer,
+  FinalizeHandlerArguments,
+  RetryStrategy
+} from "@aws-sdk/types";
+
+/**
+ * Determines whether an error is retryable based on the number of retries
+ * already attempted, the HTTP status code, and the error received (if any).
+ *
+ * @param error         The error encountered.
+ */
+export interface RetryDecider {
+  (error: SdkError): boolean;
+}
+
+/**
+ * Determines the number of milliseconds to wait before retrying an action.
+ *
+ * @param delayBase The base delay (in milliseconds).
+ * @param attempts  The number of times the action has already been tried.
+ */
+export interface DelayDecider {
+  (delayBase: number, attempts: number): number;
+}
 
 export class ExponentialBackOffStrategy implements RetryStrategy {
-  constructor(public readonly maxRetries: number) {}
-  shouldRetry(error: SdkError, retryAttempted: number) {
-    return retryAttempted < this.maxRetries && defaultRetryDecider(error);
+  constructor(
+    public readonly maxRetries: number,
+    private retryDecider: RetryDecider = defaultRetryDecider,
+    private delayDecider: DelayDecider = defaultDelayDecider
+  ) {}
+  private shouldRetry(error: SdkError, retryAttempted: number) {
+    return retryAttempted < this.maxRetries && this.retryDecider(error);
   }
-  computeDelayBeforeNextRetry(error: SdkError, retryAttempted: number): number {
-    return defaultDelayDecider(
-      isThrottlingError(error)
-        ? THROTTLING_RETRY_DELAY_BASE
-        : DEFAULT_RETRY_DELAY_BASE,
-      retryAttempted
-    );
+
+  set setRetryDecider(retryDecider: RetryDecider) {
+    this.retryDecider = retryDecider;
+  }
+
+  set setDelayDecider(delayDecider: DelayDecider) {
+    this.delayDecider = delayDecider;
+  }
+
+  async retry<Input extends object, Ouput extends MetadataBearer>(
+    next: FinalizeHandler<Input, Ouput>,
+    args: FinalizeHandlerArguments<Input>
+  ) {
+    let retries = 0;
+    let totalDelay = 0;
+    while (true) {
+      try {
+        const { response, output } = await next(args);
+        output.$metadata.retries = retries;
+        output.$metadata.totalRetryDelay = totalDelay;
+
+        return { response, output };
+      } catch (err) {
+        if (this.shouldRetry(err as SdkError, retries)) {
+          const delay = this.delayDecider(
+            isThrottlingError(err)
+              ? THROTTLING_RETRY_DELAY_BASE
+              : DEFAULT_RETRY_DELAY_BASE,
+            retries++
+          );
+          totalDelay += delay;
+
+          await new Promise(resolve => setTimeout(resolve, delay));
+          continue;
+        }
+
+        if (!err.$metadata) {
+          err.$metadata = {};
+        }
+
+        err.$metadata.retries = retries;
+        err.$metadata.totalRetryDelay = totalDelay;
+        throw err;
+      }
+    }
   }
 }

--- a/packages/retry-middleware/src/index.spec.ts
+++ b/packages/retry-middleware/src/index.spec.ts
@@ -5,8 +5,9 @@ import {
 import { retryMiddleware } from "./retryMiddleware";
 import { RetryConfig } from "./configurations";
 import * as delayDeciderModule from "./delayDecider";
-import { ExponentialBackOffStrategy } from "./defaultStrategy";
+import { ExponentialBackOffStrategy, RetryDecider } from "./defaultStrategy";
 import { HttpRequest } from "@aws-sdk/protocol-http";
+import { SdkError } from '@aws-sdk/types';
 
 describe("retryMiddleware", () => {
   it("should not retry when the handler completes successfully", async () => {
@@ -73,8 +74,8 @@ describe("retryMiddleware", () => {
       delayDeciderModule,
       "defaultDelayDecider"
     );
-    const strategy = new ExponentialBackOffStrategy(maxRetries);
-    strategy.shouldRetry = () => true;
+    const retryDecider: RetryDecider = (error: SdkError) => true;
+    const strategy = new ExponentialBackOffStrategy(maxRetries, retryDecider);
     const retryHandler = retryMiddleware({
       maxRetries,
       retryStrategy: strategy

--- a/packages/retry-middleware/src/index.ts
+++ b/packages/retry-middleware/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./retryMiddleware";
 export * from "./defaultStrategy";
 export * from "./configurations";
+export * from "./delayDecider";
+export * from "./retryDecider";

--- a/packages/retry-middleware/src/retryMiddleware.ts
+++ b/packages/retry-middleware/src/retryMiddleware.ts
@@ -3,7 +3,6 @@ import {
   FinalizeHandlerArguments,
   MetadataBearer,
   FinalizeHandlerOutput,
-  SdkError,
   InjectableMiddleware
 } from "@aws-sdk/types";
 import { RetryConfig } from "./configurations";
@@ -11,42 +10,11 @@ import { RetryConfig } from "./configurations";
 export function retryMiddleware(options: RetryConfig.Resolved) {
   return <Output extends MetadataBearer = MetadataBearer>(
     next: FinalizeHandler<any, Output>
-  ): FinalizeHandler<any, Output> =>
-    async function retry(
-      args: FinalizeHandlerArguments<any>
-    ): Promise<FinalizeHandlerOutput<Output>> {
-      let retries = 0;
-      let totalDelay = 0;
-      while (true) {
-        try {
-          const { response, output } = await next(args);
-          output.$metadata.retries = retries;
-          output.$metadata.totalRetryDelay = totalDelay;
-
-          return { response, output };
-        } catch (err) {
-          if (options.retryStrategy.shouldRetry(err as SdkError, retries)) {
-            const delay = options.retryStrategy.computeDelayBeforeNextRetry(
-              err,
-              retries
-            );
-            retries++;
-            totalDelay += delay;
-
-            await new Promise(resolve => setTimeout(resolve, delay));
-            continue;
-          }
-
-          if (!err.$metadata) {
-            err.$metadata = {};
-          }
-
-          err.$metadata.retries = retries;
-          err.$metadata.totalRetryDelay = totalDelay;
-          throw err;
-        }
-      }
-    };
+  ): FinalizeHandler<any, Output> => async (
+    args: FinalizeHandlerArguments<any>
+  ): Promise<FinalizeHandlerOutput<Output>> => {
+    return options.retryStrategy.retry(next, args);
+  };
 }
 
 export function retryPlugin<


### PR DESCRIPTION
Put retry logic into RetryStrategy itself. Keep retryMiddleware minimal.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
