### PR TITLE
chore: remove unused client.send with callbacks

### DIFF
--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -36,44 +36,12 @@ export class Client<
       SmithyResolvedConfiguration<HandlerOptions>
     >,
     options?: HandlerOptions
-  ): Promise<OutputType>;
-  send<InputType extends ClientInput, OutputType extends ClientOutput>(
-    command: Command<
-      ClientInput,
-      InputType,
-      ClientOutput,
-      OutputType,
-      SmithyResolvedConfiguration<HandlerOptions>
-    >,
-    options: HandlerOptions,
-    cb: (err: any, data?: OutputType) => void
-  ): void;
-  send<InputType extends ClientInput, OutputType extends ClientOutput>(
-    command: Command<
-      ClientInput,
-      InputType,
-      ClientOutput,
-      OutputType,
-      SmithyResolvedConfiguration<HandlerOptions>
-    >,
-    options?: HandlerOptions,
-    cb?: (err: any, data?: OutputType) => void
-  ): Promise<OutputType> | void {
+  ): Promise<OutputType> {
     const handler = command.resolveMiddleware(
       this.middlewareStack as any,
       this.config,
       options
     );
-    if (cb) {
-      handler(command)
-        .then(result => cb(null, result.output), (err: any) => cb(err))
-        .catch(
-          // prevent any errors thrown in the callback from triggering an
-          // unhandled promise rejection
-          () => {}
-        );
-    } else {
-      return handler(command).then(result => result.output);
-    }
+    return handler(command).then(result => result.output);
   }
 }

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -20,28 +20,6 @@ interface InvokeFunction<
     >,
     options?: any
   ): Promise<OutputType>;
-  <InputType extends InputTypes, OutputType extends OutputTypes>(
-    command: Command<
-      InputTypes,
-      InputType,
-      OutputTypes,
-      OutputType,
-      ResolvedClientConfiguration
-    >,
-    options: any,
-    cb: (err: any, data?: OutputType) => void
-  ): void;
-  <InputType extends InputTypes, OutputType extends OutputTypes>(
-    command: Command<
-      InputTypes,
-      InputType,
-      OutputTypes,
-      OutputType,
-      ResolvedClientConfiguration
-    >,
-    options?: any,
-    cb?: (err: any, data?: OutputType) => void
-  ): Promise<OutputType> | void;
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/449

*Description of changes:*
chore: remove unused client.send with callbacks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
