### PR TITLE
fix: add BucketEndpoint config plugin

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -118,6 +118,15 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                         .operationPredicate((m, s, o) -> o.getId().getName().equals("Predict")
                                             && testServiceId(s, "Machine Learning"))
                         .build(),
+                /**
+                 * BUCKET_ENDPOINT_MIDDLEWARE needs two separate plugins. The first resolves the config in the client.
+                 * The second applies the middleware to bucket endpoint operations.
+                 */
+                RuntimeClientPlugin.builder()
+                        .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint",
+                                         HAS_CONFIG)
+                        .servicePredicate((m, s) -> testServiceId(s, "S3"))
+                        .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint",
                                          HAS_MIDDLEWARE)

--- a/packages/middleware-bucket-endpoint/src/index.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/index.spec.ts
@@ -1,0 +1,19 @@
+import {
+  bucketEndpointMiddleware,
+  getBucketEndpointPlugin,
+  resolveBucketEndpointConfig
+} from "./index";
+
+describe("middleware-bucket-endpoint package exports", () => {
+  it("bucketEndpointMiddleware", () => {
+    expect(typeof bucketEndpointMiddleware).toBe("function");
+  });
+
+  it("getBucketEndpointPlugin", () => {
+    expect(typeof getBucketEndpointPlugin).toBe("function");
+  });
+
+  it("resolveBucketEndpointConfig", () => {
+    expect(typeof resolveBucketEndpointConfig).toBe("function");
+  });
+});

--- a/packages/middleware-bucket-endpoint/src/index.ts
+++ b/packages/middleware-bucket-endpoint/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./bucketEndpointMiddleware";
 export * from "./bucketHostname";
+export * from "./configurations";


### PR DESCRIPTION
Fixes missing config resolution for BucketEndpointMiddleware.

Adds second plugin that applies the config resolution portion of the middleware to the S3 Client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
