### PR TITLE
Update HTTP binding protocol generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build
 codegen/build
 codegen/sdk-codegen/smithy-build.json
 .gradle
+*/out/
+*/*/out/

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
@@ -27,6 +27,6 @@ public class AddProtocols implements TypeScriptIntegration {
 
     @Override
     public List<ProtocolGenerator> getProtocolGenerators() {
-        return ListUtils.of(new AwsRestJson1_1());
+        return ListUtils.of(new AwsRestJson1_0(), new AwsRestJson1_1());
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_0.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_0.java
@@ -16,21 +16,21 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 /**
- * Handles generating the aws.rest-json-1.1 protocol for services.
+ * Handles generating the aws.rest-json-1.0 protocol for services.
  *
  * @inheritDoc
  *
  * @see RestJsonProtocolGenerator
  */
-public final class AwsRestJson1_1 extends RestJsonProtocolGenerator {
+public final class AwsRestJson1_0 extends RestJsonProtocolGenerator {
 
     @Override
     public String getName() {
-        return "aws.rest-json-1.1";
+        return "aws.rest-json-1.0";
     }
 
     @Override
     protected String getDocumentContentType() {
-        return "application/x-amz-json-1.1";
+        return "application/x-amz-json-1.0";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Overrides the default implementation of BigDecimal and BigInteger shape
+ * deserialization to throw when encountered in AWS JSON based protocols.
+ */
+final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
+
+    /**
+     * @inheritDoc
+     */
+    JsonMemberDeserVisitor(
+            GenerationContext context,
+            String dataSource,
+            Format defaultTimestampFormat
+    ) {
+        super(context, dataSource, defaultTimestampFormat);
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    private String unsupportedShape(Shape shape) {
+        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
+                shape.getType(), shape.getId()));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Overrides the default implementation of BigDecimal and BigInteger shape
+ * serialization to throw when encountered in AWS JSON based protocols.
+ */
+final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
+
+    /**
+     * @inheritDoc
+     */
+    JsonMemberSerVisitor(
+            GenerationContext context,
+            String dataSource,
+            Format defaultTimestampFormat
+    ) {
+        super(context, dataSource, defaultTimestampFormat);
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    private String unsupportedShape(Shape shape) {
+        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
+                shape.getType(), shape.getId()));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Map;
+import java.util.TreeMap;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeIndex;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.DocumentShapeDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Visitor to generate deserialization functions for shapes in AWS JSON protocol
+ * document bodies.
+ *
+ * No standard visitation methods are overridden; function body generation for all
+ * expected deserializers is handled by this class.
+ *
+ * Timestamps are deserialized from {@link Format}.EPOCH_SECONDS by default.
+ */
+final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
+
+    JsonShapeDeserVisitor(GenerationContext context) {
+        super(context);
+    }
+
+    private DocumentMemberDeserVisitor getMemberVisitor(String dataSource) {
+        return new JsonMemberDeserVisitor(getContext(), dataSource, Format.EPOCH_SECONDS);
+    }
+
+    @Override
+    protected void deserializeCollection(GenerationContext context, CollectionShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        Shape target = context.getModel().getShapeIndex().getShape(shape.getMember().getTarget()).get();
+
+        // Dispatch to the output value provider for any additional handling.
+        writer.openBlock("return (output || []).map((entry: any) =>", ");", () -> {
+            writer.write(target.accept(getMemberVisitor("entry")));
+        });
+    }
+
+    @Override
+    protected void deserializeDocument(GenerationContext context, DocumentShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        // Documents are JSON content, so don't modify.
+        writer.write("return output;");
+    }
+
+    @Override
+    protected void deserializeMap(GenerationContext context, MapShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        Shape target = context.getModel().getShapeIndex().getShape(shape.getValue().getTarget()).get();
+
+        // Get the right serialization for each entry in the map. Undefined
+        // outputs won't have this deserializer invoked.
+        writer.write("let mapParams: any = {};");
+        writer.openBlock("Object.keys(output).forEach(key => {", "});", () -> {
+            // Dispatch to the output value provider for any additional handling.
+            writer.write("mapParams[key] = $L;", target.accept(getMemberVisitor("output[key]")));
+        });
+        writer.write("return mapParams;");
+    }
+
+    @Override
+    protected void deserializeStructure(GenerationContext context, StructureShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Prepare the document contents structure.
+        // Use a TreeMap to sort the members.
+        Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
+        writer.openBlock("let contents: any = {", "};", () -> {
+            writer.write("__type: $S,", shape.getId().getName());
+            if (shape.hasTrait(ErrorTrait.class)) {
+                writer.write("$$fault: $S,", shape.getTrait(ErrorTrait.class).get().getValue());
+            }
+            // Set all the members to undefined to meet type constraints.
+            members.forEach((memberName, memberShape) -> writer.write("$L: undefined,", memberName));
+        });
+        members.forEach((memberName, memberShape) -> {
+            // Use the jsonName trait value if present, otherwise use the member name.
+            String locationName = memberShape.getTrait(JsonNameTrait.class)
+                    .map(JsonNameTrait::getValue)
+                    .orElse(memberName);
+            Shape target = context.getModel().getShapeIndex().getShape(memberShape.getTarget()).get();
+
+            // Generate an if statement to set the bodyParam if the member is set.
+            writer.openBlock("if (output.$L !== undefined) {", "}", locationName, () -> {
+                writer.write("contents.$L = $L;", memberName,
+                        // Dispatch to the output value provider for any additional handling.
+                        target.accept(getMemberVisitor("output." + locationName)));
+            });
+        });
+
+        writer.write("return contents;");
+    }
+
+    @Override
+    protected void deserializeUnion(GenerationContext context, UnionShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        ShapeIndex index = context.getModel().getShapeIndex();
+
+        // Check for any known union members and return when we find one.
+        Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
+        members.forEach((memberName, memberShape) -> {
+            Shape target = index.getShape(memberShape.getTarget()).get();
+            // Use the jsonName trait value if present, otherwise use the member name.
+            String locationName = memberShape.getTrait(JsonNameTrait.class)
+                    .map(JsonNameTrait::getValue)
+                    .orElse(memberName);
+            writer.openBlock("if (output.$L !== undefined) {", "}", locationName, () -> {
+                writer.openBlock("return {", "};", () -> {
+                    // Dispatch to the output value provider for any additional handling.
+                    writer.write("$L: $L", memberName, target.accept(getMemberVisitor("output." + locationName)));
+                });
+            });
+        });
+        // Or write to the unknown member the element in the output.
+        writer.write("return { $$unknown: output[Object.keys(output)[0]] };");
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Map;
+import java.util.TreeMap;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeIndex;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Visitor to generate serialization functions for shapes in AWS JSON protocol
+ * document bodies.
+ *
+ * No standard visitation methods are overridden; function body generation for all
+ * expected serializers is handled by this class.
+ *
+ * Timestamps are serialized to {@link Format}.EPOCH_SECONDS by default.
+ */
+final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
+
+    JsonShapeSerVisitor(GenerationContext context) {
+        super(context);
+    }
+
+    private DocumentMemberSerVisitor getMemberVisitor(String dataSource) {
+        return new JsonMemberSerVisitor(getContext(), dataSource, Format.EPOCH_SECONDS);
+    }
+
+    @Override
+    public void serializeCollection(GenerationContext context, CollectionShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        Shape target = context.getModel().getShapeIndex().getShape(shape.getMember().getTarget()).get();
+
+        // Dispatch to the input value provider for any additional handling.
+        writer.openBlock("return (input || []).map(entry =>", ");", () -> {
+            writer.write(target.accept(getMemberVisitor("entry")));
+        });
+    }
+
+    @Override
+    public void serializeDocument(GenerationContext context, DocumentShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        // Documents are JSON content, so don't modify.
+        writer.write("return input;");
+    }
+
+    @Override
+    public void serializeMap(GenerationContext context, MapShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        Shape target = context.getModel().getShapeIndex().getShape(shape.getValue().getTarget()).get();
+
+        // Get the right serialization for each entry in the map. Undefined
+        // inputs won't have this serializer invoked.
+        writer.write("let mapParams: any = {};");
+        writer.openBlock("Object.keys(input).forEach(key => {", "});", () -> {
+            // Dispatch to the input value provider for any additional handling.
+            writer.write("mapParams[key] = $L;", target.accept(getMemberVisitor("input[key]")));
+        });
+        writer.write("return mapParams;");
+    }
+
+    @Override
+    public void serializeStructure(GenerationContext context, StructureShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.write("let bodyParams: any = {};");
+        // Use a TreeMap to sort the members.
+        Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
+        members.forEach((memberName, memberShape) -> {
+            // Use the jsonName trait value if present, otherwise use the member name.
+            String locationName = memberShape.getTrait(JsonNameTrait.class)
+                    .map(JsonNameTrait::getValue)
+                    .orElse(memberName);
+            Shape target = context.getModel().getShapeIndex().getShape(memberShape.getTarget()).get();
+
+            // Generate an if statement to set the bodyParam if the member is set.
+            writer.openBlock("if (input.$L !== undefined) {", "}", memberName, () -> {
+                // Dispatch to the input value provider for any additional handling.
+                writer.write("bodyParams['$L'] = $L;", locationName,
+                        target.accept(getMemberVisitor("input." + memberName)));
+            });
+        });
+        writer.write("return bodyParams;");
+    }
+
+    @Override
+    public void serializeUnion(GenerationContext context, UnionShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        ShapeIndex index = context.getModel().getShapeIndex();
+
+        // Visit over the union type, then get the right serialization for the member.
+        writer.openBlock("return $L.visit(input, {", "});", shape.getId().getName(), () -> {
+            // Use a TreeMap to sort the members.
+            Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
+            members.forEach((memberName, memberShape) -> {
+                    Shape target = index.getShape(memberShape.getTarget()).get();
+                    // Dispatch to the input value provider for any additional handling.
+                    writer.write("$L: value => $L,", memberName, target.accept(getMemberVisitor("value")));
+                });
+            writer.write("_: value => value");
+        });
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
+import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
+
+/**
+ * Handles general components across the AWS JSON protocols that have HTTP bindings.
+ * It handles reading and writing from document bodies, including generating any
+ * functions needed for performing serde.
+ *
+ * This builds on the foundations of the {@link HttpBindingProtocolGenerator} to handle
+ * components of binding to HTTP requests and responses.
+ *
+ * @see JsonShapeSerVisitor
+ * @see JsonShapeDeserVisitor
+ * @see JsonMemberSerVisitor
+ * @see DocumentMemberDeserVisitor
+ * @see <a href="https://awslabs.github.io/smithy/spec/http.html">Smithy HTTP protocol bindings.</a>
+ */
+abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
+
+    @Override
+    protected TimestampFormatTrait.Format getDocumentTimestampFormat() {
+        return TimestampFormatTrait.Format.EPOCH_SECONDS;
+    }
+
+    @Override
+    protected void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes) {
+        generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+    }
+
+    @Override
+    protected void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
+        generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
+    }
+
+    private void generateDocumentShapeSerde(GenerationContext context, Set<Shape> shapes, ShapeVisitor<Void> visitor) {
+        // Walk all the shapes within those in the document and generate for them as well.
+        Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
+        Set<Shape> shapesToDeserialize = new TreeSet<>(shapes);
+        shapes.forEach(shape -> shapesToDeserialize.addAll(shapeWalker.walkShapes(shape)));
+        shapesToDeserialize.forEach(shape -> shape.accept(visitor));
+    }
+
+    @Override
+    public void generateSharedComponents(GenerationContext context) {
+        super.generateSharedComponents(context);
+        TypeScriptWriter writer = context.getWriter();
+
+        // Include a JSON body parser used to deserialize documents from HTTP responses.
+        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        writer.openBlock("const parseBody = (streamBody: any, context: SerdeContext): any => {", "};", () -> {
+            writer.openBlock("return context.streamCollector(streamBody).then((body: any) => {", "});", () -> {
+                writer.write("const encoded = context.utf8Encoder(body);");
+                writer.openBlock("if (encoded.length) {", "}", () -> {
+                    writer.write("return JSON.parse(encoded);");
+                });
+                writer.write("return {};");
+            });
+        });
+
+        writer.write("");
+    }
+
+    @Override
+    public void serializeInputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+    ) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.write("let bodyParams: any = {};");
+        for (HttpBinding binding : documentBindings) {
+            MemberShape member = binding.getMember();
+            // The name of the member to get from the input shape.
+            String memberName = symbolProvider.toMemberName(member);
+            // Use the jsonName trait value if present, otherwise use the member name.
+            String locationName = binding.getMember().getTrait(JsonNameTrait.class)
+                    .map(JsonNameTrait::getValue)
+                    .orElseGet(binding::getLocationName);
+            Shape target = context.getModel().getShapeIndex().getShape(member.getTarget()).get();
+
+            // Generate an if statement to set the bodyParam if the member is set.
+            writer.openBlock("if (input.$L !== undefined) {", "}", memberName, () -> {
+                writer.write("bodyParams['$L'] = $L;", locationName,
+                        target.accept(getMemberSerVisitor(context, "input." + memberName)));
+            });
+        }
+
+        writer.write("body = JSON.stringify(bodyParams);");
+    }
+
+    private DocumentMemberSerVisitor getMemberSerVisitor(GenerationContext context, String dataSource) {
+        return new JsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
+    }
+
+    @Override
+    protected void writeErrorCodeParser(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.write("errorCode = output.headers[\"x-amzn-errortype\"].split(':')[0];");
+    }
+
+    @Override
+    public void deserializeOutputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+
+        for (HttpBinding binding : documentBindings) {
+            Shape target = context.getModel().getShapeIndex().getShape(binding.getMember().getTarget()).get();
+            // The name of the member to get from the input shape.
+            String memberName = symbolProvider.toMemberName(binding.getMember());
+            // Use the jsonName trait value if present, otherwise use the member name.
+            String locationName = binding.getMember().getTrait(JsonNameTrait.class)
+                    .map(JsonNameTrait::getValue)
+                    .orElseGet(binding::getLocationName);
+            writer.openBlock("if (data.$L !== undefined) {", "}", locationName, () -> {
+                writer.write("contents.$L = $L;", memberName,
+                        target.accept(getMemberDeserVisitor(context, "data." + locationName)));
+            });
+        }
+    }
+
+    private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
+        return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
+    }
+}


### PR DESCRIPTION
This commit updates the support for `aws.rest-json-1.1` to build atop
the refactor of protocol generation done in smithy-typescript. It
also introduces support for the `aws.rest-json-1.0` protocol.

In doing so, general components were built atop the abstractions
provided. The aws.rest-json-1.* set of protocols serialize BigInteger
and BigDecimal shapes as JSON numbers on the wire, so an implementation
of the DocumentMember[Deser|Ser]Visitor was created to fail generation.
Implementations of the DocumentShape[Deser|Ser]Visitor classes are
also included to support serde of shapes in request and response
bodies.

A rest-json implementation of the `HttpBindingProtocolGenerator` has been
created to combine the above aspects and handling of document bodies.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
