### PR TITLE
feat: update JSON protocol codegen for cleanliness

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_0.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_0.java
@@ -22,7 +22,7 @@ package software.amazon.smithy.aws.typescript.codegen;
  *
  * @see JsonRpcProtocolGenerator
  */
-public class AwsJsonRpc1_0 extends JsonRpcProtocolGenerator {
+final class AwsJsonRpc1_0 extends JsonRpcProtocolGenerator {
 
     @Override
     protected String getDocumentContentType() {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
@@ -22,7 +22,7 @@ package software.amazon.smithy.aws.typescript.codegen;
  *
  * @see JsonRpcProtocolGenerator
  */
-public class AwsJsonRpc1_1 extends JsonRpcProtocolGenerator {
+final class AwsJsonRpc1_1 extends JsonRpcProtocolGenerator {
 
     @Override
     protected String getDocumentContentType() {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -15,8 +15,14 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import java.util.Set;
+import java.util.TreeSet;
 import software.amazon.smithy.aws.traits.UnsignedPayloadTrait;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
+import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
@@ -47,6 +53,26 @@ final class AwsProtocolUtils {
     }
 
     /**
+     * Writes a serde function for a set of shapes using the passed visitor.
+     * This will walk the input set of shapes and invoke the visitor for any
+     * members of aggregate shapes in the set.
+     *
+     * @see software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVisitor
+     * @see software.amazon.smithy.typescript.codegen.integration.DocumentShapeDeserVisitor
+     *
+     * @param context The generation context.
+     * @param shapes A list of shapes to generate serde for, including their members.
+     * @param visitor A ShapeVisitor that generates a serde function for shapes.
+     */
+    static void generateDocumentShapeSerde(GenerationContext context, Set<Shape> shapes, ShapeVisitor<Void> visitor) {
+        // Walk all the shapes within those in the document and generate for them as well.
+        Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
+        Set<Shape> shapesToGenerate = new TreeSet<>(shapes);
+        shapes.forEach(shape -> shapesToGenerate.addAll(shapeWalker.walkShapes(shape)));
+        shapesToGenerate.forEach(shape -> shape.accept(visitor));
+    }
+
+    /**
      * Writes a response body parser function for JSON protocols. This
      * will parse a present body after converting it to utf-8.
      *
@@ -56,8 +82,8 @@ final class AwsProtocolUtils {
         TypeScriptWriter writer = context.getWriter();
 
         // Include a JSON body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
-        writer.openBlock("const parseBody = (streamBody: any, context: SerdeContext): any => {", "};", () -> {
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): any => {", "};", () -> {
             writer.openBlock("return context.streamCollector(streamBody).then((body: any) => {", "});", () -> {
                 writer.write("const encoded = context.utf8Encoder(body);");
                 writer.openBlock("if (encoded.length) {", "}", () -> {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -64,7 +64,11 @@ final class AwsProtocolUtils {
      * @param shapes A list of shapes to generate serde for, including their members.
      * @param visitor A ShapeVisitor that generates a serde function for shapes.
      */
-    static void generateDocumentShapeSerde(GenerationContext context, Set<Shape> shapes, ShapeVisitor<Void> visitor) {
+    static void generateDocumentBodyShapeSerde(
+            GenerationContext context,
+            Set<Shape> shapes,
+            ShapeVisitor<Void> visitor
+    ) {
         // Walk all the shapes within those in the document and generate for them as well.
         Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
         Set<Shape> shapesToGenerate = new TreeSet<>(shapes);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -32,11 +32,7 @@ final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
     /**
      * @inheritDoc
      */
-    JsonMemberDeserVisitor(
-            GenerationContext context,
-            String dataSource,
-            Format defaultTimestampFormat
-    ) {
+    JsonMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
@@ -32,11 +32,7 @@ final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
     /**
      * @inheritDoc
      */
-    JsonMemberSerVisitor(
-            GenerationContext context,
-            String dataSource,
-            Format defaultTimestampFormat
-    ) {
+    JsonMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
     }
 
@@ -53,7 +49,7 @@ final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
+        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
                 shape.getType(), shape.getId()));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -46,13 +46,13 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     }
 
     @Override
-    protected void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+    protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
     }
 
     @Override
-    protected void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
+    protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -16,12 +16,8 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Set;
-import java.util.TreeSet;
-import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
-import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
@@ -41,6 +37,7 @@ import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGene
  * @see JsonShapeDeserVisitor
  * @see JsonMemberSerVisitor
  * @see JsonMemberDeserVisitor
+ * @see AwsProtocolUtils
  */
 abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
@@ -50,20 +47,12 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
     @Override
     protected void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
     }
 
     @Override
     protected void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
-    }
-
-    private void generateDocumentShapeSerde(GenerationContext context, Set<Shape> shapes, ShapeVisitor<Void> visitor) {
-        // Walk all the shapes within those in the document and generate for them as well.
-        Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
-        Set<Shape> shapesToDeserialize = new TreeSet<>(shapes);
-        shapes.forEach(shape -> shapesToDeserialize.addAll(shapeWalker.walkShapes(shape)));
-        shapesToDeserialize.forEach(shape -> shape.accept(visitor));
+        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -135,6 +135,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
             });
         });
         // Or write to the unknown member the element in the output.
