### PR TITLE
Add support for AWS JSON RPC protocols

### DIFF
--- a/codegen/config/checkstyle/suppressions.xml
+++ b/codegen/config/checkstyle/suppressions.xml
@@ -19,5 +19,5 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
     <suppress checks="TypeName"
-              files="AwsRestJson1_1.java|AwsRestJson1_0.java"/>
+              files="/Aws.*\d_\d.java$"/>
 </suppressions>

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -56,7 +56,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions("@aws-sdk/middleware-sdk-api-gateway", "^0.1.0-preview.5",
                                         "AcceptsHeader", HAS_MIDDLEWARE)
-                        .servicePredicate((m,s) -> s.getId().getName().equals("BackplaneControlService"))
+                        .servicePredicate((m, s) -> s.getId().getName().equals("BackplaneControlService"))
                         .build()
         );
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_0.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_0.java
@@ -15,19 +15,22 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
-import java.util.List;
-import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
-import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
-import software.amazon.smithy.utils.ListUtils;
-
 /**
- * Adds all built-in AWS protocols.
+ * Handles generating the aws.json-1.0 protocol for services.
+ *
+ * @inheritDoc
+ *
+ * @see JsonRpcProtocolGenerator
  */
-public class AddProtocols implements TypeScriptIntegration {
+public class AwsJsonRpc1_0 extends JsonRpcProtocolGenerator {
 
     @Override
-    public List<ProtocolGenerator> getProtocolGenerators() {
-        return ListUtils.of(new AwsRestJson1_0(), new AwsRestJson1_1(),
-                new AwsJsonRpc1_0(), new AwsJsonRpc1_1());
+    protected String getDocumentContentType() {
+        return "application/x-amz-json-1.0";
+    }
+
+    @Override
+    public String getName() {
+        return "aws.json-1.0";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
@@ -15,19 +15,22 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
-import java.util.List;
-import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
-import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
-import software.amazon.smithy.utils.ListUtils;
-
 /**
- * Adds all built-in AWS protocols.
+ * Handles generating the aws.json-1.1 protocol for services.
+ *
+ * @inheritDoc
+ *
+ * @see JsonRpcProtocolGenerator
  */
-public class AddProtocols implements TypeScriptIntegration {
+public class AwsJsonRpc1_1 extends JsonRpcProtocolGenerator {
 
     @Override
-    public List<ProtocolGenerator> getProtocolGenerators() {
-        return ListUtils.of(new AwsRestJson1_0(), new AwsRestJson1_1(),
-                new AwsJsonRpc1_0(), new AwsJsonRpc1_1());
+    protected String getDocumentContentType() {
+        return "application/x-amz-json-1.1";
+    }
+
+    @Override
+    public String getName() {
+        return "aws.json-1.1";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_0.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_0.java
@@ -25,12 +25,12 @@ package software.amazon.smithy.aws.typescript.codegen;
 public final class AwsRestJson1_0 extends RestJsonProtocolGenerator {
 
     @Override
-    public String getName() {
-        return "aws.rest-json-1.0";
+    protected String getDocumentContentType() {
+        return "application/x-amz-json-1.0";
     }
 
     @Override
-    protected String getDocumentContentType() {
-        return "application/x-amz-json-1.0";
+    public String getName() {
+        return "aws.rest-json-1.0";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_1.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_1.java
@@ -25,12 +25,12 @@ package software.amazon.smithy.aws.typescript.codegen;
 public final class AwsRestJson1_1 extends RestJsonProtocolGenerator {
 
     @Override
-    public String getName() {
-        return "aws.rest-json-1.1";
+    protected String getDocumentContentType() {
+        return "application/x-amz-json-1.1";
     }
 
     @Override
-    protected String getDocumentContentType() {
-        return "application/x-amz-json-1.1";
+    public String getName() {
+        return "aws.rest-json-1.1";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonProtocolUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Utility methods for generating JSON based protocols.
+ */
+final class JsonProtocolUtils {
+
+    private JsonProtocolUtils() {}
+
+    /**
+     * Writes a response body parser function for JSON protocols. This
+     * will parse a present body after converting it to utf-8.
+     *
+     * @param context The generation context.
+     */
+    static void generateParseBody(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Include a JSON body parser used to deserialize documents from HTTP responses.
+        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        writer.openBlock("const parseBody = (streamBody: any, context: SerdeContext): any => {", "};", () -> {
+            writer.openBlock("return context.streamCollector(streamBody).then((body: any) => {", "});", () -> {
+                writer.write("const encoded = context.utf8Encoder(body);");
+                writer.openBlock("if (encoded.length) {", "}", () -> {
+                    writer.write("return JSON.parse(encoded);");
+                });
+                writer.write("return {};");
+            });
+        });
+
+        writer.write("");
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
+import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
+
+/**
+ * Handles general components across the AWS JSON protocols that have do not have
+ * HTTP bindings. It handles reading and writing from document bodies, including
+ * generating any functions needed for performing serde.
+ *
+ * This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle
+ * standard components of the HTTP requests and responses.
+ *
+ * @see JsonShapeSerVisitor
+ * @see JsonShapeDeserVisitor
+ * @see JsonMemberSerVisitor
+ * @see JsonMemberDeserVisitor
+ */
+abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
+
+    protected Format getDocumentTimestampFormat() {
+        return Format.EPOCH_SECONDS;
+    }
+
+    @Override
+    protected void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes) {
+        generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+    }
+
+    @Override
+    protected void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
+        generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
+    }
+
+    private void generateDocumentShapeSerde(GenerationContext context, Set<Shape> shapes, ShapeVisitor<Void> visitor) {
+        // Walk all the shapes within those in the document and generate for them as well.
+        Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
+        Set<Shape> shapesToDeserialize = new TreeSet<>(shapes);
+        shapes.forEach(shape -> shapesToDeserialize.addAll(shapeWalker.walkShapes(shape)));
+        shapesToDeserialize.forEach(shape -> shape.accept(visitor));
+    }
+
+    @Override
+    public void generateSharedComponents(GenerationContext context) {
+        super.generateSharedComponents(context);
+        JsonProtocolUtils.generateParseBody(context);
+    }
+
+    @Override
+    protected void serializeInputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            StructureShape inputStructure
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Input documents are wrapped in an input shape named wrapper, build that.
+        writer.openBlock("let wrappedBody: any = {", "};", () -> {
+            writer.write("$L: $L,", inputStructure.getId().getName(),
+                    inputStructure.accept(getMemberSerVisitor(context, "input")));
+        });
+        writer.write("body = JSON.stringify(wrappedBody);");
+    }
+
+    private DocumentMemberSerVisitor getMemberSerVisitor(GenerationContext context, String dataSource) {
+        return new JsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
+    }
+
+    @Override
+    protected void writeErrorCodeParser(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.write("let errorTypeParts: String = data[\"__type\"].split('#');");
+        writer.write("errorCode = (errorTypeParts[1] === undefined) ? errorTypeParts[0] : errorTypeParts[1];");
+    }
+
+    @Override
+    protected void deserializeOutputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            StructureShape outputStructure
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.write("contents = $L;",
+                outputStructure.accept(getMemberDeserVisitor(context, "data." + outputStructure.getId().getName())));
+    }
+
+    private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
+        return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -44,7 +44,7 @@ import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocol
  * @see JsonShapeSerVisitor
  * @see JsonShapeDeserVisitor
  * @see JsonMemberSerVisitor
- * @see DocumentMemberDeserVisitor
+ * @see JsonMemberDeserVisitor
  * @see <a href="https://awslabs.github.io/smithy/spec/http.html">Smithy HTTP protocol bindings.</a>
  */
 abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
@@ -75,21 +75,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     @Override
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
-        TypeScriptWriter writer = context.getWriter();
-
-        // Include a JSON body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
-        writer.openBlock("const parseBody = (streamBody: any, context: SerdeContext): any => {", "};", () -> {
-            writer.openBlock("return context.streamCollector(streamBody).then((body: any) => {", "});", () -> {
-                writer.write("const encoded = context.utf8Encoder(body);");
-                writer.openBlock("if (encoded.length) {", "}", () -> {
-                    writer.write("return JSON.parse(encoded);");
-                });
-                writer.write("return {};");
-            });
-        });
-
-        writer.write("");
+        JsonProtocolUtils.generateParseBody(context);
     }
 
     @Override


### PR DESCRIPTION
This commit adds support for the AWS JSON RPC protocols,
building on top of the `HttpRpcProtocolGenerator` via the
`JsonRpcProtocolGenerator` abstract class. Specific
implementations are provided for `aws.json-1.0` and
`aws.json-1.1`.

Shared code between the JSON-based `ProtocolGenerator`
implementations has been moved to a utils class, specific
implementations have been updated.

Insubstantial tweaks and documentation updates have also
been made for clarity.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
