### PR TITLE
fix: remove /src/ from .npmignore (for sourcemaps)

### DIFF
--- a/clients/browser/client-acm-browser/.npmignore
+++ b/clients/browser/client-acm-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-acm-pca-browser/.npmignore
+++ b/clients/browser/client-acm-pca-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-alexa-for-business-browser/.npmignore
+++ b/clients/browser/client-alexa-for-business-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-amplify-browser/.npmignore
+++ b/clients/browser/client-amplify-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-api-gateway-browser/.npmignore
+++ b/clients/browser/client-api-gateway-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-apigatewaymanagementapi-browser/.npmignore
+++ b/clients/browser/client-apigatewaymanagementapi-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-apigatewayv2-browser/.npmignore
+++ b/clients/browser/client-apigatewayv2-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-app-mesh-browser/.npmignore
+++ b/clients/browser/client-app-mesh-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-application-auto-scaling-browser/.npmignore
+++ b/clients/browser/client-application-auto-scaling-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-application-discovery-service-browser/.npmignore
+++ b/clients/browser/client-application-discovery-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-application-insights-browser/.npmignore
+++ b/clients/browser/client-application-insights-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-appstream-browser/.npmignore
+++ b/clients/browser/client-appstream-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-appsync-browser/.npmignore
+++ b/clients/browser/client-appsync-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-athena-browser/.npmignore
+++ b/clients/browser/client-athena-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-auto-scaling-browser/.npmignore
+++ b/clients/browser/client-auto-scaling-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-auto-scaling-plans-browser/.npmignore
+++ b/clients/browser/client-auto-scaling-plans-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-backup-browser/.npmignore
+++ b/clients/browser/client-backup-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-batch-browser/.npmignore
+++ b/clients/browser/client-batch-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-budgets-browser/.npmignore
+++ b/clients/browser/client-budgets-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-chime-browser/.npmignore
+++ b/clients/browser/client-chime-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloud9-browser/.npmignore
+++ b/clients/browser/client-cloud9-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-clouddirectory-browser/.npmignore
+++ b/clients/browser/client-clouddirectory-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudformation-browser/.npmignore
+++ b/clients/browser/client-cloudformation-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudfront-browser/.npmignore
+++ b/clients/browser/client-cloudfront-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudhsm-browser/.npmignore
+++ b/clients/browser/client-cloudhsm-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudhsm-v2-browser/.npmignore
+++ b/clients/browser/client-cloudhsm-v2-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudsearch-browser/.npmignore
+++ b/clients/browser/client-cloudsearch-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudsearch-domain-browser/.npmignore
+++ b/clients/browser/client-cloudsearch-domain-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudtrail-browser/.npmignore
+++ b/clients/browser/client-cloudtrail-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudwatch-browser/.npmignore
+++ b/clients/browser/client-cloudwatch-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudwatch-events-browser/.npmignore
+++ b/clients/browser/client-cloudwatch-events-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cloudwatch-logs-browser/.npmignore
+++ b/clients/browser/client-cloudwatch-logs-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-codebuild-browser/.npmignore
+++ b/clients/browser/client-codebuild-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-codecommit-browser/.npmignore
+++ b/clients/browser/client-codecommit-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-codedeploy-browser/.npmignore
+++ b/clients/browser/client-codedeploy-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-codepipeline-browser/.npmignore
+++ b/clients/browser/client-codepipeline-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-codestar-browser/.npmignore
+++ b/clients/browser/client-codestar-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cognito-identity-browser/.npmignore
+++ b/clients/browser/client-cognito-identity-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cognito-identity-provider-browser/.npmignore
+++ b/clients/browser/client-cognito-identity-provider-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cognito-sync-browser/.npmignore
+++ b/clients/browser/client-cognito-sync-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-comprehend-browser/.npmignore
+++ b/clients/browser/client-comprehend-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-comprehendmedical-browser/.npmignore
+++ b/clients/browser/client-comprehendmedical-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-config-service-browser/.npmignore
+++ b/clients/browser/client-config-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-connect-browser/.npmignore
+++ b/clients/browser/client-connect-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cost-and-usage-report-service-browser/.npmignore
+++ b/clients/browser/client-cost-and-usage-report-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-cost-explorer-browser/.npmignore
+++ b/clients/browser/client-cost-explorer-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-data-pipeline-browser/.npmignore
+++ b/clients/browser/client-data-pipeline-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-database-migration-service-browser/.npmignore
+++ b/clients/browser/client-database-migration-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-datasync-browser/.npmignore
+++ b/clients/browser/client-datasync-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-dax-browser/.npmignore
+++ b/clients/browser/client-dax-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-device-farm-browser/.npmignore
+++ b/clients/browser/client-device-farm-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-direct-connect-browser/.npmignore
+++ b/clients/browser/client-direct-connect-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-directory-service-browser/.npmignore
+++ b/clients/browser/client-directory-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-dlm-browser/.npmignore
+++ b/clients/browser/client-dlm-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-docdb-browser/.npmignore
+++ b/clients/browser/client-docdb-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-dynamodb-browser/.npmignore
+++ b/clients/browser/client-dynamodb-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-dynamodb-streams-browser/.npmignore
+++ b/clients/browser/client-dynamodb-streams-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-ec2-browser/.npmignore
+++ b/clients/browser/client-ec2-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-ec2-instance-connect-browser/.npmignore
+++ b/clients/browser/client-ec2-instance-connect-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-ecr-browser/.npmignore
+++ b/clients/browser/client-ecr-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-ecs-browser/.npmignore
+++ b/clients/browser/client-ecs-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-efs-browser/.npmignore
+++ b/clients/browser/client-efs-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-eks-browser/.npmignore
+++ b/clients/browser/client-eks-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-elastic-beanstalk-browser/.npmignore
+++ b/clients/browser/client-elastic-beanstalk-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-elastic-load-balancing-browser/.npmignore
+++ b/clients/browser/client-elastic-load-balancing-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-elastic-load-balancing-v2-browser/.npmignore
+++ b/clients/browser/client-elastic-load-balancing-v2-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-elastic-transcoder-browser/.npmignore
+++ b/clients/browser/client-elastic-transcoder-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-elasticache-browser/.npmignore
+++ b/clients/browser/client-elasticache-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-elasticsearch-service-browser/.npmignore
+++ b/clients/browser/client-elasticsearch-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-emr-browser/.npmignore
+++ b/clients/browser/client-emr-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-eventbridge-browser/.npmignore
+++ b/clients/browser/client-eventbridge-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-firehose-browser/.npmignore
+++ b/clients/browser/client-firehose-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-fms-browser/.npmignore
+++ b/clients/browser/client-fms-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-fsx-browser/.npmignore
+++ b/clients/browser/client-fsx-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-gamelift-browser/.npmignore
+++ b/clients/browser/client-gamelift-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-glacier-browser/.npmignore
+++ b/clients/browser/client-glacier-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-global-accelerator-browser/.npmignore
+++ b/clients/browser/client-global-accelerator-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-glue-browser/.npmignore
+++ b/clients/browser/client-glue-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-greengrass-browser/.npmignore
+++ b/clients/browser/client-greengrass-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-groundstation-browser/.npmignore
+++ b/clients/browser/client-groundstation-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-guardduty-browser/.npmignore
+++ b/clients/browser/client-guardduty-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-health-browser/.npmignore
+++ b/clients/browser/client-health-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iam-browser/.npmignore
+++ b/clients/browser/client-iam-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-inspector-browser/.npmignore
+++ b/clients/browser/client-inspector-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iot-1click-devices-service-browser/.npmignore
+++ b/clients/browser/client-iot-1click-devices-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iot-1click-projects-browser/.npmignore
+++ b/clients/browser/client-iot-1click-projects-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iot-browser/.npmignore
+++ b/clients/browser/client-iot-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iot-data-plane-browser/.npmignore
+++ b/clients/browser/client-iot-data-plane-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iot-events-browser/.npmignore
+++ b/clients/browser/client-iot-events-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iot-events-data-browser/.npmignore
+++ b/clients/browser/client-iot-events-data-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iot-jobs-data-plane-browser/.npmignore
+++ b/clients/browser/client-iot-jobs-data-plane-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iotanalytics-browser/.npmignore
+++ b/clients/browser/client-iotanalytics-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-iotthingsgraph-browser/.npmignore
+++ b/clients/browser/client-iotthingsgraph-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kafka-browser/.npmignore
+++ b/clients/browser/client-kafka-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kinesis-analytics-browser/.npmignore
+++ b/clients/browser/client-kinesis-analytics-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kinesis-analytics-v2-browser/.npmignore
+++ b/clients/browser/client-kinesis-analytics-v2-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kinesis-browser/.npmignore
+++ b/clients/browser/client-kinesis-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kinesis-video-archived-media-browser/.npmignore
+++ b/clients/browser/client-kinesis-video-archived-media-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kinesis-video-browser/.npmignore
+++ b/clients/browser/client-kinesis-video-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kinesis-video-media-browser/.npmignore
+++ b/clients/browser/client-kinesis-video-media-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-kms-browser/.npmignore
+++ b/clients/browser/client-kms-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-lambda-browser/.npmignore
+++ b/clients/browser/client-lambda-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-lex-model-building-service-browser/.npmignore
+++ b/clients/browser/client-lex-model-building-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-lex-runtime-service-browser/.npmignore
+++ b/clients/browser/client-lex-runtime-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-license-manager-browser/.npmignore
+++ b/clients/browser/client-license-manager-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-lightsail-browser/.npmignore
+++ b/clients/browser/client-lightsail-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-machine-learning-browser/.npmignore
+++ b/clients/browser/client-machine-learning-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-macie-browser/.npmignore
+++ b/clients/browser/client-macie-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-managedblockchain-browser/.npmignore
+++ b/clients/browser/client-managedblockchain-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-marketplace-commerce-analytics-browser/.npmignore
+++ b/clients/browser/client-marketplace-commerce-analytics-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-marketplace-entitlement-service-browser/.npmignore
+++ b/clients/browser/client-marketplace-entitlement-service-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-marketplace-metering-browser/.npmignore
+++ b/clients/browser/client-marketplace-metering-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mediaconnect-browser/.npmignore
+++ b/clients/browser/client-mediaconnect-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mediaconvert-browser/.npmignore
+++ b/clients/browser/client-mediaconvert-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-medialive-browser/.npmignore
+++ b/clients/browser/client-medialive-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mediapackage-browser/.npmignore
+++ b/clients/browser/client-mediapackage-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mediapackage-vod-browser/.npmignore
+++ b/clients/browser/client-mediapackage-vod-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mediastore-browser/.npmignore
+++ b/clients/browser/client-mediastore-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mediastore-data-browser/.npmignore
+++ b/clients/browser/client-mediastore-data-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mediatailor-browser/.npmignore
+++ b/clients/browser/client-mediatailor-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-migration-hub-browser/.npmignore
+++ b/clients/browser/client-migration-hub-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mobile-browser/.npmignore
+++ b/clients/browser/client-mobile-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mq-browser/.npmignore
+++ b/clients/browser/client-mq-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-mturk-browser/.npmignore
+++ b/clients/browser/client-mturk-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-neptune-browser/.npmignore
+++ b/clients/browser/client-neptune-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-opsworks-browser/.npmignore
+++ b/clients/browser/client-opsworks-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-opsworkscm-browser/.npmignore
+++ b/clients/browser/client-opsworkscm-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-organizations-browser/.npmignore
+++ b/clients/browser/client-organizations-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-personalize-browser/.npmignore
+++ b/clients/browser/client-personalize-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-personalize-events-browser/.npmignore
+++ b/clients/browser/client-personalize-events-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-personalize-runtime-browser/.npmignore
+++ b/clients/browser/client-personalize-runtime-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-pi-browser/.npmignore
+++ b/clients/browser/client-pi-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-pinpoint-browser/.npmignore
+++ b/clients/browser/client-pinpoint-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-pinpoint-email-browser/.npmignore
+++ b/clients/browser/client-pinpoint-email-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-pinpoint-sms-voice-browser/.npmignore
+++ b/clients/browser/client-pinpoint-sms-voice-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-polly-browser/.npmignore
+++ b/clients/browser/client-polly-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-pricing-browser/.npmignore
+++ b/clients/browser/client-pricing-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-quicksight-browser/.npmignore
+++ b/clients/browser/client-quicksight-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-ram-browser/.npmignore
+++ b/clients/browser/client-ram-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-rds-browser/.npmignore
+++ b/clients/browser/client-rds-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-rds-data-browser/.npmignore
+++ b/clients/browser/client-rds-data-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-redshift-browser/.npmignore
+++ b/clients/browser/client-redshift-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-rekognition-browser/.npmignore
+++ b/clients/browser/client-rekognition-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-resource-groups-browser/.npmignore
+++ b/clients/browser/client-resource-groups-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-resource-groups-tagging-api-browser/.npmignore
+++ b/clients/browser/client-resource-groups-tagging-api-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-robomaker-browser/.npmignore
+++ b/clients/browser/client-robomaker-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-route-53-browser/.npmignore
+++ b/clients/browser/client-route-53-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-route-53-domains-browser/.npmignore
+++ b/clients/browser/client-route-53-domains-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-route53resolver-browser/.npmignore
+++ b/clients/browser/client-route53resolver-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-s3-browser/.npmignore
+++ b/clients/browser/client-s3-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-s3-control-browser/.npmignore
+++ b/clients/browser/client-s3-control-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-sagemaker-browser/.npmignore
+++ b/clients/browser/client-sagemaker-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-sagemaker-runtime-browser/.npmignore
+++ b/clients/browser/client-sagemaker-runtime-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-secrets-manager-browser/.npmignore
+++ b/clients/browser/client-secrets-manager-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-securityhub-browser/.npmignore
+++ b/clients/browser/client-securityhub-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-serverlessapplicationrepository-browser/.npmignore
+++ b/clients/browser/client-serverlessapplicationrepository-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-service-catalog-browser/.npmignore
+++ b/clients/browser/client-service-catalog-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-service-quotas-browser/.npmignore
+++ b/clients/browser/client-service-quotas-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-servicediscovery-browser/.npmignore
+++ b/clients/browser/client-servicediscovery-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-ses-browser/.npmignore
+++ b/clients/browser/client-ses-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-sfn-browser/.npmignore
+++ b/clients/browser/client-sfn-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-shield-browser/.npmignore
+++ b/clients/browser/client-shield-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-signer-browser/.npmignore
+++ b/clients/browser/client-signer-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-sms-browser/.npmignore
+++ b/clients/browser/client-sms-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-snowball-browser/.npmignore
+++ b/clients/browser/client-snowball-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-sns-browser/.npmignore
+++ b/clients/browser/client-sns-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-sqs-browser/.npmignore
+++ b/clients/browser/client-sqs-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-ssm-browser/.npmignore
+++ b/clients/browser/client-ssm-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-storage-gateway-browser/.npmignore
+++ b/clients/browser/client-storage-gateway-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-sts-browser/.npmignore
+++ b/clients/browser/client-sts-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-support-browser/.npmignore
+++ b/clients/browser/client-support-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-swf-browser/.npmignore
+++ b/clients/browser/client-swf-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-textract-browser/.npmignore
+++ b/clients/browser/client-textract-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-transcribe-browser/.npmignore
+++ b/clients/browser/client-transcribe-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-transfer-browser/.npmignore
+++ b/clients/browser/client-transfer-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-translate-browser/.npmignore
+++ b/clients/browser/client-translate-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-waf-browser/.npmignore
+++ b/clients/browser/client-waf-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-waf-regional-browser/.npmignore
+++ b/clients/browser/client-waf-regional-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-workdocs-browser/.npmignore
+++ b/clients/browser/client-workdocs-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-worklink-browser/.npmignore
+++ b/clients/browser/client-worklink-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-workmail-browser/.npmignore
+++ b/clients/browser/client-workmail-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-workspaces-browser/.npmignore
+++ b/clients/browser/client-workspaces-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/browser/client-xray-browser/.npmignore
+++ b/clients/browser/client-xray-browser/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-acm-node/.npmignore
+++ b/clients/node/client-acm-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-acm-pca-node/.npmignore
+++ b/clients/node/client-acm-pca-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-alexa-for-business-node/.npmignore
+++ b/clients/node/client-alexa-for-business-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-amplify-node/.npmignore
+++ b/clients/node/client-amplify-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-api-gateway-node/.npmignore
+++ b/clients/node/client-api-gateway-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-apigatewaymanagementapi-node/.npmignore
+++ b/clients/node/client-apigatewaymanagementapi-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-apigatewayv2-node/.npmignore
+++ b/clients/node/client-apigatewayv2-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-app-mesh-node/.npmignore
+++ b/clients/node/client-app-mesh-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-application-auto-scaling-node/.npmignore
+++ b/clients/node/client-application-auto-scaling-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-application-discovery-service-node/.npmignore
+++ b/clients/node/client-application-discovery-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-application-insights-node/.npmignore
+++ b/clients/node/client-application-insights-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-appstream-node/.npmignore
+++ b/clients/node/client-appstream-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-appsync-node/.npmignore
+++ b/clients/node/client-appsync-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-athena-node/.npmignore
+++ b/clients/node/client-athena-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-auto-scaling-node/.npmignore
+++ b/clients/node/client-auto-scaling-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-auto-scaling-plans-node/.npmignore
+++ b/clients/node/client-auto-scaling-plans-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-backup-node/.npmignore
+++ b/clients/node/client-backup-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-batch-node/.npmignore
+++ b/clients/node/client-batch-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-budgets-node/.npmignore
+++ b/clients/node/client-budgets-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-chime-node/.npmignore
+++ b/clients/node/client-chime-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloud9-node/.npmignore
+++ b/clients/node/client-cloud9-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-clouddirectory-node/.npmignore
+++ b/clients/node/client-clouddirectory-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudformation-node/.npmignore
+++ b/clients/node/client-cloudformation-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudfront-node/.npmignore
+++ b/clients/node/client-cloudfront-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudhsm-node/.npmignore
+++ b/clients/node/client-cloudhsm-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudhsm-v2-node/.npmignore
+++ b/clients/node/client-cloudhsm-v2-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudsearch-domain-node/.npmignore
+++ b/clients/node/client-cloudsearch-domain-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudsearch-node/.npmignore
+++ b/clients/node/client-cloudsearch-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudtrail-node/.npmignore
+++ b/clients/node/client-cloudtrail-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudwatch-events-node/.npmignore
+++ b/clients/node/client-cloudwatch-events-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudwatch-logs-node/.npmignore
+++ b/clients/node/client-cloudwatch-logs-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cloudwatch-node/.npmignore
+++ b/clients/node/client-cloudwatch-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-codebuild-node/.npmignore
+++ b/clients/node/client-codebuild-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-codecommit-node/.npmignore
+++ b/clients/node/client-codecommit-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-codedeploy-node/.npmignore
+++ b/clients/node/client-codedeploy-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-codepipeline-node/.npmignore
+++ b/clients/node/client-codepipeline-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-codestar-node/.npmignore
+++ b/clients/node/client-codestar-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cognito-identity-node/.npmignore
+++ b/clients/node/client-cognito-identity-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cognito-identity-provider-node/.npmignore
+++ b/clients/node/client-cognito-identity-provider-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cognito-sync-node/.npmignore
+++ b/clients/node/client-cognito-sync-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-comprehend-node/.npmignore
+++ b/clients/node/client-comprehend-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-comprehendmedical-node/.npmignore
+++ b/clients/node/client-comprehendmedical-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-config-service-node/.npmignore
+++ b/clients/node/client-config-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-connect-node/.npmignore
+++ b/clients/node/client-connect-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cost-and-usage-report-service-node/.npmignore
+++ b/clients/node/client-cost-and-usage-report-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-cost-explorer-node/.npmignore
+++ b/clients/node/client-cost-explorer-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-data-pipeline-node/.npmignore
+++ b/clients/node/client-data-pipeline-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-database-migration-service-node/.npmignore
+++ b/clients/node/client-database-migration-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-datasync-node/.npmignore
+++ b/clients/node/client-datasync-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-dax-node/.npmignore
+++ b/clients/node/client-dax-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-device-farm-node/.npmignore
+++ b/clients/node/client-device-farm-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-direct-connect-node/.npmignore
+++ b/clients/node/client-direct-connect-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-directory-service-node/.npmignore
+++ b/clients/node/client-directory-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-dlm-node/.npmignore
+++ b/clients/node/client-dlm-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-docdb-node/.npmignore
+++ b/clients/node/client-docdb-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-dynamodb-node/.npmignore
+++ b/clients/node/client-dynamodb-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-dynamodb-streams-node/.npmignore
+++ b/clients/node/client-dynamodb-streams-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-ec2-instance-connect-node/.npmignore
+++ b/clients/node/client-ec2-instance-connect-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-ec2-node/.npmignore
+++ b/clients/node/client-ec2-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-ecr-node/.npmignore
+++ b/clients/node/client-ecr-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-ecs-node/.npmignore
+++ b/clients/node/client-ecs-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-efs-node/.npmignore
+++ b/clients/node/client-efs-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-eks-node/.npmignore
+++ b/clients/node/client-eks-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-elastic-beanstalk-node/.npmignore
+++ b/clients/node/client-elastic-beanstalk-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-elastic-load-balancing-node/.npmignore
+++ b/clients/node/client-elastic-load-balancing-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-elastic-load-balancing-v2-node/.npmignore
+++ b/clients/node/client-elastic-load-balancing-v2-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-elastic-transcoder-node/.npmignore
+++ b/clients/node/client-elastic-transcoder-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-elasticache-node/.npmignore
+++ b/clients/node/client-elasticache-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-elasticsearch-service-node/.npmignore
+++ b/clients/node/client-elasticsearch-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-emr-node/.npmignore
+++ b/clients/node/client-emr-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-eventbridge-node/.npmignore
+++ b/clients/node/client-eventbridge-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-firehose-node/.npmignore
+++ b/clients/node/client-firehose-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-fms-node/.npmignore
+++ b/clients/node/client-fms-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-fsx-node/.npmignore
+++ b/clients/node/client-fsx-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-gamelift-node/.npmignore
+++ b/clients/node/client-gamelift-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-glacier-node/.npmignore
+++ b/clients/node/client-glacier-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-global-accelerator-node/.npmignore
+++ b/clients/node/client-global-accelerator-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-glue-node/.npmignore
+++ b/clients/node/client-glue-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-greengrass-node/.npmignore
+++ b/clients/node/client-greengrass-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-groundstation-node/.npmignore
+++ b/clients/node/client-groundstation-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-guardduty-node/.npmignore
+++ b/clients/node/client-guardduty-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-health-node/.npmignore
+++ b/clients/node/client-health-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iam-node/.npmignore
+++ b/clients/node/client-iam-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-inspector-node/.npmignore
+++ b/clients/node/client-inspector-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iot-1click-devices-service-node/.npmignore
+++ b/clients/node/client-iot-1click-devices-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iot-1click-projects-node/.npmignore
+++ b/clients/node/client-iot-1click-projects-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iot-data-plane-node/.npmignore
+++ b/clients/node/client-iot-data-plane-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iot-events-data-node/.npmignore
+++ b/clients/node/client-iot-events-data-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iot-events-node/.npmignore
+++ b/clients/node/client-iot-events-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iot-jobs-data-plane-node/.npmignore
+++ b/clients/node/client-iot-jobs-data-plane-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iot-node/.npmignore
+++ b/clients/node/client-iot-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iotanalytics-node/.npmignore
+++ b/clients/node/client-iotanalytics-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-iotthingsgraph-node/.npmignore
+++ b/clients/node/client-iotthingsgraph-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kafka-node/.npmignore
+++ b/clients/node/client-kafka-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kinesis-analytics-node/.npmignore
+++ b/clients/node/client-kinesis-analytics-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kinesis-analytics-v2-node/.npmignore
+++ b/clients/node/client-kinesis-analytics-v2-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kinesis-node/.npmignore
+++ b/clients/node/client-kinesis-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kinesis-video-archived-media-node/.npmignore
+++ b/clients/node/client-kinesis-video-archived-media-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kinesis-video-media-node/.npmignore
+++ b/clients/node/client-kinesis-video-media-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kinesis-video-node/.npmignore
+++ b/clients/node/client-kinesis-video-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-kms-node/.npmignore
+++ b/clients/node/client-kms-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-lambda-node/.npmignore
+++ b/clients/node/client-lambda-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-lex-model-building-service-node/.npmignore
+++ b/clients/node/client-lex-model-building-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-lex-runtime-service-node/.npmignore
+++ b/clients/node/client-lex-runtime-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-license-manager-node/.npmignore
+++ b/clients/node/client-license-manager-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-lightsail-node/.npmignore
+++ b/clients/node/client-lightsail-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-machine-learning-node/.npmignore
+++ b/clients/node/client-machine-learning-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-macie-node/.npmignore
+++ b/clients/node/client-macie-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-managedblockchain-node/.npmignore
+++ b/clients/node/client-managedblockchain-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-marketplace-commerce-analytics-node/.npmignore
+++ b/clients/node/client-marketplace-commerce-analytics-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-marketplace-entitlement-service-node/.npmignore
+++ b/clients/node/client-marketplace-entitlement-service-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-marketplace-metering-node/.npmignore
+++ b/clients/node/client-marketplace-metering-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mediaconnect-node/.npmignore
+++ b/clients/node/client-mediaconnect-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mediaconvert-node/.npmignore
+++ b/clients/node/client-mediaconvert-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-medialive-node/.npmignore
+++ b/clients/node/client-medialive-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mediapackage-node/.npmignore
+++ b/clients/node/client-mediapackage-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mediapackage-vod-node/.npmignore
+++ b/clients/node/client-mediapackage-vod-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mediastore-data-node/.npmignore
+++ b/clients/node/client-mediastore-data-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mediastore-node/.npmignore
+++ b/clients/node/client-mediastore-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mediatailor-node/.npmignore
+++ b/clients/node/client-mediatailor-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-migration-hub-node/.npmignore
+++ b/clients/node/client-migration-hub-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mobile-node/.npmignore
+++ b/clients/node/client-mobile-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mq-node/.npmignore
+++ b/clients/node/client-mq-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-mturk-node/.npmignore
+++ b/clients/node/client-mturk-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-neptune-node/.npmignore
+++ b/clients/node/client-neptune-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-opsworks-node/.npmignore
+++ b/clients/node/client-opsworks-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-opsworkscm-node/.npmignore
+++ b/clients/node/client-opsworkscm-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-organizations-node/.npmignore
+++ b/clients/node/client-organizations-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-personalize-events-node/.npmignore
+++ b/clients/node/client-personalize-events-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-personalize-node/.npmignore
+++ b/clients/node/client-personalize-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-personalize-runtime-node/.npmignore
+++ b/clients/node/client-personalize-runtime-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-pi-node/.npmignore
+++ b/clients/node/client-pi-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-pinpoint-email-node/.npmignore
+++ b/clients/node/client-pinpoint-email-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-pinpoint-node/.npmignore
+++ b/clients/node/client-pinpoint-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-pinpoint-sms-voice-node/.npmignore
+++ b/clients/node/client-pinpoint-sms-voice-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-polly-node/.npmignore
+++ b/clients/node/client-polly-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-pricing-node/.npmignore
+++ b/clients/node/client-pricing-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-quicksight-node/.npmignore
+++ b/clients/node/client-quicksight-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-ram-node/.npmignore
+++ b/clients/node/client-ram-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-rds-data-node/.npmignore
+++ b/clients/node/client-rds-data-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-rds-node/.npmignore
+++ b/clients/node/client-rds-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-redshift-node/.npmignore
+++ b/clients/node/client-redshift-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-rekognition-node/.npmignore
+++ b/clients/node/client-rekognition-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-resource-groups-node/.npmignore
+++ b/clients/node/client-resource-groups-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-resource-groups-tagging-api-node/.npmignore
+++ b/clients/node/client-resource-groups-tagging-api-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-robomaker-node/.npmignore
+++ b/clients/node/client-robomaker-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-route-53-domains-node/.npmignore
+++ b/clients/node/client-route-53-domains-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-route-53-node/.npmignore
+++ b/clients/node/client-route-53-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-route53resolver-node/.npmignore
+++ b/clients/node/client-route53resolver-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-s3-control-node/.npmignore
+++ b/clients/node/client-s3-control-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-s3-node/.npmignore
+++ b/clients/node/client-s3-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-sagemaker-node/.npmignore
+++ b/clients/node/client-sagemaker-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-sagemaker-runtime-node/.npmignore
+++ b/clients/node/client-sagemaker-runtime-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-secrets-manager-node/.npmignore
+++ b/clients/node/client-secrets-manager-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-securityhub-node/.npmignore
+++ b/clients/node/client-securityhub-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-serverlessapplicationrepository-node/.npmignore
+++ b/clients/node/client-serverlessapplicationrepository-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-service-catalog-node/.npmignore
+++ b/clients/node/client-service-catalog-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-service-quotas-node/.npmignore
+++ b/clients/node/client-service-quotas-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-servicediscovery-node/.npmignore
+++ b/clients/node/client-servicediscovery-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-ses-node/.npmignore
+++ b/clients/node/client-ses-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-sfn-node/.npmignore
+++ b/clients/node/client-sfn-node/.npmignore
@@ -1,6 +1,5 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js

