### PR TITLE
fix: remove ServiceException from util-error-constructor

### DIFF
--- a/packages/util-error-constructor/src/index.spec.ts
+++ b/packages/util-error-constructor/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { initServiceException } from "./";
-import { ServiceException, ResponseMetadata } from "../../types/build/index";
+import { ResponseMetadata } from "../../types/build/index";
 
 describe("initServiceException", () => {
   const metadata: ResponseMetadata = {

--- a/packages/util-error-constructor/src/index.ts
+++ b/packages/util-error-constructor/src/index.ts
@@ -1,4 +1,4 @@
-import { ResponseMetadata, ServiceException } from "@aws-sdk/types";
+import { ResponseMetadata } from "@aws-sdk/types";
 
 /**
  * An interface used to construct a ServiceException.
@@ -23,7 +23,7 @@ export interface ServiceExceptionOption {
 export function initServiceException(
   error: Error,
   option: ServiceExceptionOption
-): ServiceException {
+): any {
   const { name, $metadata, rawException, message, operationName } = option;
   const serviceException: any = error;
   serviceException.name = name || `${operationName || ""}Error`;
@@ -34,5 +34,5 @@ export function initServiceException(
       : error.message);
   serviceException.details = rawException || {};
   serviceException.$metadata = $metadata;
-  return serviceException as ServiceException;
+  return serviceException;
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/584#issuecomment-569868064

*Description of changes:*
remove ServiceException from util-error-constructor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