-        writer.write("return { $$unknown: output[Object.keys(output)[0]] };");
+        writer.write("const key = Object.keys(output)[0];");
+        writer.write("return { $$unknown: [key, output[key]] };");
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -17,12 +17,12 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Map;
 import java.util.TreeMap;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.DocumentShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.JsonNameTrait;
@@ -54,7 +54,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
     @Override
     protected void deserializeCollection(GenerationContext context, CollectionShape shape) {
         TypeScriptWriter writer = context.getWriter();
-        Shape target = context.getModel().getShapeIndex().getShape(shape.getMember().getTarget()).get();
+        Shape target = context.getModel().expectShape(shape.getMember().getTarget());
 
         // Dispatch to the output value provider for any additional handling.
         writer.openBlock("return (output || []).map((entry: any) =>", ");", () -> {
@@ -72,7 +72,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
     @Override
     protected void deserializeMap(GenerationContext context, MapShape shape) {
         TypeScriptWriter writer = context.getWriter();
-        Shape target = context.getModel().getShapeIndex().getShape(shape.getValue().getTarget()).get();
+        Shape target = context.getModel().expectShape(shape.getValue().getTarget());
 
         // Get the right serialization for each entry in the map. Undefined
         // outputs won't have this deserializer invoked.
@@ -101,7 +101,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
             String locationName = memberShape.getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)
                     .orElse(memberName);
-            Shape target = context.getModel().getShapeIndex().getShape(memberShape.getTarget()).get();
+            Shape target = context.getModel().expectShape(memberShape.getTarget());
 
             // Generate an if statement to set the bodyParam if the member is set.
             writer.openBlock("if (output.$L !== undefined) {", "}", locationName, () -> {
@@ -117,12 +117,12 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
     @Override
     protected void deserializeUnion(GenerationContext context, UnionShape shape) {
         TypeScriptWriter writer = context.getWriter();
-        ShapeIndex index = context.getModel().getShapeIndex();
+        Model model = context.getModel();
 
         // Check for any known union members and return when we find one.
         Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
         members.forEach((memberName, memberShape) -> {
-            Shape target = index.getShape(memberShape.getTarget()).get();
+            Shape target = model.expectShape(memberShape.getTarget());
             // Use the jsonName trait value if present, otherwise use the member name.
             String locationName = memberShape.getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -91,7 +91,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             String locationName = member.getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)
                     .orElseGet(binding::getLocationName);
-            Shape target = context.getModel().getShapeIndex().getShape(member.getTarget()).get();
+            Shape target = context.getModel().expectShape(member.getTarget());
 
             // Generate an if statement to set the bodyParam if the member is set.
             writer.openBlock("if (input.$L !== undefined) {", "}", memberName, () -> {
@@ -124,7 +124,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         for (HttpBinding binding : documentBindings) {
-            Shape target = context.getModel().getShapeIndex().getShape(binding.getMember().getTarget()).get();
+            Shape target = context.getModel().expectShape(binding.getMember().getTarget());
             // The name of the member to get from the input shape.
             String memberName = symbolProvider.toMemberName(binding.getMember());
             // Use the jsonName trait value if present, otherwise use the member name.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -52,13 +52,13 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    protected void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+    protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
     }
 
     @Override
-    protected void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
+    protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -17,15 +17,11 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.knowledge.HttpBinding;
-import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
-import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
@@ -45,6 +41,7 @@ import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocol
  * @see JsonShapeDeserVisitor
  * @see JsonMemberSerVisitor
  * @see JsonMemberDeserVisitor
+ * @see AwsProtocolUtils
  * @see <a href="https://awslabs.github.io/smithy/spec/http.html">Smithy HTTP protocol bindings.</a>
  */
 abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
@@ -56,20 +53,12 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
     }
 
     @Override
     protected void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
-    }
-
-    private void generateDocumentShapeSerde(GenerationContext context, Set<Shape> shapes, ShapeVisitor<Void> visitor) {
-        // Walk all the shapes within those in the document and generate for them as well.
-        Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
-        Set<Shape> shapesToDeserialize = new TreeSet<>(shapes);
-        shapes.forEach(shape -> shapesToDeserialize.addAll(shapeWalker.walkShapes(shape)));
-        shapesToDeserialize.forEach(shape -> shape.accept(visitor));
+        AwsProtocolUtils.generateDocumentShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
     }
 
     @Override
@@ -99,7 +88,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             // The name of the member to get from the input shape.
             String memberName = symbolProvider.toMemberName(member);
             // Use the jsonName trait value if present, otherwise use the member name.
-            String locationName = binding.getMember().getTrait(JsonNameTrait.class)
+            String locationName = member.getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)
                     .orElseGet(binding::getLocationName);
             Shape target = context.getModel().getShapeIndex().getShape(member.getTarget()).get();

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -23,7 +23,7 @@ public class AwsServiceIdIntegrationTest {
                 .discoverModels()
                 .assemble()
                 .unwrap();
-        Shape service = model.getShapeIndex().getShape(ShapeId.from("smithy.example#OriginalName")).get();
+        Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         SymbolProvider decorated = integration.decorateSymbolProvider(


### PR DESCRIPTION
This commit includes assorted updates to the protocol generators
to improve reusability, set proper visibility, use an import alias
for SerdeContext, and other minor updates.

It also includes a fix for handling the unknown case when
deserializing a union.

-----

Use Model instead of deprecated ShapeIndex. This commit will require using the latest version of Smithy published locally.

-----

Use better name for document body shape serde gen

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