--- a/clients/node/client-shield-node/.npmignore
+++ b/clients/node/client-shield-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-signer-node/.npmignore
+++ b/clients/node/client-signer-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-sms-node/.npmignore
+++ b/clients/node/client-sms-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-snowball-node/.npmignore
+++ b/clients/node/client-snowball-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-sns-node/.npmignore
+++ b/clients/node/client-sns-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-sqs-node/.npmignore
+++ b/clients/node/client-sqs-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-ssm-node/.npmignore
+++ b/clients/node/client-ssm-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-storage-gateway-node/.npmignore
+++ b/clients/node/client-storage-gateway-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-sts-node/.npmignore
+++ b/clients/node/client-sts-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-support-node/.npmignore
+++ b/clients/node/client-support-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-swf-node/.npmignore
+++ b/clients/node/client-swf-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-textract-node/.npmignore
+++ b/clients/node/client-textract-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-transcribe-node/.npmignore
+++ b/clients/node/client-transcribe-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-transfer-node/.npmignore
+++ b/clients/node/client-transfer-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-translate-node/.npmignore
+++ b/clients/node/client-translate-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-waf-node/.npmignore
+++ b/clients/node/client-waf-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-waf-regional-node/.npmignore
+++ b/clients/node/client-waf-regional-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-workdocs-node/.npmignore
+++ b/clients/node/client-workdocs-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-worklink-node/.npmignore
+++ b/clients/node/client-worklink-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-workmail-node/.npmignore
+++ b/clients/node/client-workmail-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-workspaces-node/.npmignore
+++ b/clients/node/client-workspaces-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/clients/node/client-xray-node/.npmignore
+++ b/clients/node/client-xray-node/.npmignore
@@ -1,6 +1,4 @@
 /coverage/
 /docs/
