### PR TITLE
fix: apply header only in node environment

### DIFF
--- a/packages/middleware-expect-continue/src/index.spec.ts
+++ b/packages/middleware-expect-continue/src/index.spec.ts
@@ -8,8 +8,11 @@ describe("addExpectContinueMiddleware", () => {
     jest.clearAllMocks();
   });
 
-  it("sets the Expect header to 100-continue if there is a request body", async () => {
-    const handler = addExpectContinueMiddleware()(mockNextHandler, {} as any);
+  it("sets the Expect header to 100-continue if there is a request body in node runtime", async () => {
+    const handler = addExpectContinueMiddleware({ runtime: "node" })(
+      mockNextHandler,
+      {} as any
+    );
     await handler({
       input: {},
       request: new HttpRequest({
@@ -24,11 +27,33 @@ describe("addExpectContinueMiddleware", () => {
     expect(request.headers["Expect"]).toBe("100-continue");
   });
 
-  it("does not set the Expect header to 100-continue if there is no request body", async () => {
-    const handler = addExpectContinueMiddleware()(mockNextHandler, {} as any);
+  it("does not set the Expect header to 100-continue if there is no request body in node runtime", async () => {
+    const handler = addExpectContinueMiddleware({ runtime: "node" })(
+      mockNextHandler,
+      {} as any
+    );
     await handler({
       input: {},
       request: new HttpRequest({
+        headers: {}
+      })
+    });
+
+    const { calls } = (mockNextHandler as any).mock;
+    expect(calls.length).toBe(1);
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers["Expect"]).toBeUndefined();
+  });
+
+  it("does not set the Expect header to 100-continue for browser runtime", async () => {
+    const handler = addExpectContinueMiddleware({ runtime: "browser" })(
+      mockNextHandler,
+      {} as any
+    );
+    await handler({
+      input: {},
+      request: new HttpRequest({
+        body: "foo",
         headers: {}
       })
     });


### PR DESCRIPTION
Only set 100-continue header in node environment.

Uses runtime config added in https://github.com/awslabs/smithy-typescript/pull/64

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
