### PR TITLE
doc: bundle style difference between non-modular and modular approaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ async function example() {
 example();
 ```
 
-For users want to use legacy (v2-like) interfaces, you can import client with only the service name(e.g DynamoDB), and call the operation name directly from the client:
+If you want to use non-modular (v2-like) interfaces, you can import client with only the service name (e.g DynamoDB), and call the operation name directly from the client:
 
 ```javascript
 const { DynamoDB } = require("@aws-sdk/client-dynamodb-node");
@@ -57,7 +57,7 @@ async function example() {
 example();
 ```
 
-If you use tree shaking to reduce bundle size, using legacy interface will increase the bundle size as compared to using modular interface.
+If you use tree shaking to reduce bundle size, using non-modular interface will increase the bundle size as compared to using modular interface.
 In our workshop code, a lambda with DynamoDBClient and a command takes ~18kB while DynamoDB takes ~26 kB ([details](https://github.com/aws-samples/aws-sdk-js-v3-workshop/blob/dc3ad778b04dfe3f8f277dca67162da79c937eca/Exercise1/backend/README.md#reduce-bundle-size-by-just-importing-dynamodb))
 
 ## New features

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ async function example() {
 example();
 ```
 
-For users want to use V2-like interfaces, you can import client with only the service name(e.g DynamoDB), and call the operation name directly from the client:
+For users want to use legacy (v2-like) interfaces, you can import client with only the service name(e.g DynamoDB), and call the operation name directly from the client:
 
 ```javascript
 const { DynamoDB } = require("@aws-sdk/client-dynamodb-node");
@@ -57,7 +57,8 @@ async function example() {
 example();
 ```
 
-Note that this client is subject to change. It might be removed with SDK V3 comes closer to production-ready.
+If you use tree shaking to reduce bundle size, using legacy interface will increase the bundle size as compared to using modular interface.
+In our workshop code, a lambda with DynamoDBClient and a command takes ~18kB while DynamoDB takes ~26 kB ([details](https://github.com/aws-samples/aws-sdk-js-v3-workshop/blob/dc3ad778b04dfe3f8f277dca67162da79c937eca/Exercise1/backend/README.md#reduce-bundle-size-by-just-importing-dynamodb))
 
 ## New features
 


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/364

*Description of changes:*
We decided to ship legacy interface in v3, adding this note so that customers are aware of the bundle size differences

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
