### PR TITLE
fix: add @aws-sdk/protocol-http as a dependency

### DIFF
--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -14,6 +14,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/protocol-http": "^0.1.0-beta.0",
     "@aws-sdk/types": "^0.1.0-beta.0",
     "tslib": "^1.8.0"
   },

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -15,6 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "^0.1.0-beta.0",
+    "@aws-sdk/protocol-http": "^0.1.0-beta.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -14,6 +14,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/protocol-http": "^0.1.0-beta.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/584

*Description of changes:*

This dependency was missed in:
* https://github.com/aws/aws-sdk-js-v3/pull/473
* https://github.com/aws/aws-sdk-js-v3/pull/552
* https://github.com/aws/aws-sdk-js-v3/pull/553

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