-*.ts
-!*.d.ts
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/abort-controller/.npmignore
+++ b/packages/abort-controller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/abort-controller/.npmignore
+++ b/packages/abort-controller/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/add-glacier-checksum-headers-browser/.npmignore
+++ b/packages/add-glacier-checksum-headers-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/add-glacier-checksum-headers-browser/.npmignore
+++ b/packages/add-glacier-checksum-headers-browser/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/add-glacier-checksum-headers-node/.npmignore
+++ b/packages/add-glacier-checksum-headers-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/add-glacier-checksum-headers-node/.npmignore
+++ b/packages/add-glacier-checksum-headers-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/add-glacier-checksum-headers-universal/.npmignore
+++ b/packages/add-glacier-checksum-headers-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/add-glacier-checksum-headers-universal/.npmignore
+++ b/packages/add-glacier-checksum-headers-universal/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/apply-body-checksum-middleware/.npmignore
+++ b/packages/apply-body-checksum-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/apply-body-checksum-middleware/.npmignore
+++ b/packages/apply-body-checksum-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/bucket-endpoint-middleware/.npmignore
+++ b/packages/bucket-endpoint-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/bucket-endpoint-middleware/.npmignore
+++ b/packages/bucket-endpoint-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/build-types/.npmignore
+++ b/packages/build-types/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/build-types/.npmignore
+++ b/packages/build-types/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/chunked-blob-reader/.npmignore
+++ b/packages/chunked-blob-reader/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/chunked-blob-reader/.npmignore
+++ b/packages/chunked-blob-reader/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/chunked-stream-reader-node/.npmignore
+++ b/packages/chunked-stream-reader-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/chunked-stream-reader-node/.npmignore
+++ b/packages/chunked-stream-reader-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/client-documentation-generator/.npmignore
+++ b/packages/client-documentation-generator/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/client-documentation-generator/.npmignore
+++ b/packages/client-documentation-generator/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/config-resolver/.npmignore
+++ b/packages/config-resolver/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/config-resolver/.npmignore
+++ b/packages/config-resolver/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/core-handler/.npmignore
+++ b/packages/core-handler/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/core-handler/.npmignore
+++ b/packages/core-handler/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-cognito-identity/.npmignore
+++ b/packages/credential-provider-cognito-identity/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/credential-provider-cognito-identity/.npmignore
+++ b/packages/credential-provider-cognito-identity/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-env/.npmignore
+++ b/packages/credential-provider-env/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-env/.npmignore
+++ b/packages/credential-provider-env/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-env/tsconfig.json
+++ b/packages/credential-provider-env/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "sourceMap": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/credential-provider-imds/.npmignore
+++ b/packages/credential-provider-imds/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-imds/.npmignore
+++ b/packages/credential-provider-imds/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-imds/tsconfig.json
+++ b/packages/credential-provider-imds/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "noEmitHelpers": true,
     "incremental": true

