### PR TITLE
feat: integ tests for database-migration-service from v2

### DIFF
--- a/features/dms/step_definitions/dms.js
+++ b/features/dms/step_definitions/dms.js
@@ -1,6 +1,8 @@
+var { DatabaseMigrationService } = require('../../../clients/node/client-database-migration-service-node');
+
 module.exports = function() {
   this.Before("@dms", function (callback) {
-    this.service = new this.AWS.DMS();
+    this.service = new DatabaseMigrationService({});
     callback();
   });
 

--- a/features/dynamodb/crc32.feature
+++ b/features/dynamodb/crc32.feature
@@ -1,20 +1,19 @@
 # language: en
-"""
-@dynamodb @dynamodb-2011-12-05 @crc32
-Feature: CRC32 response validation
 
-  Scenario: Retry on corrupted request
-    Given my first request is corrupted with CRC checking ON
-    Then the request should be retried
-    And the request should not fail with a CRC checking error
+# @dynamodb @dynamodb-2011-12-05 @crc32
+# Feature: CRC32 response validation
 
-  Scenario: Failed retries on corrupted request
-    Given all of my requests are corrupted with CRC checking ON
-    Then the request is retried the maximum number of times
-    And the request should fail with a CRC checking error
+#   Scenario: Retry on corrupted request
+#     Given my first request is corrupted with CRC checking ON
+#     Then the request should be retried
+#     And the request should not fail with a CRC checking error
 
-  Scenario: Ignore corrupted request with CRC checking OFF
-    Given my first request is corrupted with CRC checking OFF
-    Then the request should not be retried
-    And the request should not fail with a CRC checking error
-"""
+#   Scenario: Failed retries on corrupted request
+#     Given all of my requests are corrupted with CRC checking ON
+#     Then the request is retried the maximum number of times
+#     And the request should fail with a CRC checking error
+
+#   Scenario: Ignore corrupted request with CRC checking OFF
+#     Given my first request is corrupted with CRC checking OFF
+#     Then the request should not be retried
+#     And the request should not fail with a CRC checking error


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* integ tests for database-migration-service from v2
* verified by running:
  ```console
  AWS_PROFILE=<profileName> yarn integ-test --tags @dms
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.