### PR TITLE
feat(signature-v4): add support to override the set of unsignableHeaders

### DIFF
--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -469,7 +469,7 @@ describe("SignatureV4", () => {
         }
       );
       expect(headers[AUTH_HEADER]).toMatch(
-        /^AWS4-HMAC-SHA256 Credential=foo\/20000101\/us-bar-1\/foo\/aws4_request, SignedHeaders=host;foo;user-agent;x-amz-content-sha256;x-amz-date, Signature=/
+        /^AWS4-HMAC-SHA256 Credential=foo\/20000101\/us-bar-1\/foo\/aws4_request, SignedHeaders=foo;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=/
       );
     });
 

--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -452,6 +452,27 @@ describe("SignatureV4", () => {
       );
     });
 
+    it("should allow specifying custom signable headers to override custom and always unsignable ones", async () => {
+      const { headers } = await signer.sign(
+        {
+          ...minimalRequest,
+          headers: {
+            host: "foo.us-bar-1.amazonaws.com",
+            foo: "bar",
+            "user-agent": "baz"
+          }
+        },
+        {
+          signingDate: new Date("2000-01-01T00:00:00.000Z"),
+          unsignableHeaders: new Set(["foo"]),
+          signableHeaders: new Set(["foo", "user-agent"])
+        }
+      );
+      expect(headers[AUTH_HEADER]).toMatch(
+        /^AWS4-HMAC-SHA256 Credential=foo\/20000101\/us-bar-1\/foo\/aws4_request, SignedHeaders=host;foo;user-agent;x-amz-content-sha256;x-amz-date, Signature=/
+      );
+    });
+
     it("should support signing with asynchronously resolved credentials", async () => {
       const credsProvider = () =>
         Promise.resolve({

--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -61,4 +61,30 @@ describe("getCanonicalHeaders", () => {
       host: "foo.us-east-1.amazonaws.com"
     });
   });
+
+  it("should allow specifying custom signable headers that override unsignable ones", () => {
+    const request: HttpRequest<never> = {
+      method: "POST",
+      protocol: "https:",
+      path: "/",
+      headers: {
+        host: "foo.us-east-1.amazonaws.com",
+        foo: "bar",
+        "user-agent": "foo-user"
+      },
+      hostname: "foo.us-east-1.amazonaws.com"
+    };
+
+    expect(
+      getCanonicalHeaders(
+        request,
+        new Set(["foo"]),
+        new Set(["foo", "user-agent"])
+      )
+    ).toEqual({
+      host: "foo.us-east-1.amazonaws.com",
+      foo: "bar",
+      "user-agent": "foo-user"
+    });
+  });
 });

--- a/packages/signature-v4/src/getCanonicalHeaders.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.ts
@@ -10,7 +10,8 @@ import {
  */
 export function getCanonicalHeaders(
   { headers }: HttpRequest<any>,
-  unsignableHeaders?: Set<string>
+  unsignableHeaders?: Set<string>,
+  signableHeaders?: Set<string>
 ): HeaderBag {
   const canonical: HeaderBag = {};
   for (let headerName of Object.keys(headers).sort()) {
@@ -21,7 +22,12 @@ export function getCanonicalHeaders(
       PROXY_HEADER_PATTERN.test(canonicalHeaderName) ||
       SEC_HEADER_PATTERN.test(canonicalHeaderName)
     ) {
-      continue;
+      if (
+        !signableHeaders ||
+        (signableHeaders && !signableHeaders.has(canonicalHeaderName))
+      ) {
+        continue;
+      }
     }
 
     canonical[canonicalHeaderName] = headers[headerName]

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -23,6 +23,16 @@ export interface RequestSigningArguments extends SigningArguments {
    * lower case and then checked for existence in the unsignableHeaders set.
    */
   unsignableHeaders?: Set<string>;
+
+  /**
+   * A set of strings whose members represents headers that should be signed.
+   * Any values passed here will override those provided via unsignableHeaders,
+   * allowing them to be signed.
+   *
+   * All headers in the provided request will have their names converted to
+   * lower case before signing.
+   */
+  signableHeaders?: Set<string>;
 }
 
 export interface RequestPresigner {


### PR DESCRIPTION
*Issue #, if available:*
Add support to override the set of unsignableHeaders; in cases where signing those headers (such as user-agent) would be desirable.

*Description of changes:*
Added a new set of signableHeaders, which is checked for inclusion before the specified header is removed for being an unsignable one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
