### PR TITLE
Add support for unsignedPayloads in SigV4

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -69,7 +69,13 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     @Override
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
-        JsonProtocolUtils.generateParseBody(context);
+        AwsProtocolUtils.generateJsonParseBody(context);
+    }
+
+    @Override
+    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
+        super.writeDefaultHeaders(context, operation);
+        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -75,7 +75,13 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     @Override
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
-        JsonProtocolUtils.generateParseBody(context);
+        AwsProtocolUtils.generateJsonParseBody(context);
+    }
+
+    @Override
+    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
+        super.writeDefaultHeaders(context, operation);
+        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
     }
 
     @Override


### PR DESCRIPTION
Includes a minor refactoring of the `JsonProtocolUtils` to be a more generic `AwsProtocolUtils`.

Generated header shows up as follows:

```ts
export async function serializeAws_restJson1_1PutFooCommand(
  input: BatchExecuteStatementCommandInput,
  context: SerdeContext
): Promise<__HttpRequest> {
  const headers: any = {};
  headers['Content-Type'] = "application/json";
  headers['x-amz-content-sha256'] = 'UNSIGNED_PAYLOAD';
  let body: any = {};
  if (input.foo !== undefined) {
    body = input.foo;
  }
  return new __HttpRequest({
    ...context.endpoint,
    protocol: "https",
    method: "PUT",
    path: "/PutFoo",
    headers: headers,
    body: body,
  });
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
