### PR TITLE
fix: remove HttpRequest generic and unused import

### DIFF
--- a/packages/util-format-url/src/index.spec.ts
+++ b/packages/util-format-url/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { formatUrl } from "./";
-import { HttpRequest, QueryParameterBag } from "@aws-sdk/types";
+import { HttpRequest } from "@aws-sdk/types";
 
 describe("format url", () => {
   const requestTemplate: HttpRequest = {

--- a/packages/util-format-url/src/index.ts
+++ b/packages/util-format-url/src/index.ts
@@ -1,9 +1,7 @@
-import { HttpRequest, QueryParameterBag } from "@aws-sdk/types";
+import { HttpRequest } from "@aws-sdk/types";
 import { buildQueryString } from "@aws-sdk/querystring-builder";
 
-export function formatUrl<StreamType>(
-  request: HttpRequest<StreamType>
-): string {
+export function formatUrl(request: HttpRequest): string {
   let { protocol, path, hostname, port, query } = request;
   if (protocol && protocol.substr(-1) !== ":") {
     protocol += ":";


### PR DESCRIPTION
Removes StreamType generic on HttpRequest and unused QueryParameterBag import.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
