### PR TITLE
fix: add argument to getAddExpectContinuePlugin

### DIFF
--- a/packages/middleware-expect-continue/src/index.ts
+++ b/packages/middleware-expect-continue/src/index.ts
@@ -15,7 +15,7 @@ export function addExpectContinueMiddleware(): BuildMiddleware<any, any> {
   ): BuildHandler<any, Output> => async (
     args: BuildHandlerArguments<any>
   ): Promise<BuildHandlerOutput<Output>> => {
-    let request = { ...args.request };
+    let { request } = args;
     if (HttpRequest.isInstance(request) && request.body) {
       request.headers = {
         ...request.headers,
@@ -35,7 +35,9 @@ export const addExpectContinueMiddlewareOptions: BuildHandlerOptions = {
   name: "addExpectContinueMiddleware"
 };
 
-export const getAddExpectContinuePlugin = (): Pluggable<any, any> => ({
+export const getAddExpectContinuePlugin = (
+  unused: any
+): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     clientStack.add(
       addExpectContinueMiddleware(),


### PR DESCRIPTION
Adds missing unused argument to comply with codegen conventions for middleware/plugins

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
