### PR TITLE
feat: make command generic types optional

### DIFF
--- a/clients/client-rds-data/commands/ExecuteStatementCommand.ts
+++ b/clients/client-rds-data/commands/ExecuteStatementCommand.ts
@@ -21,9 +21,7 @@ import {
 } from "../RdsDataServiceClient";
 
 export class ExecuteStatementCommand extends Command<
-  ServiceInputTypes,
   ExecuteStatementRequest,
-  ServiceOutputTypes,
   ExecuteStatementResponse,
   RdsDataServiceResolvedConfig
 > {

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -2,11 +2,11 @@ import { MiddlewareStack } from "@aws-sdk/middleware-stack";
 import { Command as ICommand, MetadataBearer, Handler } from "@aws-sdk/types";
 
 export abstract class Command<
-  ClientInput extends object,
   Input extends ClientInput,
-  ClientOutput extends MetadataBearer,
   Output extends ClientOutput,
-  ResolvedClientConfiguration
+  ResolvedClientConfiguration,
+  ClientInput extends object = any,
+  ClientOutput extends MetadataBearer = any
 >
   implements
     ICommand<


### PR DESCRIPTION
Makes ClientInput and ClientOutput generics optional on Command.

Matching update in Codegen: https://github.com/awslabs/smithy-typescript/pull/30/commits/2344f57fa1d18e1cbaf72c0eb3ac6fb955f642e4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
