### PR TITLE
Add X-Amz-Target header to JsonRpc protocols

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -76,6 +76,12 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
         super.writeDefaultHeaders(context, operation);
         AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+
+        // AWS JSON RPC protocols use a combination of the service and operation shape names,
+        // separated by a '.' character, for the target header.
+        TypeScriptWriter writer = context.getWriter();
+        String target = context.getService().getId().getName() + "." + operation.getId().getName();
+        writer.write("headers['X-Amz-Target'] = $S;", target);
     }
 
     @Override


### PR DESCRIPTION
Generated header shows up as follows:

```ts
export async function serializeAws_restJson1_1PutFooCommand(
  input: PutFooCommandInput,
  context: SerdeContext
): Promise<__HttpRequest> {
  const headers: any = {};
  headers['Content-Type'] = "application/x-amz-json-1.1";
  headers['X-Amz-Target'] = "FooService.PutFoo";
  let body: any = {};
  if (input.foo !== undefined) {
    body = input.foo;
  }
  return new __HttpRequest({
    ...context.endpoint,
    protocol: "https",
    method: "PUT",
    path: "/PutFoo",
    headers: headers,
    body: body,
  });
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
