### PR TITLE
chore: set initial version to 0.1.0-preview.1

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -54,7 +54,7 @@ tasks.register("generate-smithy-build") {
                             .withMember("typescript-codegen", Node.objectNodeBuilder()
                                     .withMember("package", "@aws-sdk/client-" + sdkId.toLowerCase())
                                     // Note that this version is replaced by Lerna when publishing.
-                                    .withMember("packageVersion", "1.0.0")
+                                    .withMember("packageVersion", "0.1.0-preview.1")
                                     .withMember("packageJson", manifestOverwrites)
                                     .build()))
                     .build()


### PR DESCRIPTION
*Issue #, if available:*
Refs:
* Issue https://github.com/aws/aws-sdk-js-v3/issues/672
* Manual update https://github.com/aws/aws-sdk-js-v3/pull/666

*Description of changes:*
* set initial version for packages to "0.1.0-preview.1"
* this should be later passed while calling typescript-codegen

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
