### PR TITLE
chore: change client version to 0.1.0-preview.1

### DIFF
--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-acm-pca",
   "description": "@aws-sdk/client-acm-pca client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-acm",
   "description": "@aws-sdk/client-acm client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-alexa-for-business",
   "description": "@aws-sdk/client-alexa-for-business client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-application-auto-scaling",
   "description": "@aws-sdk/client-application-auto-scaling client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-application-discovery-service",
   "description": "@aws-sdk/client-application-discovery-service client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-application-insights",
   "description": "@aws-sdk/client-application-insights client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-appstream",
   "description": "@aws-sdk/client-appstream client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-athena",
   "description": "@aws-sdk/client-athena client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-auto-scaling-plans",
   "description": "@aws-sdk/client-auto-scaling-plans client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-budgets",
   "description": "@aws-sdk/client-budgets client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cloud9",
   "description": "@aws-sdk/client-cloud9 client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cloudhsm-v2",
   "description": "@aws-sdk/client-cloudhsm-v2 client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cloudhsm",
   "description": "@aws-sdk/client-cloudhsm client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cloudtrail",
   "description": "@aws-sdk/client-cloudtrail client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cloudwatch-events",
   "description": "@aws-sdk/client-cloudwatch-events client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cloudwatch-logs",
   "description": "@aws-sdk/client-cloudwatch-logs client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-codebuild",
   "description": "@aws-sdk/client-codebuild client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-codecommit",
   "description": "@aws-sdk/client-codecommit client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-codedeploy",
   "description": "@aws-sdk/client-codedeploy client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-codepipeline",
   "description": "@aws-sdk/client-codepipeline client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-codestar",
   "description": "@aws-sdk/client-codestar client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cognito-identity-provider",
   "description": "@aws-sdk/client-cognito-identity-provider client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cognito-identity",
   "description": "@aws-sdk/client-cognito-identity client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-comprehend",
   "description": "@aws-sdk/client-comprehend client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-comprehendmedical",
   "description": "@aws-sdk/client-comprehendmedical client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-compute-optimizer",
   "description": "@aws-sdk/client-compute-optimizer client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-config-service",
   "description": "@aws-sdk/client-config-service client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cost-and-usage-report-service",
   "description": "@aws-sdk/client-cost-and-usage-report-service client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cost-explorer",
   "description": "@aws-sdk/client-cost-explorer client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-data-pipeline",
   "description": "@aws-sdk/client-data-pipeline client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-database-migration-service",
   "description": "@aws-sdk/client-database-migration-service client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-datasync",
   "description": "@aws-sdk/client-datasync client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-dax",
   "description": "@aws-sdk/client-dax client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-device-farm",
   "description": "@aws-sdk/client-device-farm client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-direct-connect",
   "description": "@aws-sdk/client-direct-connect client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-directory-service",
   "description": "@aws-sdk/client-directory-service client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-dynamodb-streams",
   "description": "@aws-sdk/client-dynamodb-streams client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-dynamodb",
   "description": "@aws-sdk/client-dynamodb client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-ec2-instance-connect",
   "description": "@aws-sdk/client-ec2-instance-connect client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-ecr",
   "description": "@aws-sdk/client-ecr client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-ecs",
   "description": "@aws-sdk/client-ecs client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-emr",
   "description": "@aws-sdk/client-emr client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-eventbridge",
   "description": "@aws-sdk/client-eventbridge client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-firehose",
   "description": "@aws-sdk/client-firehose client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-fms",
   "description": "@aws-sdk/client-fms client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-forecast",
   "description": "@aws-sdk/client-forecast client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-forecastquery",
   "description": "@aws-sdk/client-forecastquery client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-frauddetector",
   "description": "@aws-sdk/client-frauddetector client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-fsx",
   "description": "@aws-sdk/client-fsx client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-gamelift",
   "description": "@aws-sdk/client-gamelift client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-global-accelerator",
   "description": "@aws-sdk/client-global-accelerator client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-glue",
   "description": "@aws-sdk/client-glue client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-health",
   "description": "@aws-sdk/client-health client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-inspector",
   "description": "@aws-sdk/client-inspector client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-iotsecuretunneling",
   "description": "@aws-sdk/client-iotsecuretunneling client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-iotthingsgraph",
   "description": "@aws-sdk/client-iotthingsgraph client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-kendra",
   "description": "@aws-sdk/client-kendra client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-kinesis-analytics-v2",
   "description": "@aws-sdk/client-kinesis-analytics-v2 client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-kinesis-analytics",
   "description": "@aws-sdk/client-kinesis-analytics client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-kinesis",
   "description": "@aws-sdk/client-kinesis client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-kms",
   "description": "@aws-sdk/client-kms client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-lakeformation",
   "description": "@aws-sdk/client-lakeformation client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-license-manager",
   "description": "@aws-sdk/client-license-manager client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-lightsail",
   "description": "@aws-sdk/client-lightsail client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-machine-learning",
   "description": "@aws-sdk/client-machine-learning client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-macie",
   "description": "@aws-sdk/client-macie client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-marketplace-commerce-analytics",
   "description": "@aws-sdk/client-marketplace-commerce-analytics client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-marketplace-entitlement-service",
   "description": "@aws-sdk/client-marketplace-entitlement-service client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-marketplace-metering",
   "description": "@aws-sdk/client-marketplace-metering client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-mediastore",
   "description": "@aws-sdk/client-mediastore client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-migration-hub",
   "description": "@aws-sdk/client-migration-hub client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-migrationhub-config",
   "description": "@aws-sdk/client-migrationhub-config client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-mturk",
   "description": "@aws-sdk/client-mturk client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-opsworks",
   "description": "@aws-sdk/client-opsworks client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-opsworkscm",
   "description": "@aws-sdk/client-opsworkscm client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-organizations",
   "description": "@aws-sdk/client-organizations client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-personalize",
   "description": "@aws-sdk/client-personalize client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-pi",
   "description": "@aws-sdk/client-pi client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-pricing",
   "description": "@aws-sdk/client-pricing client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-qldb-session",
   "description": "@aws-sdk/client-qldb-session client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-rekognition",
   "description": "@aws-sdk/client-rekognition client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-resource-groups-tagging-api",
   "description": "@aws-sdk/client-resource-groups-tagging-api client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-route-53-domains",
   "description": "@aws-sdk/client-route-53-domains client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-route53resolver",
   "description": "@aws-sdk/client-route53resolver client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-sagemaker",
   "description": "@aws-sdk/client-sagemaker client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-secrets-manager",
   "description": "@aws-sdk/client-secrets-manager client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-service-catalog",
   "description": "@aws-sdk/client-service-catalog client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-service-quotas",
   "description": "@aws-sdk/client-service-quotas client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-servicediscovery",
   "description": "@aws-sdk/client-servicediscovery client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-sfn",
   "description": "@aws-sdk/client-sfn client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-shield",
   "description": "@aws-sdk/client-shield client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-sms",
   "description": "@aws-sdk/client-sms client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-snowball",
   "description": "@aws-sdk/client-snowball client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-ssm",
   "description": "@aws-sdk/client-ssm client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-storage-gateway",
   "description": "@aws-sdk/client-storage-gateway client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-support",
   "description": "@aws-sdk/client-support client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-swf",
   "description": "@aws-sdk/client-swf client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-textract",
   "description": "@aws-sdk/client-textract client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-transcribe",
   "description": "@aws-sdk/client-transcribe client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-transfer",
   "description": "@aws-sdk/client-transfer client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-translate",
   "description": "@aws-sdk/client-translate client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-waf-regional",
   "description": "@aws-sdk/client-waf-regional client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-waf",
   "description": "@aws-sdk/client-waf client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-wafv2",
   "description": "@aws-sdk/client-wafv2 client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-workspaces",
   "description": "@aws-sdk/client-workspaces client",
-  "version": "1.0.0",
+  "version": "0.1.0-preview.1",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",


### PR DESCRIPTION
*Issue #, if available:*
The version numbers were set to 1.0.0 in CodeGen:
* https://github.com/aws/aws-sdk-js-v3/pull/658
* https://github.com/aws/aws-sdk-js-v3/pull/656

*Description of changes:*
* Manually change client versions to 0.1.0-preview.1
* Follow-up issue in CodeGen repo at https://github.com/awslabs/smithy-typescript/issues/79

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
