### PR TITLE
fix: update input and resolved naming

### DIFF
--- a/clients/client-rds-data/RdsDataServiceClient.ts
+++ b/clients/client-rds-data/RdsDataServiceClient.ts
@@ -23,30 +23,30 @@ import {
   Encoder
 } from "@aws-sdk/types";
 import {
-  EndpointsConfigInput,
-  EndpointsConfigResolved,
+  EndpointsInputConfig,
+  EndpointsResolvedConfig,
   resolveEndpointsConfig,
   destroyRequestHandlerConfig,
-  RegionConfigInput,
-  RegionConfigResolved,
+  RegionInputConfig,
+  RegionResolvedConfig,
   resolveRegionConfig
 } from "@aws-sdk/config-resolver";
 import { getContentLengthPlugin } from "@aws-sdk/middleware-content-length";
 import {
-  UserAgentConfigInput,
-  UserAgentConfigResolved,
+  UserAgentInputConfig,
+  UserAgentResolvedConfig,
   resolveUserAgentConfig,
   getUserAgentPlugin
 } from "@aws-sdk/middleware-user-agent";
 import {
-  RetryConfigInput,
-  RetryConfigResolved,
+  RetryInputConfig,
+  RetryResolvedConfig,
   resolveRetryConfig,
   getRetryPlugin
 } from "@aws-sdk/middleware-retry";
 import {
-  AwsAuthConfigInput,
-  AwsAuthConfigResolved,
+  AwsAuthInputConfig,
+  AwsAuthResolvedConfig,
   resolveAwsAuthConfig,
   getAwsAuthPlugin
 } from "@aws-sdk/middleware-signing";
@@ -151,21 +151,21 @@ export interface RDSDataRuntimeDependencies {
 }
 
 export type RdsDataServiceConfig = RDSDataRuntimeDependencies &
-  AwsAuthConfigInput &
-  RegionConfigInput &
-  RetryConfigInput &
-  EndpointsConfigInput &
-  UserAgentConfigInput;
+  AwsAuthInputConfig &
+  RegionInputConfig &
+  RetryInputConfig &
+  EndpointsInputConfig &
+  UserAgentInputConfig;
 
 export type RdsDataServiceResolvedConfig = SmithyResolvedConfiguration<
   __HttpOptions
 > &
   Required<RDSDataRuntimeDependencies> &
-  AwsAuthConfigResolved &
-  RegionConfigResolved &
-  RetryConfigResolved &
-  EndpointsConfigResolved &
-  UserAgentConfigResolved;
+  AwsAuthResolvedConfig &
+  RegionResolvedConfig &
+  RetryResolvedConfig &
+  EndpointsResolvedConfig &
+  UserAgentResolvedConfig;
 
 export class RdsDataService extends SmithyClient<
   __HttpOptions,

--- a/packages/config-resolver/src/EndpointsConfig.ts
+++ b/packages/config-resolver/src/EndpointsConfig.ts
@@ -14,7 +14,7 @@ export function normalizeEndpoint(
   return endpoint!;
 }
 
