### PR TITLE
feat: remove headerName config option

### DIFF
--- a/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.spec.ts
+++ b/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.spec.ts
@@ -27,9 +27,8 @@ describe("applyMd5BodyChecksumMiddleware", () => {
     new Uint8Array(10),
     void 0
   ]) {
-    it("should calculate the body hash, encode the result, and set the encoded hash to the provided header", async () => {
+    it("should calculate the body hash, encode the result, and set the encoded hash to Content-MD5 header", async () => {
       const handler = applyMd5BodyChecksumMiddleware({
-        headerName: "checksumHeader",
         md5: MockHash,
         base64Encoder: mockEncoder,
         streamHasher: async (stream: ExoticStream) => new Uint8Array(5)
@@ -44,13 +43,12 @@ describe("applyMd5BodyChecksumMiddleware", () => {
 
       expect(next.mock.calls.length).toBe(1);
       const { request } = next.mock.calls[0][0];
-      expect(request.headers["checksumHeader"]).toBe("encoded");
+      expect(request.headers["Content-MD5"]).toBe("encoded");
       expect(mockHashUpdate.mock.calls).toEqual([[body || ""]]);
     });
 
     it("should do nothing if a case-insenitive match for the desired header has already been set", async () => {
       const handler = applyMd5BodyChecksumMiddleware({
-        headerName: "checksumHeader",
         md5: MockHash,
         base64Encoder: mockEncoder,
         streamHasher: async (stream: ExoticStream) => new Uint8Array(5)
@@ -61,15 +59,15 @@ describe("applyMd5BodyChecksumMiddleware", () => {
         request: new HttpRequest({
           body: body,
           headers: {
-            cHeCkSuMhEaDeR: "foo"
+            "CoNtEnT-Md5": "foo"
           }
         })
       });
 
       expect(next.mock.calls.length).toBe(1);
       const { request } = next.mock.calls[0][0];
-      expect(request.headers["cHeCkSuMhEaDeR"]).toBe("foo");
-      expect(request.headers["checksumHeader"]).toBe(undefined);
+      expect(request.headers["CoNtEnT-Md5"]).toBe("foo");
+      expect(request.headers["Content-MD5"]).toBe(undefined);
       expect(mockHashUpdate.mock.calls.length).toBe(0);
       expect(mockHashDigest.mock.calls.length).toBe(0);
       expect(mockEncoder.mock.calls.length).toBe(0);
@@ -78,7 +76,6 @@ describe("applyMd5BodyChecksumMiddleware", () => {
 
   it("should use the supplied stream hasher to calculate the hash of a streaming body", async () => {
     const handler = applyMd5BodyChecksumMiddleware({
-      headerName: "checksumHeader",
       md5: MockHash,
       base64Encoder: mockEncoder,
       streamHasher: async (stream: ExoticStream) => new Uint8Array(5)
@@ -94,7 +91,7 @@ describe("applyMd5BodyChecksumMiddleware", () => {
     expect(next.mock.calls.length).toBe(1);
     const { request } = next.mock.calls[0][0];
     expect(request.body).toStrictEqual(new ExoticStream());
-    expect(request.headers["checksumHeader"]).toBe("encoded");
+    expect(request.headers["Content-MD5"]).toBe("encoded");
     expect(mockHashDigest.mock.calls.length).toBe(0);
     expect(mockEncoder.mock.calls.length).toBe(1);
     expect(mockEncoder.mock.calls).toEqual([[new Uint8Array(5)]]);

--- a/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
+++ b/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
@@ -20,38 +20,38 @@ export function applyMd5BodyChecksumMiddleware(
   ): BuildHandler<any, Output> => async (
     args: BuildHandlerArguments<any>
   ): Promise<BuildHandlerOutput<Output>> => {
-      let request = { ...args.request };
-      if (HttpRequest.isInstance(request)) {
-        const { body, headers } = request;
-        if (!hasHeader(options.headerName, headers)) {
-          let digest: Promise<Uint8Array>;
-          if (
-            body === undefined ||
-            typeof body === "string" ||
-            ArrayBuffer.isView(body) ||
-            isArrayBuffer(body)
-          ) {
-            const hash = new options.md5();
-            hash.update(body || "");
-            digest = hash.digest();
-          } else {
-            digest = options.streamHasher(options.md5, body);
-          }
-
-          request = {
-            ...request,
-            headers: {
-              ...headers,
-              [options.headerName]: options.base64Encoder(await digest)
-            }
-          };
+    let { request } = args;
+    if (HttpRequest.isInstance(request)) {
+      const { body, headers } = request;
+      if (!hasHeader("Content-MD5", headers)) {
+        let digest: Promise<Uint8Array>;
+        if (
+          body === undefined ||
+          typeof body === "string" ||
+          ArrayBuffer.isView(body) ||
+          isArrayBuffer(body)
+        ) {
+          const hash = new options.md5();
+          hash.update(body || "");
+          digest = hash.digest();
+        } else {
+          digest = options.streamHasher(options.md5, body);
         }
+
+        request = {
+          ...request,
+          headers: {
+            ...headers,
+            "Content-MD5": options.base64Encoder(await digest)
+          }
+        };
       }
-      return next({
-        ...args,
-        request
-      });
-    };
+    }
+    return next({
+      ...args,
+      request
+    });
+  };
 }
 
 export const applyMd5BodyChecksumMiddlewareOptions: BuildHandlerOptions = {

--- a/packages/middleware-apply-body-checksum/src/md5Configuration.ts
+++ b/packages/middleware-apply-body-checksum/src/md5Configuration.ts
@@ -1,15 +1,12 @@
 import { Encoder, Hash, StreamHasher } from "@aws-sdk/types";
 
-export interface Md5BodyChecksumInputConfig {
-  headerName?: string;
-}
+export interface Md5BodyChecksumInputConfig {}
 interface PreviouslyResolved {
   md5: { new (): Hash };
   base64Encoder: Encoder;
   streamHasher: StreamHasher<any>;
 }
 export interface Md5BodyChecksumResolvedConfig {
-  headerName: string;
   md5: { new (): Hash };
   base64Encoder: Encoder;
   streamHasher: StreamHasher<any>;
@@ -18,7 +15,6 @@ export function resolveMd5BodyChecksumConfig<T>(
   input: T & PreviouslyResolved & Md5BodyChecksumInputConfig
 ): T & Md5BodyChecksumResolvedConfig {
   return {
-    ...input,
-    headerName: input.headerName || "Content-MD5"
+    ...input
   };
 }


### PR DESCRIPTION
removes headerName config option on applyMd5BodyChecksumMiddleware.  Instead, this middleware only sets the "Content-MD5" header.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
