### PR TITLE
fix: import HttpResponse from protocol-http

### DIFF
--- a/packages/response-metadata-extractor/package.json
+++ b/packages/response-metadata-extractor/package.json
@@ -14,6 +14,7 @@
   "license": "Apache-2.0",
   "main": "./build/index.js",
   "dependencies": {
+    "@aws-sdk/protocol-http": "^0.1.0-beta.0",
     "@aws-sdk/types": "^0.1.0-beta.0",
     "tslib": "^1.8.0"
   },

--- a/packages/response-metadata-extractor/src/index.spec.ts
+++ b/packages/response-metadata-extractor/src/index.spec.ts
@@ -2,7 +2,7 @@ import { extractMetadata } from "./";
 import { HttpResponse } from "@aws-sdk/protocol-http";
 
 describe("extractMetadata", () => {
-  const response: HttpResponse<string> = {
+  const response = new HttpResponse({
     statusCode: 200,
     headers: {
       Foo: "bar",
@@ -10,7 +10,7 @@ describe("extractMetadata", () => {
       Snap: "crackle, pop"
     },
     body: "this is body"
-  };
+  });
 
   it("should extract the status code from responses", () => {
     expect(extractMetadata(response).httpStatusCode).toBe(response.statusCode);

--- a/packages/response-metadata-extractor/src/index.spec.ts
+++ b/packages/response-metadata-extractor/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { extractMetadata } from "./";
-import { HttpResponse } from "@aws-sdk/types";
+import { HttpResponse } from "@aws-sdk/protocol-http";
 
 describe("extractMetadata", () => {
   const response: HttpResponse<string> = {

--- a/packages/response-metadata-extractor/src/index.ts
+++ b/packages/response-metadata-extractor/src/index.ts
@@ -1,4 +1,5 @@
-import { HeaderBag, HttpResponse, ResponseMetadata } from "@aws-sdk/types";
+import { HeaderBag, ResponseMetadata } from "@aws-sdk/types";
+import { HttpResponse } from "@aws-sdk/protocol-http";
 
 const REQUEST_ID_HEADER = "x-amz-request-id";
 const REQUEST_ID_ALT_HEADER = "x-amzn-requestid";
@@ -6,7 +7,7 @@ const EXTENDED_REQUEST_ID_HEADER = "x-amz-id-2";
 const CF_ID_HEADER = "x-amz-cf-id";
 
 export function extractMetadata(
-  httpResponse: HttpResponse<any>
+  httpResponse: HttpResponse
 ): ResponseMetadata {
   const httpHeaders: HeaderBag = Object.keys(httpResponse.headers).reduce(
     (lowercase: HeaderBag, headerName: string) => {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/584#issuecomment-569866333

*Description of changes:*
import HttpResponse from protocol-http in response-metadata-extractor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
