### PR TITLE
feat: enable clockSkew correction by default

### DIFF
--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -18,9 +18,14 @@ export interface AwsAuthInputConfig {
   signer?: RequestSigner;
 
   /**
-   * Whether to escape request path when signing the request
+   * Whether to escape request path when signing the request.
    */
   signingEscapePath?: boolean;
+
+  /**
+   * An offset value in milliseconds to apply to all signing times.
+   */
+  systemClockOffset?: number;
 }
 interface PreviouslyResolved {
   credentialDefaultProvider: (input: any) => Provider<Credentials>;
@@ -32,6 +37,7 @@ export interface AwsAuthResolvedConfig {
   credentials: Provider<Credentials>;
   signer: RequestSigner;
   signingEscapePath: boolean;
+  systemClockOffset: number;
 }
 export function resolveAwsAuthConfig<T>(
   input: T & AwsAuthInputConfig & PreviouslyResolved

--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -46,8 +46,10 @@ export function resolveAwsAuthConfig<T>(
     input.credentials || input.credentialDefaultProvider(input as any);
   const normalizedCreds = normalizeProvider(credentials);
   const signingEscapePath = input.signingEscapePath || false;
+  const systemClockOffset = input.systemClockOffset || 0;
   return {
     ...input,
+    systemClockOffset,
     signingEscapePath,
     credentials: normalizedCreds,
     signer: new SignatureV4({

--- a/packages/middleware-signing/src/middleware.spec.ts
+++ b/packages/middleware-signing/src/middleware.spec.ts
@@ -4,12 +4,13 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 
 describe("SigningHandler", () => {
   const noOpSigner: RequestSigner = {
-    sign: (request: HttpRequest) =>
+    sign: (request: HttpRequest, options: { signingDate: Date }) =>
       Promise.resolve({
         ...request,
         headers: {
           ...request.headers,
-          signed: "true"
+          signed: "true",
+          signingDateTime: options.signingDate.getTime()
         }
       })
   } as any;
@@ -34,5 +35,28 @@ describe("SigningHandler", () => {
     const { calls } = (noOpNext as any).mock;
     expect(calls.length).toBe(1);
     expect(calls[0][0].request.headers.signed).toBe("true");
+  });
+
+  it("should add systemClockOffset while signing the request", async () => {
+    const systemClockOffset = 100000;
+    const now = Date.now();
+    const signingHandler = awsAuthMiddleware({
+      signer: noOpSigner,
+      systemClockOffset
+    } as any)(noOpNext, {} as any);
+    await signingHandler({
+      input: {},
+      request: new HttpRequest({
+        headers: {}
+      })
+    });
+
+    const { calls } = (noOpNext as any).mock;
+    expect(calls.length).toBe(1);
+    expect(calls[0][0].request.headers.signed).toBe("true");
+    // Using greater than to ensure there are no timing issues
+    expect(calls[0][0].request.headers.signingDateTime).toBeGreaterThan(
+      now + systemClockOffset - 1
+    );
   });
 });

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -22,7 +22,11 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
       if (!HttpRequest.isInstance(args.request)) return next(args);
       return next({
         ...args,
-        request: await options.signer.sign(args.request)
+        request: await options.signer.sign(args.request, {
+          signingDate: new Date(
+            new Date().getTime() + options.systemClockOffset
+          )
+        })
       });
     };
 }

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -23,9 +23,7 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
       return next({
         ...args,
         request: await options.signer.sign(args.request, {
-          signingDate: new Date(
-            new Date().getTime() + options.systemClockOffset
-          )
+          signingDate: new Date(Date.now() + options.systemClockOffset)
         })
       });
     };

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -27,14 +27,14 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
       args: FinalizeHandlerArguments<Input>
     ): Promise<FinalizeHandlerOutput<Output>> {
       if (!HttpRequest.isInstance(args.request)) return next(args);
-      const { response } = await next({
+      const output = await next({
         ...args,
         request: await options.signer.sign(args.request, {
           signingDate: new Date(Date.now() + options.systemClockOffset)
         })
       });
 
-      const { headers } = response as any;
+      const { headers } = output.response as any;
       const dateHeader = headers && (headers.date || headers.Date);
       if (dateHeader) {
         const serverTime = Date.parse(dateHeader);
@@ -43,8 +43,7 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
         }
       }
 
-      // @ts-ignore
-      return { response };
+      return output;
     };
 }
 

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -10,6 +10,13 @@ import {
 import { AwsAuthResolvedConfig } from "./configurations";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
+const isClockSkewed = (newServerTime: number, systemClockOffset: number) =>
+  Math.abs(getSkewCorrectedDate(systemClockOffset).getTime() - newServerTime) >=
+  300000;
+
+const getSkewCorrectedDate = (systemClockOffset: number) =>
+  new Date(Date.now() + systemClockOffset);
+
 export function awsAuthMiddleware<Input extends object, Output extends object>(
   options: AwsAuthResolvedConfig
 ): FinalizeRequestMiddleware<Input, Output> {
@@ -20,12 +27,24 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
       args: FinalizeHandlerArguments<Input>
     ): Promise<FinalizeHandlerOutput<Output>> {
       if (!HttpRequest.isInstance(args.request)) return next(args);
-      return next({
+      const { response } = await next({
         ...args,
         request: await options.signer.sign(args.request, {
           signingDate: new Date(Date.now() + options.systemClockOffset)
         })
       });
+
+      const { headers } = response as any;
+      const dateHeader = headers && (headers.date || headers.Date);
+      if (dateHeader) {
+        const serverTime = Date.parse(dateHeader);
+        if (isClockSkewed(serverTime, options.systemClockOffset)) {
+          options.systemClockOffset = serverTime - Date.now();
+        }
+      }
+
+      // @ts-ignore
+      return { response };
     };
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Enables clockSkew correction by default

In v2:
* The `applyClockOffset` is called in name `HTTP_HEADERS` with eventName `httpHeaders` ([code](https://github.com/aws/aws-sdk-js/blob/1ca7b9894d72b01425852c079cb47e378e206886/lib/event_listeners.js#L360-L377))
* The code which adds listeners from AWS.EventListeners.Core (and others) to request ([code](https://github.com/aws/aws-sdk-js/blob/1ca7b9894d72b01425852c079cb47e378e206886/lib/service.js#L259-L285))
* The function which calls httpHeaders callback ([code](https://github.com/aws/aws-sdk-js/blob/1ca7b9894d72b01425852c079cb47e378e206886/lib/event_listeners.js#L270-L273))
* The callback is passed to handleRequest in executeSend ([code](https://github.com/aws/aws-sdk-js/blob/1ca7b9894d72b01425852c079cb47e378e206886/lib/event_listeners.js#L342-L343))

How signing works in v3:
* SignatureV4 sign method uses current Date for signing if one is not passed in options ([code](https://github.com/aws/aws-sdk-js-v3/blob/8d6b27a97cf7f256b35986a305b27180e933f459/packages/signature-v4/src/SignatureV4.ts#L198-L201))
* signing happens in signRequest/signString ([code](https://github.com/aws/aws-sdk-js-v3/blob/8d6b27a97cf7f256b35986a305b27180e933f459/packages/signature-v4/src/SignatureV4.ts#L232-L288))
* signing-middleware calls signer.sign passing request and no options ([code](https://github.com/aws/aws-sdk-js-v3/blob/a4d20e2a60cffe75b679fe2f55dec11950134fcb/packages/signing-middleware/src/index.ts#L20))

In v3 smithy-codegen branch:
* AwsAuthPlugin does the functionality of signing ([code](https://github.com/aws/aws-sdk-js-v3/blob/3c333fb32f955e8e3ceff7e8d23b44db1ea42c90/clients/client-rds-data/RdsDataServiceClient.ts#L191))
* The auth plugin calls the signingMiddleware ([code](https://github.com/aws/aws-sdk-js-v3/blob/3c333fb32f955e8e3ceff7e8d23b44db1ea42c90/packages/middleware-signing/src/middleware.ts#L32))
* signer.sign operation is called in middleware ([code](https://github.com/aws/aws-sdk-js-v3/blob/3c333fb32f955e8e3ceff7e8d23b44db1ea42c90/packages/middleware-signing/src/middleware.ts#L23))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
