### PR TITLE
fix: issues with HTTPRequest while rebasing #474 to master

### DIFF
--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "^0.1.0-preview.1",
-    "@aws-sdk/http-serialization": "^0.1.0-beta.1",
     "@aws-sdk/util-buffer-from": "^0.1.0-beta.1",
     "@aws-sdk/protocol-http": "^0.1.0-beta.1",
     "@types/jest": "^24.0.12",

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -148,8 +148,8 @@ export class SignatureV4
     if (ttl > MAX_PRESIGNED_TTL) {
       return Promise.reject(
         "Signature version 4 presigned URLs" +
-          " must have an expiration date less than one week in" +
-          " the future"
+        " must have an expiration date less than one week in" +
+        " the future"
       );
     }
 
@@ -284,7 +284,7 @@ export class SignatureV4
     credentials: Credentials,
     unsignableHeaders?: Set<string>,
     signableHeaders?: Set<string>
-  ): Promise<HttpRequest<any>> {
+  ): Promise<HttpRequest> {
     const request = prepareRequest(originalRequest);
     const { longDate, shortDate } = formatDate(signingDate);
     const scope = createScope(shortDate, region, this.service);

--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -65,7 +65,7 @@ describe("getCanonicalHeaders", () => {
   });
 
   it("should allow specifying custom signable headers that override unsignable ones", () => {
-    const request: HttpRequest<never> = {
+    const request = new HttpRequest({
       method: "POST",
       protocol: "https:",
       path: "/",
@@ -75,7 +75,7 @@ describe("getCanonicalHeaders", () => {
         "user-agent": "foo-user"
       },
       hostname: "foo.us-east-1.amazonaws.com"
-    };
+    });
 
     expect(
       getCanonicalHeaders(

--- a/packages/signature-v4/src/getCanonicalHeaders.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.ts
@@ -9,7 +9,7 @@ import {
  * @internal
  */
 export function getCanonicalHeaders(
-  { headers }: HttpRequest<any>,
+  { headers }: HttpRequest,
   unsignableHeaders?: Set<string>,
   signableHeaders?: Set<string>
 ): HeaderBag {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/585#issuecomment-569786412

*Description of changes:*
* fixes issues with HTTPRequest while rebasing #474 to master
* confirmed that following command successfully executes:
```console
./node_modules/.bin/lerna run --scope '@aws-sdk/client-rds-data' --include-dependencies pretest
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
