### PR TITLE
fix: update input and resolved config naming

### DIFF
--- a/clients/client-rds-data/RdsDataServiceClient.ts
+++ b/clients/client-rds-data/RdsDataServiceClient.ts
@@ -24,33 +24,33 @@ import {
   Encoder
 } from "@aws-sdk/types";
 import {
-  EndpointsConfigInput,
-  EndpointsConfigResolved,
+  EndpointsInputConfig,
+  EndpointsResolvedConfig,
   resolveEndpointsConfig,
-  ClientProtocolConfigInput,
-  ClientProtocolConfigResolved,
+  ClientProtocolInputConfig,
+  ClientProtocolResolvedConfig,
   resolveClientProtocolConfig,
   destroyClientProtocolConfig,
-  RegionConfigInput,
-  RegionConfigResolved,
+  RegionInputConfig,
+  RegionResolvedConfig,
   resolveRegionConfig
 } from "@aws-sdk/config-resolver";
 import { getContentLengthPlugin } from "@aws-sdk/middleware-content-length";
 import {
-  UserAgentConfigInput,
-  UserAgentConfigResolved,
+  UserAgentInputConfig,
+  UserAgentResolvedConfig,
   resolveUserAgentConfig,
   getUserAgentPlugin
 } from "@aws-sdk/middleware-user-agent";
 import {
-  RetryConfigInput,
-  RetryConfigResolved,
+  RetryInputConfig,
+  RetryResolvedConfig,
   resolveRetryConfig,
   getRetryPlugin
 } from "@aws-sdk/middleware-retry";
 import {
-  AwsAuthConfigInput,
-  AwsAuthConfigResolved,
+  AwsAuthInputConfig,
+  AwsAuthResolvedConfig,
   resolveAwsAuthConfig,
   getAwsAuthPlugin
 } from "@aws-sdk/middleware-signing";
@@ -157,23 +157,23 @@ export interface RDSDataRuntimeDependencies {
 }
 
 export type RdsDataServiceConfig = RDSDataRuntimeDependencies &
-  AwsAuthConfigInput &
-  RegionConfigInput &
-  RetryConfigInput &
-  EndpointsConfigInput &
-  ClientProtocolConfigInput &
-  UserAgentConfigInput;
+  AwsAuthInputConfig &
+  RegionInputConfig &
+  RetryInputConfig &
+  EndpointsInputConfig &
+  ClientProtocolInputConfig &
+  UserAgentInputConfig;
 
 export type RdsDataServiceResolvedConfig = SmithyResolvedConfiguration<
   __HttpOptions
 > &
   Required<RDSDataRuntimeDependencies> &
-  AwsAuthConfigResolved &
-  RegionConfigResolved &
-  RetryConfigResolved &
-  EndpointsConfigResolved &
-  ClientProtocolConfigResolved &
-  UserAgentConfigResolved;
+  AwsAuthResolvedConfig &
+  RegionResolvedConfig &
+  RetryResolvedConfig &
+  EndpointsResolvedConfig &
+  ClientProtocolResolvedConfig &
+  UserAgentResolvedConfig;
 
 export class RdsDataService extends SmithyClient<
   __HttpOptions,

--- a/packages/config-resolver/src/EndpointsConfig.ts
+++ b/packages/config-resolver/src/EndpointsConfig.ts
@@ -14,7 +14,7 @@ export function normalizeEndpoint(
   return endpoint!;
 }
 
