### PR TITLE
fix: dynamodb integ test delete table

### DIFF
--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -108,6 +108,19 @@ module.exports = function() {
     });
   }
 
+  this.Given(/^I have a table$/, function(callback) {
+    var world = this;
+    this.service.listTables({}, function(err, data) {
+      for (var i = 0; i < data.TableNames.length; i++) {
+        if (data.TableNames[i] == world.tableName) {
+          callback();
+          return;
+        }
+      }
+      createTable(world, callback);
+    });
+  });
+
   this.When(/^I create a table$/, function(callback) {
     var world = this;
     this.tableName = 'aws-sdk-js-integration-' + Math.random().toString(36).substring(2);

--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -2,6 +2,7 @@ var jmespath = require('jmespath');
 var { DynamoDB } = require('../../../clients/node/client-dynamodb-node');
 
 function waitForTableExists(tableName, callback) {
+  console.log("waiting for creation of " + tableName);
   const db = new DynamoDB({});
   const params = {
     TableName: tableName
@@ -39,6 +40,7 @@ function waitForTableExists(tableName, callback) {
 };
 
 function waitForTableNotExists(tableName, callback) {
+  console.log("waiting for deletion of " + tableName);
   const db = new DynamoDB({});
   const params = {
     TableName: tableName
@@ -109,7 +111,7 @@ module.exports = function() {
     });
   }
 
-  this.Given(/^I have a table$/, function(callback) {
+  this.When(/^I create a table$/, function(callback) {
     var world = this;
     this.tableName = 'aws-sdk-js-integration-' + Math.random().toString(36).substring(2);
     this.service.listTables({}, function(err, data) {
@@ -141,6 +143,10 @@ module.exports = function() {
   this.When(/^I delete the table$/, function(next) {
     var params = {TableName: this.tableName};
     this.request(null, 'deleteTable', params, next);
+  });
+
+  this.Then(/^the table should eventually exist$/, function(callback) {
+    waitForTableExists(this.tableName, callback);
   });
 
   this.Then(/^the table should eventually not exist$/, function(callback) {

--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -2,7 +2,6 @@ var jmespath = require('jmespath');
 var { DynamoDB } = require('../../../clients/node/client-dynamodb-node');
 
 function waitForTableExists(tableName, callback) {
-  console.log("waiting for creation of " + tableName);
   const db = new DynamoDB({});
   const params = {
     TableName: tableName
@@ -40,7 +39,6 @@ function waitForTableExists(tableName, callback) {
 };
 
 function waitForTableNotExists(tableName, callback) {
-  console.log("waiting for deletion of " + tableName);
   const db = new DynamoDB({});
   const params = {
     TableName: tableName
@@ -72,7 +70,6 @@ function waitForTableNotExists(tableName, callback) {
         }, 20000);
       }
     });
-    checkForTableNotExists(params, callback);
   }
   checkForTableNotExists(params, callback);
 };

--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -111,7 +111,7 @@ module.exports = function() {
 
   this.Given(/^I have a table$/, function(callback) {
     var world = this;
-    this.tableName = 'aws-sdk-js-integration-test';
+    this.tableName = 'aws-sdk-js-integration-' + Math.random().toString(36).substring(2);
     this.service.listTables({}, function(err, data) {
       for (var i = 0; i < data.TableNames.length; i++) {
         if (data.TableNames[i] == world.tableName) {
@@ -144,7 +144,7 @@ module.exports = function() {
   });
 
   this.Then(/^the table should eventually not exist$/, function(callback) {
-    waitForTableNotExists(this.tableName, calback);
+    waitForTableNotExists(this.tableName, callback);
   });
 
   this.Given(/^my first request is corrupted with CRC checking (ON|OFF)$/, function(toggle, callback) {

--- a/features/dynamodb/tables.feature
+++ b/features/dynamodb/tables.feature
@@ -8,6 +8,7 @@ Feature: DynamoDB Tables
     Then the table should eventually exist
 
   Scenario: Item CRUD
+    Given I have a table
     When I put the item:
     """
     {"id": {"S": "foo"}, "data": {"S": "bår"}}
@@ -30,6 +31,7 @@ Feature: DynamoDB Tables
 
   @recursive
   Scenario: Recursive Attributes
+    Given I have a table
     When I put the item:
     """
     {

--- a/features/dynamodb/tables.feature
+++ b/features/dynamodb/tables.feature
@@ -43,3 +43,8 @@ Feature: DynamoDB Tables
     Then the request should be successful
     And the item with id "fooRecursive" should exist
     And it should have attribute "data.M.attr1.L[1].L[0].M.attr12.S" containing "value2"
+
+  Scenario: Deleting a table
+    Given I have a table
+    When I delete the table
+    Then the table should eventually not exist

--- a/features/dynamodb/tables.feature
+++ b/features/dynamodb/tables.feature
@@ -3,8 +3,11 @@
 @dynamodb @tables
 Feature: DynamoDB Tables
 
+  Scenario: Creating a table
+    When I create a table
+    Then the table should eventually exist
+
   Scenario: Item CRUD
-    Given I have a table
     When I put the item:
     """
     {"id": {"S": "foo"}, "data": {"S": "bår"}}
@@ -27,7 +30,6 @@ Feature: DynamoDB Tables
 
   @recursive
   Scenario: Recursive Attributes
-    Given I have a table
     When I put the item:
     """
     {
@@ -44,7 +46,6 @@ Feature: DynamoDB Tables
     And the item with id "fooRecursive" should exist
     And it should have attribute "data.M.attr1.L[1].L[0].M.attr12.S" containing "value2"
 
-  Scenario: Deleting a table
-    Given I have a table
+  Scenario: Deleting the created table
     When I delete the table
     Then the table should eventually not exist


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws/aws-sdk-js/issues/2986
* https://github.com/aws/aws-sdk-js-v3/pull/480

*Description of changes:*
* This code change deletes the table when dynamodb integration tests are completed
* It appends random string at the end of tableName, so that it doesn't the tableName is unique to particular run (say `aws-sdk-js-integration-shj93i6u6je`)

Confirmed that tests are successful:
```console
AWS_PROFILE=<profileName> yarn integ-test --tags @dynamodb
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
