### PR TITLE
chore: fix AWS integrations and dependencies

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.logging.Logger;
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+
+/**
+ * AWS clients need to know the service name used to sign requests,
+ * credentials for signing requests, and the region name used to resolve
+ * endpoints.
+ *
+ * <p>This plugin adds the following config interface fields:
+ *
+ * <ul>
+ *     <li>signingName: Defines the service name that signs AWS requests.</li>
+ *     <li>credentialDefaultProvider: Provides credentials if no credentials
+ *     are explicitly provided.</li>
+ *     <li>regionDefaultProvider: Provides a region if no region is
+ *     explicitly provided</li>
+ * </ul>
+ *
+ * <p>This plugin adds the following Node runtime specific values:
+ *
+ * <ul>
+ *     <li>signingName: Sets this to the signing name derived from the model.</li>
+ *     <li>credentialDefaultProvider: Uses the default credential provider that
+ *     checks things like environment variables and the AWS config file.</li>
+ *     <li>regionDefaultProvider: Uses the default region provider that
+ *     checks things like environment variables and the AWS config file.</li>
+ * </ul>
+ *
+ * <p>This plugin adds the following Browser runtime specific values:
+ *
+ * <ul>
+ *     <li>signingName: Sets this to the signing name derived from the model.</li>
+ *     <li>credentialDefaultProvider: Throws an exception since credentials must
+ *     be explicitly provided in the browser (environment variables and
+ *     the shared config can't be resolved from the browser).</li>
+ *     <li>regionDefaultProvider: Throws an exception since a region must
+ *     be explicitly provided in the browser (environment variables and
+ *     the shared config can't be resolved from the browser).</li>
+ * </ul>
+ */
+public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
+
+    private static final Logger LOGGER = Logger.getLogger(AddAwsRuntimeConfig.class.getName());
+
+    @Override
+    public void addConfigInterfaceFields(
+            TypeScriptSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            TypeScriptWriter writer
+    ) {
+        writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("Credentials", "__Credentials", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+
+        writer.writeDocs("The service name with which to sign requests.")
+                .write("signingName?: string;\n");
+        writer.writeDocs("Default credentials provider; Not available in browser runtime")
+                .write("credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;\n");
+        writer.writeDocs("Provider function that return promise of a region string")
+                .write("regionDefaultProvider?: (input: any) => __Provider<string>;\n");
+    }
+
+    @Override
+    public void addRuntimeConfigValues(
+            TypeScriptSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            TypeScriptWriter writer,
+            LanguageTarget target
+    ) {
+        ServiceShape service = settings.getService(model);
+        String signingName = service.getTrait(ServiceTrait.class)
+                .map(ServiceTrait::getArnNamespace)
+                .orElse(null);
+
+        if (signingName != null) {
+            writer.write("signingName: $S,", signingName);
+        } else {
+            LOGGER.info("Cannot generate a signing name for the client because no aws.api#Service "
+                        + "trait was found on " + service.getId());
+        }
+
+        switch (target) {
+            case NODE:
+                writeNodeConfig(writer);
+                break;
+            case BROWSER:
+                writeBrowserConfig(writer);
+                break;
+            default:
+                LOGGER.info("Unknown JavaScript target: " + target);
+        }
+    }
+
+    private void writeBrowserConfig(TypeScriptWriter writer) {
+        writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
+        writer.addImport("invalidFunction", "invalidFunction", TypeScriptDependency.INVALID_DEPENDENCY.packageName);
+        writer.write("credentialDefaultProvider: invalidFunction(\"Credential is missing\") as any,");
+        writer.write("regionDefaultProvider: invalidFunction(\"Region is missing\") as any,");
+    }
+
+    private void writeNodeConfig(TypeScriptWriter writer) {
+        writer.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
+        writer.addDependency(AwsDependency.REGION_PROVIDER);
+        writer.addImport("defaultProvider", "credentialDefaultProvider",
+                         AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName);
+        writer.addImport("defaultProvider", "regionDefaultProvider", AwsDependency.REGION_PROVIDER.packageName);
+        writer.write("credentialDefaultProvider,");
+        writer.write("regionDefaultProvider,");
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -15,9 +15,11 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
-import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention;
+import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_CONFIG;
+import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
 import java.util.List;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.ListUtils;
@@ -27,33 +29,29 @@ import software.amazon.smithy.utils.ListUtils;
  */
 public class AddBuiltinPlugins implements TypeScriptIntegration {
 
-    private static final String CONFIG_RESOLVER_VERSION = "^0.1.0-preview.5";
-
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         // Note that order is significant because configurations might
         // rely on previously resolved values.
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
-                        .withConventions("@aws-sdk/config-resolver", CONFIG_RESOLVER_VERSION, "Region",
-                                         Convention.HAS_CONFIG)
+                        .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions("@aws-sdk/middleware-signing", "^0.1.0-preview.7", "AwsAuth")
+                        .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth")
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions("@aws-sdk/config-resolver", CONFIG_RESOLVER_VERSION, "Endpoints",
-                                         Convention.HAS_CONFIG)
+                        .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Endpoints", HAS_CONFIG)
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions("@aws-sdk/middleware-retry", "^0.1.0-preview.5", "Retry")
+                        .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "Retry")
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions("@aws-sdk/middleware-user-agent", "^0.1.0-preview.1", "UserAgent")
+                        .withConventions(TypeScriptDependency.MIDDLEWARE_USER_AGENT.dependency, "UserAgent")
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions("@aws-sdk/middleware-content-length", "^0.1.0-preview.5", "ContentLength",
-                                         Convention.HAS_MIDDLEWARE)
+                        .withConventions(TypeScriptDependency.MIDDLEWARE_CONTENT_LENGTH.dependency, "ContentLength",
+                                         HAS_MIDDLEWARE)
                         .build()
         );
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import static software.amazon.smithy.typescript.codegen.TypeScriptDependency.NORMAL_DEPENDENCY;
+
+import java.util.Collections;
+import java.util.List;
+import software.amazon.smithy.codegen.core.SymbolDependency;
+import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+
+/**
+ * This enum should define all TypeScript dependencies that are introduced by
+ * this package.
+ */
+public enum AwsDependency implements SymbolDependencyContainer {
+
+    MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing", "^0.1.0-preview.7"),
+    CREDENTIAL_PROVIDER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/credential-provider-node", "^0.1.0-preview.7"),
+    REGION_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/region-provider", "^0.1.0-preview.5");
+
+    public final String packageName;
+    public final String version;
+    public final SymbolDependency dependency;
+
+    AwsDependency(String type, String name, String version) {
+        this.dependency = SymbolDependency.builder().dependencyType(type).packageName(name).version(version).build();
+        this.packageName = name;
+        this.version = version;
+    }
+
+    @Override
+    public List<SymbolDependency> getDependencies() {
+        return Collections.singletonList(dependency);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
@@ -17,9 +17,9 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.logging.Logger;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 
@@ -33,9 +33,14 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
 
     @Override
     public SymbolProvider decorateSymbolProvider(
-            PluginContext context, TypeScriptSettings settings, SymbolProvider symbolProvider) {
+            TypeScriptSettings settings, Model model, SymbolProvider symbolProvider) {
         return shape -> {
             Symbol symbol = symbolProvider.toSymbol(shape);
+
+            if (!shape.isServiceShape()) {
+                return symbol;
+            }
+
             // If the SDK service ID trait is present, use that, otherwise fall back to
             // the default naming strategy for the service.
             return shape.getTrait(ServiceTrait.class)
@@ -49,11 +54,11 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
     }
 
     private static Symbol updateServiceSymbol(Symbol symbol, String serviceId) {
-        String name = serviceId.replace(" ", "");
+        String name = serviceId.replace(" ", "") + "Client";
         return symbol.toBuilder()
                 .name(name)
-                .namespace("./" + name + "Client", "/")
-                .definitionFile(name + "Client.ts")
+                .namespace("./" + name, "/")
+                .definitionFile(name + ".ts")
                 .build();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -1,3 +1,4 @@
+software.amazon.smithy.aws.typescript.codegen.AddAwsRuntimeConfig
 software.amazon.smithy.aws.typescript.codegen.AddBuiltinPlugins
 software.amazon.smithy.aws.typescript.codegen.AddProtocols
 software.amazon.smithy.aws.typescript.codegen.AwsServiceIdIntegration

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
@@ -1,0 +1,45 @@
+package software.amazon.smithy.aws.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
+
+public class AddAwsRuntimeConfigTest {
+    @Test
+    public void addsAwsRuntimeConfigSettings() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("serviceid.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                                  .withMember("service", Node.from("smithy.example#OriginalName"))
+                                  .withMember("package", Node.from("example"))
+                                  .withMember("packageVersion", Node.from("1.0.0"))
+                                  .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check that one of the many dependencies was added.
+        assertThat(manifest.getFileString("package.json").get(),
+                   containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
+
+        // Check that both the config files were updated.
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("credentialDefaultProvider"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("invalidFunction"));
+
+        // Check that the dependency interface was updated.
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("credentialDefaultProvider?"));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -7,8 +7,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.build.MockManifest;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -29,15 +27,10 @@ public class AwsServiceIdIntegrationTest {
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         SymbolProvider decorated = integration.decorateSymbolProvider(
-                PluginContext.builder()
-                        .model(model)
-                        .fileManifest(new MockManifest())
-                        .build(),
-                new TypeScriptSettings(),
-                provider);
+                new TypeScriptSettings(), model, provider);
         Symbol symbol = decorated.toSymbol(service);
 
-        assertThat(symbol.getName(), equalTo("NotSame"));
+        assertThat(symbol.getName(), equalTo("NotSameClient"));
         assertThat(symbol.getNamespace(), equalTo("./NotSameClient"));
         assertThat(symbol.getDefinitionFile(), equalTo("NotSameClient.ts"));
     }

--- a/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/serviceid.smithy
+++ b/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/serviceid.smithy
@@ -1,6 +1,7 @@
 namespace smithy.example
 
 @aws.api#service(sdkId: "Not Same")
+@protocols([{name: "aws.rest-json-1.1"}])
 service OriginalName {
     version: "2019-10-15",
 }


### PR DESCRIPTION
This commit adds AWS runtime config integrations and fixes dependency
management to match smithy-typescript. It also fixes an issue where the
SymbolProvider decoration was not happening.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
