### PR TITLE
fix: use httpRequestOptions in signature-v4

### DIFF
--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -65,7 +65,7 @@ describe("getCanonicalHeaders", () => {
   });
 
   it("should allow specifying custom signable headers that override unsignable ones", () => {
-    const request: HttpRequest<never> = {
+    const request = new HttpRequest({
       method: "POST",
       protocol: "https:",
       path: "/",
@@ -75,7 +75,7 @@ describe("getCanonicalHeaders", () => {
         "user-agent": "foo-user"
       },
       hostname: "foo.us-east-1.amazonaws.com"
-    };
+    });
 
     expect(
       getCanonicalHeaders(

--- a/packages/signature-v4/src/getCanonicalQuery.spec.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.spec.ts
@@ -1,24 +1,24 @@
 import { getCanonicalQuery } from "./getCanonicalQuery";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
-const request = new HttpRequest({
+const httpRequestOptions = {
   method: "POST",
   protocol: "https:",
   path: "/",
   headers: {},
   hostname: "foo.us-east-1.amazonaws.com"
-});
+};
 
 describe("getCanonicalQuery", () => {
   it("should return an empty string for requests with no querystring", () => {
-    expect(getCanonicalQuery(request)).toBe("");
+    expect(getCanonicalQuery(new HttpRequest(httpRequestOptions))).toBe("");
   });
 
   it("should serialize simple key => value pairs", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: { fizz: "buzz", foo: "bar" }
         })
       )
@@ -29,7 +29,7 @@ describe("getCanonicalQuery", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: { foo: "bar", baz: "quux", fizz: "buzz" }
         })
       )
@@ -40,7 +40,7 @@ describe("getCanonicalQuery", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: { "🐎": "🦄", "💩": "☃️" }
         })
       )
@@ -51,7 +51,7 @@ describe("getCanonicalQuery", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: {
             "x-amz-signature": "foo",
             "X-Amz-Signature": "bar",
@@ -66,7 +66,7 @@ describe("getCanonicalQuery", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: { foo: ["bar", "baz"] }
         })
       )
@@ -77,7 +77,7 @@ describe("getCanonicalQuery", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: { snap: ["pop", "crackle"] }
         })
       )
@@ -88,7 +88,7 @@ describe("getCanonicalQuery", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: { "🐎": ["💩", "🦄"] }
         })
       )
@@ -99,7 +99,7 @@ describe("getCanonicalQuery", () => {
     expect(
       getCanonicalQuery(
         new HttpRequest({
-          ...request,
+          ...httpRequestOptions,
           query: { foo: "bar", baz: new Uint8Array(0) as any }
         })
       )


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/622

*Description of changes:*
use httpRequestOptions in getCanonicalQuery.spec.ts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
