### PR TITLE
chore: reintroduce client.send overloads with callbacks

### DIFF
--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -20,6 +20,28 @@ interface InvokeFunction<
     >,
     options?: any
   ): Promise<OutputType>;
+  <InputType extends InputTypes, OutputType extends OutputTypes>(
+    command: Command<
+      InputTypes,
+      InputType,
+      OutputTypes,
+      OutputType,
+      ResolvedClientConfiguration
+    >,
+    options: any,
+    cb: (err: any, data?: OutputType) => void
+  ): void;
+  <InputType extends InputTypes, OutputType extends OutputTypes>(
+    command: Command<
+      InputTypes,
+      InputType,
+      OutputTypes,
+      OutputType,
+      ResolvedClientConfiguration
+    >,
+    options?: any,
+    cb?: (err: any, data?: OutputType) => void
+  ): Promise<OutputType> | void;
 }
 
 /**


### PR DESCRIPTION
This reverts commit 60105ee5792aebbfa78a6b1a84714f881ed98be7.

*Issue #, if available:*
N/A

*Description of changes:*
We decided to reintroduce legacy style clients as discussed in https://github.com/aws/aws-sdk-js-v3/issues/364

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
