### PR TITLE
fix: missing getAcceptsHeaderPlugin param

### DIFF
--- a/packages/middleware-sdk-api-gateway/src/index.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.ts
@@ -15,7 +15,7 @@ export function acceptsHeaderMiddleware(): BuildMiddleware<any, any> {
   ): BuildHandler<any, Output> => async (
     args: BuildHandlerArguments<any>
   ): Promise<BuildHandlerOutput<Output>> => {
-    let request = { ...args.request };
+    let { request } = args;
     if (HttpRequest.isInstance(request)) {
       request.headers = {
         ...request.headers,
@@ -35,7 +35,7 @@ export const acceptsHeaderMiddlewareOptions: BuildHandlerOptions = {
   name: "acceptsHeaderMiddleware"
 };
 
-export const getAcceptsHeaderPlugin = (): Pluggable<any, any> => ({
+export const getAcceptsHeaderPlugin = (unused: any): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     clientStack.add(acceptsHeaderMiddleware(), acceptsHeaderMiddlewareOptions);
   }


### PR DESCRIPTION
adds missing getAcceptsHeaderPlugin param used by convention in codegen

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