-export interface EndpointsConfigInput {
+export interface EndpointsInputConfig {
   /**
    * The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3).
    */
@@ -35,13 +35,13 @@ interface PreviouslyResolved {
   region: Provider<string>;
   service: string;
 }
-export interface EndpointsConfigResolved
-  extends Required<EndpointsConfigInput> {
+export interface EndpointsResolvedConfig
+  extends Required<EndpointsInputConfig> {
   endpoint: Provider<Endpoint>;
 }
 export function resolveEndpointsConfig<T>(
-  input: T & EndpointsConfigInput & PreviouslyResolved
-): T & EndpointsConfigResolved {
+  input: T & EndpointsInputConfig & PreviouslyResolved
+): T & EndpointsResolvedConfig {
   const tls = input.tls || true;
   const defaultProvider = (tls: boolean, region: string) => ({
     protocol: tls ? "https:" : "http:",

--- a/packages/config-resolver/src/ProtocolConfig.ts
+++ b/packages/config-resolver/src/ProtocolConfig.ts
@@ -1,7 +1,7 @@
 import { Protocol, HttpOptions } from "@aws-sdk/types";
 import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 
-export interface ClientProtocolConfigInput {
+export interface ClientProtocolInputConfig {
   /**
    * The serializing protocol to used in request
    */
@@ -13,17 +13,17 @@ interface PreviouslyResolved {
     handler: HttpHandler
   ) => Protocol<HttpRequest, HttpResponse, HttpOptions>;
 }
-export type ClientProtocolConfigResolved = Required<ClientProtocolConfigInput>;
+export type ClientProtocolResolvedConfig = Required<ClientProtocolInputConfig>;
 export function resolveClientProtocolConfig<T>(
-  input: T & ClientProtocolConfigInput & PreviouslyResolved
-): T & ClientProtocolConfigResolved {
+  input: T & ClientProtocolInputConfig & PreviouslyResolved
+): T & ClientProtocolResolvedConfig {
   return {
     ...input,
     protocol: input.protocol || input.protocolDefaultProvider(input.httpHandler)
   };
 }
 export function destroyClientProtocolConfig(
-  config: ClientProtocolConfigResolved
+  config: ClientProtocolResolvedConfig
 ): void {
   config.protocol.destroy();
 }

--- a/packages/config-resolver/src/RegionConfig.ts
+++ b/packages/config-resolver/src/RegionConfig.ts
@@ -1,6 +1,6 @@
 import { Provider } from "@aws-sdk/types";
 
-export interface RegionConfigInput {
+export interface RegionInputConfig {
   /**
    * The AWS region to which this client will send requests
    */
@@ -9,12 +9,12 @@ export interface RegionConfigInput {
 interface PreviouslyResolved {
   regionDefaultProvider: (input: any) => Provider<string>;
 }
-export interface RegionConfigResolved {
+export interface RegionResolvedConfig {
   region: Provider<string>;
 }
 export function resolveRegionConfig<T>(
-  input: T & RegionConfigInput & PreviouslyResolved
-): T & RegionConfigResolved {
+  input: T & RegionInputConfig & PreviouslyResolved
+): T & RegionResolvedConfig {
   let region = input.region || input.regionDefaultProvider(input as any);
   return {
     ...input,

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -1,7 +1,7 @@
 import { RetryStrategy } from "@aws-sdk/types";
 import { ExponentialBackOffStrategy } from "./defaultStrategy";
 
-export interface RetryConfigInput {
+export interface RetryInputConfig {
   /**
    * The maximum number of times requests that encounter potentially transient failures should be retried
    */
@@ -11,13 +11,13 @@ export interface RetryConfigInput {
    */
   retryStrategy?: RetryStrategy;
 }
-export interface RetryConfigResolved {
+export interface RetryResolvedConfig {
   maxRetries: number;
   retryStrategy: RetryStrategy;
 }
 export function resolveRetryConfig<T>(
-  input: T & RetryConfigInput
-): T & RetryConfigResolved {
+  input: T & RetryInputConfig
+): T & RetryResolvedConfig {
   const maxRetries = input.maxRetries === undefined ? 3 : input.maxRetries;
   return {
     ...input,

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -5,9 +5,9 @@ import {
   FinalizeHandlerOutput,
   Pluggable
 } from "@aws-sdk/types";
-import { RetryConfigResolved } from "./configurations";
+import { RetryResolvedConfig } from "./configurations";
 
-export function retryMiddleware(options: RetryConfigResolved) {
+export function retryMiddleware(options: RetryResolvedConfig) {
   return <Output extends MetadataBearer = MetadataBearer>(
     next: FinalizeHandler<any, Output>
   ): FinalizeHandler<any, Output> => async (
@@ -18,7 +18,7 @@ export function retryMiddleware(options: RetryConfigResolved) {
 }
 
 export const getRetryPlugin = (
-  options: RetryConfigResolved
+  options: RetryResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     if (options.maxRetries > 0) {

--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -6,7 +6,7 @@ import {
 } from "@aws-sdk/types";
 import { SignatureV4 } from "@aws-sdk/signature-v4";
 
-export interface AwsAuthConfigInput {
+export interface AwsAuthInputConfig {
   /**
    * The credentials used to sign requests.
    */
@@ -28,14 +28,14 @@ interface PreviouslyResolved {
   signingName: string;
   sha256: HashConstructor;
 }
-export interface AwsAuthConfigResolved {
+export interface AwsAuthResolvedConfig {
   credentials: Provider<Credentials>;
   signer: RequestSigner;
   signingEscapePath: boolean;
 }
 export function resolveAwsAuthConfig<T>(
-  input: T & AwsAuthConfigInput & PreviouslyResolved
-): T & AwsAuthConfigResolved {
+  input: T & AwsAuthInputConfig & PreviouslyResolved
+): T & AwsAuthResolvedConfig {
   let credentials =
     input.credentials || input.credentialDefaultProvider(input as any);
   const normalizedCreds = normalizeProvider(credentials);

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -5,11 +5,11 @@ import {
   FinalizeHandlerOutput,
   Pluggable
 } from "@aws-sdk/types";
-import { AwsAuthConfigResolved } from "./configurations";
+import { AwsAuthResolvedConfig } from "./configurations";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
 export function signingMiddleware<Input extends object, Output extends object>(
-  options: AwsAuthConfigResolved
+  options: AwsAuthResolvedConfig
 ): FinalizeRequestMiddleware<Input, Output> {
   return (
     next: FinalizeHandler<Input, Output>
@@ -26,7 +26,7 @@ export function signingMiddleware<Input extends object, Output extends object>(
 }
 
 export const getAwsAuthPlugin = (
-  options: AwsAuthConfigResolved
+  options: AwsAuthResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     clientStack.add(signingMiddleware(options), {

--- a/packages/middleware-user-agent/src/configurations.ts
+++ b/packages/middleware-user-agent/src/configurations.ts
@@ -1,4 +1,4 @@
-export interface UserAgentConfigInput {
+export interface UserAgentInputConfig {
   /**
    * The custom user agent header that would be appended to default one
    */
@@ -7,12 +7,12 @@ export interface UserAgentConfigInput {
 interface PreviouslyResolved {
   defaultUserAgent: string;
 }
-export interface UserAgentConfigResolved {
+export interface UserAgentResolvedConfig {
   defaultUserAgent: string;
   customUserAgent?: string;
 }
 export function resolveUserAgentConfig<T>(
-  input: T & PreviouslyResolved & UserAgentConfigInput
-): T & UserAgentConfigResolved {
+  input: T & PreviouslyResolved & UserAgentInputConfig
+): T & UserAgentResolvedConfig {
   return input;
 }

--- a/packages/middleware-user-agent/src/middleware.ts
+++ b/packages/middleware-user-agent/src/middleware.ts
@@ -6,11 +6,11 @@ import {
   Pluggable
 } from "@aws-sdk/types";
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { UserAgentConfigResolved } from "./configurations";
+import { UserAgentResolvedConfig } from "./configurations";
 
 const userAgentHeader = "User-Agent";
 
-export function userAgentMiddleware(options: UserAgentConfigResolved) {
+export function userAgentMiddleware(options: UserAgentResolvedConfig) {
   return <Output extends MetadataBearer>(
     next: BuildHandler<any, any>
   ): BuildHandler<any, any> => (
@@ -35,7 +35,7 @@ export function userAgentMiddleware(options: UserAgentConfigResolved) {
 }
 
 export const getUserAgentPlugin = (
-  config: UserAgentConfigResolved
+  config: UserAgentResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     clientStack.add(userAgentMiddleware(config), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2034,6 +2034,13 @@ babel-runtime@^6.23.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
+backbone@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
+  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
+  dependencies:
+    underscore ">=1.8.3"
+
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -4320,6 +4327,11 @@ highlight.js@^9.13.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
   integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
 
+highlight.js@^9.15.8:
+  version "9.16.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.16.2.tgz#68368d039ffe1c6211bcc07e483daf95de3e403e"
+  integrity sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5362,6 +5374,11 @@ jest@^24.7.1:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5918,6 +5935,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lunr@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.8.tgz#a8b89c31f30b5a044b97d2d28e2da191b6ba2072"
+  integrity sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -5995,6 +6017,11 @@ marked@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
   integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
+
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -7138,7 +7165,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0, progress@^2.0.1:
+progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -7724,6 +7751,13 @@ rimraf@2, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -7880,7 +7914,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shelljs@^0.8.2:
+shelljs@^0.8.2, shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
@@ -8616,7 +8650,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-tslib@^1.8.0, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
@@ -8678,6 +8712,16 @@ typedoc-default-themes@^0.5.0:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
   integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
 
+typedoc-default-themes@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz#7e73bf54dd9e11550dd0fb576d5176b758f8f8b5"
+  integrity sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==
+  dependencies:
+    backbone "^1.4.0"
+    jquery "^3.4.1"
+    lunr "^2.3.6"
+    underscore "^1.9.1"
+
 typedoc@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.14.2.tgz#769f457f4f9e4bdb8b5f3b177c86b6a31d8c3dc3"
@@ -8701,15 +8745,42 @@ typedoc@^0.14.2:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
+typedoc@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.15.0.tgz#21eaf4db41cf2797bad027a74f2a75cd08ae0c2d"
+  integrity sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==
+  dependencies:
+    "@types/minimatch" "3.0.3"
+    fs-extra "^8.1.0"
+    handlebars "^4.1.2"
+    highlight.js "^9.15.8"
+    lodash "^4.17.15"
+    marked "^0.7.0"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    shelljs "^0.8.3"
+    typedoc-default-themes "^0.6.0"
+    typescript "3.5.x"
+
 typescript@3.2.x:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
+typescript@3.5.x:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
 typescript@3.7.0-dev.20190926:
   version "3.7.0-dev.20190926"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-dev.20190926.tgz#2e90fa4e56fad0fddb87e4d837cd33c7e4a55e7c"
   integrity sha512-uOQij3UHJnzxY/8Kv1kdmvWTjghgbCD0kBOgVGbY7Rni8ER51O8iPMmI4YpanZmaiZbPK6zUaS60b04/2C91bA==
+
+typescript@^3.6.3, typescript@^3.7.0-dev.20190926:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 typescript@~3.4.0:
   version "3.4.5"
@@ -8738,6 +8809,11 @@ umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+underscore@>=1.8.3, underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Brings naming of input and resolved config interfaces in line with https://github.com/awslabs/smithy-typescript/commit/a5734d2377a77261148f9d13ea4461f869b56fe3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
