### PR TITLE
chore: replace TravisCI badge with that CodeBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS SDK for JavaScript V3 Developer Preview
 
-[![Build Status](https://travis-ci.org/aws/aws-sdk-js-v3.svg?branch=master)](https://travis-ci.org/aws/aws-sdk-js-v3)
+![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiMmtFajZWQmNUbEhidnBKN1VncjRrNVI3d0JUcFpGWUd3STh4T3N3Rnljc1BMaEIrYm9HU2t4YTV1RlE1YmlnUG9XM3luY0Ftc2tBc0xTeVFJMkVOa24wPSIsIml2UGFyYW1ldGVyU3BlYyI6IlBDMDl6UEROK1dlU1h1OWciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 [![codecov](https://codecov.io/gh/aws/aws-sdk-js-v3/branch/master/graph/badge.svg)](https://codecov.io/gh/aws/aws-sdk-js-v3)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 


### PR DESCRIPTION
*Issue #, if available:*
TravisCI was removed in https://github.com/aws/aws-sdk-js-v3/pull/386

*Description of changes:*
* chore: replace TravisCI badge with that CodeBuild
* It currently shows "unknown", it could be because it was just created by following [these instructions](https://docs.aws.amazon.com/en_pv/codebuild/latest/userguide/sample-build-badges)
![codebuild-badge](https://user-images.githubusercontent.com/16024985/67899600-dfdef680-fb1f-11e9-8506-cda571da49ba.png)
* AWS CDK badge for reference https://github.com/aws/aws-cdk/blob/master/README.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
