### PR TITLE
feat: integ tests for cloudwatchlogs from v2

### DIFF
--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -1,6 +1,8 @@
+var { CloudWatchLogs } = require('../../../clients/node/client-cloudwatch-logs-node');
+
 module.exports = function() {
   this.Before("@cloudwatchlogs", function (callback) {
-    this.service = new this.AWS.CloudWatchLogs();
+    this.service = new CloudWatchLogs({});
     callback();
   });
 

--- a/packages/protocol-json-rpc/src/JsonRpcParser.ts
+++ b/packages/protocol-json-rpc/src/JsonRpcParser.ts
@@ -38,7 +38,7 @@ export class JsonRpcParser<StreamType> implements ResponseParser<StreamType> {
     }
     const partialOutput = this.bodyParser.parse<Partial<OutputType>>(
       operation.output,
-      body
+      body || "{}"
     );
     partialOutput.$metadata = extractMetadata(input);
     return partialOutput as OutputType;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* integ tests for cloudwatchlogs from v2
* verified by running:
  ```console
  AWS_PROFILE=<profileName> yarn integ-test --tags @cloudwatchlogs
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.