-export interface EndpointsConfigInput {
+export interface EndpointsInputConfig {
   /**
    * The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3).
    */
@@ -35,13 +35,13 @@ interface PreviouslyResolved {
   region: Provider<string>;
   service: string;
 }
-export interface EndpointsConfigResolved
-  extends Required<EndpointsConfigInput> {
+export interface EndpointsResolvedConfig
+  extends Required<EndpointsInputConfig> {
   endpoint: Provider<Endpoint>;
 }
 export function resolveEndpointsConfig<T>(
-  input: T & EndpointsConfigInput & PreviouslyResolved
-): T & EndpointsConfigResolved {
+  input: T & EndpointsInputConfig & PreviouslyResolved
+): T & EndpointsResolvedConfig {
   const tls = input.tls || true;
   const defaultProvider = (tls: boolean, region: string) => ({
     protocol: tls ? "https:" : "http:",

--- a/packages/config-resolver/src/RegionConfig.ts
+++ b/packages/config-resolver/src/RegionConfig.ts
@@ -1,6 +1,6 @@
 import { Provider } from "@aws-sdk/types";
 
-export interface RegionConfigInput {
+export interface RegionInputConfig {
   /**
    * The AWS region to which this client will send requests
    */
@@ -9,12 +9,12 @@ export interface RegionConfigInput {
 interface PreviouslyResolved {
   regionDefaultProvider: (input: any) => Provider<string>;
 }
-export interface RegionConfigResolved {
+export interface RegionResolvedConfig {
   region: Provider<string>;
 }
 export function resolveRegionConfig<T>(
-  input: T & RegionConfigInput & PreviouslyResolved
-): T & RegionConfigResolved {
+  input: T & RegionInputConfig & PreviouslyResolved
+): T & RegionResolvedConfig {
   let region = input.region || input.regionDefaultProvider(input as any);
   return {
     ...input,

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -1,7 +1,7 @@
 import { RetryStrategy } from "@aws-sdk/types";
 import { ExponentialBackOffStrategy } from "./defaultStrategy";
 
-export interface RetryConfigInput {
+export interface RetryInputConfig {
   /**
    * The maximum number of times requests that encounter potentially transient failures should be retried
    */
@@ -11,13 +11,13 @@ export interface RetryConfigInput {
    */
   retryStrategy?: RetryStrategy;
 }
-export interface RetryConfigResolved {
+export interface RetryResolvedConfig {
   maxRetries: number;
   retryStrategy: RetryStrategy;
 }
 export function resolveRetryConfig<T>(
-  input: T & RetryConfigInput
-): T & RetryConfigResolved {
+  input: T & RetryInputConfig
+): T & RetryResolvedConfig {
   const maxRetries = input.maxRetries === undefined ? 3 : input.maxRetries;
   return {
     ...input,

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -5,9 +5,9 @@ import {
   FinalizeHandlerOutput,
   Pluggable
 } from "@aws-sdk/types";
-import { RetryConfigResolved } from "./configurations";
+import { RetryResolvedConfig } from "./configurations";
 
-export function retryMiddleware(options: RetryConfigResolved) {
+export function retryMiddleware(options: RetryResolvedConfig) {
   return <Output extends MetadataBearer = MetadataBearer>(
     next: FinalizeHandler<any, Output>
   ): FinalizeHandler<any, Output> => async (
@@ -18,7 +18,7 @@ export function retryMiddleware(options: RetryConfigResolved) {
 }
 
 export const getRetryPlugin = (
-  options: RetryConfigResolved
+  options: RetryResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     if (options.maxRetries > 0) {

--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -6,7 +6,7 @@ import {
 } from "@aws-sdk/types";
 import { SignatureV4 } from "@aws-sdk/signature-v4";
 
-export interface AwsAuthConfigInput {
+export interface AwsAuthInputConfig {
   /**
    * The credentials used to sign requests.
    */
@@ -28,14 +28,14 @@ interface PreviouslyResolved {
   signingName: string;
   sha256: HashConstructor;
 }
-export interface AwsAuthConfigResolved {
+export interface AwsAuthResolvedConfig {
   credentials: Provider<Credentials>;
   signer: RequestSigner;
   signingEscapePath: boolean;
 }
 export function resolveAwsAuthConfig<T>(
-  input: T & AwsAuthConfigInput & PreviouslyResolved
-): T & AwsAuthConfigResolved {
+  input: T & AwsAuthInputConfig & PreviouslyResolved
+): T & AwsAuthResolvedConfig {
   let credentials =
     input.credentials || input.credentialDefaultProvider(input as any);
   const normalizedCreds = normalizeProvider(credentials);

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -5,11 +5,11 @@ import {
   FinalizeHandlerOutput,
   Pluggable
 } from "@aws-sdk/types";
-import { AwsAuthConfigResolved } from "./configurations";
+import { AwsAuthResolvedConfig } from "./configurations";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
 export function signingMiddleware<Input extends object, Output extends object>(
-  options: AwsAuthConfigResolved
+  options: AwsAuthResolvedConfig
 ): FinalizeRequestMiddleware<Input, Output> {
   return (
     next: FinalizeHandler<Input, Output>
@@ -26,7 +26,7 @@ export function signingMiddleware<Input extends object, Output extends object>(
 }
 
 export const getAwsAuthPlugin = (
-  options: AwsAuthConfigResolved
+  options: AwsAuthResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     clientStack.add(signingMiddleware(options), {

--- a/packages/middleware-user-agent/src/configurations.ts
+++ b/packages/middleware-user-agent/src/configurations.ts
@@ -1,4 +1,4 @@
-export interface UserAgentConfigInput {
+export interface UserAgentInputConfig {
   /**
    * The custom user agent header that would be appended to default one
    */
@@ -7,12 +7,12 @@ export interface UserAgentConfigInput {
 interface PreviouslyResolved {
   defaultUserAgent: string;
 }
-export interface UserAgentConfigResolved {
+export interface UserAgentResolvedConfig {
   defaultUserAgent: string;
   customUserAgent?: string;
 }
 export function resolveUserAgentConfig<T>(
-  input: T & PreviouslyResolved & UserAgentConfigInput
-): T & UserAgentConfigResolved {
+  input: T & PreviouslyResolved & UserAgentInputConfig
+): T & UserAgentResolvedConfig {
   return input;
 }

--- a/packages/middleware-user-agent/src/middleware.ts
+++ b/packages/middleware-user-agent/src/middleware.ts
@@ -6,11 +6,11 @@ import {
   Pluggable
 } from "@aws-sdk/types";
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { UserAgentConfigResolved } from "./configurations";
+import { UserAgentResolvedConfig } from "./configurations";
 
 const userAgentHeader = "User-Agent";
 
-export function userAgentMiddleware(options: UserAgentConfigResolved) {
+export function userAgentMiddleware(options: UserAgentResolvedConfig) {
   return <Output extends MetadataBearer>(
     next: BuildHandler<any, any>
   ): BuildHandler<any, any> => (
@@ -35,7 +35,7 @@ export function userAgentMiddleware(options: UserAgentConfigResolved) {
 }
 
 export const getUserAgentPlugin = (
-  config: UserAgentConfigResolved
+  config: UserAgentResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     clientStack.add(userAgentMiddleware(config), {


### PR DESCRIPTION
Brings naming of input and resolved config interfaces in line with awslabs/smithy-typescript@a5734d2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
