### PR TITLE
Dynamodb integ tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ async function example() {
 example();
 ```
 
-For users want to use legacy (v2-like) interfaces, you can import client with only the service name(e.g DynamoDB), and call the operation name directly from the client:
+For users want to use V2-like interfaces, you can import client with only the service name(e.g DynamoDB), and call the operation name directly from the client:
 
 ```javascript
 const { DynamoDB } = require("@aws-sdk/client-dynamodb-node");
@@ -57,8 +57,7 @@ async function example() {
 example();
 ```
 
-If you use tree shaking to reduce bundle size, using legacy interface will increase the bundle size as compared to using modular interface.
-In our workshop code, a lambda with DynamoDBClient and a command takes ~18kB while DynamoDB takes ~26 kB ([details](https://github.com/aws-samples/aws-sdk-js-v3-workshop/blob/dc3ad778b04dfe3f8f277dca67162da79c937eca/Exercise1/backend/README.md#reduce-bundle-size-by-just-importing-dynamodb))
+Note that this client is subject to change. It might be removed with SDK V3 comes closer to production-ready.
 
 ## New features
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ async function example() {
 example();
 ```
 
-For users want to use V2-like interfaces, you can import client with only the service name(e.g DynamoDB), and call the operation name directly from the client:
+For users want to use legacy (v2-like) interfaces, you can import client with only the service name(e.g DynamoDB), and call the operation name directly from the client:
 
 ```javascript
 const { DynamoDB } = require("@aws-sdk/client-dynamodb-node");
@@ -57,7 +57,8 @@ async function example() {
 example();
 ```
 
-Note that this client is subject to change. It might be removed with SDK V3 comes closer to production-ready.
+If you use tree shaking to reduce bundle size, using legacy interface will increase the bundle size as compared to using modular interface.
+In our workshop code, a lambda with DynamoDBClient and a command takes ~18kB while DynamoDB takes ~26 kB ([details](https://github.com/aws-samples/aws-sdk-js-v3-workshop/blob/dc3ad778b04dfe3f8f277dca67162da79c937eca/Exercise1/backend/README.md#reduce-bundle-size-by-just-importing-dynamodb))
 
 ## New features
 

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -7,7 +7,8 @@ describe("DynamoDB integration tests", () => {
     .substring(2)}`;
 
   describe("Table CRUD operations", () => {
-    beforeAll(async () => {
+    beforeAll(async done => {
+      console.log("ENTER beforeAll");
       const params = {
         TableName: tableName,
         AttributeDefinitions: [
@@ -37,15 +38,20 @@ describe("DynamoDB integration tests", () => {
       };
       const response = await client.createTable(params);
       console.log(response);
+      console.log("EXIT beforeAll");
+      done();
     });
 
     it("single test", () => {});
 
-    afterAll(async () => {
+    afterAll(async done => {
+      console.log("ENTER afterAll");
       const response = await client.deleteTable({
         TableName: tableName
       });
       console.log(response);
+      console.log("EXIT afterAll");
+      done();
     });
   });
 });

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -1,0 +1,49 @@
+import { DynamoDB } from "../../DynamoDB";
+
+describe("DynamoDB integration tests", () => {
+  const client = new DynamoDB({});
+  const tableName = `aws-js-integration-${Math.random()
+    .toString(36)
+    .substring(2)}`;
+
+  describe("Table CRUD operations", () => {
+    beforeAll(async () => {
+      const params = {
+        TableName: tableName,
+        AttributeDefinitions: [
+          {
+            AttributeName: "Artist",
+            AttributeType: "S"
+          },
+          {
+            AttributeName: "SongTitle",
+            AttributeType: "S"
+          }
+        ],
+        KeySchema: [
+          {
+            AttributeName: "Artist",
+            KeyType: "HASH"
+          },
+          {
+            AttributeName: "SongTitle",
+            KeyType: "RANGE"
+          }
+        ],
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 5,
+          WriteCapacityUnits: 5
+        }
+      };
+      const response = await client.createTable(params);
+      console.log(response);
+    });
+
+    afterAll(async () => {
+      const response = await client.deleteTable({
+        TableName: tableName
+      });
+      console.log(response);
+    });
+  });
+});

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -126,6 +126,40 @@ describe("DynamoDB integration tests", () => {
       expect(item.Item && item.Item.AlbumTitle.S).toBe(albumTitle);
     });
 
+    it("updates an item in the table", async () => {
+      expect.assertions(1);
+
+      const item = await client.getItem({
+        Key: itemKey,
+        TableName: tableName
+      });
+
+      const newAlbumTitle = `New ${item.Item && item.Item.AlbumTitle.S}`;
+      var params = {
+        ExpressionAttributeNames: {
+          "#AT": "AlbumTitle"
+        },
+        ExpressionAttributeValues: {
+          ":t": {
+            S: newAlbumTitle
+          }
+        },
+        Key: itemKey,
+        ReturnValues: "ALL_NEW",
+        TableName: tableName,
+        UpdateExpression: "SET #AT = :t"
+      };
+      await client.updateItem(params);
+
+      const updatedItem = await client.getItem({
+        Key: itemKey,
+        TableName: tableName
+      });
+      expect(updatedItem.Item && updatedItem.Item.AlbumTitle.S).toBe(
+        newAlbumTitle
+      );
+    });
+
     it("deletes an item from the table", async () => {
       expect.assertions(1);
 

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -1,10 +1,41 @@
 import { DynamoDB } from "../../DynamoDB";
 
 describe("DynamoDB integration tests", () => {
+  // Move this timeout to jest config for integ tests
+  jest.setTimeout(500000);
+
   const client = new DynamoDB({});
   const tableName = `aws-js-integration-${Math.random()
     .toString(36)
     .substring(2)}`;
+
+  // Replace with waiters once available
+  const tableExists = async (tableName: string) => {
+    const params = { TableName: tableName };
+    const sleepFor = (ms: number) =>
+      new Promise(resolve => setTimeout(resolve, ms));
+
+    // Iterate totalTries times
+    const totalTries = 25;
+    for (let i = 0; i < totalTries; i++) {
+      try {
+        const response = await client.describeTable(params);
+        if (response.Table && response.Table.TableStatus === "ACTIVE") {
+          return true;
+        } else {
+          if (i === totalTries - 1) {
+            throw `Table ${tableName} not in active status`;
+          }
+          await sleepFor(20000);
+        }
+      } catch (e) {
+        if (i === totalTries - 1) {
+          throw e;
+        }
+        await sleepFor(20000);
+      }
+    }
+  };
 
   describe("Table CRUD operations", () => {
     beforeAll(async done => {
@@ -38,6 +69,7 @@ describe("DynamoDB integration tests", () => {
       };
       const response = await client.createTable(params);
       console.log(response);
+      await tableExists(tableName);
       console.log("EXIT beforeAll");
       done();
     });

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -5,9 +5,10 @@ describe("DynamoDB integration tests", () => {
   jest.setTimeout(500000);
 
   const client = new DynamoDB({});
-  const tableName = `aws-js-integration-${Math.random()
-    .toString(36)
-    .substring(2)}`;
+  // const tableName = `aws-js-integration-${Math.random()
+  //   .toString(36)
+  //   .substring(2)}`;
+  const tableName = "aws-js-integration";
   const sleepFor = (ms: number) =>
     new Promise(resolve => setTimeout(resolve, ms));
 
@@ -62,47 +63,47 @@ describe("DynamoDB integration tests", () => {
   };
 
   describe("Table CRUD operations", () => {
-    beforeAll(async done => {
-      const params = {
-        TableName: tableName,
-        AttributeDefinitions: [
-          {
-            AttributeName: "Artist",
-            AttributeType: "S"
-          },
-          {
-            AttributeName: "SongTitle",
-            AttributeType: "S"
-          }
-        ],
-        KeySchema: [
-          {
-            AttributeName: "Artist",
-            KeyType: "HASH"
-          },
-          {
-            AttributeName: "SongTitle",
-            KeyType: "RANGE"
-          }
-        ],
-        ProvisionedThroughput: {
-          ReadCapacityUnits: 5,
-          WriteCapacityUnits: 5
-        }
-      };
-      await client.createTable(params);
-      await tableExists(tableName);
-      done();
-    });
+    // beforeAll(async done => {
+    //   const params = {
+    //     TableName: tableName,
+    //     AttributeDefinitions: [
+    //       {
+    //         AttributeName: "Artist",
+    //         AttributeType: "S"
+    //       },
+    //       {
+    //         AttributeName: "SongTitle",
+    //         AttributeType: "S"
+    //       }
+    //     ],
+    //     KeySchema: [
+    //       {
+    //         AttributeName: "Artist",
+    //         KeyType: "HASH"
+    //       },
+    //       {
+    //         AttributeName: "SongTitle",
+    //         KeyType: "RANGE"
+    //       }
+    //     ],
+    //     ProvisionedThroughput: {
+    //       ReadCapacityUnits: 5,
+    //       WriteCapacityUnits: 5
+    //     }
+    //   };
+    //   await client.createTable(params);
+    //   await tableExists(tableName);
+    //   done();
+    // });
 
     it("single test", () => {});
 
-    afterAll(async done => {
-      await client.deleteTable({
-        TableName: tableName
-      });
-      await tableNotExists(tableName);
-      done();
-    });
+    // afterAll(async done => {
+    //   await client.deleteTable({
+    //     TableName: tableName
+    //   });
+    //   await tableNotExists(tableName);
+    //   done();
+    // });
   });
 });

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -39,6 +39,8 @@ describe("DynamoDB integration tests", () => {
       console.log(response);
     });
 
+    it("single test", () => {});
+
     afterAll(async () => {
       const response = await client.deleteTable({
         TableName: tableName

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -126,6 +126,20 @@ describe("DynamoDB integration tests", () => {
       expect(item.Item && item.Item.AlbumTitle.S).toBe(albumTitle);
     });
 
+    it("deletes an item from the table", async () => {
+      expect.assertions(1);
+
+      await client.deleteItem({
+        Key: itemKey,
+        TableName: tableName
+      });
+      const item = await client.getItem({
+        Key: itemKey,
+        TableName: tableName
+      });
+      expect(item.Item).toBeUndefined();
+    });
+
     // afterAll(async done => {
     //   await client.deleteTable({
     //     TableName: tableName

--- a/clients/node/client-dynamodb-node/test/integ/index.spec.ts
+++ b/clients/node/client-dynamodb-node/test/integ/index.spec.ts
@@ -63,6 +63,14 @@ describe("DynamoDB integration tests", () => {
   };
 
   describe("Table CRUD operations", () => {
+    const itemKey = {
+      Artist: {
+        S: "Acme Band"
+      },
+      SongTitle: {
+        S: "Happy Day"
+      }
+    };
     // beforeAll(async done => {
     //   const params = {
     //     TableName: tableName,
@@ -96,7 +104,27 @@ describe("DynamoDB integration tests", () => {
     //   done();
     // });
 
-    it("single test", () => {});
+    it("adds an item to the table", async () => {
+      expect.assertions(1);
+
+      const albumTitle = "Somewhat Famous";
+      const params = {
+        Item: {
+          ...itemKey,
+          AlbumTitle: {
+            S: albumTitle
+          }
+        },
+        TableName: tableName
+      };
+
+      await client.putItem(params);
+      const item = await client.getItem({
+        Key: itemKey,
+        TableName: tableName
+      });
+      expect(item.Item && item.Item.AlbumTitle.S).toBe(albumTitle);
+    });
 
     // afterAll(async done => {
     //   await client.deleteTable({


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add integration tests using jest for DynamoDB

To verify:
* run `yarn` from root
* run following command from root to install dynamodb dependencies
  `lerna run pretest --scope '@aws-sdk/client-dynamodb-node' --include-dependencies`
* cd clients/node/client-dynamodb-node
* run `AWS_PROFILE=<profileName> jest test/integ/index.spec.js`

ToDo (if approved):
* we can add npm command - say `integ-test` - just like existing `smoke-test` which accept AWS_PROFILE name
* we can add separate config - say `jest.integ.js` - and separate extension - say `.ispec.ts` - for integ tests ([post](https://medium.com/coding-stones/separating-unit-and-integration-tests-in-jest-f6dd301f399c))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