--- a/packages/credential-provider-ini/.npmignore
+++ b/packages/credential-provider-ini/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-ini/.npmignore
+++ b/packages/credential-provider-ini/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-ini/tsconfig.json
+++ b/packages/credential-provider-ini/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "noEmitHelpers": true,
     "incremental": true

--- a/packages/credential-provider-node/.npmignore
+++ b/packages/credential-provider-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-node/.npmignore
+++ b/packages/credential-provider-node/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-process/.npmignore
+++ b/packages/credential-provider-process/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-process/.npmignore
+++ b/packages/credential-provider-process/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-process/tsconfig.json
+++ b/packages/credential-provider-process/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "noEmitHelpers": true,
     "incremental": true

--- a/packages/ec2-error-unmarshaller/.npmignore
+++ b/packages/ec2-error-unmarshaller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/ec2-error-unmarshaller/.npmignore
+++ b/packages/ec2-error-unmarshaller/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/eventstream-marshaller/.npmignore
+++ b/packages/eventstream-marshaller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/eventstream-marshaller/.npmignore
+++ b/packages/eventstream-marshaller/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/fetch-http-handler/.npmignore
+++ b/packages/fetch-http-handler/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/fetch-http-handler/.npmignore
+++ b/packages/fetch-http-handler/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/hash-blob-browser/.npmignore
+++ b/packages/hash-blob-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/hash-blob-browser/.npmignore
+++ b/packages/hash-blob-browser/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/hash-node/.npmignore
+++ b/packages/hash-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/hash-node/.npmignore
+++ b/packages/hash-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/hash-stream-node/.npmignore
+++ b/packages/hash-stream-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/hash-stream-node/.npmignore
+++ b/packages/hash-stream-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/http-headers/.npmignore
+++ b/packages/http-headers/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/http-headers/.npmignore
+++ b/packages/http-headers/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/http-serialization/.npmignore
+++ b/packages/http-serialization/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/http-serialization/.npmignore
+++ b/packages/http-serialization/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/is-array-buffer/.npmignore
+++ b/packages/is-array-buffer/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/is-array-buffer/.npmignore
+++ b/packages/is-array-buffer/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/is-array-buffer/tsconfig.json
+++ b/packages/is-array-buffer/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "strict": true,
     "sourceMap": true,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/is-iterable/.npmignore
