### PR TITLE
fix: update how HTTPResponse is created

### DIFF
--- a/packages/response-metadata-extractor/src/index.spec.ts
+++ b/packages/response-metadata-extractor/src/index.spec.ts
@@ -2,7 +2,7 @@ import { extractMetadata } from "./";
 import { HttpResponse } from "@aws-sdk/protocol-http";
 
 describe("extractMetadata", () => {
-  const response = new HttpResponse({
+  const httpResponseOptions = {
     statusCode: 200,
     headers: {
       Foo: "bar",
@@ -10,13 +10,15 @@ describe("extractMetadata", () => {
       Snap: "crackle, pop"
     },
     body: "this is body"
-  });
+  };
 
   it("should extract the status code from responses", () => {
+    const response = new HttpResponse(httpResponseOptions);
     expect(extractMetadata(response).httpStatusCode).toBe(response.statusCode);
   });
 
   it("should extract and downcase headers", () => {
+    const response = new HttpResponse(httpResponseOptions);
     expect(extractMetadata(response).httpHeaders).toEqual({
       foo: response.headers.Foo,
       fizz: response.headers.Fizz,
@@ -26,57 +28,57 @@ describe("extractMetadata", () => {
 
   it("should extract the request ID from the standard header", () => {
     expect(
-      extractMetadata({
-        ...response,
+      extractMetadata(new HttpResponse({
+        ...httpResponseOptions,
         headers: {
           "X-Amz-Request-ID": "id"
         }
-      }).requestId
+      })).requestId
     ).toBe("id");
   });
 
   it("should extract the request ID from the alternate header", () => {
     expect(
-      extractMetadata({
-        ...response,
+      extractMetadata(new HttpResponse({
+        ...httpResponseOptions,
         headers: {
           "X-Amzn-RequestId": "id"
         }
-      }).requestId
+      })).requestId
     ).toBe("id");
   });
 
   it("should prefer the request ID from the standard header", () => {
     expect(
-      extractMetadata({
-        ...response,
+      extractMetadata(new HttpResponse({
+        ...httpResponseOptions,
         headers: {
           "X-Amz-Request-ID": "id",
           "X-Amz-RequestId": "alt_id"
         }
-      }).requestId
+      })).requestId
     ).toBe("id");
   });
 
   it("should extract the extended request ID from the standard header", () => {
     expect(
-      extractMetadata({
-        ...response,
+      extractMetadata(new HttpResponse({
+        ...httpResponseOptions,
         headers: {
           "X-Amz-ID-2": "extendedId"
         }
-      }).extendedRequestId
+      })).extendedRequestId
     ).toBe("extendedId");
   });
 
   it("should extract the CloudFront ID from the standard header", () => {
     expect(
-      extractMetadata({
-        ...response,
+      extractMetadata(new HttpResponse({
+        ...httpResponseOptions,
         headers: {
           "X-Amz-CF-ID": "cfId"
         }
-      }).cfId
+      })).cfId
     ).toBe("cfId");
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/584#issuecomment-570065168

*Description of changes:*
fix: update how HTTPResponse is created in response-metadata-extractor/src/index.spec.ts 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
