### PR TITLE
fix: remove usage of types from remove-sensitive-logs

### DIFF
--- a/packages/remove-sensitive-logs/package.json
+++ b/packages/remove-sensitive-logs/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/remove-sensitive-logs",
   "version": "0.1.0-beta.0",
   "dependencies": {
-    "@aws-sdk/types": "^0.1.0-beta.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/remove-sensitive-logs/src/index.spec.ts
+++ b/packages/remove-sensitive-logs/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { removeSensitiveLogs } from "./";
-import { Member } from "@aws-sdk/types";
+// import { Member } from "@aws-sdk/types";
 import {
   mapWithSensitiveValue,
   sensitiveMapShape,
@@ -23,7 +23,7 @@ describe("remove sensitive parameters from logging", () => {
       foo: "secret_key_id"
     };
     it("structure with sensitive members", () => {
-      const shape: Member = {
+      const shape = {
         shape: structureWithSensitiveMember
       };
       const logString = removeSensitiveLogs(param, shape);
@@ -34,7 +34,7 @@ describe("remove sensitive parameters from logging", () => {
     });
 
     it("sensitive structure shape", () => {
-      const shape: Member = {
+      const shape = {
         shape: sensitiveStructureShape
       };
       expect(removeSensitiveLogs(param, shape)).toBe('"<**-redacted-**>"');
@@ -44,7 +44,7 @@ describe("remove sensitive parameters from logging", () => {
   describe("list shape", () => {
     const param = { param: ["secret_key_0", "secret_key_1"] };
     it("list with sensitive member", () => {
-      const shape: Member = {
+      const shape = {
         shape: {
           type: "structure",
           required: [],
@@ -62,7 +62,7 @@ describe("remove sensitive parameters from logging", () => {
     });
 
     it("sensitive structure shape", () => {
-      const shape: Member = {
+      const shape = {
         shape: {
           type: "structure",
           required: [],
@@ -84,7 +84,7 @@ describe("remove sensitive parameters from logging", () => {
       key: "secret_key"
     };
     it("map with sensitive values", () => {
-      const shape: Member = {
+      const shape = {
         shape: mapWithSensitiveValue
       };
       const map = JSON.parse(removeSensitiveLogs(param, shape));
@@ -94,7 +94,7 @@ describe("remove sensitive parameters from logging", () => {
     });
 
     it("sensitive map shape", () => {
-      const shape: Member = {
+      const shape = {
         shape: sensitiveMapShape
       };
       expect(removeSensitiveLogs(param, shape)).toBe('"<**-redacted-**>"');
@@ -114,7 +114,7 @@ describe("remove sensitive parameters from logging", () => {
         sensitiveStringShape,
         sensitiveTimestampShape
       ].forEach(scalerShape => {
-        const shape: Member = {
+        const shape = {
           shape: {
             type: "structure",
             required: [],
@@ -135,11 +135,12 @@ describe("remove sensitive parameters from logging", () => {
 
   describe("undefined input", () => {
     it("undefined", () => {
-      let shape: Member = {
+      let shape = {
         shape: sensitiveStructureShape
       };
       let param = undefined;
       expect(removeSensitiveLogs(param, shape)).toEqual(undefined);
+      // @ts-ignore TS2741
       shape.shape = structureWithSensitiveMember;
       param = { foo: undefined };
       expect(JSON.parse(removeSensitiveLogs(param, shape))).toEqual({
@@ -150,7 +151,7 @@ describe("remove sensitive parameters from logging", () => {
 
   describe("recursive shape", () => {
     it("recursive shape", () => {
-      const shape: Member = {
+      const shape = {
         shape: recursiveShape
       };
       const param = {

--- a/packages/remove-sensitive-logs/src/index.ts
+++ b/packages/remove-sensitive-logs/src/index.ts
@@ -1,6 +1,6 @@
-import { Member, SerializationModel } from "@aws-sdk/types";
+// import { Member, SerializationModel } from "@aws-sdk/types";
 
-function mapObjToShape(obj: any, shape: SerializationModel): any {
+function mapObjToShape(obj: any, shape: any): any {
   if (shape.sensitive) {
     return "<**-redacted-**>";
   }
@@ -37,7 +37,7 @@ function mapObjToShape(obj: any, shape: SerializationModel): any {
   }
 }
 
-function mapObjToMember(obj: any, member: Member): any {
+function mapObjToMember(obj: any, member: any): any {
   if (obj === undefined || obj === null) {
     return undefined;
   }
@@ -47,6 +47,6 @@ function mapObjToMember(obj: any, member: Member): any {
   return mapObjToShape(obj, member.shape);
 }
 
-export function removeSensitiveLogs(obj: any, member: Member): string {
+export function removeSensitiveLogs(obj: any, member: any): string {
   return JSON.stringify(mapObjToMember(obj, member));
 }

--- a/packages/remove-sensitive-logs/src/shapes.fixture.ts
+++ b/packages/remove-sensitive-logs/src/shapes.fixture.ts
@@ -1,4 +1,4 @@
-import {
+/*import {
   Blob,
   Boolean,
   Float,
@@ -8,9 +8,9 @@ import {
   String,
   Structure,
   Timestamp
-} from "@aws-sdk/types";
+} from "@aws-sdk/types";*/
 
-export const structureWithSensitiveMember: Structure = {
+export const structureWithSensitiveMember = {
   type: "structure",
   required: [],
   members: {
@@ -24,7 +24,7 @@ export const structureWithSensitiveMember: Structure = {
   }
 };
 
-export const listWithSensitiveMember: List = {
+export const listWithSensitiveMember = {
   type: "list",
   member: {
     shape: { type: "string" },
@@ -32,7 +32,7 @@ export const listWithSensitiveMember: List = {
   }
 };
 
-export const mapWithSensitiveValue: Map = {
+export const mapWithSensitiveValue = {
   type: "map",
   key: {
     shape: { type: "string" }
@@ -43,14 +43,14 @@ export const mapWithSensitiveValue: Map = {
   }
 };
 
-export const sensitiveStructureShape: Structure = {
+export const sensitiveStructureShape = {
   type: "structure",
   required: [],
   members: {},
   sensitive: true
 };
 
-export const sensitiveListShape: List = {
+export const sensitiveListShape = {
   type: "list",
   member: {
     shape: { type: "string" }
@@ -58,7 +58,7 @@ export const sensitiveListShape: List = {
   sensitive: true
 };
 
-export const sensitiveMapShape: Map = {
+export const sensitiveMapShape = {
   type: "map",
   key: {
     shape: { type: "string" }
@@ -69,37 +69,37 @@ export const sensitiveMapShape: Map = {
   sensitive: true
 };
 
-export const sensitiveStringShape: String = {
+export const sensitiveStringShape = {
   type: "string",
   sensitive: true
 };
 
-export const sensitiveBlobShape: Blob = {
+export const sensitiveBlobShape = {
   type: "blob",
   sensitive: true
 };
 
-export const sensitiveTimestampShape: Timestamp = {
+export const sensitiveTimestampShape = {
   type: "timestamp",
   sensitive: true
 };
 
-export const sensitiveBooleanShape: Boolean = {
+export const sensitiveBooleanShape = {
   type: "boolean",
   sensitive: true
 };
 
-export const sensitiveIntegerShape: Integer = {
+export const sensitiveIntegerShape = {
   type: "integer",
   sensitive: true
 };
 
-export const sensitiveFloatShape: Float = {
+export const sensitiveFloatShape = {
   type: "float",
   sensitive: true
 };
 
-export const recursiveShape: Structure = {
+export const recursiveShape = {
   type: "structure",
   required: [],
   members: {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/584#issuecomment-569859880

*Description of changes:*
remove usage of types from remove-sensitive-logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