+++ b/packages/is-iterable/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/is-iterable/.npmignore
+++ b/packages/is-iterable/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/is-node/.npmignore
+++ b/packages/is-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/is-node/.npmignore
+++ b/packages/is-node/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/json-builder/.npmignore
+++ b/packages/json-builder/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/json-builder/.npmignore
+++ b/packages/json-builder/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/json-error-unmarshaller/.npmignore
+++ b/packages/json-error-unmarshaller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/json-error-unmarshaller/.npmignore
+++ b/packages/json-error-unmarshaller/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/json-parser/.npmignore
+++ b/packages/json-parser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/json-parser/.npmignore
+++ b/packages/json-parser/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/karma-credential-loader/.npmignore
+++ b/packages/karma-credential-loader/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/karma-credential-loader/.npmignore
+++ b/packages/karma-credential-loader/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/location-constraint-middleware/.npmignore
+++ b/packages/location-constraint-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/location-constraint-middleware/.npmignore
+++ b/packages/location-constraint-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/logger/.npmignore
+++ b/packages/logger/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/logger/.npmignore
+++ b/packages/logger/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/md5-js/.npmignore
+++ b/packages/md5-js/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/md5-js/.npmignore
+++ b/packages/md5-js/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/md5-universal/.npmignore
+++ b/packages/md5-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/md5-universal/.npmignore
+++ b/packages/md5-universal/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-content-length/.npmignore
+++ b/packages/middleware-content-length/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-content-length/.npmignore
+++ b/packages/middleware-content-length/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-ec2-copysnapshot/.npmignore
+++ b/packages/middleware-ec2-copysnapshot/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-ec2-copysnapshot/.npmignore
+++ b/packages/middleware-ec2-copysnapshot/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-expect-continue/.npmignore
+++ b/packages/middleware-expect-continue/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-expect-continue/.npmignore
+++ b/packages/middleware-expect-continue/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-header-default/.npmignore
+++ b/packages/middleware-header-default/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-header-default/.npmignore
+++ b/packages/middleware-header-default/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-input-default/.npmignore
+++ b/packages/middleware-input-default/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-input-default/.npmignore
+++ b/packages/middleware-input-default/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-operation-logging/.npmignore
+++ b/packages/middleware-operation-logging/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-operation-logging/.npmignore
+++ b/packages/middleware-operation-logging/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-rds-presignedurl/.npmignore
+++ b/packages/middleware-rds-presignedurl/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-rds-presignedurl/.npmignore
+++ b/packages/middleware-rds-presignedurl/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-api-gateway/.npmignore
+++ b/packages/middleware-sdk-api-gateway/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-api-gateway/.npmignore
+++ b/packages/middleware-sdk-api-gateway/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-glacier/.npmignore
+++ b/packages/middleware-sdk-glacier/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-glacier/.npmignore
+++ b/packages/middleware-sdk-glacier/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-s3/.npmignore
+++ b/packages/middleware-sdk-s3/.npmignore
@@ -3,6 +3,7 @@
 tsconfig.test.json
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-s3/.npmignore
+++ b/packages/middleware-sdk-s3/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-serializer/.npmignore
+++ b/packages/middleware-serializer/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-serializer/.npmignore
+++ b/packages/middleware-serializer/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-stack/.npmignore
+++ b/packages/middleware-stack/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/middleware-stack/.npmignore
+++ b/packages/middleware-stack/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/modeled-endpoint-middleware/.npmignore
+++ b/packages/modeled-endpoint-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/modeled-endpoint-middleware/.npmignore
+++ b/packages/modeled-endpoint-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/node-http-handler/.npmignore
+++ b/packages/node-http-handler/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/node-http-handler/.npmignore
+++ b/packages/node-http-handler/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/package-generator/.npmignore
+++ b/packages/package-generator/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/package-generator/.npmignore
+++ b/packages/package-generator/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/property-provider/.npmignore
+++ b/packages/property-provider/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/property-provider/.npmignore
+++ b/packages/property-provider/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/protocol-json-rpc/.npmignore
+++ b/packages/protocol-json-rpc/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/protocol-json-rpc/.npmignore
+++ b/packages/protocol-json-rpc/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/protocol-query/.npmignore
+++ b/packages/protocol-query/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/protocol-query/.npmignore
+++ b/packages/protocol-query/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/protocol-rest/.npmignore
+++ b/packages/protocol-rest/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/protocol-rest/.npmignore
+++ b/packages/protocol-rest/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/protocol-timestamp/.npmignore
+++ b/packages/protocol-timestamp/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/protocol-timestamp/.npmignore
+++ b/packages/protocol-timestamp/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/protocol-timestamp/tsconfig.json
+++ b/packages/protocol-timestamp/tsconfig.json
@@ -6,7 +6,7 @@
     "sourceMap": true,
     "strict": true,
     "lib": ["es5", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/query-builder/.npmignore
+++ b/packages/query-builder/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/query-builder/.npmignore
+++ b/packages/query-builder/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/query-error-unmarshaller/.npmignore
+++ b/packages/query-error-unmarshaller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/query-error-unmarshaller/.npmignore
+++ b/packages/query-error-unmarshaller/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/query-request-presigner/.npmignore
+++ b/packages/query-request-presigner/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/query-request-presigner/.npmignore
+++ b/packages/query-request-presigner/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/querystring-builder/.npmignore
+++ b/packages/querystring-builder/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/querystring-builder/.npmignore
+++ b/packages/querystring-builder/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/querystring-parser/.npmignore
+++ b/packages/querystring-parser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/querystring-parser/.npmignore
+++ b/packages/querystring-parser/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/region-provider/.npmignore
+++ b/packages/region-provider/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/region-provider/.npmignore
+++ b/packages/region-provider/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/remove-sensitive-logs/.npmignore
+++ b/packages/remove-sensitive-logs/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/remove-sensitive-logs/.npmignore
+++ b/packages/remove-sensitive-logs/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/response-metadata-extractor/.npmignore
+++ b/packages/response-metadata-extractor/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/response-metadata-extractor/.npmignore
+++ b/packages/response-metadata-extractor/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/response-metadata-extractor/tsconfig.json
+++ b/packages/response-metadata-extractor/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "sourceMap": true,
     "lib": ["es5", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/retry-middleware/.npmignore
+++ b/packages/retry-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/retry-middleware/.npmignore
+++ b/packages/retry-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/route53-id-normalizer-middleware/.npmignore
+++ b/packages/route53-id-normalizer-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/route53-id-normalizer-middleware/.npmignore
+++ b/packages/route53-id-normalizer-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/s3-error-unmarshaller/.npmignore
+++ b/packages/s3-error-unmarshaller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/s3-error-unmarshaller/.npmignore
+++ b/packages/s3-error-unmarshaller/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/s3-request-presigner/.npmignore
+++ b/packages/s3-request-presigner/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/s3-request-presigner/.npmignore
+++ b/packages/s3-request-presigner/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/service-error-classification/.npmignore
+++ b/packages/service-error-classification/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/service-error-classification/.npmignore
+++ b/packages/service-error-classification/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/service-model/.npmignore
+++ b/packages/service-model/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/service-model/.npmignore
+++ b/packages/service-model/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/service-types-generator/.npmignore
+++ b/packages/service-types-generator/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/service-types-generator/.npmignore
+++ b/packages/service-types-generator/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/sha256-tree-hash/.npmignore
+++ b/packages/sha256-tree-hash/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/sha256-tree-hash/.npmignore
+++ b/packages/sha256-tree-hash/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/shared-ini-file-loader/.npmignore
+++ b/packages/shared-ini-file-loader/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/shared-ini-file-loader/.npmignore
+++ b/packages/shared-ini-file-loader/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/shared-ini-file-loader/tsconfig.json
+++ b/packages/shared-ini-file-loader/tsconfig.json
@@ -6,7 +6,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/signature-v4-browser/.npmignore
+++ b/packages/signature-v4-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/signature-v4-browser/.npmignore
+++ b/packages/signature-v4-browser/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/signature-v4-node/.npmignore
+++ b/packages/signature-v4-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/signature-v4-node/.npmignore
+++ b/packages/signature-v4-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/signature-v4-universal/.npmignore
+++ b/packages/signature-v4-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/signature-v4-universal/.npmignore
+++ b/packages/signature-v4-universal/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/signature-v4/.npmignore
+++ b/packages/signature-v4/.npmignore
@@ -3,7 +3,9 @@
 /scripts/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map

--- a/packages/signature-v4/.npmignore
+++ b/packages/signature-v4/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /suite/
 /scripts/

--- a/packages/signing-middleware/.npmignore
+++ b/packages/signing-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/signing-middleware/.npmignore
+++ b/packages/signing-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/ssec-middleware/.npmignore
+++ b/packages/ssec-middleware/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/ssec-middleware/.npmignore
+++ b/packages/ssec-middleware/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/stream-collector-browser/.npmignore
+++ b/packages/stream-collector-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/stream-collector-browser/.npmignore
+++ b/packages/stream-collector-browser/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/stream-collector-node/.npmignore
+++ b/packages/stream-collector-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/stream-collector-node/.npmignore
+++ b/packages/stream-collector-node/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/test-protocol-rest-json/.npmignore
+++ b/packages/test-protocol-rest-json/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/test-protocol-rest-json/.npmignore
+++ b/packages/test-protocol-rest-json/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/test-protocol-rest-xml/.npmignore
+++ b/packages/test-protocol-rest-xml/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/test-protocol-rest-xml/.npmignore
+++ b/packages/test-protocol-rest-xml/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/url-parser-browser/.npmignore
+++ b/packages/url-parser-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/url-parser-browser/.npmignore
+++ b/packages/url-parser-browser/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/url-parser-node/.npmignore
+++ b/packages/url-parser-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/url-parser-node/.npmignore
+++ b/packages/url-parser-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/url-parser-universal/.npmignore
+++ b/packages/url-parser-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/url-parser-universal/.npmignore
+++ b/packages/url-parser-universal/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-base64-browser/.npmignore
+++ b/packages/util-base64-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-base64-browser/.npmignore
+++ b/packages/util-base64-browser/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-base64-node/.npmignore
+++ b/packages/util-base64-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-base64-node/.npmignore
+++ b/packages/util-base64-node/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-base64-universal/.npmignore
+++ b/packages/util-base64-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-base64-universal/.npmignore
+++ b/packages/util-base64-universal/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-body-length-browser/.npmignore
+++ b/packages/util-body-length-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-body-length-browser/.npmignore
+++ b/packages/util-body-length-browser/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-body-length-node/.npmignore
+++ b/packages/util-body-length-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-body-length-node/.npmignore
+++ b/packages/util-body-length-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-buffer-from/.npmignore
+++ b/packages/util-buffer-from/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-buffer-from/.npmignore
+++ b/packages/util-buffer-from/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-buffer-from/tsconfig.json
+++ b/packages/util-buffer-from/tsconfig.json
@@ -6,7 +6,7 @@
     "sourceMap": true,
     "strict": true,
     "lib": ["es5", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-create-request/.npmignore
+++ b/packages/util-create-request/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-create-request/.npmignore
+++ b/packages/util-create-request/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-error-constructor/.npmignore
+++ b/packages/util-error-constructor/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-error-constructor/.npmignore
+++ b/packages/util-error-constructor/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-format-url/.npmignore
+++ b/packages/util-format-url/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-format-url/.npmignore
+++ b/packages/util-format-url/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-hex-encoding/.npmignore
+++ b/packages/util-hex-encoding/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-hex-encoding/.npmignore
+++ b/packages/util-hex-encoding/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-hex-encoding/tsconfig.json
+++ b/packages/util-hex-encoding/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "sourceMap": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-locate-window/.npmignore
+++ b/packages/util-locate-window/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-locate-window/.npmignore
+++ b/packages/util-locate-window/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-uri-escape/.npmignore
+++ b/packages/util-uri-escape/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-uri-escape/.npmignore
+++ b/packages/util-uri-escape/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-user-agent-browser/.npmignore
+++ b/packages/util-user-agent-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-user-agent-browser/.npmignore
+++ b/packages/util-user-agent-browser/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-user-agent-node/.npmignore
+++ b/packages/util-user-agent-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-user-agent-node/.npmignore
+++ b/packages/util-user-agent-node/.npmignore
@@ -2,8 +2,10 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-utf8-browser/.npmignore
+++ b/packages/util-utf8-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-utf8-browser/.npmignore
+++ b/packages/util-utf8-browser/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-utf8-node/.npmignore
+++ b/packages/util-utf8-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-utf8-node/.npmignore
+++ b/packages/util-utf8-node/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-utf8-universal/.npmignore
+++ b/packages/util-utf8-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-utf8-universal/.npmignore
+++ b/packages/util-utf8-universal/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/xml-body-builder/.npmignore
+++ b/packages/xml-body-builder/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/xml-body-builder/.npmignore
+++ b/packages/xml-body-builder/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/xml-body-parser/.npmignore
+++ b/packages/xml-body-parser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/xml-body-parser/.npmignore
+++ b/packages/xml-body-parser/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/xml-builder/.npmignore
+++ b/packages/xml-builder/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/xml-builder/.npmignore
+++ b/packages/xml-builder/.npmignore
@@ -1,8 +1,10 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 


### PR DESCRIPTION
Crrently, SDKV3 publishes sourcemaps to npm but doesn't publish the source files that those sourcemaps point to. This missing source files breaks debugging use-cases, especially for VSCode users because the VSCode debugger relies on source files for setting breakpoints in the debugger, for debugger call stacks, for "step into" original source, and any other debugger use-cases.  Even outside of debugging use-cases, it's helpful for developers consuming transpiled libraries to have original source so they can better understand what the library is doing. Finally, some tools will show warnings when sourcemaps are present but source files are missing, and this PR will fix these warnings.

This PR:
* removes `/src` from npm for non-client packages, but adds adds `jest.config.js` and `*.spec.ts` to these packages' .npmignore because it's not expected to be able to run your tests using an NPM download.
* removes `*.ts` from npm for client packages. (also removes `!*.d.ts` which is now unnecessary)
* in 10 non-client packages, changes `sourceRoot` to `rootDir` in tsconfig.json.  The latter setting is used by all other SDKV3 packages, and it produces sourcemaps with an empty `sourceRoot` field. This is ideal, because the `sourceRoot` feature turned out to be buggy in some sourcemap-reading and sourcemap-writing tools. Leaving it blank maximizes compatibility with more tools.
 
This PR is similar to https://github.com/aws/aws-sdk-js-crypto-helpers/pull/5 in the AWS Crypto Helpers library, and https://github.com/aws-amplify/amplify-js/pull/2680 which made similar changes to AWS Amplify library earlier this year.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
