### PR TITLE
feat: move sendpointProvider and signingRegionProvider to client metadata[WIP]

### DIFF
--- a/clients/node/client-rds-data-node/ClientMetadata.ts
+++ b/clients/node/client-rds-data-node/ClientMetadata.ts
@@ -1,7 +1,7 @@
 import { HttpEndpoint } from '@aws-sdk/protocol-http';
-export function endpointProvider(tls: boolean, region: string): HttpEndpoint {
+export function endpointProvider(region: string, options: { tls?: boolean } = { tls: true }): HttpEndpoint {
   return {
-    protocol: tls ? "https:" : "http:",
+    protocol: options.tls ? "https:" : "http:",
     path: "/",
     hostname: `rds-data.${region}.amazonaws.com`
   }

--- a/clients/node/client-rds-data-node/ClientMetadata.ts
+++ b/clients/node/client-rds-data-node/ClientMetadata.ts
@@ -1,0 +1,12 @@
+import { HttpEndpoint } from '@aws-sdk/protocol-http';
+export function endpointProvider(tls: boolean, region: string): HttpEndpoint {
+  return {
+    protocol: tls ? "https:" : "http:",
+    path: "/",
+    hostname: `rds-data.${region}.amazonaws.com`
+  }
+}
+
+export function signingRegionProvider(region: string): string {
+  return region;
+}

--- a/clients/node/client-rds-data-node/RDSDataConfiguration.ts
+++ b/clients/node/client-rds-data-node/RDSDataConfiguration.ts
@@ -22,6 +22,7 @@ import {
   ProtocolConfigInput,
   AWSClientRuntimeConfiguration
 } from '@aws-sdk/config-resolver';
+import { endpointProvider, signingRegionProvider } from './ClientMetadata';
 
 export type AWSClientRuntimeResolvedConfiguration = Required<AWSClientRuntimeConfiguration>;
 
@@ -29,6 +30,8 @@ export const RDSRuntimeConfiguration: AWSClientRuntimeResolvedConfiguration = {
   protocolDefaultProvider: (handler) => new RestJsonProtocol(handler),
   signingName: "rds-data",
   service: "rds-data",
+  endpointProvider,
+  signingRegionProvider,
   httpHandler: new NodeHttpHandler(),
   sha256: Hash.bind(null, "sha256"),
   credentialDefaultProvider,

--- a/clients/node/client-rds-data-node/protocol/AwsRestJson1_1.ts
+++ b/clients/node/client-rds-data-node/protocol/AwsRestJson1_1.ts
@@ -95,7 +95,7 @@ export async function executeStatementAwsRestJson1_1Deserialize(
 async function executeStatementAwsRestJson1_1DeserializeError(
   output: HttpResponse
 ): Promise<ExecuteStatementResponse> {
-  let data = await parseBody(output);
+  let data = await parseBody(output.body);
   let response: any;
   switch (output.headers["x-amzn-ErrorType"]) {
     case "BadRequestException":

--- a/packages/config-resolver/src/components.ts
+++ b/packages/config-resolver/src/components.ts
@@ -92,9 +92,19 @@ export interface AWSClientRuntimeConfiguration extends RuntimeDependencies {
   signingName?: string;
 
   /**
-   * The service name with which to construct endpoints.
+   * The name of the service. By default same to endpoint prefix
    */
   service?: string;
+
+  /**
+   * The function that provides the default endpoint
+   */
+  endpointProvider?: any;
+
+  /**
+   * The function that provides the default region used to create the signer
+   */
+  signingRegionProvider?: any;
 }
 
 export function normalizeProvider<T>(input: T | Provider<T>): Provider<T> {

--- a/packages/config-resolver/src/components.ts
+++ b/packages/config-resolver/src/components.ts
@@ -99,12 +99,12 @@ export interface AWSClientRuntimeConfiguration extends RuntimeDependencies {
   /**
    * The function that provides the default endpoint
    */
-  endpointProvider?: any;
+  endpointProvider?: (region: string, options?: any) => HttpEndpoint;
 
   /**
    * The function that provides the default region used to create the signer
    */
-  signingRegionProvider?: any;
+  signingRegionProvider?: (region: string) => string;
 }
 
 export function normalizeProvider<T>(input: T | Provider<T>): Provider<T> {
@@ -165,7 +165,7 @@ export namespace EndpointsConfig {
     /**
      * The endpoint provider to call if no endpoint is provided
      */
-    endpointProvider?: any;
+    endpointProvider?: (region: string, options?: any) => HttpEndpoint;
 
     /**
      * Whether TLS is enabled for requests.
@@ -184,7 +184,7 @@ export namespace EndpointsConfig {
     input: T & Input & PreviouslyResolved
   ): T & Resolved {
     const tls = input.tls || true;
-    const defaultProvider = (tls: boolean, region: string) => ({
+    const defaultProvider = (region: string, options: { tls: boolean }) => ({
       protocol: tls ? "https:" : "http:",
       path: "/",
       hostname: `${input.service}.${region}.amazonaws.com`
@@ -192,7 +192,7 @@ export namespace EndpointsConfig {
     const endpointProvider = input.endpointProvider || defaultProvider;
     let endpoint: Provider<HttpEndpoint> = input.endpoint
       ? normalizeEndpoint(input.endpoint, input.urlParser)
-      : () => input.region().then(region => endpointProvider(tls, region));
+      : () => input.region().then(region => endpointProvider(region, { tls }));
     return {
       ...input,
       endpointProvider,

--- a/packages/signing-middleware/src/configurations.ts
+++ b/packages/signing-middleware/src/configurations.ts
@@ -26,6 +26,7 @@ export namespace AwsAuthConfiguration {
   interface PreviouslyResolved {
     credentialDefaultProvider: (input: any) => Provider<Credentials>;
     region: string | Provider<string>;
+    signingRegionProvider: any;
     signingName: string;
     sha256: HashConstructor;
   }
@@ -47,7 +48,9 @@ export namespace AwsAuthConfiguration {
       credentials: normalizedCreds,
       signer: new SignatureV4({
         credentials: normalizedCreds,
-        region: input.region,
+        region: input.signingRegionProvider
+          ? input.signingRegionProvider(input.region)
+          : input.region,
         service: input.signingName,
         sha256: input.sha256,
         uriEscapePath: signingEscapePath

--- a/packages/signing-middleware/src/configurations.ts
+++ b/packages/signing-middleware/src/configurations.ts
@@ -25,8 +25,8 @@ export namespace AwsAuthConfiguration {
   }
   interface PreviouslyResolved {
     credentialDefaultProvider: (input: any) => Provider<Credentials>;
-    region: string | Provider<string>;
-    signingRegionProvider: any;
+    region: Provider<string>;
+    signingRegionProvider: (region: string) => string;
     signingName: string;
     sha256: HashConstructor;
   }
@@ -49,7 +49,7 @@ export namespace AwsAuthConfiguration {
       signer: new SignatureV4({
         credentials: normalizedCreds,
         region: input.signingRegionProvider
-          ? input.signingRegionProvider(input.region)
+          ? () => input.region().then(input.signingRegionProvider)
           : input.region,
         service: input.signingName,
         sha256: input.sha256,


### PR DESCRIPTION
So that they can be generated separated to the Smithy API code generation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
