### PR TITLE
fix: bump smithy dependency to 0.9.5

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -33,7 +33,7 @@ tasks.withType<Test> {
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-aws-traits:0.9.4")
+    api("software.amazon.smithy:smithy-aws-traits:0.9.5")
     api("software.amazon.smithy:smithy-typescript-codegen:0.1.0")
     testCompile("org.junit.jupiter:junit-jupiter-api:5.4.0")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")


### PR DESCRIPTION
bumps smithy dependency to 0.9.5 to match smithy-typescript.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
