### PR TITLE
chore: don't generate yarn.lock in CI

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,7 +9,7 @@ phases:
   build:
     commands:
       - echo Building...
-      - yarn
+      - yarn --frozen-lockfile
       - echo Executing unit tests
       - yarn build:smithy-client #TODO: change to `yarn test:all` after clients are ready
       - echo Executing functional test


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* don't generate yarn.lock in CI
* Docs: https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
