### PR TITLE
chore: add esbenp.prettier-vscode as editor.defaultFormatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.tabSize": 2,
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/407
Refs: https://github.com/aws/aws-sdk-js-v3/pull/404#discussion_r337174152

*Description of changes:*
add esbenp.prettier-vscode as editor.defaultFormatter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
