### PR TITLE
chore: update service models

### DIFF
--- a/codegen/sdk-codegen/aws-models/amplify.2017-07-25.json
+++ b/codegen/sdk-codegen/aws-models/amplify.2017-07-25.json
@@ -175,7 +175,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Amplify"
+        "smithy.api#title": "AWS Amplify",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://amplify.amazonaws.com"
+        }
       }
     },
     "com.amazonaws.amplify#App": {

--- a/codegen/sdk-codegen/aws-models/application-auto-scaling.2016-02-06.json
+++ b/codegen/sdk-codegen/aws-models/application-auto-scaling.2016-02-06.json
@@ -132,7 +132,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Concurrent updates caused an exception, for example, if you request an update to an\n         Application Auto Scaling resource that already has a pending update.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.autoscaling.anyscale.frontend#Cooldown": {
@@ -737,7 +738,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Failed access to resources caused an exception. This exception is thrown when Application Auto Scaling\n         is unable to retrieve the alarms associated with a scaling policy due to a client error,\n         for example, if the role ARN specified for a scalable target does not have permission to\n         call the CloudWatch <a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html\">DescribeAlarms</a> on your behalf.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.frontend#InternalServiceException": {
@@ -749,7 +751,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The service encountered an internal error.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.autoscaling.anyscale.frontend#InvalidNextTokenException": {
@@ -761,7 +764,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The next token supplied was invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.frontend#LimitExceededException": {
@@ -773,7 +777,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A per-account resource limit is exceeded. For more information, see <a href=\"https://docs.aws.amazon.com/ApplicationAutoScaling/latest/userguide/application-auto-scaling-limits.html\">Application Auto Scaling Limits</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.frontend#MaxResults": {
@@ -933,7 +938,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified object could not be found. For any operation that depends on the existence\n         of a scalable target, this exception is thrown if the scalable target with the specified\n         service namespace, resource ID, and scalable dimension does not exist. For any operation\n         that deletes or deregisters a resource, this exception is thrown if the resource cannot be\n         found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.frontend#PolicyName": {
@@ -1907,7 +1913,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception was thrown for a validation issue. Review the available parameters for the\n         API request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.frontend#XmlString": {

--- a/codegen/sdk-codegen/aws-models/application-discovery-service.2015-11-01.json
+++ b/codegen/sdk-codegen/aws-models/application-discovery-service.2015-11-01.json
@@ -121,7 +121,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Application Discovery Service"
+        "smithy.api#title": "AWS Application Discovery Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ec2.amazon.com/awsposiedon/V2015_11_01/"
+        }
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#AgentConfigurationStatus": {
@@ -360,7 +363,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The AWS user account does not have permission to perform the action. Check the IAM\n      policy associated with this account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#BatchDeleteImportData": {
@@ -565,7 +569,10 @@
     "com.amazonaws.awsposeidon.V2015_11_01#ConfigurationTagSet": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.awsposeidon.V2015_11_01#ConfigurationTag"
+        "target": "com.amazonaws.awsposeidon.V2015_11_01#ConfigurationTag",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#Configurations": {
@@ -589,7 +596,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#ContinuousExportDescription": {
@@ -1854,7 +1862,10 @@
     "com.amazonaws.awsposeidon.V2015_11_01#FilterValues": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.awsposeidon.V2015_11_01#FilterValue"
+        "target": "com.amazonaws.awsposeidon.V2015_11_01#FilterValue",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#Filters": {
@@ -1946,7 +1957,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The home region is not set. Set the home region to continue.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#ImportStatus": {
@@ -2171,7 +2183,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>One or more parameters are not valid. Verify the parameters and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#InvalidParameterValueException": {
@@ -2183,7 +2196,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The value of one or more parameters are either invalid or out of range. Verify the\n      parameter values and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#ListConfigurations": {
@@ -2425,7 +2439,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This operation is not permitted.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#OrderByElement": {
@@ -2464,7 +2479,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This issue occurs when the same <code>clientRequestToken</code> is used with the\n        <code>StartImportTask</code> action, but with different parameters. For example, you use the\n      same request token but have two different import URLs, you can encounter this issue. If the\n      import tasks are meant to be different, use a different <code>clientRequestToken</code>, and\n      try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#ResourceNotFoundException": {
@@ -2476,7 +2492,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified configuration ID was not located. Verify the configuration ID and try\n      again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#S3Bucket": {
@@ -2503,7 +2520,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The server experienced an internal error. Try again.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#StartContinuousExport": {
@@ -2963,7 +2981,10 @@
     "com.amazonaws.awsposeidon.V2015_11_01#TagSet": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.awsposeidon.V2015_11_01#Tag"
+        "target": "com.amazonaws.awsposeidon.V2015_11_01#Tag",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.awsposeidon.V2015_11_01#TagValue": {

--- a/codegen/sdk-codegen/aws-models/application-insights.2018-11-25.json
+++ b/codegen/sdk-codegen/aws-models/application-insights.2018-11-25.json
@@ -128,7 +128,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request is not understood by the server.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.ec2windowsbarley#ComponentConfiguration": {
@@ -1083,7 +1084,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The server encountered an internal error and is unable to complete the request.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.ec2windowsbarley#LifeCycle": {
@@ -1868,7 +1870,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The resource is already created or in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.ec2windowsbarley#ResourceList": {
@@ -1886,7 +1889,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The resource does not exist in the customer account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.ec2windowsbarley#ResourceType": {
@@ -2040,7 +2044,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Tags are already registered for the specified application ARN.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.ec2windowsbarley#Tier": {
@@ -2077,7 +2082,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The number of the provided tags is beyond the limit, or\n         the number of total tags you are trying to attach to the specified resource exceeds the limit.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.ec2windowsbarley#Unit": {
@@ -2405,7 +2411,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The parameter is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.ec2windowsbarley#Value": {

--- a/codegen/sdk-codegen/aws-models/appstream.2016-12-01.json
+++ b/codegen/sdk-codegen/aws-models/appstream.2016-12-01.json
@@ -463,7 +463,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An API error occurred. Wait a few minutes and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#CopyImage": {
@@ -3235,7 +3236,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The image does not support storage connectors.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#Integer": {
@@ -3253,7 +3255,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n            <p>The resource cannot be created because your AWS account is suspended. For assistance, contact AWS Support. </p>\n        ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#InvalidParameterCombinationException": {
@@ -3265,7 +3268,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates an incorrect combination of parameters, or a missing parameter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#InvalidRoleException": {
@@ -3277,7 +3281,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified role is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#LastReportGenerationExecutionError": {
@@ -3315,7 +3320,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested limit exceeds the permitted limit for an account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#ListAssociatedFleets": {
@@ -3525,7 +3531,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The attempted operation is not permitted.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#OrganizationalUnitDistinguishedName": {
@@ -3758,7 +3765,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified resource already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#ResourceError": {
@@ -3811,7 +3819,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified resource is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#ResourceNotAvailableException": {
@@ -3823,7 +3832,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified resource exists and is not in use, but isn't available.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.photon#ResourceNotFoundException": {
@@ -3835,7 +3845,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified resource was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.photon#SecurityGroupIdList": {

--- a/codegen/sdk-codegen/aws-models/appsync.2017-07-25.json
+++ b/codegen/sdk-codegen/aws-models/appsync.2017-07-25.json
@@ -169,7 +169,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS AppSync"
+        "smithy.api#title": "AWS AppSync",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://appsync.amazonaws.com"
+        }
       }
     },
     "com.amazonaws.deepdish.controlplane#AccessDeniedException": {

--- a/codegen/sdk-codegen/aws-models/auto-scaling-plans.2018-01-06.json
+++ b/codegen/sdk-codegen/aws-models/auto-scaling-plans.2018-01-06.json
@@ -102,7 +102,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Concurrent updates caused an exception, for example, if you request an update to a\n         scaling plan that already has a pending update.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.autoscaling.anyscale.scaling_planner.frontend#Cooldown": {
@@ -620,7 +621,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The service encountered an internal error.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.autoscaling.anyscale.scaling_planner.frontend#InvalidNextTokenException": {
@@ -632,7 +634,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The token provided is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.scaling_planner.frontend#LimitExceededException": {
@@ -644,7 +647,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Your account exceeded a limit. This exception is thrown when a per-account resource\n         limit is exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.scaling_planner.frontend#LoadMetricType": {
@@ -755,7 +759,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified object could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.scaling_planner.frontend#PolicyName": {
@@ -1499,7 +1504,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception was thrown for a validation issue. Review the parameters provided.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.autoscaling.anyscale.scaling_planner.frontend#XmlString": {

--- a/codegen/sdk-codegen/aws-models/auto-scaling.2011-01-01.json
+++ b/codegen/sdk-codegen/aws-models/auto-scaling.2011-01-01.json
@@ -197,7 +197,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have an Auto Scaling group or launch configuration with this name.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.fws.csls.version_2011_01_01#AsciiStringMaxLen255": {
@@ -3173,7 +3174,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The <code>NextToken</code> value is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.fws.csls.version_2011_01_01#LaunchConfiguration": {
@@ -3654,7 +3656,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have already reached a limit for your Amazon EC2 Auto Scaling resources (for example, Auto Scaling\n            groups, launch configurations, or lifecycle hooks). For more information, see <a>DescribeAccountLimits</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.fws.csls.version_2011_01_01#LoadBalancerNames": {
@@ -4502,7 +4505,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a pending update to an Amazon EC2 Auto Scaling resource (for example, an Auto Scaling group,\n            instance, or load balancer).</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.fws.csls.version_2011_01_01#ResourceInUseFault": {
@@ -4517,7 +4521,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The operation can't be performed because the resource is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.fws.csls.version_2011_01_01#ResourceName": {
@@ -4559,7 +4564,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The operation can't be performed because there are scaling activities in\n            progress.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.fws.csls.version_2011_01_01#ScalingActivityStatusCode": {
@@ -4890,7 +4896,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The service-linked role is not yet ready for use.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.fws.csls.version_2011_01_01#SetDesiredCapacity": {

--- a/codegen/sdk-codegen/aws-models/batch.2016-08-10.json
+++ b/codegen/sdk-codegen/aws-models/batch.2016-08-10.json
@@ -94,7 +94,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Batch"
+        "smithy.api#title": "AWS Batch",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://batch.amazonaws.com/doc/2016-08-10/"
+        }
       }
     },
     "com.amazonaws.dilithium.frontend#ArrayJobDependency": {

--- a/codegen/sdk-codegen/aws-models/budgets.2016-10-20.json
+++ b/codegen/sdk-codegen/aws-models/budgets.2016-10-20.json
@@ -100,7 +100,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You are not authorized to use this operation with the given parameters.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 401
       }
     },
     "com.amazonaws.awsbudgetservicegateway#AccountId": {
@@ -645,7 +646,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've exceeded the notification or subscriber limit.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsbudgetservicegateway#DeleteBudget": {
@@ -1244,7 +1246,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The budget name already exists. Budget names must be unique within an account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsbudgetservicegateway#ExpiredNextTokenException": {
@@ -1256,7 +1259,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The pagination token expired.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsbudgetservicegateway#GenericString": {
@@ -1285,7 +1289,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An error on the server occurred during the processing of your request. Try again later.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.awsbudgetservicegateway#InvalidNextTokenException": {
@@ -1297,7 +1302,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The pagination token is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsbudgetservicegateway#InvalidParameterException": {
@@ -1309,7 +1315,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsbudgetservicegateway#MaxResults": {
@@ -1332,7 +1339,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can’t locate the resource that you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsbudgetservicegateway#Notification": {

--- a/codegen/sdk-codegen/aws-models/cloudformation.2010-05-15.json
+++ b/codegen/sdk-codegen/aws-models/cloudformation.2010-05-15.json
@@ -114,7 +114,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The resource with the name requested already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "amzn.aws21.activities#Arn": {
@@ -145,7 +146,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An error occurred during a CloudFormation registry operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "amzn.aws21.activities#CancelUpdateStack": {
@@ -288,7 +290,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified change set name or ID doesn't exit. To view valid change sets for a\n         stack, use the <code>ListChangeSets</code> action.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "amzn.aws21.activities#ChangeSetStatus": {
@@ -1204,7 +1207,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource exists, but has been changed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "amzn.aws21.activities#CreationTime": {
@@ -3107,7 +3111,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The template contains resources with capabilities that weren't specified in the\n         Capabilities parameter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "amzn.aws21.activities#InvalidChangeSetStatusException": {
@@ -3119,7 +3124,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified change set can't be used to update the stack. For example, the change\n         set status might be <code>CREATE_IN_PROGRESS</code>, or the stack status might be\n            <code>UPDATE_IN_PROGRESS</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.maestro.service.v20160713#InvalidOperationException": {
@@ -3131,7 +3137,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified operation isn't valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "amzn.aws21.activities#InvalidStateTransitionException": {
@@ -3143,7 +3150,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error reserved for use by the <a href=\"https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html\">CloudFormation CLI</a>. CloudFormation does not return this error to users.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "amzn.aws21.activities#Key": {
@@ -3161,7 +3169,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The quota for the resource has already been reached.</p>\n         <p>For information on resource and stack limitations, see <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html\">Limits</a> in\n         the <i>AWS CloudFormation User Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "amzn.aws21.activities#LimitName": {
@@ -4031,7 +4040,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified name is already in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "amzn.aws21.activities#NextToken": {
@@ -4089,7 +4099,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified operation ID already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.maestro.service.v20160713#OperationInProgressException": {
@@ -4101,7 +4112,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Another operation is currently in progress for this stack set. Only one operation can\n         be performed for a stack set at a given time.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.maestro.service.v20160713#OperationNotFoundException": {
@@ -4113,7 +4125,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified ID refers to an operation that doesn't exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "amzn.aws21.activities#OperationStatus": {
@@ -4144,7 +4157,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error reserved for use by the <a href=\"https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html\">CloudFormation CLI</a>. CloudFormation does not return this error to users.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "amzn.aws21.activities#OptionalSecureUrl": {
@@ -5654,7 +5668,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified stack instance doesn't exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.maestro.service.v20160713#StackInstanceStatus": {
@@ -6343,7 +6358,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can't yet delete this stack set, because it still contains one or more stack\n         instances. Delete all stack instances from the stack set before deleting the stack\n         set.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "amzn.aws21.activities#StackSetNotFoundException": {
@@ -6355,7 +6371,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified stack set doesn't exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.maestro.service.v20160713#StackSetOperation": {
@@ -6838,7 +6855,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Another operation has been performed on this stack set since the specified operation\n         was performed. </p>\n      \n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "amzn.aws21.activities#StatusMessage": {
@@ -7040,7 +7058,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A client request token already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.maestro.service.v20160713#TotalStackInstancesCount": {
@@ -7092,7 +7111,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified type does not exist in the CloudFormation registry.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "amzn.aws21.activities#TypeSchema": {

--- a/codegen/sdk-codegen/aws-models/cloudhsm.2014-05-30.json
+++ b/codegen/sdk-codegen/aws-models/cloudhsm.2014-05-30.json
@@ -370,57 +370,66 @@
         "ClientToken": {
           "target": "com.amazonaws.cloudhsm#ClientToken",
           "traits": {
-            "smithy.api#documentation": "\n         <p>A user-defined token to ensure idempotence. Subsequent calls to this operation with the\n      same token will be ignored.</p>\n      "
+            "smithy.api#documentation": "\n         <p>A user-defined token to ensure idempotence. Subsequent calls to this operation with the\n      same token will be ignored.</p>\n      ",
+            "smithy.api#xmlName": "ClientToken"
           }
         },
         "EniIp": {
           "target": "com.amazonaws.cloudhsm#IpAddress",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The IP address to assign to the HSM's ENI.</p>\n         <p>If an IP address is not specified, an IP address will be randomly chosen from the CIDR\n      range of the subnet.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The IP address to assign to the HSM's ENI.</p>\n         <p>If an IP address is not specified, an IP address will be randomly chosen from the CIDR\n      range of the subnet.</p>\n      ",
+            "smithy.api#xmlName": "EniIp"
           }
         },
         "ExternalId": {
           "target": "com.amazonaws.cloudhsm#ExternalId",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The external ID from <code>IamRoleArn</code>, if present.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The external ID from <code>IamRoleArn</code>, if present.</p>\n      ",
+            "smithy.api#xmlName": "ExternalId"
           }
         },
         "IamRoleArn": {
           "target": "com.amazonaws.cloudhsm#IamRoleArn",
           "traits": {
             "smithy.api#documentation": "\n         <p>The ARN of an IAM role to enable the AWS CloudHSM service to allocate an ENI on your\n      behalf.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlName": "IamRoleArn"
           }
         },
         "SshKey": {
           "target": "com.amazonaws.cloudhsm#SshKey",
           "traits": {
             "smithy.api#documentation": "\n         <p>The SSH public key to install on the HSM.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlName": "SshKey"
           }
         },
         "SubnetId": {
           "target": "com.amazonaws.cloudhsm#SubnetId",
           "traits": {
             "smithy.api#documentation": "\n         <p>The identifier of the subnet in your VPC in which to place the HSM.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlName": "SubnetId"
           }
         },
         "SubscriptionType": {
           "target": "com.amazonaws.cloudhsm#SubscriptionType",
           "traits": {
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlName": "SubscriptionType"
           }
         },
         "SyslogIp": {
           "target": "com.amazonaws.cloudhsm#IpAddress",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The IP address for the syslog monitoring server. The AWS CloudHSM service only supports one\n      syslog monitoring server.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The IP address for the syslog monitoring server. The AWS CloudHSM service only supports one\n      syslog monitoring server.</p>\n      ",
+            "smithy.api#xmlName": "SyslogIp"
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "\n         <p>Contains the inputs for the <code>CreateHsm</code> operation.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Contains the inputs for the <code>CreateHsm</code> operation.</p>\n      ",
+        "smithy.api#xmlName": "CreateHsmRequest"
       }
     },
     "com.amazonaws.cloudhsm#CreateHsmResponse": {
@@ -578,12 +587,14 @@
           "target": "com.amazonaws.cloudhsm#HsmArn",
           "traits": {
             "smithy.api#documentation": "\n         <p>The ARN of the HSM to delete.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlName": "HsmArn"
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "\n         <p>Contains the inputs for the <a>DeleteHsm</a> operation.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Contains the inputs for the <a>DeleteHsm</a> operation.</p>\n      ",
+        "smithy.api#xmlName": "DeleteHsmRequest"
       }
     },
     "com.amazonaws.cloudhsm#DeleteHsmResponse": {
@@ -1515,43 +1526,50 @@
         "EniIp": {
           "target": "com.amazonaws.cloudhsm#IpAddress",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The new IP address for the elastic network interface (ENI) attached to the\n      HSM.</p>\n         <p>If the HSM is moved to a different subnet, and an IP address is not specified, an IP\n      address will be randomly chosen from the CIDR range of the new subnet.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The new IP address for the elastic network interface (ENI) attached to the\n      HSM.</p>\n         <p>If the HSM is moved to a different subnet, and an IP address is not specified, an IP\n      address will be randomly chosen from the CIDR range of the new subnet.</p>\n      ",
+            "smithy.api#xmlName": "EniIp"
           }
         },
         "ExternalId": {
           "target": "com.amazonaws.cloudhsm#ExternalId",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The new external ID.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The new external ID.</p>\n      ",
+            "smithy.api#xmlName": "ExternalId"
           }
         },
         "HsmArn": {
           "target": "com.amazonaws.cloudhsm#HsmArn",
           "traits": {
             "smithy.api#documentation": "\n         <p>The ARN of the HSM to modify.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlName": "HsmArn"
           }
         },
         "IamRoleArn": {
           "target": "com.amazonaws.cloudhsm#IamRoleArn",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The new IAM role ARN.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The new IAM role ARN.</p>\n      ",
+            "smithy.api#xmlName": "IamRoleArn"
           }
         },
         "SubnetId": {
           "target": "com.amazonaws.cloudhsm#SubnetId",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The new identifier of the subnet that the HSM is in. The new subnet must be in the same\n      Availability Zone as the current subnet.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The new identifier of the subnet that the HSM is in. The new subnet must be in the same\n      Availability Zone as the current subnet.</p>\n      ",
+            "smithy.api#xmlName": "SubnetId"
           }
         },
         "SyslogIp": {
           "target": "com.amazonaws.cloudhsm#IpAddress",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The new IP address for the syslog monitoring server. The AWS CloudHSM service only supports\n      one syslog monitoring server.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The new IP address for the syslog monitoring server. The AWS CloudHSM service only supports\n      one syslog monitoring server.</p>\n      ",
+            "smithy.api#xmlName": "SyslogIp"
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "\n         <p>Contains the inputs for the <a>ModifyHsm</a> operation.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Contains the inputs for the <a>ModifyHsm</a> operation.</p>\n      ",
+        "smithy.api#xmlName": "ModifyHsmRequest"
       }
     },
     "com.amazonaws.cloudhsm#ModifyHsmResponse": {

--- a/codegen/sdk-codegen/aws-models/cloudsearch-domain.2013-01-01.json
+++ b/codegen/sdk-codegen/aws-models/cloudsearch-domain.2013-01-01.json
@@ -58,7 +58,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon CloudSearch Domain"
+        "smithy.api#title": "Amazon CloudSearch Domain",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://cloudsearch.amazonaws.com/doc/2013-01-01/"
+        }
       }
     },
     "com.a9.cloudsearch.service2013#Blob": {

--- a/codegen/sdk-codegen/aws-models/cloudsearch.2013-01-01.json
+++ b/codegen/sdk-codegen/aws-models/cloudsearch.2013-01-01.json
@@ -1632,7 +1632,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n  <p>The request was rejected because it attempted an operation which is not enabled.</p>\n  ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.a9.cloudsearch.config2013#DocumentSuggesterOptions": {
@@ -2303,7 +2304,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n    <p>An internal error occurred while processing the request. If this problem persists,\n      report an issue from the <a href=\"http://status.aws.amazon.com/\" target=\"_blank\">Service Health Dashboard</a>.</p>\n  ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.a9.cloudsearch.config2013#InvalidTypeException": {
@@ -2318,7 +2320,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n  <p>The request was rejected because it specified an invalid type definition.</p>\n  ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.a9.cloudsearch.config2013#LatLonOptions": {
@@ -2374,7 +2377,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n  <p>The request was rejected because a resource limit has already been met.</p>\n  ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.a9.cloudsearch.config2013#Limits": {
@@ -2622,7 +2626,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n  <p>The request was rejected because it attempted to reference a resource that does not exist.</p>\n  ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.a9.cloudsearch.config2013#ScalingParameters": {
@@ -3158,7 +3163,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n    <p>The request was rejected because it has invalid parameters.</p>\n  ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.a9.cloudsearch.config2013#Word": {

--- a/codegen/sdk-codegen/aws-models/cloudtrail.2013-11-01.json
+++ b/codegen/sdk-codegen/aws-models/cloudtrail.2013-11-01.json
@@ -116,7 +116,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when an operation is called with an invalid trail ARN. The format of a trail ARN is:</p>\n         <p>\n            <code>arn:aws:cloudtrail:us-east-2:123456789012:trail/MyTrail</code>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#CloudTrailAccessNotEnabledException": {
@@ -131,7 +132,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when trusted access has not been enabled between AWS CloudTrail and AWS Organizations. For more information, \n         see <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html\">Enabling Trusted Access with Other AWS Services</a>\n         and <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html\">Prepare For Creating a Trail For Your Organization</a>. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#CloudTrail_20131101": {
@@ -209,7 +211,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS CloudTrail"
+        "smithy.api#title": "AWS CloudTrail",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://cloudtrail.amazonaws.com/doc/2013-11-01/"
+        }
       }
     },
     "com.amazonaws.cloudtrail.v20131101#CloudWatchLogsDeliveryUnavailableException": {
@@ -224,7 +229,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Cannot set a CloudWatch Logs delivery for this region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#CreateTrail": {
@@ -1091,7 +1097,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>If you run <code>GetInsightSelectors</code> on a trail that does not have Insights events enabled, the operation throws the exception <code>InsightNotEnabledException</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InsightSelector": {
@@ -1136,7 +1143,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the IAM user or role that is used to create the organization trail is lacking one or more required permissions for \n         creating an organization trail in a required service. For more information, see \n         <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html\">Prepare For Creating a Trail For Your Organization</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InsufficientEncryptionPolicyException": {
@@ -1151,7 +1159,8 @@
       },
       "traits": {
         "smithy.api#documentation": " \n         <p>This exception is thrown when the policy on the S3 bucket or KMS key is not sufficient.</p> \n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InsufficientS3BucketPolicyException": {
@@ -1166,7 +1175,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the policy on the S3 bucket is not sufficient.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InsufficientSnsTopicPolicyException": {
@@ -1181,7 +1191,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the policy on the SNS topic is not sufficient.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidCloudWatchLogsLogGroupArnException": {
@@ -1196,7 +1207,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the provided CloudWatch log group is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidCloudWatchLogsRoleArnException": {
@@ -1211,7 +1223,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the provided role is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidEventCategoryException": {
@@ -1226,7 +1239,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Occurs if an event category that is not valid is specified as a value of <code>EventCategory</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidEventSelectorsException": {
@@ -1241,7 +1255,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the <code>PutEventSelectors</code> operation is called with a number of event selectors or data resources\n         that is not valid. The combination of event selectors and data resources is not valid. A trail can have up to 5 event selectors. A trail \n         is limited to 250 data resources. These data resources can be distributed across event selectors, but the overall total cannot exceed 250.</p>\n         <p>You can:</p>\n         <ul>\n            <li>\n               <p>Specify a valid number of event selectors (1 to 5) for a trail.</p>\n            </li>\n            <li>\n               <p>Specify a valid number of data resources (1 to 250) for an event selector. \n               The limit of number of resources on an individual event selector is configurable up to 250. \n               However, this upper limit is allowed only if the total number of data resources does not \n               exceed 250 across all event selectors for a trail.</p>\n            </li>\n            <li>\n               <p>Specify a valid value for a parameter. For example, specifying the <code>ReadWriteType</code> \n               parameter with a value of <code>read-only</code> is invalid.</p>\n            </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidHomeRegionException": {
@@ -1256,7 +1271,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when an operation is called on a trail from a region other than the region in which the trail was created.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidInsightSelectorsException": {
@@ -1271,7 +1287,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The formatting or syntax of the <code>InsightSelectors</code> JSON statement in your <code>PutInsightSelectors</code> or <code>GetInsightSelectors</code> request \n         is not valid, or the specified insight type in the <code>InsightSelectors</code> statement is not a valid insight type.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidKmsKeyIdException": {
@@ -1286,7 +1303,8 @@
       },
       "traits": {
         "smithy.api#documentation": " \n         <p>This exception is thrown when the KMS key ARN is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidLookupAttributesException": {
@@ -1301,7 +1319,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Occurs when an invalid lookup attribute is specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidMaxResultsException": {
@@ -1316,7 +1335,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown if the limit specified is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidNextTokenException": {
@@ -1331,7 +1351,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Invalid token or token that was previously used in a request with different parameters. This exception is thrown if the token is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidParameterCombinationException": {
@@ -1346,7 +1367,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the combination of parameters provided is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidS3BucketNameException": {
@@ -1361,7 +1383,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the provided S3 bucket name is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidS3PrefixException": {
@@ -1376,7 +1399,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the provided S3 prefix is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidSnsTopicNameException": {
@@ -1391,7 +1415,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the provided SNS topic name is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidTagParameterException": {
@@ -1406,7 +1431,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the specified tag key or values are not valid. \n         It can also occur if there are duplicate tags or too many tags on the resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidTimeRangeException": {
@@ -1421,7 +1447,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Occurs if the timestamp values are invalid. Either the start time occurs after the end time or the time range is outside the range of possible values.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidTokenException": {
@@ -1436,7 +1463,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Reserved for future use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#InvalidTrailNameException": {
@@ -1451,7 +1479,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the provided trail name is not valid. Trail names must meet the following requirements:</p>\n         <ul>\n            <li>\n               <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-)</p>\n            </li>\n            <li>\n               <p>Start with a letter or number, and end with a letter or number</p>\n            </li>\n            <li>\n               <p>Be between 3 and 128 characters</p>\n            </li>\n            <li>\n               <p>Have no adjacent periods, underscores or dashes. Names like <code>my-_namespace</code>\n            and <code>my--namespace</code> are invalid.</p>\n            </li>\n            <li>\n               <p>Not be in IP address format (for example, 192.168.5.4)</p>\n            </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#KmsException": {
@@ -1466,7 +1495,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when there is an issue with the specified KMS key and the trail can’t be updated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#KmsKeyDisabledException": {
@@ -1482,7 +1512,8 @@
       "traits": {
         "smithy.api#deprecated": { },
         "smithy.api#documentation": "\n         <p>This exception is no longer in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#KmsKeyNotFoundException": {
@@ -1497,7 +1528,8 @@
       },
       "traits": {
         "smithy.api#documentation": " \n         <p>This exception is thrown when the KMS key does not exist, or when the S3 bucket and the KMS key are not in the same region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#ListPublicKeys": {
@@ -1901,7 +1933,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the maximum number of trails is reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.cloudtrail.v20131101#NextToken": {
@@ -1919,7 +1952,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the AWS account making the request to create or update an organization trail is not the master account for an \n         organization in AWS Organizations. For more information, see \n         <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html\">Prepare For Creating a Trail For Your Organization</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#OperationNotPermittedException": {
@@ -1934,7 +1968,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the requested operation is not permitted.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#OrganizationNotInAllFeaturesModeException": {
@@ -1949,7 +1984,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when AWS Organizations is not configured to support all features. All features must be enabled in AWS Organization to support\n         creating an organization trail. For more information, see \n         <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html\">Prepare For Creating a Trail For Your Organization</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#OrganizationsNotInUseException": {
@@ -1964,7 +2000,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the request is made from an AWS account that is not a member of an organization. \n         To make this request, sign in using the credentials of an account that belongs to an organization.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cloudtrail.v20131101#PublicKey": {
@@ -2288,7 +2325,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the specified resource is not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#ResourceTag": {
@@ -2329,7 +2367,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the specified resource type is not supported by CloudTrail.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#S3BucketDoesNotExistException": {
@@ -2344,7 +2383,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the specified S3 bucket does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cloudtrail.v20131101#StartLogging": {
@@ -2499,7 +2539,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The number of tags per trail has exceeded the permitted amount. Currently, the limit is 50.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#TagsList": {
@@ -2628,7 +2669,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the specified trail already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#TrailInfo": {
@@ -2681,7 +2723,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the trail with the given name is not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cloudtrail.v20131101#TrailNotProvidedException": {
@@ -2696,7 +2739,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is no longer in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cloudtrail.v20131101#Trails": {
@@ -2717,7 +2761,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the requested operation is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudtrail.v20131101#UpdateTrail": {

--- a/codegen/sdk-codegen/aws-models/cloudwatch-events.2015-10-07.json
+++ b/codegen/sdk-codegen/aws-models/cloudwatch-events.2015-10-07.json
@@ -139,7 +139,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon CloudWatch Events"
+        "smithy.api#title": "Amazon CloudWatch Events",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://events.amazonaws.com/doc/2015-10-07"
+        }
       }
     },
     "com.amazon.jetstream.v20151007#AccountId": {

--- a/codegen/sdk-codegen/aws-models/cloudwatch-logs.2014-03-28.json
+++ b/codegen/sdk-codegen/aws-models/cloudwatch-logs.2014-03-28.json
@@ -2410,7 +2410,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon CloudWatch Logs"
+        "smithy.api#title": "Amazon CloudWatch Logs",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://monitoring.amazonaws.com/doc/2014-03-28/"
+        }
       }
     },
     "com.amazonaws.logs.v20140328#MalformedQueryException": {

--- a/codegen/sdk-codegen/aws-models/cloudwatch.2010-08-01.json
+++ b/codegen/sdk-codegen/aws-models/cloudwatch.2010-08-01.json
@@ -246,7 +246,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>More than one process tried to modify a resource at the same time.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#Counts": {
@@ -314,7 +315,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Some part of the dashboard data is invalid.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#DashboardName": {
@@ -338,7 +340,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The specified dashboard does not exist.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#DashboardValidationMessage": {
@@ -2125,7 +2128,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Request processing has failed due to some unknown error, exception, or failure.</p>\n\t     ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#InvalidFormatFault": {
@@ -2140,7 +2144,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Data was not syntactically valid JSON.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#InvalidNextToken": {
@@ -2155,7 +2160,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The next token specified is invalid.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.coral.service#InvalidParameterCombinationException": {
@@ -2170,7 +2176,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Parameters were used together that cannot be used together.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.coral.service#InvalidParameterValueException": {
@@ -2185,7 +2192,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The value of an input parameter is bad or out-of-range.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#LastModified": {
@@ -2200,7 +2208,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The operation exceeded one or more limits.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#LimitExceededFault": {
@@ -2215,7 +2224,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The quota for alarms for this customer has already been reached.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#ListDashboards": {
@@ -2909,7 +2919,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>An input parameter that is required is missing.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#Namespace": {
@@ -3393,7 +3404,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The named resource does not exist.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#ResourceNotFoundException": {
@@ -3411,7 +3423,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The named resource does not exist.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cloudwatch.v2010_08_01#ResourceType": {

--- a/codegen/sdk-codegen/aws-models/codecommit.2015-04-13.json
+++ b/codegen/sdk-codegen/aws-models/codecommit.2015-04-13.json
@@ -1701,7 +1701,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS CodeCommit"
+        "smithy.api#title": "AWS CodeCommit",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://codecommit.amazonaws.com/doc/2015-04-13"
+        }
       }
     },
     "com.amazonaws.codecommit#Comment": {

--- a/codegen/sdk-codegen/aws-models/codedeploy.2014-10-06.json
+++ b/codegen/sdk-codegen/aws-models/codedeploy.2014-10-06.json
@@ -1139,7 +1139,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS CodeDeploy"
+        "smithy.api#title": "AWS CodeDeploy",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://codedeploy.amazonaws.com/doc/2014-10-06/"
+        }
       }
     },
     "com.amazonaws.codedeploy#CommitId": {

--- a/codegen/sdk-codegen/aws-models/codepipeline.2015-07-09.json
+++ b/codegen/sdk-codegen/aws-models/codepipeline.2015-07-09.json
@@ -1481,7 +1481,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS CodePipeline"
+        "smithy.api#title": "AWS CodePipeline",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://codepipeline.amazonaws.com/doc/2015-07-09/"
+        }
       }
     },
     "com.amazonaws.codepipeline#ConcurrentModificationException": {

--- a/codegen/sdk-codegen/aws-models/codestar.2017-04-19.json
+++ b/codegen/sdk-codegen/aws-models/codestar.2017-04-19.json
@@ -291,7 +291,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Another modification is being made. That modification must complete before you can make\n      your change.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.codestar#CreateProject": {
@@ -924,7 +925,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The next token is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#InvalidServiceRoleException": {
@@ -936,7 +938,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The service role is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#LastModifiedTimestamp": {
@@ -951,7 +954,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A resource limit has been exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#ListProjects": {
@@ -1298,7 +1302,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An AWS CodeStar project with the same ID already exists in this region for the AWS account.\n      AWS CodeStar project IDs must be unique within a region for the AWS account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#ProjectArn": {
@@ -1316,7 +1321,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Project configuration information is required but not specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#ProjectCreationFailedException": {
@@ -1328,7 +1334,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The project creation request was valid, but a nonspecific exception or error occurred\n      during project creation. The project could not be created in AWS CodeStar.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#ProjectDescription": {
@@ -1372,7 +1379,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified AWS CodeStar project was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.codestar#ProjectStatus": {
@@ -1708,7 +1716,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The team member is already associated with a role in this project.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#TeamMemberNotFoundException": {
@@ -1720,7 +1729,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified team member was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.codestar#TeamMemberResult": {
@@ -2106,7 +2116,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A user profile with that name already exists in this region for the AWS account. AWS\n      CodeStar user profile names must be unique within a region for the AWS account. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.codestar#UserProfileDisplayName": {
@@ -2129,7 +2140,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The user profile was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.codestar#UserProfileSummary": {
@@ -2179,7 +2191,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified input is either not valid, or it could not be validated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     }
   }

--- a/codegen/sdk-codegen/aws-models/cognito-identity-provider.2016-04-18.json
+++ b/codegen/sdk-codegen/aws-models/cognito-identity-provider.2016-04-18.json
@@ -349,7 +349,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Cognito Identity Provider"
+        "smithy.api#title": "Amazon Cognito Identity Provider",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://cognito-idp.amazonaws.com/doc/2016-04-18/"
+        }
       }
     },
     "com.amazonaws.cognito.identity.idp.model#AccountRecoverySettingType": {
@@ -2722,7 +2725,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a user tries to confirm the account with an email or\n            phone number that has already been supplied as an alias from a different account. This\n            exception tells user that an account with this email or phone already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#AnalyticsConfigurationType": {
@@ -3403,7 +3407,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a verification code fails to deliver\n            successfully.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#CodeMismatchException": {
@@ -3418,7 +3423,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown if the provided code does not match what the server was\n            expecting.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#CompletionMessageType": {
@@ -3492,7 +3498,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown if two or more modifications are happening\n            concurrently.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#ConfirmDevice": {
@@ -5762,7 +5769,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the provider is already supported by the user\n            pool.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#EmailAddressType": {
@@ -5891,7 +5899,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when there is a code mismatch and the service fails to\n            configure the software token TOTP multi-factor authentication (MFA).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#EventContextDataType": {
@@ -6053,7 +6062,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown if a code has expired.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#ExplicitAuthFlowsListType": {
@@ -6997,7 +7007,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when Amazon Cognito encounters a group that already exists in\n            the user pool.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#GroupListType": {
@@ -7371,7 +7382,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when Amazon Cognito is not allowed to use your email\n            identity. HTTP status code: 400.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#InvalidLambdaResponseException": {
@@ -7386,7 +7398,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the Amazon Cognito service encounters an invalid AWS\n            Lambda response.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#InvalidOAuthFlowException": {
@@ -7398,7 +7411,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the specified OAuth flow is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#InvalidParameterException": {
@@ -7413,7 +7427,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the Amazon Cognito service encounters an invalid\n            parameter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#InvalidPasswordException": {
@@ -7428,7 +7443,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the Amazon Cognito service encounters an invalid\n            password.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#InvalidSmsRoleAccessPolicyException": {
@@ -7443,7 +7459,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is returned when the role provided for SMS configuration does not have\n            permission to publish using Amazon SNS.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#InvalidSmsRoleTrustRelationshipException": {
@@ -7458,7 +7475,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the trust relationship is invalid for the role provided\n            for SMS configuration. This can happen if you do not trust <b>cognito-idp.amazonaws.com</b> or the external ID provided in the role does\n            not match what is provided in the SMS configuration for the user pool.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#InvalidUserPoolConfigurationException": {
@@ -7473,7 +7491,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the user pool configuration is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#LambdaConfigType": {
@@ -7556,7 +7575,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a user exceeds the limit for a requested AWS\n            resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#ListDevices": {
@@ -8384,7 +8404,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when Amazon Cognito cannot find a multi-factor authentication\n            (MFA) method.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#MFAOptionListType": {
@@ -8487,7 +8508,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a user is not authorized.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.cognito.identity.idp.model#NotifyConfigurationType": {
@@ -8693,7 +8715,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a password reset is required.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#PasswordType": {
@@ -8746,7 +8769,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a precondition is not met.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#PreventUserExistenceErrorTypes": {
@@ -9089,7 +9113,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the Amazon Cognito service cannot find the requested\n            resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cognito.identity.idp.model#ResourceServerIdentifierType": {
@@ -9571,7 +9596,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the specified scope does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#ScopeListType": {
@@ -10240,7 +10266,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the software token TOTP multi-factor authentication\n            (MFA) is not enabled for the user pool.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#SoftwareTokenMFAUserCodeType": {
@@ -10563,7 +10590,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the user has made too many failed attempts for a given\n            action (e.g., sign in).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#TooManyRequestsException": {
@@ -10578,7 +10606,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the user has made too many requests for a given\n            operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UICustomizationType": {
@@ -10643,7 +10672,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the Amazon Cognito service encounters an unexpected\n            exception with the AWS Lambda service.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UnsupportedIdentityProviderException": {
@@ -10655,7 +10685,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the specified identifier is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UnsupportedUserStateException": {
@@ -10670,7 +10701,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request failed because the user is in an unsupported state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UntagResource": {
@@ -11654,7 +11686,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when you are trying to modify a user pool while a user import\n            job is in progress for that pool.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UserImportJobIdType": {
@@ -11818,7 +11851,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when the Amazon Cognito service encounters a user validation\n            exception with the AWS Lambda service.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UserMFASettingListType": {
@@ -11839,7 +11873,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a user is not confirmed successfully.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UserNotFoundException": {
@@ -11854,7 +11889,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a user is not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UserPoolAddOnNotEnabledException": {
@@ -11866,7 +11902,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when user pool add-ons are not enabled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UserPoolAddOnsType": {
@@ -12148,7 +12185,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when a user pool tag cannot be set or updated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UserPoolTagsListType": {
@@ -12463,7 +12501,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This exception is thrown when Amazon Cognito encounters a user name that already\n            exists in the user pool.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.idp.model#UsernameType": {

--- a/codegen/sdk-codegen/aws-models/cognito-identity.2014-06-30.json
+++ b/codegen/sdk-codegen/aws-models/cognito-identity.2014-06-30.json
@@ -118,7 +118,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Cognito Identity"
+        "smithy.api#title": "Amazon Cognito Identity",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://cognito-identity.amazonaws.com/doc/2014-06-30/"
+        }
       }
     },
     "com.amazonaws.cognito.identity.model#AccessKeyString": {
@@ -240,7 +243,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown if there are parallel requests to modify a resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.model#CreateIdentityPool": {
@@ -577,7 +581,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The provided developer user identifier is already registered with Cognito under a\n         different identity ID.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.model#DeveloperUserIdentifier": {
@@ -620,7 +625,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception thrown when a dependent service such as Facebook or Twitter is not\n         responding</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.model#GetCredentialsForIdentity": {
@@ -1293,7 +1299,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown if the identity pool has no role associated for the given auth type\n         (auth/unauth) or if the AssumeRole fails.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.model#InvalidParameterException": {
@@ -1308,7 +1315,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown for missing or bad input parameter(s).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.model#LimitExceededException": {
@@ -1323,7 +1331,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown when the total number of user pools has exceeded a preset limit.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.cognito.identity.model#ListIdentities": {
@@ -1816,7 +1825,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown when a user is not authorized to access the requested resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.cognito.identity.model#OIDCProviderList": {
@@ -1858,7 +1868,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown when a user tries to use a login which is already linked to another\n         account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.cognito.identity.model#ResourceNotFoundException": {
@@ -1873,7 +1884,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown when the requested resource (for example, a dataset or record) does not\n         exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.cognito.identity.model#RoleMapping": {
@@ -2134,7 +2146,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Thrown when a request is throttled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.cognito.identity.model#UnlinkDeveloperIdentity": {

--- a/codegen/sdk-codegen/aws-models/cognito-sync.2014-06-30.json
+++ b/codegen/sdk-codegen/aws-models/cognito-sync.2014-06-30.json
@@ -97,7 +97,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Cognito Sync"
+        "smithy.api#title": "Amazon Cognito Sync",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://cognito-sync.amazonaws.com/doc/2014-06-30/"
+        }
       }
     },
     "com.amazonaws.cognito.sync.model#AlreadyStreamedException": {

--- a/codegen/sdk-codegen/aws-models/comprehend.2017-11-27.json
+++ b/codegen/sdk-codegen/aws-models/comprehend.2017-11-27.json
@@ -500,7 +500,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The number of documents in the request exceeds the limit of 25. Try your request again\n      with fewer documents.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#ClassifierEvaluationMetrics": {
@@ -869,7 +870,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Concurrent modification of the tags associated with an Amazon Comprehend resource is not supported. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#CreateDocumentClassifier": {
@@ -3233,7 +3235,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An internal server error occurred. Retry your request.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.comprehend#InvalidFilterException": {
@@ -3245,7 +3248,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The filter specified for the operation is invalid.\n      Specify a different filter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#InvalidRequestException": {
@@ -3257,7 +3261,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request\n      is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#JobId": {
@@ -3289,7 +3294,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified job was not found. Check the job ID and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.comprehend#JobStatus": {
@@ -3485,7 +3491,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The KMS customer managed key (CMK) entered cannot be validated. Verify the key and re-enter it.</p>\n     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#LanguageCode": {
@@ -4433,7 +4440,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified name is already in use. Use a different name and try your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#ResourceLimitExceededException": {
@@ -4445,7 +4453,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The maximum number of recognizers per account has been exceeded. Review the recognizers, perform cleanup, and then try your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#ResourceNotFoundException": {
@@ -4457,7 +4466,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource ARN was not found. Check the ARN and try your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.comprehend#ResourceUnavailableException": {
@@ -4469,7 +4479,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource is not available. Check to see if the resource is in\n      the <code>TRAINED</code> state and try your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.comprehend#S3Uri": {
@@ -5792,7 +5803,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The size of the input text exceeds the limit. Use a smaller document.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#Timestamp": {
@@ -5807,7 +5819,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The number of requests exceeds the limit. Resubmit your request later.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.comprehend#TooManyTagKeysException": {
@@ -5819,7 +5832,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request contains more tag keys than can be associated with a resource (50 tag keys per resource).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#TooManyTagsException": {
@@ -5831,7 +5845,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request contains more tags than can be associated with a resource (50 tags per resource). The maximum\n      number of tags includes both existing tags and those included in your current request.    </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#TopicsDetectionJobFilter": {
@@ -5961,7 +5976,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Amazon Comprehend can't process the language of the input text. For all custom entity recognition\n      APIs (such as <code>CreateEntityRecognizer</code>), only English is accepted. For most other APIs, such as those for Custom Classification, Amazon Comprehend accepts text in \n      all supported languages. For a list of supported languages, see <a>supported-languages</a>. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.comprehend#UntagResource": {

--- a/codegen/sdk-codegen/aws-models/comprehendmedical.2018-10-30.json
+++ b/codegen/sdk-codegen/aws-models/comprehendmedical.2018-10-30.json
@@ -868,7 +868,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> An internal server error occurred. Retry your request. </p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.deepinsight.medical#InvalidEncodingException": {
@@ -880,7 +881,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> The input text was not in valid UTF-8 character encoding. Check your text then retry your\n   request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.deepinsight.medical#InvalidRequestException": {
@@ -892,7 +894,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> The request that you made is invalid. Check your request to determine why it's invalid and\n   then retry the request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.deepinsight.medical#JobId": {
@@ -1147,7 +1150,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The resource identified by the specified Amazon Resource Name (ARN) was not found. Check the\n   ARN and try your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.deepinsight.medical#S3Bucket": {
@@ -1179,7 +1183,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> The Amazon Comprehend Medical service is temporarily unavailable. Please wait and then retry your request.\n  </p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.deepinsight.medical#StartEntitiesDetectionV2Job": {
@@ -1469,7 +1474,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> The size of the text you submitted exceeds the size limit. Reduce the size of the text or\n   use a smaller document and then retry your request. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.deepinsight.medical#Timestamp": {
@@ -1484,7 +1490,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> You have made too many requests within a short period of time. Wait for a short time and\n   then try your request again. Contact customer support for more information about a service limit\n   increase. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.deepinsight.medical#Trait": {
@@ -1548,7 +1555,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The filter that you specified for the operation is invalid. Check the filter values that you\n   entered and try your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     }
   }

--- a/codegen/sdk-codegen/aws-models/compute-optimizer.2019-11-01.json
+++ b/codegen/sdk-codegen/aws-models/compute-optimizer.2019-11-01.json
@@ -34,7 +34,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You do not have sufficient access to perform this action.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#AccountId": {
@@ -900,7 +901,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request processing has failed because of an unknown error, exception, or\n            failure.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#InvalidParameterValueException": {
@@ -912,7 +914,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An invalid or out-of-range value was supplied for the input parameter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#LastRefreshTimestamp": {
@@ -983,7 +986,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request must contain either a valid (registered) AWS access key ID or X.509\n            certificate.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#NextToken": {
@@ -998,7 +1002,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You must opt in to the service to perform this action.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#PerformanceRisk": {
@@ -1178,7 +1183,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified resource was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#ServiceUnavailableException": {
@@ -1190,7 +1196,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request has failed due to a temporary failure of the server.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#Status": {
@@ -1256,7 +1263,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The limit on the number of requests per second was exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.computeoptimizer.version_2019_11_01#Timestamp": {

--- a/codegen/sdk-codegen/aws-models/config-service.2014-11-12.json
+++ b/codegen/sdk-codegen/aws-models/config-service.2014-11-12.json
@@ -9724,7 +9724,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Config"
+        "smithy.api#title": "AWS Config",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://config.amazonaws.com/doc/2014-11-12/"
+        }
       }
     },
     "com.amazonaws.starling.dove#StartConfigRulesEvaluation": {

--- a/codegen/sdk-codegen/aws-models/cost-explorer.2017-10-25.json
+++ b/codegen/sdk-codegen/aws-models/cost-explorer.2017-10-25.json
@@ -3379,7 +3379,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            The specified ARN in the request doesn't exist.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.awsinsightsindexservice.v0#ResourceUtilization": {
@@ -4087,7 +4088,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            You've reached the limit on the number of resources you can create, or exceeded the size of an individual resources.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
       }
     },
     "com.amazonaws.awsinsightsindexservice.v0#ServiceSpecification": {

--- a/codegen/sdk-codegen/aws-models/data-pipeline.2012-10-29.json
+++ b/codegen/sdk-codegen/aws-models/data-pipeline.2012-10-29.json
@@ -287,7 +287,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Data Pipeline"
+        "smithy.api#title": "AWS Data Pipeline",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://datapipeline.amazonaws.com/doc/2012-10-29/"
+        }
       }
     },
     "com.amazon.setl.webservice#DeactivatePipeline": {

--- a/codegen/sdk-codegen/aws-models/database-migration-service.2016-01-01.json
+++ b/codegen/sdk-codegen/aws-models/database-migration-service.2016-01-01.json
@@ -69,7 +69,10 @@
     "com.amazonaws.dms.v20160101#AccountQuotaList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#AccountQuota"
+        "target": "com.amazonaws.dms.v20160101#AccountQuota",
+        "traits": {
+          "smithy.api#xmlName": "AccountQuota"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#AddTagsToResource": {
@@ -280,7 +283,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Database Migration Service"
+        "smithy.api#title": "AWS Database Migration Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://dms.amazonaws.com/doc/2016-01-01/"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#ApplyPendingMaintenanceAction": {
@@ -472,7 +478,10 @@
     "com.amazonaws.dms.v20160101#CertificateList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#Certificate"
+        "target": "com.amazonaws.dms.v20160101#Certificate",
+        "traits": {
+          "smithy.api#xmlName": "Certificate"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#CertificateWallet": {
@@ -538,7 +547,10 @@
     "com.amazonaws.dms.v20160101#ConnectionList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#Connection"
+        "target": "com.amazonaws.dms.v20160101#Connection",
+        "traits": {
+          "smithy.api#xmlName": "Connection"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#CreateEndpoint": {
@@ -3032,7 +3044,10 @@
     "com.amazonaws.dms.v20160101#EndpointList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#Endpoint"
+        "target": "com.amazonaws.dms.v20160101#Endpoint",
+        "traits": {
+          "smithy.api#xmlName": "Endpoint"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#Event": {
@@ -3076,7 +3091,10 @@
     "com.amazonaws.dms.v20160101#EventCategoriesList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#String"
+        "target": "com.amazonaws.dms.v20160101#String",
+        "traits": {
+          "smithy.api#xmlName": "EventCategory"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#EventCategoryGroup": {
@@ -3102,13 +3120,19 @@
     "com.amazonaws.dms.v20160101#EventCategoryGroupList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#EventCategoryGroup"
+        "target": "com.amazonaws.dms.v20160101#EventCategoryGroup",
+        "traits": {
+          "smithy.api#xmlName": "EventCategoryGroup"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#EventList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#Event"
+        "target": "com.amazonaws.dms.v20160101#Event",
+        "traits": {
+          "smithy.api#xmlName": "Event"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#EventSubscription": {
@@ -3176,7 +3200,10 @@
     "com.amazonaws.dms.v20160101#EventSubscriptionsList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#EventSubscription"
+        "target": "com.amazonaws.dms.v20160101#EventSubscription",
+        "traits": {
+          "smithy.api#xmlName": "EventSubscription"
+        }
       }
     },
     "com.amazonaws.dms#ExceptionMessage": {
@@ -3207,13 +3234,19 @@
     "com.amazonaws.dms.v20160101#FilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#Filter"
+        "target": "com.amazonaws.dms.v20160101#Filter",
+        "traits": {
+          "smithy.api#xmlName": "Filter"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#FilterValueList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#String"
+        "target": "com.amazonaws.dms.v20160101#String",
+        "traits": {
+          "smithy.api#xmlName": "Value"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#ImportCertificate": {
@@ -4250,7 +4283,10 @@
     "com.amazonaws.dms.v20160101#OrderableReplicationInstanceList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#OrderableReplicationInstance"
+        "target": "com.amazonaws.dms.v20160101#OrderableReplicationInstance",
+        "traits": {
+          "smithy.api#xmlName": "OrderableReplicationInstance"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#ParquetVersionValue": {
@@ -4313,13 +4349,19 @@
     "com.amazonaws.dms.v20160101#PendingMaintenanceActionDetails": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#PendingMaintenanceAction"
+        "target": "com.amazonaws.dms.v20160101#PendingMaintenanceAction",
+        "traits": {
+          "smithy.api#xmlName": "PendingMaintenanceAction"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#PendingMaintenanceActions": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#ResourcePendingMaintenanceActions"
+        "target": "com.amazonaws.dms.v20160101#ResourcePendingMaintenanceActions",
+        "traits": {
+          "smithy.api#xmlName": "ResourcePendingMaintenanceActions"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#RebootReplicationInstance": {
@@ -4934,7 +4976,10 @@
     "com.amazonaws.dms.v20160101#ReplicationInstanceList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#ReplicationInstance"
+        "target": "com.amazonaws.dms.v20160101#ReplicationInstance",
+        "traits": {
+          "smithy.api#xmlName": "ReplicationInstance"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#ReplicationInstancePrivateIpAddressList": {
@@ -5069,7 +5114,10 @@
     "com.amazonaws.dms.v20160101#ReplicationSubnetGroups": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#ReplicationSubnetGroup"
+        "target": "com.amazonaws.dms.v20160101#ReplicationSubnetGroup",
+        "traits": {
+          "smithy.api#xmlName": "ReplicationSubnetGroup"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#ReplicationTask": {
@@ -5235,13 +5283,19 @@
     "com.amazonaws.dms.v20160101#ReplicationTaskAssessmentResultList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#ReplicationTaskAssessmentResult"
+        "target": "com.amazonaws.dms.v20160101#ReplicationTaskAssessmentResult",
+        "traits": {
+          "smithy.api#xmlName": "ReplicationTaskAssessmentResult"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#ReplicationTaskList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#ReplicationTask"
+        "target": "com.amazonaws.dms.v20160101#ReplicationTask",
+        "traits": {
+          "smithy.api#xmlName": "ReplicationTask"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#ReplicationTaskStats": {
@@ -5562,7 +5616,10 @@
     "com.amazonaws.dms.v20160101#SourceIdsList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#String"
+        "target": "com.amazonaws.dms.v20160101#String",
+        "traits": {
+          "smithy.api#xmlName": "SourceId"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#SourceType": {
@@ -5826,13 +5883,19 @@
     "com.amazonaws.dms.v20160101#SubnetIdentifierList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#String"
+        "target": "com.amazonaws.dms.v20160101#String",
+        "traits": {
+          "smithy.api#xmlName": "SubnetIdentifier"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#SubnetList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#Subnet"
+        "target": "com.amazonaws.dms.v20160101#Subnet",
+        "traits": {
+          "smithy.api#xmlName": "Subnet"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#SupportedEndpointType": {
@@ -5870,7 +5933,10 @@
     "com.amazonaws.dms.v20160101#SupportedEndpointTypeList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#SupportedEndpointType"
+        "target": "com.amazonaws.dms.v20160101#SupportedEndpointType",
+        "traits": {
+          "smithy.api#xmlName": "SupportedEndpointType"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#TStamp": {
@@ -6035,7 +6101,10 @@
     "com.amazonaws.dms.v20160101#TagList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#Tag"
+        "target": "com.amazonaws.dms.v20160101#Tag",
+        "traits": {
+          "smithy.api#xmlName": "Tag"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#TestConnection": {
@@ -6118,7 +6187,10 @@
     "com.amazonaws.dms.v20160101#VpcSecurityGroupIdList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#String"
+        "target": "com.amazonaws.dms.v20160101#String",
+        "traits": {
+          "smithy.api#xmlName": "VpcSecurityGroupId"
+        }
       }
     },
     "com.amazonaws.dms.v20160101#VpcSecurityGroupMembership": {
@@ -6144,7 +6216,10 @@
     "com.amazonaws.dms.v20160101#VpcSecurityGroupMembershipList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.dms.v20160101#VpcSecurityGroupMembership"
+        "target": "com.amazonaws.dms.v20160101#VpcSecurityGroupMembership",
+        "traits": {
+          "smithy.api#xmlName": "VpcSecurityGroupMembership"
+        }
       }
     }
   }

--- a/codegen/sdk-codegen/aws-models/dax.2017-04-19.json
+++ b/codegen/sdk-codegen/aws-models/dax.2017-04-19.json
@@ -109,7 +109,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon DynamoDB Accelerator (DAX)"
+        "smithy.api#title": "Amazon DynamoDB Accelerator (DAX)",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://dax.amazonaws.com/doc/2017-04-19/"
+        }
       }
     },
     "dax.admin.v20170419#AvailabilityZoneList": {
@@ -249,7 +252,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a DAX cluster with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#ClusterList": {
@@ -273,7 +277,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cluster ID does not refer to an existing DAX cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#ClusterQuotaForCustomerExceededFault": {
@@ -285,7 +290,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have attempted to exceed the maximum number of DAX clusters for your AWS\n            account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#CreateCluster": {
@@ -1348,7 +1354,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There are not enough system resources to create the cluster you requested (or to\n            resize an already-existing cluster). </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#Integer": {
@@ -1369,7 +1376,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The Amazon Resource Name (ARN) supplied in the request is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidClusterStateFault": {
@@ -1381,7 +1389,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested DAX cluster is not in the <i>available</i>\n            state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.coral.service#InvalidParameterCombinationException": {
@@ -1393,7 +1402,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Two or more incompatible parameters were specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidParameterGroupStateFault": {
@@ -1405,7 +1415,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>One or more parameters in a parameter group are in an invalid state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.coral.service#InvalidParameterValueException": {
@@ -1417,7 +1428,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The value for a parameter is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidSubnet": {
@@ -1429,7 +1441,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An invalid subnet identifier was specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidVPCNetworkStateFault": {
@@ -1441,7 +1454,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The VPC network is in an invalid state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#IsModifiable": {
@@ -1592,7 +1606,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>None of the nodes in the cluster have the given node ID.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#NodeQuotaForClusterExceededFault": {
@@ -1604,7 +1619,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have attempted to exceed the maximum number of nodes for a DAX\n            cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#NodeQuotaForCustomerExceededFault": {
@@ -1616,7 +1632,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have attempted to exceed the maximum number of nodes for your AWS\n            account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#NodeTypeSpecificValue": {
@@ -1762,7 +1779,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified parameter group already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#ParameterGroupList": {
@@ -1786,7 +1804,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified parameter group does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#ParameterGroupQuotaExceededFault": {
@@ -1798,7 +1817,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have attempted to exceed the maximum number of parameter groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#ParameterGroupStatus": {
@@ -2017,7 +2037,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified service linked role (SLR) was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#SourceType": {
@@ -2094,7 +2115,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified subnet group already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#SubnetGroupInUseFault": {
@@ -2106,7 +2128,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified subnet group is currently in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#SubnetGroupList": {
@@ -2130,7 +2153,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested subnet group name does not refer to an existing subnet\n            group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#SubnetGroupQuotaExceededFault": {
@@ -2142,7 +2166,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of\n            subnets in a subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#SubnetIdentifierList": {
@@ -2160,7 +2185,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested subnet is being used by another subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#SubnetList": {
@@ -2178,7 +2204,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of\n            subnets in a subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#TStamp": {
@@ -2219,7 +2246,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The tag does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#TagQuotaPerResourceExceeded": {
@@ -2231,7 +2259,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the maximum number of tags for this DAX cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "dax.admin.v20170419#TagResource": {

--- a/codegen/sdk-codegen/aws-models/device-farm.2015-06-23.json
+++ b/codegen/sdk-codegen/aws-models/device-farm.2015-06-23.json
@@ -1845,7 +1845,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Device Farm"
+        "smithy.api#title": "AWS Device Farm",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://devicefarm.amazonaws.com/doc/2015-06-23/"
+        }
       }
     },
     "com.amazon.devicefarm.model#DeviceFilter": {
@@ -6745,7 +6748,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The operation was not successful. Try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.devicefarm.model#TagPolicyException": {
@@ -6760,7 +6764,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request doesn't comply with the AWS Identity and Access Management (IAM) tag policy. Correct your\n            request and then retry it.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.devicefarm.model#TagResource": {
@@ -6992,7 +6997,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The list of tags on the repository is over the limit. The maximum number of tags that can be applied to a\n            repository is 50. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.devicefarm.model#TransactionIdentifier": {

--- a/codegen/sdk-codegen/aws-models/direct-connect.2012-10-25.json
+++ b/codegen/sdk-codegen/aws-models/direct-connect.2012-10-25.json
@@ -4113,7 +4113,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Direct Connect"
+        "smithy.api#title": "AWS Direct Connect",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://directconnect.amazonaws.com/doc/2012-10-25/"
+        }
       }
     },
     "com.amazon.awsdx.overture#OwnerAccount": {

--- a/codegen/sdk-codegen/aws-models/directory-service.2015-04-16.json
+++ b/codegen/sdk-codegen/aws-models/directory-service.2015-04-16.json
@@ -3082,7 +3082,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Directory Service"
+        "smithy.api#title": "AWS Directory Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://directoryservice.amazonaws.com/doc/2015-04-16/"
+        }
       }
     },
     "com.amazonaws.directoryservice.v20150416#DirectoryShortName": {

--- a/codegen/sdk-codegen/aws-models/docdb.2014-10-31.json
+++ b/codegen/sdk-codegen/aws-models/docdb.2014-10-31.json
@@ -299,7 +299,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified CIDR IP or Amazon EC2 security group isn't authorized for the\n            specified DB security group.</p>\n        <p>Amazon DocumentDB also might not be authorized to perform necessary actions on your behalf\n            using IAM.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#AvailabilityZone": {
@@ -422,7 +423,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>CertificateIdentifier</code> doesn't refer to an existing certificate. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#CloudwatchLogsExportConfiguration": {
@@ -1252,7 +1254,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a DB cluster with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterList": {
@@ -1334,7 +1337,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBClusterIdentifier</code> doesn't refer to an existing DB cluster. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBClusterParameterGroup": {
@@ -1421,7 +1425,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBClusterParameterGroupName</code> doesn't refer to an existing DB cluster\n            parameter group. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBClusterParameterGroupsMessage": {
@@ -1453,7 +1458,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB cluster can't be created because you have reached the maximum allowed quota of\n            DB clusters.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "rds.admin.v20141031#DBClusterRole": {
@@ -1604,7 +1610,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a DB cluster snapshot with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterSnapshotAttribute": {
@@ -1694,7 +1701,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBClusterSnapshotIdentifier</code> doesn't refer to an existing DB cluster\n            snapshot. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBEngineVersion": {
@@ -1955,7 +1963,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a DB instance with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBInstanceList": {
@@ -1996,7 +2005,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBInstanceIdentifier</code> doesn't refer to an existing DB instance. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBInstanceStatusInfo": {
@@ -2049,7 +2059,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A DB parameter group with the same name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBParameterGroupNotFoundFault": {
@@ -2061,7 +2072,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBParameterGroupName</code> doesn't refer to an existing DB parameter\n            group. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBParameterGroupQuotaExceededFault": {
@@ -2073,7 +2085,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This request would cause you to exceed the allowed number of DB parameter\n            groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSecurityGroupNotFoundFault": {
@@ -2085,7 +2098,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSecurityGroupName</code> doesn't refer to an existing DB security group. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBSnapshotAlreadyExistsFault": {
@@ -2097,7 +2111,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSnapshotIdentifier</code> is already being used by an existing snapshot. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSnapshotNotFoundFault": {
@@ -2109,7 +2124,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSnapshotIdentifier</code> doesn't refer to an existing DB snapshot. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBSubnetGroup": {
@@ -2165,7 +2181,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSubnetGroupName</code> is already being used by an existing DB subnet group. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSubnetGroupDoesNotCoverEnoughAZs": {
@@ -2177,7 +2194,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Subnets in the DB subnet group should cover at least two Availability Zones unless\n            there is only one Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSubnetGroupMessage": {
@@ -2209,7 +2227,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSubnetGroupName</code> doesn't refer to an existing DB subnet group. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBSubnetGroupQuotaExceededFault": {
@@ -2221,7 +2240,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would cause you to exceed the allowed number of DB subnet groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSubnetGroups": {
@@ -2242,7 +2262,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would cause you to exceed the allowed number of subnets in a DB subnet\n            group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBUpgradeDependencyFailureFault": {
@@ -2254,7 +2275,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB upgrade failed because a resource that the DB depends on can't be\n            modified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DeleteDBCluster": {
@@ -3513,7 +3535,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would cause you to exceed the allowed number of DB instances.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InsufficientDBClusterCapacityFault": {
@@ -3525,7 +3548,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB cluster doesn't have enough capacity for the current operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "rds.admin#InsufficientDBInstanceCapacityFault": {
@@ -3537,7 +3561,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified DB instance class isn't available in the specified Availability\n            Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InsufficientStorageClusterCapacityFault": {
@@ -3549,7 +3574,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There is not enough storage available for the current action. You might be able to\n            resolve this error by updating your subnet group to use different Availability Zones\n            that have more storage available. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#Integer": {
@@ -3570,7 +3596,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The provided value isn't a valid DB cluster snapshot state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBClusterStateFault": {
@@ -3582,7 +3609,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB cluster isn't in a valid state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBInstanceStateFault": {
@@ -3594,7 +3622,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p> The specified DB instance isn't in the <i>available</i> state.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBParameterGroupStateFault": {
@@ -3606,7 +3635,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB parameter group is in use, or it is in a state that is not valid. If you are\n            trying to delete the parameter group, you can't delete it when the parameter group\n            is in this state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSecurityGroupStateFault": {
@@ -3618,7 +3648,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The state of the DB security group doesn't allow deletion.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSnapshotStateFault": {
@@ -3630,7 +3661,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The state of the DB snapshot doesn't allow deletion.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSubnetGroupStateFault": {
@@ -3642,7 +3674,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB subnet group can't be deleted because it's in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSubnetStateFault": {
@@ -3654,7 +3687,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p> The DB subnet isn't in the <i>available</i> state. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidRestoreFault": {
@@ -3666,7 +3700,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You cannot restore from a virtual private cloud (VPC) backup to a non-VPC DB\n            instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidSubnet": {
@@ -3678,7 +3713,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested subnet is not valid, or multiple subnets were requested that are not all\n            in a common virtual private cloud (VPC).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidVPCNetworkStateFault": {
@@ -3690,7 +3726,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB subnet group doesn't cover all Availability Zones after it is created\n            because of changes that were made.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#KMSKeyNotAccessibleFault": {
@@ -3702,7 +3739,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An error occurred when accessing an AWS KMS key.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#KeyList": {
@@ -4644,7 +4682,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified resource ID was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#ResourcePendingMaintenanceActions": {
@@ -4950,7 +4989,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the maximum number of accounts that you can share a manual DB\n            snapshot with. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SnapshotQuotaExceededFault": {
@@ -4962,7 +5002,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would cause you to exceed the allowed number of DB snapshots.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#SourceType": {
@@ -5057,7 +5098,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would cause you to exceed the allowed amount of storage available across\n            all DB instances.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#StorageTypeNotSupportedFault": {
@@ -5069,7 +5111,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Storage of the specified <code>StorageType</code> can't be associated with the DB\n            instance. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#String": {
@@ -5110,7 +5153,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB subnet is already in use in the Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#SubnetIdentifierList": {

--- a/codegen/sdk-codegen/aws-models/dynamodb-streams.2012-08-10.json
+++ b/codegen/sdk-codegen/aws-models/dynamodb-streams.2012-08-10.json
@@ -223,7 +223,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon DynamoDB Streams"
+        "smithy.api#title": "Amazon DynamoDB Streams",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://dynamodb.amazonaws.com/doc/2012-08-10/"
+        }
       }
     },
     "com.amazonaws.dynamodb.v20120810#ErrorMessage": {

--- a/codegen/sdk-codegen/aws-models/dynamodb.2012-08-10.json
+++ b/codegen/sdk-codegen/aws-models/dynamodb.2012-08-10.json
@@ -2633,7 +2633,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon DynamoDB"
+        "smithy.api#title": "Amazon DynamoDB",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://dynamodb.amazonaws.com/doc/2012-08-10/"
+        }
       }
     },
     "com.amazon.aws.sdk.endpointdiscovery#Endpoint": {
@@ -3324,7 +3327,8 @@
         }
       },
       "traits": {
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 421
       }
     },
     "com.amazonaws.dynamodb.v20120810#InvalidRestoreTimeException": {

--- a/codegen/sdk-codegen/aws-models/ec2-instance-connect.2018-04-02.json
+++ b/codegen/sdk-codegen/aws-models/ec2-instance-connect.2018-04-02.json
@@ -61,7 +61,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that either your AWS credentials are invalid or you do not have access to the EC2 instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.aws.sshaccessproxyservice#AvailabilityZone": {
@@ -83,7 +84,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the instance requested was not found in the given zone.  Check that you have provided a valid instance ID and the correct zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.aws.sshaccessproxyservice#InstanceId": {
@@ -115,7 +117,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that you provided bad input.  Ensure you have a valid instance ID, the correct zone, and a valid SSH public key.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.aws.sshaccessproxyservice#RequestId": {
@@ -218,7 +221,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the service encountered an error.  Follow the message's instructions and try again.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.aws.sshaccessproxyservice#String": {
@@ -236,7 +240,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates you have been making requests too frequently and have been throttled.  Wait for a while and try again.  If higher call volume is warranted contact AWS Support.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     }
   }

--- a/codegen/sdk-codegen/aws-models/ec2.2016-11-15.json
+++ b/codegen/sdk-codegen/aws-models/ec2.2016-11-15.json
@@ -27761,9 +27761,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.ec2#InferenceDeviceInfo"
-      },
-      "traits": {
-        "smithy.api#xmlName": "item"
       }
     },
     "com.amazonaws.ec2#InferenceDeviceManufacturerName": {
@@ -38953,8 +38950,7 @@
         "smithy.api#length": {
           "min": 0,
           "max": 100
-        },
-        "smithy.api#xmlName": "InstanceType"
+        }
       }
     },
     "com.amazonaws.ec2#RequestLaunchTemplateData": {

--- a/codegen/sdk-codegen/aws-models/ecr.2015-09-21.json
+++ b/codegen/sdk-codegen/aws-models/ecr.2015-09-21.json
@@ -133,7 +133,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon EC2 Container Registry"
+        "smithy.api#title": "Amazon EC2 Container Registry",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ecr.amazonaws.com/doc/2015-09-21/"
+        }
       }
     },
     "com.amazonaws.starport.frontend#Arn": {

--- a/codegen/sdk-codegen/aws-models/ecs.2014-11-13.json
+++ b/codegen/sdk-codegen/aws-models/ecs.2014-11-13.json
@@ -227,7 +227,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon EC2 Container Service"
+        "smithy.api#title": "Amazon EC2 Container Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ecs.amazonaws.com/doc/2014-11-13/"
+        }
       }
     },
     "com.amazonaws.madison.frontend#AssignPublicIp": {

--- a/codegen/sdk-codegen/aws-models/elastic-beanstalk.2010-12-01.json
+++ b/codegen/sdk-codegen/aws-models/elastic-beanstalk.2010-12-01.json
@@ -903,7 +903,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>AWS CodeBuild is not available in the specified region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#ComposeEnvironments": {
@@ -3546,7 +3547,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified account does not have sufficient privileges for one or more AWS\n      services.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.elasticbeanstalk#Integer": {
@@ -3564,7 +3566,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>One or more input parameters is not valid. Please correct the input parameters and try\n      the operation again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#Latency": {
@@ -3992,7 +3995,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Cannot modify the managed action in its current state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#ManagedActions": {
@@ -4125,7 +4129,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Unable to perform the specified operation because another operation that effects an\n      element in this activity is already in progress.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#OptionNamespace": {
@@ -4526,7 +4531,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You cannot delete the platform version because there are still environments running on it.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#Queue": {
@@ -4667,7 +4673,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A resource doesn't exist for the specified Amazon Resource Name (ARN).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#ResourceQuota": {
@@ -4751,7 +4758,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The type of the specified Amazon Resource Name (ARN) isn't supported for this operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#RestartAppServer": {
@@ -4886,7 +4894,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified S3 bucket does not belong to the S3 region in which the service is\n      running. The following regions are supported:</p>\n         <ul>\n            <li>\n\t              <p>IAD/us-east-1</p>\n\t           </li>\n            <li>\n\t              <p>PDX/us-west-2</p>\n\t           </li>\n            <li>\n\t              <p>DUB/eu-west-1</p>\n\t           </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#S3SubscriptionRequiredException": {
@@ -4901,7 +4910,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified account does not have a subscription to Amazon S3.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#SampleTimestamp": {
@@ -5045,7 +5055,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Unable to delete the Amazon S3 source bundle associated with the application version.\n      The application version was deleted successfully.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#SourceConfiguration": {
@@ -5366,7 +5377,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified account has reached its limit of applications.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#TooManyBucketsException": {
@@ -5381,7 +5393,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified account has reached its limit of Amazon S3 buckets.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#TooManyConfigurationTemplatesException": {
@@ -5396,7 +5409,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified account has reached its limit of configuration templates.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#TooManyEnvironmentsException": {
@@ -5411,7 +5425,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified account has reached its limit of environments.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#TooManyPlatformsException": {
@@ -5426,7 +5441,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded the maximum number of allowed platforms associated with the account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#TooManyTagsException": {
@@ -5441,7 +5457,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The number of tags in the resource would exceed the number of tags that each resource\n      can have.</p>\n         <p>To calculate this, the operation considers both the number of tags the resource already has\n      and the tags this operation would add if it succeeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.elasticbeanstalk#Trigger": {

--- a/codegen/sdk-codegen/aws-models/elastic-load-balancing-v2.2015-12-01.json
+++ b/codegen/sdk-codegen/aws-models/elastic-load-balancing-v2.2015-12-01.json
@@ -234,7 +234,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified allocation ID does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#AuthenticateCognitoActionAuthenticationRequestExtraParams": {
@@ -535,7 +536,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified Availability Zone is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#AvailabilityZones": {
@@ -585,7 +587,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified certificate does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#Cipher": {
@@ -1927,7 +1930,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A listener with the specified port already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#DuplicateLoadBalancerNameException": {
@@ -1939,7 +1943,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A load balancer with the specified name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#DuplicateTagKeysException": {
@@ -1951,7 +1956,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A tag key was specified more than once.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#DuplicateTargetGroupNameException": {
@@ -1963,7 +1969,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A target group with the specified name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#ElasticLoadBalancing_v10": {
@@ -2217,7 +2224,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The health of the specified targets could not be retrieved due to an internal\n      error.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.elb.version_2015_12_01#HostHeaderConditionConfig": {
@@ -2283,7 +2291,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified configuration is not valid with this protocol.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#InvalidConfigurationRequestException": {
@@ -2295,7 +2304,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested configuration is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#InvalidLoadBalancerActionException": {
@@ -2307,7 +2317,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested action is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#InvalidSchemeException": {
@@ -2319,7 +2330,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested scheme is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#InvalidSecurityGroupException": {
@@ -2331,7 +2343,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified security group does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#InvalidSubnetException": {
@@ -2343,7 +2356,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified subnet is out of available addresses.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#InvalidTargetException": {
@@ -2355,7 +2369,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified target does not exist, is not in the same VPC as the target group, or has\n      an unsupported instance type.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#IpAddress": {
@@ -2477,7 +2492,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified listener does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#Listeners": {
@@ -2676,7 +2692,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified load balancer does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#LoadBalancerSchemeEnum": {
@@ -3177,7 +3194,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This operation is not allowed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#PageSize": {
@@ -3232,7 +3250,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified priority is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#PrivateIPv4Address": {
@@ -3547,7 +3566,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A specified resource is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#Rule": {
@@ -3668,7 +3688,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified rule does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#RulePriority": {
@@ -3722,7 +3743,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified SSL policy does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#SecurityGroupId": {
@@ -4070,7 +4092,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified subnet does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#Subnets": {
@@ -4318,7 +4341,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of load balancers per target group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TargetGroupAttribute": {
@@ -4384,7 +4408,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified target group does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TargetGroupStickinessConfig": {
@@ -4605,7 +4630,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of actions per rule.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyCertificatesException": {
@@ -4617,7 +4643,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of certificates per load balancer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyListenersException": {
@@ -4629,7 +4656,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of listeners per load balancer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyLoadBalancersException": {
@@ -4641,7 +4669,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of load balancers for your AWS\n      account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyRegistrationsForTargetIdException": {
@@ -4653,7 +4682,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of times a target can be registered with a load\n      balancer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyRulesException": {
@@ -4665,7 +4695,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of rules per load balancer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyTagsException": {
@@ -4677,7 +4708,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of tags per load balancer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyTargetGroupsException": {
@@ -4689,7 +4721,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of target groups for your AWS account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyTargetsException": {
@@ -4701,7 +4734,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of targets.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#TooManyUniqueTargetGroupsPerLoadBalancerException": {
@@ -4713,7 +4747,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've reached the limit on the number of unique target groups per load balancer\n        across all listeners. If a target group is used by multiple actions for a load balancer, \n        it is counted as only one use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#UnsupportedProtocolException": {
@@ -4725,7 +4760,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified protocol is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2015_12_01#VpcId": {

--- a/codegen/sdk-codegen/aws-models/elastic-load-balancing.2012-06-01.json
+++ b/codegen/sdk-codegen/aws-models/elastic-load-balancing.2012-06-01.json
@@ -82,7 +82,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified load balancer does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#AccessPointPort": {
@@ -431,7 +432,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified ARN does not refer to a valid SSL certificate in AWS Identity and Access Management (IAM) \n            or AWS Certificate Manager (ACM). Note that if you recently uploaded the certificate to IAM, this error might \n            indicate that the certificate is not fully available yet.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#ConfigureHealthCheck": {
@@ -1074,7 +1076,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A request made by Elastic Load Balancing to another service exceeds the maximum request rate permitted for your account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#DeregisterEndPointsInput": {
@@ -1587,7 +1590,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified load balancer name already exists for this account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#DuplicateListenerException": {
@@ -1599,7 +1603,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A listener already exists for the specified load balancer name and port, but with a different instance port, protocol, or SSL certificate.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#DuplicatePolicyNameException": {
@@ -1611,7 +1616,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A policy with the specified name already exists for this load balancer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#DuplicateTagKeysException": {
@@ -1623,7 +1629,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A tag key was specified more than once.</p> \n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#ElasticLoadBalancing_v7": {
@@ -1928,7 +1935,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested configuration change is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.elb.version_2012_06_01#InvalidEndPointException": {
@@ -1940,7 +1948,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified endpoint is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#InvalidSchemeException": {
@@ -1952,7 +1961,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified value for the schema is not valid. You can only specify a scheme for load balancers in a VPC.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#InvalidSecurityGroupException": {
@@ -1964,7 +1974,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>One or more of the specified security groups do not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#InvalidSubnetException": {
@@ -1976,7 +1987,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified VPC has no associated Internet gateway.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#LBCookieStickinessPolicies": {
@@ -2107,7 +2119,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The load balancer does not have a listener configured at the specified port.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#Listeners": {
@@ -2125,7 +2138,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified load balancer attribute does not exist.</p>  \n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#LoadBalancerAttributes": {
@@ -2380,7 +2394,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This operation is not allowed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#PageSize": {
@@ -2565,7 +2580,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>One or more of the specified policies do not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#PolicyTypeDescription": {
@@ -2618,7 +2634,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>One or more of the specified policy types do not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#Ports": {
@@ -3013,7 +3030,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>One or more of the specified subnets do not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#Subnets": {
@@ -3134,7 +3152,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The quota for the number of load balancers has been reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#TooManyPoliciesException": {
@@ -3146,7 +3165,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The quota for the number of policies for this load balancer has been reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#TooManyTagsException": {
@@ -3158,7 +3178,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The quota for the number of tags that can be assigned to a load balancer has been reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#UnhealthyThreshold": {
@@ -3179,7 +3200,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified protocol or signature version is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.elb.version_2012_06_01#VPCId": {

--- a/codegen/sdk-codegen/aws-models/elastic-transcoder.2012-09-25.json
+++ b/codegen/sdk-codegen/aws-models/elastic-transcoder.2012-09-25.json
@@ -1258,7 +1258,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Elastic Transcoder"
+        "smithy.api#title": "Amazon Elastic Transcoder",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://elastictranscoder.amazonaws.com/doc/2012-09-25/"
+        }
       }
     },
     "com.amazonaws.etscustomer#ExceptionMessage": {

--- a/codegen/sdk-codegen/aws-models/elasticache.2015-02-02.json
+++ b/codegen/sdk-codegen/aws-models/elasticache.2015-02-02.json
@@ -34,7 +34,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The customer has exceeded the allowed rate of API calls.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#AZMode": {
@@ -326,7 +327,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified Amazon EC2 security group is already authorized for the specified cache security group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#AuthorizationNotFoundFault": {
@@ -338,7 +340,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified Amazon EC2 security group is not authorized for the specified cache security group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin.v20150202#AuthorizeCacheSecurityGroupIngress": {
@@ -711,7 +714,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a cluster with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CacheClusterIdList": {
@@ -764,7 +768,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cluster ID does not refer to an existing cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin.v20150202#CacheEngineVersion": {
@@ -1102,7 +1107,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A cache parameter group with the requested name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CacheParameterGroupDetails": {
@@ -1163,7 +1169,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cache parameter group name does not refer to an existing cache parameter group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#CacheParameterGroupQuotaExceededFault": {
@@ -1175,7 +1182,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the maximum number of cache security groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CacheParameterGroupStatus": {
@@ -1265,7 +1273,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A cache security group with the specified name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CacheSecurityGroupMembership": {
@@ -1335,7 +1344,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cache security group name does not refer to an existing cache security group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#CacheSecurityGroupQuotaExceededFault": {
@@ -1347,7 +1357,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of cache security groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CacheSecurityGroups": {
@@ -1400,7 +1411,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cache subnet group name is already in use by an existing cache subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#CacheSubnetGroupInUse": {
@@ -1412,7 +1424,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cache subnet group is currently in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CacheSubnetGroupMessage": {
@@ -1444,7 +1457,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cache subnet group name does not refer to an existing cache subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#CacheSubnetGroupQuotaExceededFault": {
@@ -1456,7 +1470,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of cache subnet groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CacheSubnetGroups": {
@@ -1477,7 +1492,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of subnets in a cache subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#ChangeType": {
@@ -1507,7 +1523,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of clusters per customer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#CompleteMigration": {
@@ -3901,7 +3918,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cache node type is not available in the specified Availability Zone.\n            For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ErrorMessages.html#ErrorMessages.INSUFFICIENT_CACHE_CLUSTER_CAPACITY\">InsufficientCacheClusterCapacity</a> in the ElastiCache User Guide.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#Integer": {
@@ -3922,7 +3940,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested Amazon Resource Name (ARN) does not refer to an existing resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidCacheClusterStateFault": {
@@ -3934,7 +3953,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cluster is not in the <code>available</code> state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidCacheParameterGroupStateFault": {
@@ -3946,7 +3966,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The current state of the cache parameter group does not allow the requested operation to occur.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidCacheSecurityGroupStateFault": {
@@ -3958,7 +3979,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The current state of the cache security group does not allow deletion.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidKMSKeyFault": {
@@ -3970,7 +3992,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The KMS key supplied is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.coral.service#InvalidParameterCombinationException": {
@@ -3985,7 +4008,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Two or more incompatible parameters were specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.coral.service#InvalidParameterValueException": {
@@ -4000,7 +4024,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The value for a parameter is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidReplicationGroupStateFault": {
@@ -4012,7 +4037,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested replication group is not in the <code>available</code> state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidSnapshotStateFault": {
@@ -4024,7 +4050,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The current state of the snapshot does not allow the requested operation to occur.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidSubnet": {
@@ -4036,7 +4063,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An invalid subnet identifier was specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#InvalidVPCNetworkStateFault": {
@@ -4048,7 +4076,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The VPC network is in an invalid state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#KeyList": {
@@ -4698,7 +4727,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The operation was not performed because no changes were required.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#NodeGroup": {
@@ -4928,7 +4958,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The node group specified by the <code>NodeGroupId</code> parameter could not be found.\n            Please verify that the node group exists and that you spelled the <code>NodeGroupId</code> value correctly.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin.v20150202#NodeGroupUpdateStatus": {
@@ -4969,7 +5000,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the maximum allowed number\n            of node groups (shards) in a single replication group. The default maximum is 90</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#NodeGroupsToRemoveList": {
@@ -4999,7 +5031,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of cache nodes in a single cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#NodeQuotaForCustomerExceededFault": {
@@ -5011,7 +5044,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the allowed number of cache nodes per customer.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#NodeSnapshot": {
@@ -5653,7 +5687,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified replication group already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin#ReplicationGroupAlreadyUnderMigrationFault": {
@@ -5665,7 +5700,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The targeted replication group is not available. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#ReplicationGroupIdList": {
@@ -5718,7 +5754,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified replication group does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#ReplicationGroupNotUnderMigrationFault": {
@@ -5730,7 +5767,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The designated replication group is not available for data migration.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#ReplicationGroupPendingModifiedValues": {
@@ -5860,7 +5898,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a reservation with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin.v20150202#ReservedCacheNodeList": {
@@ -5901,7 +5940,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested reserved cache node was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#ReservedCacheNodeQuotaExceededFault": {
@@ -5913,7 +5953,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the user's cache node quota.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#ReservedCacheNodesOffering": {
@@ -6010,7 +6051,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested cache node offering does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin.v20150202#ResetCacheParameterGroup": {
@@ -6211,7 +6253,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified service linked role (SLR) was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#ServiceUpdate": {
@@ -6312,7 +6355,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The service update doesn't exist</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin.v20150202#ServiceUpdateSeverity": {
@@ -6586,7 +6630,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You already have a snapshot with the given name.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#SnapshotArnsList": {
@@ -6607,7 +6652,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You attempted one of the following operations:</p>\n        <ul>\n            <li>\n               <p>Creating a snapshot of a Redis cluster running on a <code>cache.t1.micro</code> cache\n                    node.</p>\n            </li>\n            <li>\n               <p>Creating a snapshot of a cluster that is running Memcached rather than Redis.</p>\n            </li>\n         </ul>\n        <p>Neither of these are supported by ElastiCache.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#SnapshotList": {
@@ -6628,7 +6674,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested snapshot name does not refer to an existing snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#SnapshotQuotaExceededFault": {
@@ -6640,7 +6687,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would exceed the maximum number of snapshots.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#SourceType": {
@@ -6749,7 +6797,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested subnet is being used by another cache subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#SubnetList": {
@@ -6816,7 +6865,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested tag was not found on this resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "elmo.admin#TagQuotaPerResourceExceeded": {
@@ -6828,7 +6878,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be processed because it would cause the resource to have more than the allowed number of tags. The maximum number of tags permitted on a resource is 50.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#TestFailover": {
@@ -6900,7 +6951,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The <code>TestFailover</code> action is not available.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "elmo.admin.v20150202#TimeRangeFilter": {

--- a/codegen/sdk-codegen/aws-models/elasticsearch-service.2015-01-01.json
+++ b/codegen/sdk-codegen/aws-models/elasticsearch-service.2015-01-01.json
@@ -253,7 +253,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Elasticsearch Service"
+        "smithy.api#title": "Amazon Elasticsearch Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://es.amazonaws.com/doc/2015-01-01/"
+        }
       }
     },
     "com.a9.es.exceptions#BaseException": {
@@ -2694,7 +2697,10 @@
     "com.a9.es.config2015#RecurringChargeList": {
       "type": "list",
       "member": {
-        "target": "com.a9.es.config2015#RecurringCharge"
+        "target": "com.a9.es.config2015#RecurringCharge",
+        "traits": {
+          "smithy.api#xmlName": "RecurringCharge"
+        }
       }
     },
     "com.a9.es.config2015#RemoveTags": {
@@ -2904,7 +2910,10 @@
     "com.a9.es.config2015#ReservedElasticsearchInstanceOfferingList": {
       "type": "list",
       "member": {
-        "target": "com.a9.es.config2015#ReservedElasticsearchInstanceOffering"
+        "target": "com.a9.es.config2015#ReservedElasticsearchInstanceOffering",
+        "traits": {
+          "smithy.api#xmlName": "ReservedElasticsearchInstanceOffering"
+        }
       }
     },
     "com.a9.es.config2015#ReservedElasticsearchInstancePaymentOption": {

--- a/codegen/sdk-codegen/aws-models/emr.2009-03-31.json
+++ b/codegen/sdk-codegen/aws-models/emr.2009-03-31.json
@@ -1822,7 +1822,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Elastic MapReduce"
+        "smithy.api#title": "Amazon Elastic MapReduce",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://elasticmapreduce.amazonaws.com/doc/2009-03-31"
+        }
       }
     },
     "elasticmapreduce.webservice#ErrorCode": {
@@ -3163,7 +3166,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>Indicates that an error occurred while processing the request and that the request was not completed.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "elasticmapreduce.webservice#InternalServerException": {

--- a/codegen/sdk-codegen/aws-models/eventbridge.2015-10-07.json
+++ b/codegen/sdk-codegen/aws-models/eventbridge.2015-10-07.json
@@ -139,7 +139,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon EventBridge"
+        "smithy.api#title": "Amazon EventBridge",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://events.amazonaws.com/doc/2015-10-07"
+        }
       }
     },
     "com.amazon.jetstream.v20151007#AccountId": {

--- a/codegen/sdk-codegen/aws-models/firehose.2015-08-04.json
+++ b/codegen/sdk-codegen/aws-models/firehose.2015-08-04.json
@@ -1510,7 +1510,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Kinesis Firehose"
+        "smithy.api#title": "Amazon Kinesis Firehose",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://firehose.amazonaws.com/doc/2015-08-04"
+        }
       }
     },
     "com.amazonaws.firehose.v20150804#HECAcknowledgmentTimeoutInSeconds": {
@@ -3045,7 +3048,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The service is unavailable. Back off and retry the operation. If you continue to see\n         the exception, throughput limits for the delivery stream may have been exceeded. For more\n         information about limits and how to request an increase, see <a href=\"https://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Kinesis Data Firehose\n         Limits</a>.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.firehose.v20150804#SizeInMBs": {

--- a/codegen/sdk-codegen/aws-models/forecast.2018-06-26.json
+++ b/codegen/sdk-codegen/aws-models/forecast.2018-06-26.json
@@ -2296,7 +2296,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't process the request because it includes an invalid value or a value that exceeds\n      the valid range.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.seer.service#InvalidNextTokenException": {
@@ -2308,7 +2309,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The token is not valid. Tokens expire after 24 hours.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.seer.service#KMSKeyArn": {
@@ -2330,7 +2332,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The limit on the number of resources per account has been exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.seer.service#ListDatasetGroups": {
@@ -2932,7 +2935,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>There is already a resource with this name. Try again with a different name.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.seer.service#ResourceInUseException": {
@@ -2944,7 +2948,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.seer.service#ResourceNotFoundException": {
@@ -2956,7 +2961,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n    \n         <p>We can't find a resource with that Amazon Resource Name (ARN). Check the ARN and try\n      again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.seer.service#S3Config": {

--- a/codegen/sdk-codegen/aws-models/forecastquery.2018-06-26.json
+++ b/codegen/sdk-codegen/aws-models/forecastquery.2018-06-26.json
@@ -151,7 +151,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The value is invalid or is too long.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.seer.queryservice#InvalidNextTokenException": {
@@ -163,7 +164,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The token is not valid. Tokens expire after 24 hours.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.seer.queryservice#LimitExceededException": {
@@ -175,7 +177,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The limit on the number of requests per second has been exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.seer.queryservice#NextToken": {
@@ -282,7 +285,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.seer.queryservice#ResourceNotFoundException": {
@@ -294,7 +298,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find that resource. Check the information that you've provided and try\n      again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.seer.queryservice#Statistic": {

--- a/codegen/sdk-codegen/aws-models/frauddetector.2019-11-15.json
+++ b/codegen/sdk-codegen/aws-models/frauddetector.2019-11-15.json
@@ -136,7 +136,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Fraud Detector"
+        "smithy.api#title": "Amazon Fraud Detector",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://hawksnest.amazonaws.com/doc/2019-11-15"
+        }
       }
     },
     "com.amazonaws.hawksnest.servicefacade#BatchCreateVariable": {
@@ -1834,7 +1837,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception indicating an internal server error.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.hawksnest.servicefacade#IsOpaque": {
@@ -2659,7 +2663,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception indicating the specified resource was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.hawksnest.servicefacade#Role": {
@@ -2809,7 +2814,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception indicating a throttling error.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.hawksnest.servicefacade#TrainingDataSource": {
@@ -3285,7 +3291,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception indicating a specified value is not allowed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.hawksnest.servicefacade#Variable": {

--- a/codegen/sdk-codegen/aws-models/gamelift.2015-10-01.json
+++ b/codegen/sdk-codegen/aws-models/gamelift.2015-10-01.json
@@ -4241,7 +4241,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon GameLift"
+        "smithy.api#title": "Amazon GameLift",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://gamelift.amazonaws.com/doc/"
+        }
       }
     },
     "com.amazonaws.gameliftapi.v20151001#GameProperty": {

--- a/codegen/sdk-codegen/aws-models/glacier.2012-06-01.json
+++ b/codegen/sdk-codegen/aws-models/glacier.2012-06-01.json
@@ -1578,7 +1578,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Glacier"
+        "smithy.api#title": "Amazon Glacier",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://glacier.amazonaws.com/doc/2012-06-01/"
+        }
       }
     },
     "com.amazonaws.glacier.core.types#GlacierJobDescription": {

--- a/codegen/sdk-codegen/aws-models/global-accelerator.2018-08-08.json
+++ b/codegen/sdk-codegen/aws-models/global-accelerator.2018-08-08.json
@@ -122,7 +122,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The accelerator that you specified could not be disabled.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#AcceleratorNotFoundException": {
@@ -134,7 +135,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The accelerator that you specified doesn't exist.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#AcceleratorStatus": {
@@ -161,7 +163,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>You don't have access permission.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#AssociatedEndpointGroupFoundException": {
@@ -173,7 +176,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The listener that you specified has an endpoint group associated with it. You must remove all dependent resources\n\t\t\tfrom a listener before you can delete it.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#AssociatedListenerFoundException": {
@@ -185,7 +189,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The accelerator that you specified has a listener associated with it. You must remove all dependent resources from an\n\t\t\taccelerator before you can delete it.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#ClientAffinity": {
@@ -897,7 +902,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The endpoint group that you specified already exists.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#EndpointGroupNotFoundException": {
@@ -909,7 +915,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The endpoint group that you specified doesn't exist.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#EndpointGroups": {
@@ -1085,7 +1092,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>There was an internal error for AWS Global Accelerator.</p>\n\t     ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#InvalidArgumentException": {
@@ -1097,7 +1105,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>An argument that you specified is invalid.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#InvalidNextTokenException": {
@@ -1109,7 +1118,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>There isn't another item to return.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#InvalidPortRangeException": {
@@ -1121,7 +1131,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The port numbers that you specified are not valid numbers or are not unique for this accelerator.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#IpAddress": {
@@ -1184,7 +1195,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Processing your request would cause you to exceed an AWS Global Accelerator limit.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#ListAccelerators": {
@@ -1419,7 +1431,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The listener that you specified doesn't exist.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.globalaccelerator.v20180706#Listeners": {

--- a/codegen/sdk-codegen/aws-models/greengrass.2017-06-07.json
+++ b/codegen/sdk-codegen/aws-models/greengrass.2017-06-07.json
@@ -1,0 +1,7845 @@
+{
+  "smithy": "0.5.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "ids": [
+          "HttpMethodSemantics"
+        ]
+      },
+      {
+        "ids": [
+          "HttpResponseCodeSemantics"
+        ]
+      },
+      {
+        "ids": [
+          "PaginatedTrait"
+        ]
+      },
+      {
+        "ids": [
+          "HttpHeaderTrait"
+        ]
+      },
+      {
+        "ids": [
+          "HttpUriConflict"
+        ]
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.greengrass#AssociateRoleToGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#AssociateRoleToGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#AssociateRoleToGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Associates a role with a group. Your Greengrass core will use the role to access AWS cloud services. The role's permissions should allow Greengrass core Lambda functions to perform actions against the cloud.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/groups/{GroupId}/role",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#AssociateRoleToGroupRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the role you wish to associate with this group. The existence of the role is not validated.",
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#AssociateRoleToGroupResponse": {
+      "type": "structure",
+      "members": {
+        "AssociatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the role ARN was associated with the group."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#AssociateServiceRoleToAccount": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#AssociateServiceRoleToAccountRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#AssociateServiceRoleToAccountResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Associates a role with your account. AWS IoT Greengrass will use the role to access your Lambda functions and AWS IoT resources. This is necessary for deployments to succeed. The role must have at least minimum permissions in the policy ''AWSGreengrassResourceAccessRolePolicy''.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/servicerole",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#AssociateServiceRoleToAccountRequest": {
+      "type": "structure",
+      "members": {
+        "RoleArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the service role you wish to associate with your account.",
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#AssociateServiceRoleToAccountResponse": {
+      "type": "structure",
+      "members": {
+        "AssociatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time when the service role was associated with the account."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#BadRequestException": {
+      "type": "structure",
+      "members": {
+        "ErrorDetails": {
+          "target": "com.amazonaws.greengrass#ErrorDetails",
+          "traits": {
+            "smithy.api#documentation": "Details about the error."
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A message containing information about the error."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "General error information.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.greengrass#BulkDeployment": {
+      "type": "structure",
+      "members": {
+        "BulkDeploymentArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the bulk deployment."
+          }
+        },
+        "BulkDeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the bulk deployment."
+          }
+        },
+        "CreatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in ISO format, when the deployment was created."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a bulk deployment. You cannot start a new bulk deployment while another one is still running or in a non-terminal state."
+      }
+    },
+    "com.amazonaws.greengrass#BulkDeploymentMetrics": {
+      "type": "structure",
+      "members": {
+        "InvalidInputRecords": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The total number of records that returned a non-retryable error. For example, this can occur if a group record from the input file uses an invalid format or specifies a nonexistent group version, or if the execution role doesn't grant permission to deploy a group or group version."
+          }
+        },
+        "RecordsProcessed": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The total number of group records from the input file that have been processed so far, or attempted."
+          }
+        },
+        "RetryAttempts": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The total number of deployment attempts that returned a retryable error. For example, a retry is triggered if the attempt to deploy a group returns a throttling error. ''StartBulkDeployment'' retries a group deployment up to five times."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Relevant metrics on input records processed during bulk deployment."
+      }
+    },
+    "com.amazonaws.greengrass#BulkDeploymentResult": {
+      "type": "structure",
+      "members": {
+        "CreatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in ISO format, when the deployment was created."
+          }
+        },
+        "DeploymentArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the group deployment."
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group deployment."
+          }
+        },
+        "DeploymentStatus": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The current status of the group deployment: ''InProgress'', ''Building'', ''Success'', or ''Failure''."
+          }
+        },
+        "DeploymentType": {
+          "target": "com.amazonaws.greengrass#DeploymentType",
+          "traits": {
+            "smithy.api#documentation": "The type of the deployment."
+          }
+        },
+        "ErrorDetails": {
+          "target": "com.amazonaws.greengrass#ErrorDetails",
+          "traits": {
+            "smithy.api#documentation": "Details about the error."
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message for a failed deployment"
+          }
+        },
+        "GroupArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the Greengrass group."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about an individual group deployment in a bulk deployment operation."
+      }
+    },
+    "com.amazonaws.greengrass#BulkDeploymentResults": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#BulkDeploymentResult"
+      }
+    },
+    "com.amazonaws.greengrass#BulkDeploymentStatus": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The current status of the bulk deployment.",
+        "smithy.api#enum": {
+          "Initializing": {
+            "name": "Initializing"
+          },
+          "Running": {
+            "name": "Running"
+          },
+          "Completed": {
+            "name": "Completed"
+          },
+          "Stopping": {
+            "name": "Stopping"
+          },
+          "Stopped": {
+            "name": "Stopped"
+          },
+          "Failed": {
+            "name": "Failed"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#BulkDeployments": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#BulkDeployment"
+      }
+    },
+    "com.amazonaws.greengrass#ConnectivityInfo": {
+      "type": "structure",
+      "members": {
+        "HostAddress": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The endpoint for the Greengrass core. Can be an IP address or DNS."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connectivity information."
+          }
+        },
+        "Metadata": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "Metadata for this endpoint."
+          }
+        },
+        "PortNumber": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The port of the Greengrass core. Usually 8883."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a Greengrass core's connectivity."
+      }
+    },
+    "com.amazonaws.greengrass#Connector": {
+      "type": "structure",
+      "members": {
+        "ConnectorArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the connector.",
+            "smithy.api#required": true
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A descriptive or arbitrary ID for the connector. This value must be unique within the connector definition version. Max length is 128 characters with pattern [a-zA-Z0-9:_-]+.",
+            "smithy.api#required": true
+          }
+        },
+        "Parameters": {
+          "target": "com.amazonaws.greengrass#__mapOf__string",
+          "traits": {
+            "smithy.api#documentation": "The parameters or configuration that the connector uses."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a connector. Connectors run on the Greengrass core and contain built-in integration with local infrastructure, device protocols, AWS, and other cloud services."
+      }
+    },
+    "com.amazonaws.greengrass#ConnectorDefinitionVersion": {
+      "type": "structure",
+      "members": {
+        "Connectors": {
+          "target": "com.amazonaws.greengrass#__listOfConnector",
+          "traits": {
+            "smithy.api#documentation": "A list of references to connectors in this version, with their corresponding configuration settings."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about the connector definition version, which is a container for connectors."
+      }
+    },
+    "com.amazonaws.greengrass#Core": {
+      "type": "structure",
+      "members": {
+        "CertificateArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the certificate associated with the core.",
+            "smithy.api#required": true
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A descriptive or arbitrary ID for the core. This value must be unique within the core definition version. Max length is 128 characters with pattern ''[a-zA-Z0-9:_-]+''.",
+            "smithy.api#required": true
+          }
+        },
+        "SyncShadow": {
+          "target": "com.amazonaws.greengrass#__boolean",
+          "traits": {
+            "smithy.api#documentation": "If true, the core's local shadow is automatically synced with the cloud."
+          }
+        },
+        "ThingArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the thing which is the core.",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a core."
+      }
+    },
+    "com.amazonaws.greengrass#CoreDefinitionVersion": {
+      "type": "structure",
+      "members": {
+        "Cores": {
+          "target": "com.amazonaws.greengrass#__listOfCore",
+          "traits": {
+            "smithy.api#documentation": "A list of cores in the core definition version."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a core definition version."
+      }
+    },
+    "com.amazonaws.greengrass#CreateConnectorDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateConnectorDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateConnectorDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a connector definition. You may provide the initial version of the connector definition now or use ''CreateConnectorDefinitionVersion'' at a later time.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/connectors",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateConnectorDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#ConnectorDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the connector definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the connector definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateConnectorDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateConnectorDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateConnectorDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateConnectorDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a connector definition which has already been defined.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/connectors/{ConnectorDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateConnectorDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "ConnectorDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Connectors": {
+          "target": "com.amazonaws.greengrass#__listOfConnector",
+          "traits": {
+            "smithy.api#documentation": "A list of references to connectors in this version, with their corresponding configuration settings."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateConnectorDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateCoreDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateCoreDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateCoreDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a core definition. You may provide the initial version of the core definition now or use ''CreateCoreDefinitionVersion'' at a later time. Greengrass groups must each contain exactly one Greengrass core.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/cores",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateCoreDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#CoreDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the core definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the core definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information needed to create a core definition."
+      }
+    },
+    "com.amazonaws.greengrass#CreateCoreDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateCoreDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateCoreDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateCoreDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a core definition that has already been defined. Greengrass groups must each contain exactly one Greengrass core.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/cores/{CoreDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateCoreDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "CoreDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Cores": {
+          "target": "com.amazonaws.greengrass#__listOfCore",
+          "traits": {
+            "smithy.api#documentation": "A list of cores in the core definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateCoreDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateDeploymentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateDeploymentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a deployment. ''CreateDeployment'' requests are idempotent with respect to the ''X-Amzn-Client-Token'' token and the request parameters.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/groups/{GroupId}/deployments",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the deployment if you wish to redeploy a previous deployment."
+          }
+        },
+        "DeploymentType": {
+          "target": "com.amazonaws.greengrass#DeploymentType",
+          "traits": {
+            "smithy.api#documentation": "The type of deployment. When used for ''CreateDeployment'', only ''NewDeployment'' and ''Redeployment'' are valid.",
+            "smithy.api#required": true
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "GroupVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group version to be deployed."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeploymentResponse": {
+      "type": "structure",
+      "members": {
+        "DeploymentArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the deployment."
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the deployment."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeviceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateDeviceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateDeviceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a device definition. You may provide the initial version of the device definition now or use ''CreateDeviceDefinitionVersion'' at a later time.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/devices",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeviceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#DeviceDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the device definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the device definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeviceDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeviceDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateDeviceDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateDeviceDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a device definition that has already been defined.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/devices/{DeviceDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeviceDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "DeviceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Devices": {
+          "target": "com.amazonaws.greengrass#__listOfDevice",
+          "traits": {
+            "smithy.api#documentation": "A list of devices in the definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateDeviceDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateFunctionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateFunctionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateFunctionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a Lambda function definition which contains a list of Lambda functions and their configurations to be used in a group. You can create an initial version of the definition by providing a list of Lambda functions and their configurations now, or use ''CreateFunctionDefinitionVersion'' later.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/functions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateFunctionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#FunctionDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the function definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the function definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateFunctionDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateFunctionDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateFunctionDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateFunctionDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a Lambda function definition that has already been defined.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/functions/{FunctionDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateFunctionDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "DefaultConfig": {
+          "target": "com.amazonaws.greengrass#FunctionDefaultConfig",
+          "traits": {
+            "smithy.api#documentation": "The default configuration that applies to all Lambda functions in this function definition version. Individual Lambda functions can override these settings."
+          }
+        },
+        "FunctionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Lambda function definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Functions": {
+          "target": "com.amazonaws.greengrass#__listOfFunction",
+          "traits": {
+            "smithy.api#documentation": "A list of Lambda functions in this function definition version."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information needed to create a function definition version."
+      }
+    },
+    "com.amazonaws.greengrass#CreateFunctionDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a group. You may provide the initial version of the group or use ''CreateGroupVersion'' at a later time. Tip: You can use the ''gg_group_setup'' package (https://github.com/awslabs/aws-greengrass-group-setup) as a library or command-line application to create and deploy Greengrass groups.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/groups",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupCertificateAuthority": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateGroupCertificateAuthorityRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateGroupCertificateAuthorityResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a CA for the group. If a CA already exists, it will rotate the existing CA.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/groups/{GroupId}/certificateauthorities",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupCertificateAuthorityRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupCertificateAuthorityResponse": {
+      "type": "structure",
+      "members": {
+        "GroupCertificateAuthorityArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the group certificate authority."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#GroupVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the group."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the group."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateGroupVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateGroupVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a group which has already been defined.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/groups/{GroupId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "ConnectorDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the connector definition version for this group."
+          }
+        },
+        "CoreDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the core definition version for this group."
+          }
+        },
+        "DeviceDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the device definition version for this group."
+          }
+        },
+        "FunctionDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the function definition version for this group."
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "LoggerDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the logger definition version for this group."
+          }
+        },
+        "ResourceDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the resource definition version for this group."
+          }
+        },
+        "SubscriptionDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the subscription definition version for this group."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateGroupVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateLoggerDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateLoggerDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateLoggerDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a logger definition. You may provide the initial version of the logger definition now or use ''CreateLoggerDefinitionVersion'' at a later time.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/loggers",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateLoggerDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#LoggerDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the logger definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the logger definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateLoggerDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateLoggerDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateLoggerDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateLoggerDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a logger definition that has already been defined.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/loggers/{LoggerDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateLoggerDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "LoggerDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Loggers": {
+          "target": "com.amazonaws.greengrass#__listOfLogger",
+          "traits": {
+            "smithy.api#documentation": "A list of loggers."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateLoggerDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateResourceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateResourceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateResourceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a resource definition which contains a list of resources to be used in a group. You can create an initial version of the definition by providing a list of resources now, or use ''CreateResourceDefinitionVersion'' later.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/resources",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateResourceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#ResourceDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the resource definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the resource definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateResourceDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateResourceDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateResourceDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateResourceDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a resource definition that has already been defined.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/resources/{ResourceDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateResourceDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "ResourceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Resources": {
+          "target": "com.amazonaws.greengrass#__listOfResource",
+          "traits": {
+            "smithy.api#documentation": "A list of resources."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateResourceDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSoftwareUpdateJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateSoftwareUpdateJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateSoftwareUpdateJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a software update for a core or group of cores (specified as an IoT thing group.) Use this to update the OTA Agent as well as the Greengrass core software. It makes use of the IoT Jobs feature which provides additional commands to manage a Greengrass core software update job.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/updates",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSoftwareUpdateJobRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "S3UrlSignerRole": {
+          "target": "com.amazonaws.greengrass#S3UrlSignerRole",
+          "traits": {
+            "smithy.api#required": true
+          }
+        },
+        "SoftwareToUpdate": {
+          "target": "com.amazonaws.greengrass#SoftwareToUpdate",
+          "traits": {
+            "smithy.api#required": true
+          }
+        },
+        "UpdateAgentLogLevel": {
+          "target": "com.amazonaws.greengrass#UpdateAgentLogLevel"
+        },
+        "UpdateTargets": {
+          "target": "com.amazonaws.greengrass#UpdateTargets",
+          "traits": {
+            "smithy.api#required": true
+          }
+        },
+        "UpdateTargetsArchitecture": {
+          "target": "com.amazonaws.greengrass#UpdateTargetsArchitecture",
+          "traits": {
+            "smithy.api#required": true
+          }
+        },
+        "UpdateTargetsOperatingSystem": {
+          "target": "com.amazonaws.greengrass#UpdateTargetsOperatingSystem",
+          "traits": {
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSoftwareUpdateJobResponse": {
+      "type": "structure",
+      "members": {
+        "IotJobArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The IoT Job ARN corresponding to this update."
+          }
+        },
+        "IotJobId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The IoT Job Id corresponding to this update."
+          }
+        },
+        "PlatformSoftwareVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The software version installed on the device or devices after the update."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSubscriptionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateSubscriptionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateSubscriptionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a subscription definition. You may provide the initial version of the subscription definition now or use ''CreateSubscriptionDefinitionVersion'' at a later time.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/subscriptions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSubscriptionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "InitialVersion": {
+          "target": "com.amazonaws.greengrass#SubscriptionDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the initial version of the subscription definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the subscription definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSubscriptionDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSubscriptionDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#CreateSubscriptionDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#CreateSubscriptionDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a version of a subscription definition which has already been defined.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSubscriptionDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "SubscriptionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Subscriptions": {
+          "target": "com.amazonaws.greengrass#__listOfSubscription",
+          "traits": {
+            "smithy.api#documentation": "A list of subscriptions."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#CreateSubscriptionDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DefinitionInformation": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn.",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a definition."
+      }
+    },
+    "com.amazonaws.greengrass#DeleteConnectorDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteConnectorDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteConnectorDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a connector definition.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/definition/connectors/{ConnectorDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteConnectorDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "ConnectorDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteConnectorDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DeleteCoreDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteCoreDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteCoreDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a core definition.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/definition/cores/{CoreDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteCoreDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "CoreDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteCoreDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DeleteDeviceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteDeviceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteDeviceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a device definition.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/definition/devices/{DeviceDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteDeviceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "DeviceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteDeviceDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DeleteFunctionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteFunctionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteFunctionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a Lambda function definition.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/definition/functions/{FunctionDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteFunctionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "FunctionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Lambda function definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteFunctionDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DeleteGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a group.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/groups/{GroupId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteGroupRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteGroupResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DeleteLoggerDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteLoggerDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteLoggerDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a logger definition.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/definition/loggers/{LoggerDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteLoggerDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "LoggerDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteLoggerDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DeleteResourceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteResourceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteResourceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a resource definition.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/definition/resources/{ResourceDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteResourceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteResourceDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DeleteSubscriptionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DeleteSubscriptionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DeleteSubscriptionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a subscription definition.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteSubscriptionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "SubscriptionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DeleteSubscriptionDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#Deployment": {
+      "type": "structure",
+      "members": {
+        "CreatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the deployment was created."
+          }
+        },
+        "DeploymentArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the deployment."
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the deployment."
+          }
+        },
+        "DeploymentType": {
+          "target": "com.amazonaws.greengrass#DeploymentType",
+          "traits": {
+            "smithy.api#documentation": "The type of the deployment."
+          }
+        },
+        "GroupArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the group for this deployment."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a deployment."
+      }
+    },
+    "com.amazonaws.greengrass#DeploymentType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The type of deployment. When used for ''CreateDeployment'', only ''NewDeployment'' and ''Redeployment'' are valid.",
+        "smithy.api#enum": {
+          "NewDeployment": {
+            "name": "NewDeployment"
+          },
+          "Redeployment": {
+            "name": "Redeployment"
+          },
+          "ResetDeployment": {
+            "name": "ResetDeployment"
+          },
+          "ForceResetDeployment": {
+            "name": "ForceResetDeployment"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#Deployments": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Deployment"
+      }
+    },
+    "com.amazonaws.greengrass#Device": {
+      "type": "structure",
+      "members": {
+        "CertificateArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the certificate associated with the device.",
+            "smithy.api#required": true
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A descriptive or arbitrary ID for the device. This value must be unique within the device definition version. Max length is 128 characters with pattern ''[a-zA-Z0-9:_-]+''.",
+            "smithy.api#required": true
+          }
+        },
+        "SyncShadow": {
+          "target": "com.amazonaws.greengrass#__boolean",
+          "traits": {
+            "smithy.api#documentation": "If true, the device's local shadow will be automatically synced with the cloud."
+          }
+        },
+        "ThingArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The thing ARN of the device.",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a device."
+      }
+    },
+    "com.amazonaws.greengrass#DeviceDefinitionVersion": {
+      "type": "structure",
+      "members": {
+        "Devices": {
+          "target": "com.amazonaws.greengrass#__listOfDevice",
+          "traits": {
+            "smithy.api#documentation": "A list of devices in the definition version."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a device definition version."
+      }
+    },
+    "com.amazonaws.greengrass#DisassociateRoleFromGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DisassociateRoleFromGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DisassociateRoleFromGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Disassociates the role from a group.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/groups/{GroupId}/role",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DisassociateRoleFromGroupRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DisassociateRoleFromGroupResponse": {
+      "type": "structure",
+      "members": {
+        "DisassociatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the role was disassociated from the group."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DisassociateServiceRoleFromAccount": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#DisassociateServiceRoleFromAccountRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#DisassociateServiceRoleFromAccountResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Disassociates the service role from your account. Without a service role, deployments will not work.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/greengrass/servicerole",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#DisassociateServiceRoleFromAccountRequest": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#DisassociateServiceRoleFromAccountResponse": {
+      "type": "structure",
+      "members": {
+        "DisassociatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time when the service role was disassociated from the account."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#EncodingType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "binary": {
+            "name": "binary"
+          },
+          "json": {
+            "name": "json"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ErrorDetail": {
+      "type": "structure",
+      "members": {
+        "DetailedErrorCode": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A detailed error code."
+          }
+        },
+        "DetailedErrorMessage": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A detailed error message."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Details about the error."
+      }
+    },
+    "com.amazonaws.greengrass#ErrorDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#ErrorDetail"
+      },
+      "traits": {
+        "smithy.api#documentation": "A list of error details."
+      }
+    },
+    "com.amazonaws.greengrass#Function": {
+      "type": "structure",
+      "members": {
+        "FunctionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the Lambda function."
+          }
+        },
+        "FunctionConfiguration": {
+          "target": "com.amazonaws.greengrass#FunctionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "The configuration of the Lambda function."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A descriptive or arbitrary ID for the function. This value must be unique within the function definition version. Max length is 128 characters with pattern ''[a-zA-Z0-9:_-]+''.",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a Lambda function."
+      }
+    },
+    "com.amazonaws.greengrass#FunctionConfiguration": {
+      "type": "structure",
+      "members": {
+        "EncodingType": {
+          "target": "com.amazonaws.greengrass#EncodingType",
+          "traits": {
+            "smithy.api#documentation": "The expected encoding type of the input payload for the function. The default is ''json''."
+          }
+        },
+        "Environment": {
+          "target": "com.amazonaws.greengrass#FunctionConfigurationEnvironment",
+          "traits": {
+            "smithy.api#documentation": "The environment configuration of the function."
+          }
+        },
+        "ExecArgs": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The execution arguments."
+          }
+        },
+        "Executable": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the function executable."
+          }
+        },
+        "MemorySize": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The memory size, in KB, which the function requires. This setting is not applicable and should be cleared when you run the Lambda function without containerization."
+          }
+        },
+        "Pinned": {
+          "target": "com.amazonaws.greengrass#__boolean",
+          "traits": {
+            "smithy.api#documentation": "True if the function is pinned. Pinned means the function is long-lived and starts when the core starts."
+          }
+        },
+        "Timeout": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The allowed function execution time, after which Lambda should terminate the function. This timeout still applies to pinned Lambda functions for each request."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The configuration of the Lambda function."
+      }
+    },
+    "com.amazonaws.greengrass#FunctionConfigurationEnvironment": {
+      "type": "structure",
+      "members": {
+        "AccessSysfs": {
+          "target": "com.amazonaws.greengrass#__boolean",
+          "traits": {
+            "smithy.api#documentation": "If true, the Lambda function is allowed to access the host's /sys folder. Use this when the Lambda function needs to read device information from /sys. This setting applies only when you run the Lambda function in a Greengrass container."
+          }
+        },
+        "Execution": {
+          "target": "com.amazonaws.greengrass#FunctionExecutionConfig",
+          "traits": {
+            "smithy.api#documentation": "Configuration related to executing the Lambda function"
+          }
+        },
+        "ResourceAccessPolicies": {
+          "target": "com.amazonaws.greengrass#__listOfResourceAccessPolicy",
+          "traits": {
+            "smithy.api#documentation": "A list of the resources, with their permissions, to which the Lambda function will be granted access. A Lambda function can have at most 10 resources. ResourceAccessPolicies apply only when you run the Lambda function in a Greengrass container."
+          }
+        },
+        "Variables": {
+          "target": "com.amazonaws.greengrass#__mapOf__string",
+          "traits": {
+            "smithy.api#documentation": "Environment variables for the Lambda function's configuration."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The environment configuration of the function."
+      }
+    },
+    "com.amazonaws.greengrass#FunctionDefaultConfig": {
+      "type": "structure",
+      "members": {
+        "Execution": {
+          "target": "com.amazonaws.greengrass#FunctionDefaultExecutionConfig"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The default configuration that applies to all Lambda functions in the group. Individual Lambda functions can override these settings."
+      }
+    },
+    "com.amazonaws.greengrass#FunctionDefaultExecutionConfig": {
+      "type": "structure",
+      "members": {
+        "IsolationMode": {
+          "target": "com.amazonaws.greengrass#FunctionIsolationMode"
+        },
+        "RunAs": {
+          "target": "com.amazonaws.greengrass#FunctionRunAsConfig"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Configuration information that specifies how a Lambda function runs. "
+      }
+    },
+    "com.amazonaws.greengrass#FunctionDefinitionVersion": {
+      "type": "structure",
+      "members": {
+        "DefaultConfig": {
+          "target": "com.amazonaws.greengrass#FunctionDefaultConfig",
+          "traits": {
+            "smithy.api#documentation": "The default configuration that applies to all Lambda functions in this function definition version. Individual Lambda functions can override these settings."
+          }
+        },
+        "Functions": {
+          "target": "com.amazonaws.greengrass#__listOfFunction",
+          "traits": {
+            "smithy.api#documentation": "A list of Lambda functions in this function definition version."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a function definition version."
+      }
+    },
+    "com.amazonaws.greengrass#FunctionExecutionConfig": {
+      "type": "structure",
+      "members": {
+        "IsolationMode": {
+          "target": "com.amazonaws.greengrass#FunctionIsolationMode"
+        },
+        "RunAs": {
+          "target": "com.amazonaws.greengrass#FunctionRunAsConfig"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Configuration information that specifies how a Lambda function runs. "
+      }
+    },
+    "com.amazonaws.greengrass#FunctionIsolationMode": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "Specifies whether the Lambda function runs in a Greengrass container (default) or without containerization. Unless your scenario requires that you run without containerization, we recommend that you run in a Greengrass container. Omit this value to run the Lambda function with the default containerization for the group.",
+        "smithy.api#enum": {
+          "GreengrassContainer": {
+            "name": "GreengrassContainer"
+          },
+          "NoContainer": {
+            "name": "NoContainer"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#FunctionRunAsConfig": {
+      "type": "structure",
+      "members": {
+        "Gid": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The group ID whose permissions are used to run a Lambda function."
+          }
+        },
+        "Uid": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The user ID whose permissions are used to run a Lambda function."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Specifies the user and group whose permissions are used when running the Lambda function. You can specify one or both values to override the default values. We recommend that you avoid running as root unless absolutely necessary to minimize the risk of unintended changes or malicious attacks. To run as root, you must set ''IsolationMode'' to ''NoContainer'' and update config.json in ''greengrass-root/config'' to set ''allowFunctionsToRunAsRoot'' to ''yes''."
+      }
+    },
+    "com.amazonaws.greengrass#GetAssociatedRole": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetAssociatedRoleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetAssociatedRoleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves the role associated with a particular group.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/role",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetAssociatedRoleRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetAssociatedRoleResponse": {
+      "type": "structure",
+      "members": {
+        "AssociatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time when the role was associated with the group."
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the role that is associated with the group."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetBulkDeploymentStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetBulkDeploymentStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetBulkDeploymentStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Returns the status of a bulk deployment.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/bulk/deployments/{BulkDeploymentId}/status",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetBulkDeploymentStatusRequest": {
+      "type": "structure",
+      "members": {
+        "BulkDeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the bulk deployment.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetBulkDeploymentStatusResponse": {
+      "type": "structure",
+      "members": {
+        "BulkDeploymentMetrics": {
+          "target": "com.amazonaws.greengrass#BulkDeploymentMetrics",
+          "traits": {
+            "smithy.api#documentation": "Relevant metrics on input records processed during bulk deployment."
+          }
+        },
+        "BulkDeploymentStatus": {
+          "target": "com.amazonaws.greengrass#BulkDeploymentStatus",
+          "traits": {
+            "smithy.api#documentation": "The status of the bulk deployment."
+          }
+        },
+        "CreatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in ISO format, when the deployment was created."
+          }
+        },
+        "ErrorDetails": {
+          "target": "com.amazonaws.greengrass#ErrorDetails",
+          "traits": {
+            "smithy.api#documentation": "Error details"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "Error message"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectivityInfo": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetConnectivityInfoRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetConnectivityInfoResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves the connectivity information for a core.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/things/{ThingName}/connectivityInfo",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectivityInfoRequest": {
+      "type": "structure",
+      "members": {
+        "ThingName": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The thing name.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectivityInfoResponse": {
+      "type": "structure",
+      "members": {
+        "ConnectivityInfo": {
+          "target": "com.amazonaws.greengrass#__listOfConnectivityInfo",
+          "traits": {
+            "smithy.api#documentation": "Connectivity info list."
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A message about the connectivity info request.",
+            "smithy.api#jsonName": "message"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectorDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetConnectorDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetConnectorDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a connector definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/connectors/{ConnectorDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectorDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "ConnectorDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectorDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectorDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetConnectorDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetConnectorDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a connector definition version, including the connectors that the version contains. Connectors are prebuilt modules that interact with local infrastructure, device protocols, AWS, and other cloud services.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/connectors/{ConnectorDefinitionId}/versions/{ConnectorDefinitionVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectorDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "ConnectorDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "ConnectorDefinitionVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListConnectorDefinitionVersions'' requests. If the version is the last one that was associated with a connector definition, the value also maps to the ''LatestVersion'' property of the corresponding ''DefinitionInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetConnectorDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the connector definition version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the connector definition version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#ConnectorDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the connector definition version."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition version."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The version of the connector definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetCoreDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetCoreDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetCoreDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a core definition version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/cores/{CoreDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetCoreDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "CoreDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetCoreDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetCoreDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetCoreDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetCoreDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a core definition version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/cores/{CoreDefinitionId}/versions/{CoreDefinitionVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetCoreDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "CoreDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "CoreDefinitionVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListCoreDefinitionVersions'' requests. If the version is the last one that was associated with a core definition, the value also maps to the ''LatestVersion'' property of the corresponding ''DefinitionInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetCoreDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the core definition version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the core definition version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#CoreDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the core definition version."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition version."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The version of the core definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeploymentStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetDeploymentStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetDeploymentStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Returns the status of a deployment.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/deployments/{DeploymentId}/status",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeploymentStatusRequest": {
+      "type": "structure",
+      "members": {
+        "DeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the deployment.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeploymentStatusResponse": {
+      "type": "structure",
+      "members": {
+        "DeploymentStatus": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The status of the deployment: ''InProgress'', ''Building'', ''Success'', or ''Failure''."
+          }
+        },
+        "DeploymentType": {
+          "target": "com.amazonaws.greengrass#DeploymentType",
+          "traits": {
+            "smithy.api#documentation": "The type of the deployment."
+          }
+        },
+        "ErrorDetails": {
+          "target": "com.amazonaws.greengrass#ErrorDetails",
+          "traits": {
+            "smithy.api#documentation": "Error details"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "Error message"
+          }
+        },
+        "UpdatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the deployment status was updated."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeviceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetDeviceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetDeviceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a device definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/devices/{DeviceDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeviceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "DeviceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeviceDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeviceDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetDeviceDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetDeviceDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a device definition version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/devices/{DeviceDefinitionId}/versions/{DeviceDefinitionVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeviceDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "DeviceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "DeviceDefinitionVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListDeviceDefinitionVersions'' requests. If the version is the last one that was associated with a device definition, the value also maps to the ''LatestVersion'' property of the corresponding ''DefinitionInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetDeviceDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the device definition version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the device definition version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#DeviceDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the device definition version."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition version."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The version of the device definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetFunctionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetFunctionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetFunctionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a Lambda function definition, including its creation time and latest version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/functions/{FunctionDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetFunctionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "FunctionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Lambda function definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetFunctionDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetFunctionDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetFunctionDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetFunctionDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a Lambda function definition version, including which Lambda functions are included in the version and their configurations.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/functions/{FunctionDefinitionId}/versions/{FunctionDefinitionVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetFunctionDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "FunctionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Lambda function definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "FunctionDefinitionVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the function definition version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListFunctionDefinitionVersions'' requests. If the version is the last one that was associated with a function definition, the value also maps to the ''LatestVersion'' property of the corresponding ''DefinitionInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetFunctionDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the function definition version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the function definition version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#FunctionDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information on the definition."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the function definition version."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The version of the function definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a group.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupCertificateAuthority": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetGroupCertificateAuthorityRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetGroupCertificateAuthorityResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retreives the CA associated with a group. Returns the public key of the CA.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/certificateauthorities/{CertificateAuthorityId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupCertificateAuthorityRequest": {
+      "type": "structure",
+      "members": {
+        "CertificateAuthorityId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the certificate authority.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#pattern": "^(?!configuration).*$",
+            "smithy.api#required": true
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupCertificateAuthorityResponse": {
+      "type": "structure",
+      "members": {
+        "GroupCertificateAuthorityArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the certificate authority for the group."
+          }
+        },
+        "GroupCertificateAuthorityId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the certificate authority for the group."
+          }
+        },
+        "PemEncodedCertificate": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The PEM encoded certificate for the group."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupCertificateConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetGroupCertificateConfigurationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetGroupCertificateConfigurationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves the current configuration for the CA used by the group.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/certificateauthorities/configuration/expiry",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupCertificateConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupCertificateConfigurationResponse": {
+      "type": "structure",
+      "members": {
+        "CertificateAuthorityExpiryInMilliseconds": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The amount of time remaining before the certificate authority expires, in milliseconds."
+          }
+        },
+        "CertificateExpiryInMilliseconds": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The amount of time remaining before the certificate expires, in milliseconds."
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group certificate configuration."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetGroupVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetGroupVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a group version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/versions/{GroupVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupVersionRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "GroupVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListGroupVersions'' requests. If the version is the last one that was associated with a group, the value also maps to the ''LatestVersion'' property of the corresponding ''GroupInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetGroupVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the group version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the group version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#GroupVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the group version definition."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetLoggerDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetLoggerDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetLoggerDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a logger definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/loggers/{LoggerDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetLoggerDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "LoggerDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetLoggerDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetLoggerDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetLoggerDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetLoggerDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a logger definition version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/loggers/{LoggerDefinitionId}/versions/{LoggerDefinitionVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetLoggerDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "LoggerDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "LoggerDefinitionVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListLoggerDefinitionVersions'' requests. If the version is the last one that was associated with a logger definition, the value also maps to the ''LatestVersion'' property of the corresponding ''DefinitionInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetLoggerDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the logger definition version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the logger definition version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#LoggerDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the logger definition version."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition version."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The version of the logger definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetResourceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetResourceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetResourceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a resource definition, including its creation time and latest version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/resources/{ResourceDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetResourceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetResourceDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetResourceDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetResourceDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetResourceDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a resource definition version, including which resources are included in the version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/resources/{ResourceDefinitionId}/versions/{ResourceDefinitionVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetResourceDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "ResourceDefinitionVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListResourceDefinitionVersions'' requests. If the version is the last one that was associated with a resource definition, the value also maps to the ''LatestVersion'' property of the corresponding ''DefinitionInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetResourceDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "Arn of the resource definition version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the resource definition version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#ResourceDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the definition."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition version."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The version of the resource definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetServiceRoleForAccount": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetServiceRoleForAccountRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetServiceRoleForAccountResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves the service role that is attached to your account.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/servicerole",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetServiceRoleForAccountRequest": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#GetServiceRoleForAccountResponse": {
+      "type": "structure",
+      "members": {
+        "AssociatedAt": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time when the service role was associated with the account."
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the role which is associated with the account."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetSubscriptionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetSubscriptionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetSubscriptionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a subscription definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetSubscriptionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "SubscriptionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetSubscriptionDefinitionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the definition."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the definition."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the definition was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the definition."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the definition."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) attached to the resource arn."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetSubscriptionDefinitionVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#GetSubscriptionDefinitionVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#GetSubscriptionDefinitionVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves information about a subscription definition version.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}/versions/{SubscriptionDefinitionVersionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetSubscriptionDefinitionVersionRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "SubscriptionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "SubscriptionDefinitionVersionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition version. This value maps to the ''Version'' property of the corresponding ''VersionInformation'' object, which is returned by ''ListSubscriptionDefinitionVersions'' requests. If the version is the last one that was associated with a subscription definition, the value also maps to the ''LatestVersion'' property of the corresponding ''DefinitionInformation'' object.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#GetSubscriptionDefinitionVersionResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the subscription definition version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the subscription definition version was created."
+          }
+        },
+        "Definition": {
+          "target": "com.amazonaws.greengrass#SubscriptionDefinitionVersion",
+          "traits": {
+            "smithy.api#documentation": "Information about the subscription definition version."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition version."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The version of the subscription definition version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#Greengrass": {
+      "type": "service",
+      "version": "2017-06-07",
+      "operations": [
+        {
+          "target": "com.amazonaws.greengrass#AssociateRoleToGroup"
+        },
+        {
+          "target": "com.amazonaws.greengrass#AssociateServiceRoleToAccount"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateConnectorDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateConnectorDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateCoreDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateCoreDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateDeployment"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateDeviceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateDeviceDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateFunctionDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateFunctionDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateGroup"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateGroupCertificateAuthority"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateGroupVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateLoggerDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateLoggerDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateResourceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateResourceDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateSoftwareUpdateJob"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateSubscriptionDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#CreateSubscriptionDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteConnectorDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteCoreDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteDeviceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteFunctionDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteGroup"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteLoggerDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteResourceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DeleteSubscriptionDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DisassociateRoleFromGroup"
+        },
+        {
+          "target": "com.amazonaws.greengrass#DisassociateServiceRoleFromAccount"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetAssociatedRole"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetBulkDeploymentStatus"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetConnectivityInfo"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetConnectorDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetConnectorDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetCoreDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetCoreDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetDeploymentStatus"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetDeviceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetDeviceDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetFunctionDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetFunctionDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetGroup"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetGroupCertificateAuthority"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetGroupCertificateConfiguration"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetGroupVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetLoggerDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetLoggerDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetResourceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetResourceDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetServiceRoleForAccount"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetSubscriptionDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#GetSubscriptionDefinitionVersion"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListBulkDeploymentDetailedReports"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListBulkDeployments"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListConnectorDefinitionVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListConnectorDefinitions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListCoreDefinitionVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListCoreDefinitions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListDeployments"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListDeviceDefinitionVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListDeviceDefinitions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListFunctionDefinitionVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListFunctionDefinitions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListGroupCertificateAuthorities"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListGroupVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListGroups"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListLoggerDefinitionVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListLoggerDefinitions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListResourceDefinitionVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListResourceDefinitions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListSubscriptionDefinitionVersions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListSubscriptionDefinitions"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.greengrass#ResetDeployments"
+        },
+        {
+          "target": "com.amazonaws.greengrass#StartBulkDeployment"
+        },
+        {
+          "target": "com.amazonaws.greengrass#StopBulkDeployment"
+        },
+        {
+          "target": "com.amazonaws.greengrass#TagResource"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateConnectivityInfo"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateConnectorDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateCoreDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateDeviceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateFunctionDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateGroup"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateGroupCertificateConfiguration"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateLoggerDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateResourceDefinition"
+        },
+        {
+          "target": "com.amazonaws.greengrass#UpdateSubscriptionDefinition"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Greengrass",
+          "arnNamespace": "greengrass",
+          "cloudFormationName": "Greengrass",
+          "cloudTrailEventSource": "greengrass.amazonaws.com"
+        },
+        "smithy.api#documentation": "AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act locally on the data they generate, while still using the cloud for management, analytics, and durable storage. AWS IoT Greengrass ensures your devices can respond quickly to local events and operate with intermittent connectivity. AWS IoT Greengrass minimizes the cost of transmitting data to the cloud by allowing you to author AWS Lambda functions that execute locally.",
+        "smithy.api#protocols": [
+          {
+            "name": "aws.rest-json-1.1",
+            "auth": [
+              "aws.v4"
+            ]
+          }
+        ],
+        "smithy.api#title": "AWS Greengrass"
+      }
+    },
+    "com.amazonaws.greengrass#GroupCertificateAuthorityProperties": {
+      "type": "structure",
+      "members": {
+        "GroupCertificateAuthorityArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the certificate authority for the group."
+          }
+        },
+        "GroupCertificateAuthorityId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the certificate authority for the group."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a certificate authority for a group."
+      }
+    },
+    "com.amazonaws.greengrass#GroupInformation": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the group."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the group was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group."
+          }
+        },
+        "LastUpdatedTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the group was last updated."
+          }
+        },
+        "LatestVersion": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the latest version associated with the group."
+          }
+        },
+        "LatestVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the latest version associated with the group."
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the group."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a group."
+      }
+    },
+    "com.amazonaws.greengrass#GroupOwnerSetting": {
+      "type": "structure",
+      "members": {
+        "AutoAddGroupOwner": {
+          "target": "com.amazonaws.greengrass#__boolean",
+          "traits": {
+            "smithy.api#documentation": "If true, AWS IoT Greengrass automatically adds the specified Linux OS group owner of the resource to the Lambda process privileges. Thus the Lambda process will have the file access permissions of the added Linux group."
+          }
+        },
+        "GroupOwner": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the Linux OS group whose privileges will be added to the Lambda process. This field is optional."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Group owner related settings for local resources."
+      }
+    },
+    "com.amazonaws.greengrass#GroupVersion": {
+      "type": "structure",
+      "members": {
+        "ConnectorDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the connector definition version for this group."
+          }
+        },
+        "CoreDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the core definition version for this group."
+          }
+        },
+        "DeviceDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the device definition version for this group."
+          }
+        },
+        "FunctionDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the function definition version for this group."
+          }
+        },
+        "LoggerDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the logger definition version for this group."
+          }
+        },
+        "ResourceDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the resource definition version for this group."
+          }
+        },
+        "SubscriptionDefinitionVersionArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the subscription definition version for this group."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a group version."
+      }
+    },
+    "com.amazonaws.greengrass#InternalServerErrorException": {
+      "type": "structure",
+      "members": {
+        "ErrorDetails": {
+          "target": "com.amazonaws.greengrass#ErrorDetails",
+          "traits": {
+            "smithy.api#documentation": "Details about the error."
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A message containing information about the error."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "General error information.",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.greengrass#ListBulkDeploymentDetailedReports": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListBulkDeploymentDetailedReportsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListBulkDeploymentDetailedReportsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Gets a paginated list of the deployments that have been started in a bulk deployment operation, and their current deployment status.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/bulk/deployments/{BulkDeploymentId}/detailed-reports",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListBulkDeploymentDetailedReportsRequest": {
+      "type": "structure",
+      "members": {
+        "BulkDeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the bulk deployment.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListBulkDeploymentDetailedReportsResponse": {
+      "type": "structure",
+      "members": {
+        "Deployments": {
+          "target": "com.amazonaws.greengrass#BulkDeploymentResults",
+          "traits": {
+            "smithy.api#documentation": "A list of the individual group deployments in the bulk deployment operation."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListBulkDeployments": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListBulkDeploymentsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListBulkDeploymentsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Returns a list of bulk deployments.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/bulk/deployments",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListBulkDeploymentsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListBulkDeploymentsResponse": {
+      "type": "structure",
+      "members": {
+        "BulkDeployments": {
+          "target": "com.amazonaws.greengrass#BulkDeployments",
+          "traits": {
+            "smithy.api#documentation": "A list of bulk deployments."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListConnectorDefinitionVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListConnectorDefinitionVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListConnectorDefinitionVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a connector definition, which are containers for connectors. Connectors run on the Greengrass core and contain built-in integration with local infrastructure, device protocols, AWS, and other cloud services.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/connectors/{ConnectorDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListConnectorDefinitionVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConnectorDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListConnectorDefinitionVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListConnectorDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListConnectorDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListConnectorDefinitionsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of connector definitions.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/connectors",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListConnectorDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListConnectorDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "Definitions": {
+          "target": "com.amazonaws.greengrass#__listOfDefinitionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a definition."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListCoreDefinitionVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListCoreDefinitionVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListCoreDefinitionVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a core definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/cores/{CoreDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListCoreDefinitionVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "CoreDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListCoreDefinitionVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListCoreDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListCoreDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListCoreDefinitionsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of core definitions.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/cores",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListCoreDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListCoreDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "Definitions": {
+          "target": "com.amazonaws.greengrass#__listOfDefinitionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a definition."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeployments": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListDeploymentsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListDeploymentsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Returns a history of deployments for the group.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/deployments",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeploymentsRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeploymentsResponse": {
+      "type": "structure",
+      "members": {
+        "Deployments": {
+          "target": "com.amazonaws.greengrass#Deployments",
+          "traits": {
+            "smithy.api#documentation": "A list of deployments for the requested groups."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeviceDefinitionVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListDeviceDefinitionVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListDeviceDefinitionVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a device definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/devices/{DeviceDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeviceDefinitionVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "DeviceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeviceDefinitionVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeviceDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListDeviceDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListDeviceDefinitionsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of device definitions.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/devices",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeviceDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListDeviceDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "Definitions": {
+          "target": "com.amazonaws.greengrass#__listOfDefinitionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a definition."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListFunctionDefinitionVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListFunctionDefinitionVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListFunctionDefinitionVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a Lambda function definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/functions/{FunctionDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListFunctionDefinitionVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "FunctionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Lambda function definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListFunctionDefinitionVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListFunctionDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListFunctionDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListFunctionDefinitionsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of Lambda function definitions.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/functions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListFunctionDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListFunctionDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "Definitions": {
+          "target": "com.amazonaws.greengrass#__listOfDefinitionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a definition."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupCertificateAuthorities": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListGroupCertificateAuthoritiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListGroupCertificateAuthoritiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves the current CAs for a group.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/certificateauthorities",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupCertificateAuthoritiesRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupCertificateAuthoritiesResponse": {
+      "type": "structure",
+      "members": {
+        "GroupCertificateAuthorities": {
+          "target": "com.amazonaws.greengrass#__listOfGroupCertificateAuthorityProperties",
+          "traits": {
+            "smithy.api#documentation": "A list of certificate authorities associated with the group."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListGroupVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListGroupVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a group.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups/{GroupId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroups": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListGroupsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListGroupsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of groups.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/groups",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListGroupsResponse": {
+      "type": "structure",
+      "members": {
+        "Groups": {
+          "target": "com.amazonaws.greengrass#__listOfGroupInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a group."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListLoggerDefinitionVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListLoggerDefinitionVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListLoggerDefinitionVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a logger definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/loggers/{LoggerDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListLoggerDefinitionVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "LoggerDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListLoggerDefinitionVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListLoggerDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListLoggerDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListLoggerDefinitionsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of logger definitions.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/loggers",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListLoggerDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListLoggerDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "Definitions": {
+          "target": "com.amazonaws.greengrass#__listOfDefinitionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a definition."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListResourceDefinitionVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListResourceDefinitionVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListResourceDefinitionVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a resource definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/resources/{ResourceDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListResourceDefinitionVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "ResourceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListResourceDefinitionVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListResourceDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListResourceDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListResourceDefinitionsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of resource definitions.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/resources",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListResourceDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListResourceDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "Definitions": {
+          "target": "com.amazonaws.greengrass#__listOfDefinitionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a definition."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListSubscriptionDefinitionVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListSubscriptionDefinitionVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListSubscriptionDefinitionVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists the versions of a subscription definition.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}/versions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListSubscriptionDefinitionVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "SubscriptionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListSubscriptionDefinitionVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        },
+        "Versions": {
+          "target": "com.amazonaws.greengrass#__listOfVersionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a version."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListSubscriptionDefinitions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListSubscriptionDefinitionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListSubscriptionDefinitionsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of subscription definitions.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/greengrass/definition/subscriptions",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListSubscriptionDefinitionsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to be returned per request.",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results.",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListSubscriptionDefinitionsResponse": {
+      "type": "structure",
+      "members": {
+        "Definitions": {
+          "target": "com.amazonaws.greengrass#__listOfDefinitionInformation",
+          "traits": {
+            "smithy.api#documentation": "Information about a definition."
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The token for the next set of results, or ''null'' if there are no additional results."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Retrieves a list of resource tags for a resource arn.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/tags/{ResourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The Amazon Resource Name (ARN) of the resource.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags"
+        }
+      }
+    },
+    "com.amazonaws.greengrass#LocalDeviceResourceData": {
+      "type": "structure",
+      "members": {
+        "GroupOwnerSetting": {
+          "target": "com.amazonaws.greengrass#GroupOwnerSetting",
+          "traits": {
+            "smithy.api#documentation": "Group/owner related settings for local resources."
+          }
+        },
+        "SourcePath": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The local absolute path of the device resource. The source path for a device resource can refer only to a character device or block device under ''/dev''."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Attributes that define a local device resource."
+      }
+    },
+    "com.amazonaws.greengrass#LocalVolumeResourceData": {
+      "type": "structure",
+      "members": {
+        "DestinationPath": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The absolute local path of the resource inside the Lambda environment."
+          }
+        },
+        "GroupOwnerSetting": {
+          "target": "com.amazonaws.greengrass#GroupOwnerSetting",
+          "traits": {
+            "smithy.api#documentation": "Allows you to configure additional group privileges for the Lambda process. This field is optional."
+          }
+        },
+        "SourcePath": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The local absolute path of the volume resource on the host. The source path for a volume resource type cannot start with ''/sys''."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Attributes that define a local volume resource."
+      }
+    },
+    "com.amazonaws.greengrass#Logger": {
+      "type": "structure",
+      "members": {
+        "Component": {
+          "target": "com.amazonaws.greengrass#LoggerComponent",
+          "traits": {
+            "smithy.api#documentation": "The component that will be subject to logging.",
+            "smithy.api#required": true
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A descriptive or arbitrary ID for the logger. This value must be unique within the logger definition version. Max length is 128 characters with pattern ''[a-zA-Z0-9:_-]+''.",
+            "smithy.api#required": true
+          }
+        },
+        "Level": {
+          "target": "com.amazonaws.greengrass#LoggerLevel",
+          "traits": {
+            "smithy.api#documentation": "The level of the logs.",
+            "smithy.api#required": true
+          }
+        },
+        "Space": {
+          "target": "com.amazonaws.greengrass#__integer",
+          "traits": {
+            "smithy.api#documentation": "The amount of file space, in KB, to use if the local file system is used for logging purposes."
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.greengrass#LoggerType",
+          "traits": {
+            "smithy.api#documentation": "The type of log output which will be used.",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a logger"
+      }
+    },
+    "com.amazonaws.greengrass#LoggerComponent": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "GreengrassSystem": {
+            "name": "GreengrassSystem"
+          },
+          "Lambda": {
+            "name": "Lambda"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#LoggerDefinitionVersion": {
+      "type": "structure",
+      "members": {
+        "Loggers": {
+          "target": "com.amazonaws.greengrass#__listOfLogger",
+          "traits": {
+            "smithy.api#documentation": "A list of loggers."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a logger definition version."
+      }
+    },
+    "com.amazonaws.greengrass#LoggerLevel": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "DEBUG": {
+            "name": "DEBUG"
+          },
+          "INFO": {
+            "name": "INFO"
+          },
+          "WARN": {
+            "name": "WARN"
+          },
+          "ERROR": {
+            "name": "ERROR"
+          },
+          "FATAL": {
+            "name": "FATAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#LoggerType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "FileSystem": {
+            "name": "FileSystem"
+          },
+          "AWSCloudWatch": {
+            "name": "AWSCloudWatch"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#Permission": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The type of permission a function has to access a resource.",
+        "smithy.api#enum": {
+          "ro": {
+            "name": "ro"
+          },
+          "rw": {
+            "name": "rw"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ResetDeployments": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#ResetDeploymentsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#ResetDeploymentsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Resets a group's deployments.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/groups/{GroupId}/deployments/$reset",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#ResetDeploymentsRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "Force": {
+          "target": "com.amazonaws.greengrass#__boolean",
+          "traits": {
+            "smithy.api#documentation": "If true, performs a best-effort only core reset."
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information needed to reset deployments."
+      }
+    },
+    "com.amazonaws.greengrass#ResetDeploymentsResponse": {
+      "type": "structure",
+      "members": {
+        "DeploymentArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the deployment."
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the deployment."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#Resource": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The resource ID, used to refer to a resource in the Lambda function configuration. Max length is 128 characters with pattern ''[a-zA-Z0-9:_-]+''. This must be unique within a Greengrass group.",
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The descriptive resource name, which is displayed on the AWS IoT Greengrass console. Max length 128 characters with pattern ''[a-zA-Z0-9:_-]+''. This must be unique within a Greengrass group.",
+            "smithy.api#required": true
+          }
+        },
+        "ResourceDataContainer": {
+          "target": "com.amazonaws.greengrass#ResourceDataContainer",
+          "traits": {
+            "smithy.api#documentation": "A container of data for all resource types.",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a resource."
+      }
+    },
+    "com.amazonaws.greengrass#ResourceAccessPolicy": {
+      "type": "structure",
+      "members": {
+        "Permission": {
+          "target": "com.amazonaws.greengrass#Permission",
+          "traits": {
+            "smithy.api#documentation": "The permissions that the Lambda function has to the resource. Can be one of ''rw'' (read/write) or ''ro'' (read-only)."
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource. (This ID is assigned to the resource when you create the resource definiton.)",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A policy used by the function to access a resource."
+      }
+    },
+    "com.amazonaws.greengrass#ResourceDataContainer": {
+      "type": "structure",
+      "members": {
+        "LocalDeviceResourceData": {
+          "target": "com.amazonaws.greengrass#LocalDeviceResourceData",
+          "traits": {
+            "smithy.api#documentation": "Attributes that define the local device resource."
+          }
+        },
+        "LocalVolumeResourceData": {
+          "target": "com.amazonaws.greengrass#LocalVolumeResourceData",
+          "traits": {
+            "smithy.api#documentation": "Attributes that define the local volume resource."
+          }
+        },
+        "S3MachineLearningModelResourceData": {
+          "target": "com.amazonaws.greengrass#S3MachineLearningModelResourceData",
+          "traits": {
+            "smithy.api#documentation": "Attributes that define an Amazon S3 machine learning resource."
+          }
+        },
+        "SageMakerMachineLearningModelResourceData": {
+          "target": "com.amazonaws.greengrass#SageMakerMachineLearningModelResourceData",
+          "traits": {
+            "smithy.api#documentation": "Attributes that define an Amazon SageMaker machine learning resource."
+          }
+        },
+        "SecretsManagerSecretResourceData": {
+          "target": "com.amazonaws.greengrass#SecretsManagerSecretResourceData",
+          "traits": {
+            "smithy.api#documentation": "Attributes that define a secret resource, which references a secret from AWS Secrets Manager."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A container for resource data. The container takes only one of the following supported resource data types: ''LocalDeviceResourceData'', ''LocalVolumeResourceData'', ''SageMakerMachineLearningModelResourceData'', ''S3MachineLearningModelResourceData'', ''SecretsManagerSecretResourceData''."
+      }
+    },
+    "com.amazonaws.greengrass#ResourceDefinitionVersion": {
+      "type": "structure",
+      "members": {
+        "Resources": {
+          "target": "com.amazonaws.greengrass#__listOfResource",
+          "traits": {
+            "smithy.api#documentation": "A list of resources."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a resource definition version."
+      }
+    },
+    "com.amazonaws.greengrass#ResourceDownloadOwnerSetting": {
+      "type": "structure",
+      "members": {
+        "GroupOwner": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The group owner of the resource. This is the name of an existing Linux OS group on the system or a GID. The group's permissions are added to the Lambda process.",
+            "smithy.api#required": true
+          }
+        },
+        "GroupPermission": {
+          "target": "com.amazonaws.greengrass#Permission",
+          "traits": {
+            "smithy.api#documentation": "The permissions that the group owner has to the resource. Valid values are ''rw'' (read/write) or ''ro'' (read-only).",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The owner setting for downloaded machine learning resources."
+      }
+    },
+    "com.amazonaws.greengrass#S3MachineLearningModelResourceData": {
+      "type": "structure",
+      "members": {
+        "DestinationPath": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The absolute local path of the resource inside the Lambda environment."
+          }
+        },
+        "OwnerSetting": {
+          "target": "com.amazonaws.greengrass#ResourceDownloadOwnerSetting"
+        },
+        "S3Uri": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The URI of the source model in an S3 bucket. The model package must be in tar.gz or .zip format."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Attributes that define an Amazon S3 machine learning resource."
+      }
+    },
+    "com.amazonaws.greengrass#S3UrlSignerRole": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The IAM Role that Greengrass will use to create pre-signed URLs pointing towards the update artifact."
+      }
+    },
+    "com.amazonaws.greengrass#SageMakerMachineLearningModelResourceData": {
+      "type": "structure",
+      "members": {
+        "DestinationPath": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The absolute local path of the resource inside the Lambda environment."
+          }
+        },
+        "OwnerSetting": {
+          "target": "com.amazonaws.greengrass#ResourceDownloadOwnerSetting"
+        },
+        "SageMakerJobArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the Amazon SageMaker training job that represents the source model."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Attributes that define an Amazon SageMaker machine learning resource."
+      }
+    },
+    "com.amazonaws.greengrass#SecretsManagerSecretResourceData": {
+      "type": "structure",
+      "members": {
+        "ARN": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the Secrets Manager secret to make available on the core. The value of the secret's latest version (represented by the ''AWSCURRENT'' staging label) is included by default."
+          }
+        },
+        "AdditionalStagingLabelsToDownload": {
+          "target": "com.amazonaws.greengrass#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "Optional. The staging labels whose values you want to make available on the core, in addition to ''AWSCURRENT''."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Attributes that define a secret resource, which references a secret from AWS Secrets Manager. AWS IoT Greengrass stores a local, encrypted copy of the secret on the Greengrass core, where it can be securely accessed by connectors and Lambda functions."
+      }
+    },
+    "com.amazonaws.greengrass#SoftwareToUpdate": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The piece of software on the Greengrass core that will be updated.",
+        "smithy.api#enum": {
+          "core": {
+            "name": "core"
+          },
+          "ota_agent": {
+            "name": "ota_agent"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#StartBulkDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#StartBulkDeploymentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#StartBulkDeploymentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deploys multiple groups in one operation. This action starts the bulk deployment of a specified set of group versions. Each group version deployment will be triggered with an adaptive rate that has a fixed upper limit. We recommend that you include an ''X-Amzn-Client-Token'' token in every ''StartBulkDeployment'' request. These requests are idempotent with respect to the token and the request parameters.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/greengrass/bulk/deployments",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#StartBulkDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "AmznClientToken": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A client token used to correlate requests and responses.",
+            "smithy.api#httpHeader": "X-Amzn-Client-Token"
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the execution role to associate with the bulk deployment operation. This IAM role must allow the ''greengrass:CreateDeployment'' action for all group versions that are listed in the input file. This IAM role must have access to the S3 bucket containing the input file.",
+            "smithy.api#required": true
+          }
+        },
+        "InputFileUri": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The URI of the input file contained in the S3 bucket. The execution role must have ''getObject'' permissions on this bucket to access the input file. The input file is a JSON-serialized, line delimited file with UTF-8 encoding that provides a list of group and version IDs and the deployment type. This file must be less than 100 MB. Currently, AWS IoT Greengrass supports only ''NewDeployment'' deployment types.",
+            "smithy.api#required": true
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags",
+          "traits": {
+            "smithy.api#documentation": "Tag(s) to add to the new resource."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#StartBulkDeploymentResponse": {
+      "type": "structure",
+      "members": {
+        "BulkDeploymentArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the bulk deployment."
+          }
+        },
+        "BulkDeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the bulk deployment."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#StopBulkDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#StopBulkDeploymentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#StopBulkDeploymentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Stops the execution of a bulk deployment. This action returns a status of ''Stopping'' until the deployment is stopped. You cannot start a new bulk deployment while a previous deployment is in the ''Stopping'' state. This action doesn't rollback completed deployments or cancel pending deployments.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/bulk/deployments/{BulkDeploymentId}/$stop",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#StopBulkDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "BulkDeploymentId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the bulk deployment.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#StopBulkDeploymentResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#Subscription": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A descriptive or arbitrary ID for the subscription. This value must be unique within the subscription definition version. Max length is 128 characters with pattern ''[a-zA-Z0-9:_-]+''.",
+            "smithy.api#required": true
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The source of the subscription. Can be a thing ARN, a Lambda function ARN, a connector ARN, 'cloud' (which represents the AWS IoT cloud), or 'GGShadowService'.",
+            "smithy.api#required": true
+          }
+        },
+        "Subject": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The MQTT topic used to route the message.",
+            "smithy.api#required": true
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "Where the message is sent to. Can be a thing ARN, a Lambda function ARN, a connector ARN, 'cloud' (which represents the AWS IoT cloud), or 'GGShadowService'.",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a subscription."
+      }
+    },
+    "com.amazonaws.greengrass#SubscriptionDefinitionVersion": {
+      "type": "structure",
+      "members": {
+        "Subscriptions": {
+          "target": "com.amazonaws.greengrass#__listOfSubscription",
+          "traits": {
+            "smithy.api#documentation": "A list of subscriptions."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a subscription definition version."
+      }
+    },
+    "com.amazonaws.greengrass#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#TagResourceRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Adds tags to a Greengrass resource. Valid resources are 'Group', 'ConnectorDefinition', 'CoreDefinition', 'DeviceDefinition', 'FunctionDefinition', 'LoggerDefinition', 'SubscriptionDefinition', 'ResourceDefinition', and 'BulkDeployment'.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/tags/{ResourceArn}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.greengrass#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The Amazon Resource Name (ARN) of the resource.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.greengrass#Tags"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A map of the key-value pairs for the resource tag."
+      }
+    },
+    "com.amazonaws.greengrass#Tags": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.greengrass#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.greengrass#__string"
+      },
+      "traits": {
+        "smithy.api#documentation": "The key-value pair for the resource tag."
+      }
+    },
+    "com.amazonaws.greengrass#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UntagResourceRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Remove resource tags from a Greengrass Resource.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/tags/{ResourceArn}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The Amazon Resource Name (ARN) of the resource.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.greengrass#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "An array of tag keys to delete",
+            "smithy.api#httpQuery": "tagKeys",
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateAgentLogLevel": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The minimum level of log statements that should be logged by the OTA Agent during an update.",
+        "smithy.api#enum": {
+          "NONE": {
+            "name": "NONE"
+          },
+          "TRACE": {
+            "name": "TRACE"
+          },
+          "DEBUG": {
+            "name": "DEBUG"
+          },
+          "VERBOSE": {
+            "name": "VERBOSE"
+          },
+          "INFO": {
+            "name": "INFO"
+          },
+          "WARN": {
+            "name": "WARN"
+          },
+          "ERROR": {
+            "name": "ERROR"
+          },
+          "FATAL": {
+            "name": "FATAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateConnectivityInfo": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateConnectivityInfoRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateConnectivityInfoResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates the connectivity information for the core. Any devices that belong to the group which has this core will receive this information in order to find the location of the core and connect to it.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/things/{ThingName}/connectivityInfo",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateConnectivityInfoRequest": {
+      "type": "structure",
+      "members": {
+        "ConnectivityInfo": {
+          "target": "com.amazonaws.greengrass#__listOfConnectivityInfo",
+          "traits": {
+            "smithy.api#documentation": "A list of connectivity info."
+          }
+        },
+        "ThingName": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The thing name.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Connectivity information."
+      }
+    },
+    "com.amazonaws.greengrass#UpdateConnectivityInfoResponse": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "A message about the connectivity info update request.",
+            "smithy.api#jsonName": "message"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The new version of the connectivity info."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateConnectorDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateConnectorDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateConnectorDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a connector definition.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/definition/connectors/{ConnectorDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateConnectorDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "ConnectorDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the connector definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateConnectorDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateCoreDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateCoreDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateCoreDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a core definition.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/definition/cores/{CoreDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateCoreDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "CoreDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the core definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateCoreDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateDeviceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateDeviceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateDeviceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a device definition.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/definition/devices/{DeviceDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateDeviceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "DeviceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the device definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateDeviceDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateFunctionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateFunctionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateFunctionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a Lambda function definition.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/definition/functions/{FunctionDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateFunctionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "FunctionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Lambda function definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateFunctionDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a group.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/groups/{GroupId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateGroupCertificateConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateGroupCertificateConfigurationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateGroupCertificateConfigurationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.greengrass#InternalServerErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates the Certificate expiry time for a group.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/groups/{GroupId}/certificateauthorities/configuration/expiry",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateGroupCertificateConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "CertificateExpiryInMilliseconds": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The amount of time remaining before the certificate expires, in milliseconds."
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateGroupCertificateConfigurationResponse": {
+      "type": "structure",
+      "members": {
+        "CertificateAuthorityExpiryInMilliseconds": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The amount of time remaining before the certificate authority expires, in milliseconds."
+          }
+        },
+        "CertificateExpiryInMilliseconds": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The amount of time remaining before the certificate expires, in milliseconds."
+          }
+        },
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the group certificate configuration."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateGroupRequest": {
+      "type": "structure",
+      "members": {
+        "GroupId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the Greengrass group.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateGroupResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateLoggerDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateLoggerDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateLoggerDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a logger definition.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/definition/loggers/{LoggerDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateLoggerDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "LoggerDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the logger definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateLoggerDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateResourceDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateResourceDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateResourceDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a resource definition.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/definition/resources/{ResourceDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateResourceDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "ResourceDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the resource definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateResourceDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateSubscriptionDefinition": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.greengrass#UpdateSubscriptionDefinitionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.greengrass#UpdateSubscriptionDefinitionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.greengrass#BadRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates a subscription definition.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateSubscriptionDefinitionRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the definition."
+          }
+        },
+        "SubscriptionDefinitionId": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the subscription definition.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateSubscriptionDefinitionResponse": {
+      "type": "structure",
+      "members": { }
+    },
+    "com.amazonaws.greengrass#UpdateTargets": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#__string"
+      },
+      "traits": {
+        "smithy.api#documentation": "The ARNs of the targets (IoT things or IoT thing groups) that this update will be applied to."
+      }
+    },
+    "com.amazonaws.greengrass#UpdateTargetsArchitecture": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The architecture of the cores which are the targets of an update.",
+        "smithy.api#enum": {
+          "armv6l": {
+            "name": "armv6l"
+          },
+          "armv7l": {
+            "name": "armv7l"
+          },
+          "x86_64": {
+            "name": "x86_64"
+          },
+          "aarch64": {
+            "name": "aarch64"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#UpdateTargetsOperatingSystem": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "The operating system of the cores which are the targets of an update.",
+        "smithy.api#enum": {
+          "ubuntu": {
+            "name": "ubuntu"
+          },
+          "raspbian": {
+            "name": "raspbian"
+          },
+          "amazon_linux": {
+            "name": "amazon_linux"
+          },
+          "openwrt": {
+            "name": "openwrt"
+          }
+        }
+      }
+    },
+    "com.amazonaws.greengrass#VersionInformation": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the version."
+          }
+        },
+        "CreationTimestamp": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The time, in milliseconds since the epoch, when the version was created."
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the parent definition that the version is associated with."
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.greengrass#__string",
+          "traits": {
+            "smithy.api#documentation": "The ID of the version."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about a version."
+      }
+    },
+    "com.amazonaws.greengrass#__boolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.greengrass#__integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.greengrass#__listOfConnectivityInfo": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#ConnectivityInfo"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfConnector": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Connector"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfCore": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Core"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfDefinitionInformation": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#DefinitionInformation"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfDevice": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Device"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfFunction": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Function"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfGroupCertificateAuthorityProperties": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#GroupCertificateAuthorityProperties"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfGroupInformation": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#GroupInformation"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfLogger": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Logger"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfResource": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Resource"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfResourceAccessPolicy": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#ResourceAccessPolicy"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfSubscription": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#Subscription"
+      }
+    },
+    "com.amazonaws.greengrass#__listOfVersionInformation": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#VersionInformation"
+      }
+    },
+    "com.amazonaws.greengrass#__listOf__string": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.greengrass#__string"
+      }
+    },
+    "com.amazonaws.greengrass#__mapOf__string": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.greengrass#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.greengrass#__string"
+      }
+    },
+    "com.amazonaws.greengrass#__string": {
+      "type": "string"
+    }
+  }
+}

--- a/codegen/sdk-codegen/aws-models/iam.2010-05-08.json
+++ b/codegen/sdk-codegen/aws-models/iam.2010-05-08.json
@@ -1015,7 +1015,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because multiple requests to change this object were submitted simultaneously. Wait a few minutes and submit your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#ConcurrentModificationMessage": {
@@ -2002,7 +2003,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the most recent credential report has expired. To\n      generate a new credential report, use <a>GenerateCredentialReport</a>. For more\n      information about credential report expiration, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html\">Getting Credential Reports</a> in the\n        <i>IAM User Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 410
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#CredentialReportNotPresentException": {
@@ -2014,7 +2016,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the credential report does not exist. To generate a\n      credential report, use <a>GenerateCredentialReport</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 410
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#CredentialReportNotReadyException": {
@@ -2026,7 +2029,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the credential report is still being\n      generated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#DeactivateMFADevice": {
@@ -2167,7 +2171,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because it attempted to delete a resource that has attached\n      subordinate entities. The error message describes these entities.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#DeleteGroup": {
@@ -3091,7 +3096,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the same certificate is associated with an IAM user in\n      the account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#DuplicateSSHPublicKeyException": {
@@ -3103,7 +3109,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the SSH public key is already associated with the\n      specified IAM user.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#EnableMFADevice": {
@@ -3177,7 +3184,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because it attempted to create a resource that already\n      exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#EntityDetails": {
@@ -3251,7 +3259,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because it referenced an entity that is temporarily\n      unmodifiable, such as a user name that was deleted and then recreated. The error indicates\n      that the request is likely to succeed if you try again after waiting several minutes. The\n      error message describes the entity.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#EntityType": {
@@ -5148,7 +5157,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the authentication code was not recognized. The error\n      message describes the specific error.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#InvalidCertificateException": {
@@ -5160,7 +5170,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the certificate is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#InvalidInputException": {
@@ -5172,7 +5183,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because an invalid or out-of-range value was supplied for an\n      input parameter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#InvalidPublicKeyException": {
@@ -5184,7 +5196,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the public key is malformed or otherwise\n      invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#InvalidUserTypeException": {
@@ -5196,7 +5209,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the type of user for the transaction was\n      incorrect.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#KeyPairMismatchException": {
@@ -5208,7 +5222,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the public key certificate and the private key do not\n      match.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#LimitExceededException": {
@@ -5220,7 +5235,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because it attempted to create resources beyond the current\n      AWS account limits. The error message describes the limit exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#LineNumber": {
@@ -7352,7 +7368,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the certificate was malformed or expired. The error\n      message describes the specific error.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#MalformedPolicyDocumentException": {
@@ -7364,7 +7381,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the policy document was malformed. The error message\n      describes the specific error.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#ManagedPolicyDetail": {
@@ -7459,7 +7477,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because it referenced a resource entity that does not exist. The error\n      message describes the resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#OpenIDConnectProviderListEntry": {
@@ -7583,7 +7602,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the provided password did not meet the requirements\n      imposed by the account password policy.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#PermissionsBoundaryAttachmentType": {
@@ -7712,7 +7732,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request failed because a provided policy could not be successfully evaluated. An\n      additional detailed message indicates the source of the failure.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#PolicyGrantingServiceAccess": {
@@ -7790,7 +7811,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request failed because AWS service role policies can only be attached to the\n      service-linked role for that service.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#PolicyRole": {
@@ -8330,7 +8352,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request failed because the maximum number of concurrent requests for this\n    account are already running.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#ReportStateDescriptionType": {
@@ -8953,7 +8976,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request processing has failed because of an unknown error, exception or\n      failure.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#ServiceLastAccessed": {
@@ -9005,7 +9029,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified service does not support service-specific credentials.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#ServiceSpecificCredential": {
@@ -9623,7 +9648,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because only the service that depends on the service-linked\n      role can modify or delete the role on your behalf. The error message includes the name of the\n      service that depends on this service-linked role. You must request the change through that\n      service.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#UnrecognizedPublicKeyEncodingException": {
@@ -9635,7 +9661,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the public key encoding format is unsupported or\n      unrecognized.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.webservices.auth.identity.v20100508#UntagRole": {

--- a/codegen/sdk-codegen/aws-models/inspector.2016-02-16.json
+++ b/codegen/sdk-codegen/aws-models/inspector.2016-02-16.json
@@ -83,7 +83,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You do not have required permissions to access the requested resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.inspector.v20160216#AddAttributesToFindings": {
@@ -4769,7 +4770,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The serice is temporary unavailable.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.inspector.v20160216#SetTagsForResource": {

--- a/codegen/sdk-codegen/aws-models/iotsecuretunneling.2018-10-05.json
+++ b/codegen/sdk-codegen/aws-models/iotsecuretunneling.2018-10-05.json
@@ -54,7 +54,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n\t\t       <p>Closes a tunnel identified by the unique tunnel id. When a <code>CloseTunnel</code>\n\t\t\trequest is received, we close the WebSocket connections between the client and proxy\n\t\t\tserver so no data can be transmitted.</p>\n\t     "
+        "smithy.api#documentation": "\n\t\t       <p>Closes a tunnel identified by the unique tunnel id. When a <code>CloseTunnel</code>\n\t\t\trequest is received, we close the WebSocket connections between the client and proxy\n\t\t\tserver so no data can be transmitted.</p>\n\t     ",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/tunnels/{tunnelId}",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.envoy.frontend#CloseTunnelRequest": {
@@ -64,13 +69,15 @@
           "target": "com.amazonaws.envoy.frontend#DeleteFlag",
           "traits": {
             "smithy.api#box": true,
-            "smithy.api#documentation": "\n\t\t       <p>When set to true, AWS IoT Secure Tunneling deletes the tunnel data\n\t\t\timmediately.</p>\n\t     "
+            "smithy.api#documentation": "\n\t\t       <p>When set to true, AWS IoT Secure Tunneling deletes the tunnel data\n\t\t\timmediately.</p>\n\t     ",
+            "smithy.api#httpQuery": "delete"
           }
         },
         "tunnelId": {
           "target": "com.amazonaws.envoy.frontend#TunnelId",
           "traits": {
             "smithy.api#documentation": "\n\t\t       <p>The ID of the tunnel to close.</p>\n\t     ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -133,7 +140,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n\t\t       <p>Gets information about a tunnel identified by the unique tunnel id.</p>\n\t     "
+        "smithy.api#documentation": "\n\t\t       <p>Gets information about a tunnel identified by the unique tunnel id.</p>\n\t     ",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/tunnels/{tunnelId}",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.envoy.frontend#DescribeTunnelRequest": {
@@ -143,6 +155,7 @@
           "target": "com.amazonaws.envoy.frontend#TunnelId",
           "traits": {
             "smithy.api#documentation": "\n\t\t       <p>The tunnel to describe.</p>\n\t     ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -244,7 +257,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Thrown when a tunnel limit is exceeded.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.envoy.frontend#ListTagsForResource": {
@@ -261,7 +275,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n\t\t       <p>Lists the tags for the specified resource.</p>\n\t     "
+        "smithy.api#documentation": "\n\t\t       <p>Lists the tags for the specified resource.</p>\n\t     ",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/tags",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.envoy.frontend#ListTagsForResourceRequest": {
@@ -271,6 +290,7 @@
           "target": "com.amazonaws.envoy.frontend#AmazonResourceName",
           "traits": {
             "smithy.api#documentation": "\n\t\t       <p>The resource ARN.</p>\n\t     ",
+            "smithy.api#httpQuery": "resourceArn",
             "smithy.api#required": true
           }
         }
@@ -297,6 +317,11 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>List all tunnels for an AWS account. Tunnels are listed by creation time in\n\t\t\tdescending order, newer tunnels will be listed before older tunnels.</p>\n\t     ",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/tunnels",
+          "code": 200
+        },
         "smithy.api#paginated": {
           "inputToken": "nextToken",
           "outputToken": "nextToken",
@@ -311,19 +336,22 @@
           "target": "com.amazonaws.envoy.frontend#MaxResults",
           "traits": {
             "smithy.api#box": true,
-            "smithy.api#documentation": "\n\t\t       <p>The maximum number of results to return at once.</p>\n\t     "
+            "smithy.api#documentation": "\n\t\t       <p>The maximum number of results to return at once.</p>\n\t     ",
+            "smithy.api#httpQuery": "maxResults"
           }
         },
         "nextToken": {
           "target": "com.amazonaws.envoy.frontend#NextToken",
           "traits": {
-            "smithy.api#documentation": "\n\t\t       <p>A token to retrieve the next set of results.</p>\n\t     "
+            "smithy.api#documentation": "\n\t\t       <p>A token to retrieve the next set of results.</p>\n\t     ",
+            "smithy.api#httpQuery": "nextToken"
           }
         },
         "thingName": {
           "target": "com.amazonaws.envoy.frontend#ThingName",
           "traits": {
-            "smithy.api#documentation": "\n\t\t       <p>The name of the IoT thing associated with the destination device.</p>\n\t     "
+            "smithy.api#documentation": "\n\t\t       <p>The name of the IoT thing associated with the destination device.</p>\n\t     ",
+            "smithy.api#httpQuery": "thingName"
           }
         }
       }
@@ -374,7 +402,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n\t\t       <p>Creates a new tunnel, and returns two client access tokens for clients to use to\n\t\t\tconnect to the AWS IoT Secure Tunneling proxy server. .</p>\n\t     "
+        "smithy.api#documentation": "\n\t\t       <p>Creates a new tunnel, and returns two client access tokens for clients to use to\n\t\t\tconnect to the AWS IoT Secure Tunneling proxy server. .</p>\n\t     ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/tunnels",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.envoy.frontend#OpenTunnelRequest": {
@@ -444,7 +477,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Thrown when an operation is attempted on a resource that does not exist.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.envoy.frontend#Service": {
@@ -539,7 +573,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n\t\t       <p>A resource tag.</p>\n\t     "
+        "smithy.api#documentation": "\n\t\t       <p>A resource tag.</p>\n\t     ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/tags",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.envoy.frontend#TagResourceRequest": {
@@ -775,7 +814,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n\t\t       <p>Removes a tag from a resource.</p>\n\t     "
+        "smithy.api#documentation": "\n\t\t       <p>Removes a tag from a resource.</p>\n\t     ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/untag",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.envoy.frontend#UntagResourceRequest": {

--- a/codegen/sdk-codegen/aws-models/iotthingsgraph.2018-09-06.json
+++ b/codegen/sdk-codegen/aws-models/iotthingsgraph.2018-09-06.json
@@ -1765,7 +1765,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.iot.thingsgraph.types#InvalidRequestException": {
@@ -1777,7 +1778,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.iot.thingsgraph#IotThingsGraphFrontEndService": {
@@ -1918,7 +1920,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 410
       }
     },
     "com.amazonaws.iot.thingsgraph#ListFlowExecutionMessages": {
@@ -2144,7 +2147,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.iot.thingsgraph.types#ResourceArn": {
@@ -2165,7 +2169,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 412
       }
     },
     "com.amazonaws.iot.thingsgraph.types#ResourceNotFoundException": {
@@ -2177,7 +2182,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.iot.thingsgraph.types#RoleArn": {
@@ -3133,7 +3139,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.iot.thingsgraph.types#Timestamp": {

--- a/codegen/sdk-codegen/aws-models/kendra.2019-02-03.json
+++ b/codegen/sdk-codegen/aws-models/kendra.2019-02-03.json
@@ -132,7 +132,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.kendra#AclConfiguration": {
@@ -598,7 +599,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.kendra#ConnectionConfiguration": {
@@ -2464,7 +2466,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.kendra#KmsKeyId": {
@@ -3230,7 +3233,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.kendra#ResourceInUseException": {
@@ -3242,7 +3246,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.kendra#ResourceNotFoundException": {
@@ -3254,7 +3259,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.kendra#ResourceUnavailableException": {
@@ -3266,7 +3272,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.kendra#ResultId": {
@@ -3440,7 +3447,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
       }
     },
     "com.amazonaws.kendra#SharePointConfiguration": {
@@ -3764,7 +3772,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.kendra#TimeRange": {
@@ -3958,7 +3967,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.kendra#ValueImportanceMap": {

--- a/codegen/sdk-codegen/aws-models/kinesis-analytics-v2.2018-05-23.json
+++ b/codegen/sdk-codegen/aws-models/kinesis-analytics-v2.2018-05-23.json
@@ -1336,7 +1336,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Exception thrown as a result of concurrent modifications to an application. This error can\n      be the result of attempting to modify an application without using the current application\n      ID.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.kinesis.analytics.v20180523#ConfigurationType": {
@@ -2918,7 +2919,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Kinesis Analytics"
+        "smithy.api#title": "Amazon Kinesis Analytics",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://analytics.kinesis.amazonaws.com/doc/2018-05-23"
+        }
       }
     },
     "com.amazonaws.kinesis.analytics.v20180523#KinesisFirehoseInput": {
@@ -4460,7 +4464,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The service cannot complete the request.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.kinesis.analytics.v20180523#SnapshotDetails": {

--- a/codegen/sdk-codegen/aws-models/kinesis-analytics.2015-08-14.json
+++ b/codegen/sdk-codegen/aws-models/kinesis-analytics.2015-08-14.json
@@ -728,7 +728,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Exception thrown as a result of concurrent modification to an application. For example, two individuals attempting to edit the same application at the same time.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.kinesis.analytics.v20150814#CreateApplication": {
@@ -1871,7 +1872,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Kinesis Analytics"
+        "smithy.api#title": "Amazon Kinesis Analytics",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://analytics.kinesis.amazonaws.com/doc/2015-08-14"
+        }
       }
     },
     "com.amazonaws.kinesis.analytics.v20150814#KinesisFirehoseInput": {
@@ -2929,7 +2933,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The service is unavailable. Back off and retry the operation. </p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.kinesis.analytics.v20150814#SourceSchema": {

--- a/codegen/sdk-codegen/aws-models/kinesis-video.2017-09-30.json
+++ b/codegen/sdk-codegen/aws-models/kinesis-video.2017-09-30.json
@@ -497,7 +497,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Kinesis Video Streams"
+        "smithy.api#title": "Amazon Kinesis Video Streams",
+        "smithy.api#xmlNamespace": {
+          "uri": "https://kinesisvideo.amazonaws.com/doc/2017-09-30/"
+        }
       }
     },
     "com.amazon.kinesis.video.v20170930#KmsKeyId": {

--- a/codegen/sdk-codegen/aws-models/kinesis.2013-12-02.json
+++ b/codegen/sdk-codegen/aws-models/kinesis.2013-12-02.json
@@ -1272,7 +1272,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Kinesis"
+        "smithy.api#title": "Amazon Kinesis",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://kinesis.amazonaws.com/doc/2013-12-02"
+        }
       }
     },
     "com.amazonaws.kinesis.v20131202#LimitExceededException": {

--- a/codegen/sdk-codegen/aws-models/kms.2014-11-01.json
+++ b/codegen/sdk-codegen/aws-models/kms.2014-11-01.json
@@ -95,7 +95,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because it attempted to create a resource that already\n      exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.trent#ArnType": {
@@ -189,7 +190,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified AWS CloudHSM cluster is already associated with a\n      custom key store or it shares a backup history with a cluster that is associated with a custom\n      key store. Each custom key store must be associated with a different AWS CloudHSM cluster.</p>\n         <p>Clusters that share a backup history have the same cluster certificate. To view the\n      cluster certificate of a cluster, use the <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html\">DescribeClusters</a> operation.</p> \n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CloudHsmClusterInvalidConfigurationException": {
@@ -201,7 +203,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the associated AWS CloudHSM cluster did not meet the\n      configuration requirements for a custom key store.</p>\n\n         <ul>\n            <li>\n               <p>The cluster must be configured with private subnets in at least two different\n          Availability Zones in the Region.</p>\n            </li>\n            <li>\n               <p>The <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html\">security group for\n            the cluster</a> (cloudhsm-cluster-<i><cluster-id></i>-sg) must\n          include inbound rules and outbound rules that allow TCP traffic on ports 2223-2225. The\n            <b>Source</b> in the inbound rules and the <b>Destination</b> in the outbound rules must match the security group\n          ID. These rules are set by default when you create the cluster. Do not delete or change\n          them. To get information about a particular security group, use the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html\">DescribeSecurityGroups</a> operation.</p>\n            </li>\n            <li>\n               <p>The cluster must contain at least as many HSMs as the operation requires. To add HSMs,\n          use the AWS CloudHSM <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html\">CreateHsm</a> operation.</p>\n               <p>For the <a>CreateCustomKeyStore</a>, <a>UpdateCustomKeyStore</a>, and <a>CreateKey</a> operations, the AWS CloudHSM cluster must have at least two\n          active HSMs, each in a different Availability Zone. For the <a>ConnectCustomKeyStore</a> operation, the AWS CloudHSM must contain at least one active\n          HSM.</p>\n            </li>\n         </ul>\n         <p>For information about the requirements for an AWS CloudHSM cluster that is associated with a\n      custom key store, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore\">Assemble the Prerequisites</a>\n      in the <i>AWS Key Management Service Developer Guide</i>. For information about creating a private subnet for an AWS CloudHSM cluster,\n      see <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html\">Create a Private\n        Subnet</a> in the <i>AWS CloudHSM User Guide</i>. For information about cluster security groups, see\n        <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html\">Configure a Default Security\n        Group</a> in the <i>\n               <i>AWS CloudHSM User Guide</i>\n            </i>. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CloudHsmClusterNotActiveException": {
@@ -213,7 +216,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the AWS CloudHSM cluster that is associated with the custom key\n      store is not active. Initialize and activate the cluster and try the command again. For\n      detailed instructions, see <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html\">Getting Started</a> in the <i>AWS CloudHSM User Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CloudHsmClusterNotFoundException": {
@@ -225,7 +229,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster with the specified\n      cluster ID. Retry the request with a different cluster ID.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CloudHsmClusterNotRelatedException": {
@@ -237,7 +242,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified AWS CloudHSM cluster has a different cluster\n      certificate than the original cluster. You cannot use the operation to specify an unrelated\n      cluster.</p>\n         <p>Specify a cluster that shares a backup history with the original cluster. This includes\n      clusters that were created from a backup of the current cluster, and clusters that were\n      created from the same backup that produced the current cluster.</p> \n         <p>Clusters that share a backup history have the same cluster certificate. To view the\n      cluster certificate of a cluster, use the <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html\">DescribeClusters</a> operation.</p> \n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#ConnectCustomKeyStore": {
@@ -684,7 +690,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the custom key store contains AWS KMS customer master keys\n      (CMKs). After verifying that you do not need to use the CMKs, use the <a>ScheduleKeyDeletion</a> operation to delete the CMKs. After they are deleted, you\n      can delete the custom key store.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CustomKeyStoreIdType": {
@@ -705,7 +712,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because of the <code>ConnectionState</code> of the custom key\n      store. To get the <code>ConnectionState</code> of a custom key store, use the <a>DescribeCustomKeyStores</a> operation.</p>\n         <p>This exception is thrown under the following conditions:</p>\n         <ul>\n            <li>\n               <p>You requested the <a>CreateKey</a> or <a>GenerateRandom</a>\n          operation in a custom key store that is not connected. These operations are valid only\n          when the custom key store <code>ConnectionState</code> is <code>CONNECTED</code>.</p>\n            </li>\n            <li>\n               <p>You requested the <a>UpdateCustomKeyStore</a> or <a>DeleteCustomKeyStore</a> operation on a custom key store that is not\n          disconnected. This operation is valid only when the custom key store\n            <code>ConnectionState</code> is <code>DISCONNECTED</code>.</p>\n            </li>\n            <li>\n               <p>You requested the <a>ConnectCustomKeyStore</a> operation on a custom key\n          store with a <code>ConnectionState</code> of <code>DISCONNECTING</code> or\n            <code>FAILED</code>. This operation is valid for all other <code>ConnectionState</code>\n          values.</p>\n            </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CustomKeyStoreNameInUseException": {
@@ -717,7 +725,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified custom key store name is already assigned\n      to another custom key store in the account. Try again with a custom key store name that is\n      unique in the account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CustomKeyStoreNameType": {
@@ -738,7 +747,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because AWS KMS cannot find a custom key store with the specified\n      key store name or ID.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#CustomKeyStoresList": {
@@ -1102,7 +1112,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The system timed out while trying to fulfill the request. The request can be\n      retried.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazon.trent#DescribeCustomKeyStores": {
@@ -1332,7 +1343,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified CMK is not enabled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.trent#DisconnectCustomKeyStore": {
@@ -1619,7 +1631,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified import token is expired. Use <a>GetParametersForImport</a> to get a new import token and public key, use the new\n      public key to encrypt the key material, and then try the request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#GenerateDataKey": {
@@ -2648,7 +2661,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified CMK cannot decrypt the data. The\n        <code>KeyId</code> in a <a>Decrypt</a> request and the <code>SourceKeyId</code>\n      in a <a>ReEncrypt</a> request must identify the same CMK that was used to encrypt\n      the ciphertext.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#IncorrectKeyMaterialException": {
@@ -2660,7 +2674,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the key material in the request is, expired, invalid, or\n      is not the same key material that was previously imported into this customer master key\n      (CMK).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#IncorrectTrustAnchorException": {
@@ -2672,7 +2687,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the trust anchor certificate in the request is not the\n      trust anchor certificate for the specified AWS CloudHSM cluster.</p>\n         <p>When you <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr\">initialize the cluster</a>, you create the trust anchor certificate and save it in the\n      <code>customerCA.crt</code> file.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidAliasNameException": {
@@ -2684,7 +2700,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified alias name is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidArnException": {
@@ -2696,7 +2713,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because a specified ARN, or an ARN in a key policy, is not\n      valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidCiphertextException": {
@@ -2708,7 +2726,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>From the <a>Decrypt</a> or <a>ReEncrypt</a> operation, the request was rejected because the specified ciphertext, or additional authenticated data\n      incorporated into the ciphertext, such as the encryption context, is corrupted, missing, or\n      otherwise invalid.</p>\n         <p>From the <a>ImportKeyMaterial</a> operation, the request was rejected because\n      AWS KMS could not decrypt the encrypted (wrapped) key material. </p>\n      \n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidGrantIdException": {
@@ -2720,7 +2739,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified <code>GrantId</code> is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidGrantTokenException": {
@@ -2732,7 +2752,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified grant token is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidImportTokenException": {
@@ -2744,7 +2765,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the provided import token is invalid or is associated\n      with a different customer master key (CMK).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidKeyUsageException": {
@@ -2756,7 +2778,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected for one of the following reasons: </p>\n         <ul>\n            <li>\n               <p>The <code>KeyUsage</code> value of the CMK is incompatible with the API operation.</p>\n            </li>\n            <li>\n               <p>The encryption algorithm or signing algorithm specified for the operation is incompatible with\n          the type of key material in the CMK <code>(CustomerMasterKeySpec</code>).</p>\n            </li>\n         </ul>\n         <p>For encrypting, decrypting, re-encrypting, and generating data keys, the <code>KeyUsage</code> must be\n        <code>ENCRYPT_DECRYPT</code>. For signing and verifying, the <code>KeyUsage</code> must be\n        <code>SIGN_VERIFY</code>. To find the <code>KeyUsage</code> of a CMK, use the <a>DescribeKey</a> operation.</p>\n         <p>To find the encryption or signing algorithms supported for a particular CMK, use the <a>DescribeKey</a> operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#InvalidMarkerException": {
@@ -2768,7 +2791,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the marker that specifies where pagination should next\n      begin is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#KMSInternalException": {
@@ -2780,7 +2804,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because an internal exception occurred. The request can be\n      retried.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.trent#KMSInvalidStateException": {
@@ -2792,7 +2817,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the state of the specified resource is not valid for this\n      request.</p>\n         <p>For more information about how key state affects the use of a CMK, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">How Key State Affects Use of a\n        Customer Master Key</a> in the <i>\n               <i>AWS Key Management Service Developer Guide</i>\n            </i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.trent#KeyIdType": {
@@ -3000,7 +3026,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified CMK was not available. You can retry the\n      request.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.trent#KeyUsageType": {
@@ -3025,7 +3052,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because a limit was exceeded. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/limits.html\">Limits</a> in the\n      <i>AWS Key Management Service Developer Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#LimitType": {
@@ -3490,7 +3518,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified policy is not syntactically or semantically\n      correct.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#MarkerType": {
@@ -3525,7 +3554,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because the specified entity or resource could not be\n      found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.trent#NumberOfBytesType": {
@@ -4154,7 +4184,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because one or more tags are not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#TagKeyList": {
@@ -4394,7 +4425,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Key Management Service"
+        "smithy.api#title": "AWS Key Management Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "https://trent.amazonaws.com/doc/2014-11-01/"
+        }
       }
     },
     "com.amazon.trent#TrustAnchorCertificateType": {
@@ -4415,7 +4449,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was rejected because a specified parameter is not supported or a specified\n      resource is not valid for this operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.trent#UntagResource": {

--- a/codegen/sdk-codegen/aws-models/license-manager.2018-08-01.json
+++ b/codegen/sdk-codegen/aws-models/license-manager.2018-08-01.json
@@ -94,7 +94,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS License Manager"
+        "smithy.api#title": "AWS License Manager",
+        "smithy.api#xmlNamespace": {
+          "uri": "https://license-manager.amazonaws.com/doc/2018_08_01"
+        }
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#AccessDeniedException": {
@@ -106,7 +109,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Access to resource denied.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 401
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#AuthorizationException": {
@@ -118,7 +122,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The AWS user account does not have permission to perform the action. Check the IAM\n         policy associated with this account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#AutomatedDiscoveryInformation": {
@@ -337,7 +342,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A dependency required to run the API is missing.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 424
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#Filter": {
@@ -369,7 +375,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request uses too many filters or too many filter values.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#FilterName": {
@@ -381,13 +388,19 @@
     "com.amazonaws.license.manager.V2018_08_01#FilterValues": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.license.manager.V2018_08_01#FilterValue"
+        "target": "com.amazonaws.license.manager.V2018_08_01#FilterValue",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#Filters": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.license.manager.V2018_08_01#Filter"
+        "target": "com.amazonaws.license.manager.V2018_08_01#Filter",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#GetLicenseConfiguration": {
@@ -606,7 +619,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>One or more parameter values are not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#InvalidResourceStateException": {
@@ -618,7 +632,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>License Manager cannot allocate a license to a resource because of its state. </p>\n         <p>For example, you cannot allocate a license to an instance in the process of shutting\n         down.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#InventoryFilter": {
@@ -990,7 +1005,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You do not have enough licenses available to support a new resource launch.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 412
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#ListAssociationsForLicenseConfiguration": {
@@ -1632,7 +1648,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Too many requests have been submitted. Try again after a brief wait.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#ResourceInventory": {
@@ -1694,7 +1711,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Your resource limits have been exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#ResourceType": {
@@ -1728,7 +1746,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The server experienced an internal error. Try again.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.license.manager.V2018_08_01#String": {

--- a/codegen/sdk-codegen/aws-models/lightsail.2016-11-28.json
+++ b/codegen/sdk-codegen/aws-models/lightsail.2016-11-28.json
@@ -43,7 +43,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Lightsail throws this exception when the user cannot be authenticated or uses invalid\n      credentials to access a resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.lightsail#AccessDirection": {
@@ -77,7 +78,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Lightsail throws this exception when an account is still in the setup in progress\n      state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 428
       }
     },
     "com.amazonaws.lightsail#AddOn": {
@@ -187,7 +189,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Allocates a static IP address.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Allocates a static IP address.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/AllocateStaticIp",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#AllocateStaticIpRequest": {
@@ -245,7 +252,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Attaches a block storage disk to a running or stopped Lightsail instance and exposes\n      it to the instance with the specified disk name.</p>\n         <p>The <code>attach disk</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>disk name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Attaches a block storage disk to a running or stopped Lightsail instance and exposes\n      it to the instance with the specified disk name.</p>\n         <p>The <code>attach disk</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>disk name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/AttachDisk",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#AttachDiskRequest": {
@@ -317,7 +329,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Attaches one or more Lightsail instances to a load balancer.</p>\n         <p>After some time, the instances are attached to the load balancer and the health check\n      status is available.</p>\n         <p>The <code>attach instances to load balancer</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Attaches one or more Lightsail instances to a load balancer.</p>\n         <p>After some time, the instances are attached to the load balancer and the health check\n      status is available.</p>\n         <p>The <code>attach instances to load balancer</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/AttachInstancesToLoadBalancer",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#AttachInstancesToLoadBalancerRequest": {
@@ -382,7 +399,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Attaches a Transport Layer Security (TLS) certificate to your load balancer. TLS is\n      just an updated, more secure version of Secure Socket Layer (SSL).</p>\n         <p>Once you create and validate your certificate, you can attach it to your load balancer.\n      You can also use this API to rotate the certificates on your account. Use the <code>attach\n        load balancer tls certificate</code> operation with the non-attached certificate, and it\n      will replace the existing one and become the attached certificate.</p>\n         <p>The <code>attach load balancer tls certificate</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Attaches a Transport Layer Security (TLS) certificate to your load balancer. TLS is\n      just an updated, more secure version of Secure Socket Layer (SSL).</p>\n         <p>Once you create and validate your certificate, you can attach it to your load balancer.\n      You can also use this API to rotate the certificates on your account. Use the <code>attach\n        load balancer tls certificate</code> operation with the non-attached certificate, and it\n      will replace the existing one and become the attached certificate.</p>\n         <p>The <code>attach load balancer tls certificate</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/AttachLoadBalancerTlsCertificate",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#AttachLoadBalancerTlsCertificateRequest": {
@@ -447,7 +469,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Attaches a static IP address to a specific Amazon Lightsail instance.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Attaches a static IP address to a specific Amazon Lightsail instance.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/AttachStaticIp",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#AttachStaticIpRequest": {
@@ -832,7 +859,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Closes the public ports on a specific Amazon Lightsail instance.</p>\n         <p>The <code>close instance public ports</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>instance name</code>.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Closes the public ports on a specific Amazon Lightsail instance.</p>\n         <p>The <code>close instance public ports</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>instance name</code>.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CloseInstancePublicPorts",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CloseInstancePublicPortsRequest": {
@@ -1001,7 +1033,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Copies a manual instance or disk snapshot as another manual snapshot, or copies an\n      automatic instance or disk snapshot as a manual snapshot. This operation can also be used to\n      copy a manual or automatic snapshot of an instance or a disk from one AWS Region to another\n      in Amazon Lightsail.</p>\n         <p>When copying a <i>manual snapshot</i>, be sure to define the <code>source\n        region</code>, <code>source snapshot name</code>, and <code>target snapshot name</code>\n      parameters.</p>\n         <p>When copying an <i>automatic snapshot</i>, be sure to define the\n        <code>source region</code>, <code>source resource name</code>, <code>target snapshot\n        name</code>, and either the <code>restore date</code> or the <code>use latest restorable\n        auto snapshot</code> parameters.</p>\n         <note>\n            <p>Database snapshots cannot be copied at this time.</p>\n         </note>\n      "
+        "smithy.api#documentation": "\n         <p>Copies a manual instance or disk snapshot as another manual snapshot, or copies an\n      automatic instance or disk snapshot as a manual snapshot. This operation can also be used to\n      copy a manual or automatic snapshot of an instance or a disk from one AWS Region to another\n      in Amazon Lightsail.</p>\n         <p>When copying a <i>manual snapshot</i>, be sure to define the <code>source\n        region</code>, <code>source snapshot name</code>, and <code>target snapshot name</code>\n      parameters.</p>\n         <p>When copying an <i>automatic snapshot</i>, be sure to define the\n        <code>source region</code>, <code>source resource name</code>, <code>target snapshot\n        name</code>, and either the <code>restore date</code> or the <code>use latest restorable\n        auto snapshot</code> parameters.</p>\n         <note>\n            <p>Database snapshots cannot be copied at this time.</p>\n         </note>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CopySnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CopySnapshotRequest": {
@@ -1090,7 +1127,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates an AWS CloudFormation stack, which creates a new Amazon EC2 instance from an exported\n      Amazon Lightsail snapshot. This operation results in a CloudFormation stack record that can be\n      used to track the AWS CloudFormation stack created. Use the <code>get cloud formation stack\n        records</code> operation to get a list of the CloudFormation stacks created.</p>\n         <important>\n            <p>Wait until after your new Amazon EC2 instance is created before running the <code>create\n          cloud formation stack</code> operation again with the same export snapshot record.</p>\n         </important>\n      "
+        "smithy.api#documentation": "\n         <p>Creates an AWS CloudFormation stack, which creates a new Amazon EC2 instance from an exported\n      Amazon Lightsail snapshot. This operation results in a CloudFormation stack record that can be\n      used to track the AWS CloudFormation stack created. Use the <code>get cloud formation stack\n        records</code> operation to get a list of the CloudFormation stacks created.</p>\n         <important>\n            <p>Wait until after your new Amazon EC2 instance is created before running the <code>create\n          cloud formation stack</code> operation again with the same export snapshot record.</p>\n         </important>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateCloudFormationStack",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateCloudFormationStackRequest": {
@@ -1148,7 +1190,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a block storage disk that can be attached to an Amazon Lightsail instance in the\n      same Availability Zone (e.g., <code>us-east-2a</code>).</p>\n         <p>The <code>create disk</code> operation supports tag-based access control via request\n      tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a block storage disk that can be attached to an Amazon Lightsail instance in the\n      same Availability Zone (e.g., <code>us-east-2a</code>).</p>\n         <p>The <code>create disk</code> operation supports tag-based access control via request\n      tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateDisk",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateDiskFromSnapshot": {
@@ -1183,7 +1230,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a block storage disk from a manual or automatic snapshot of a disk. The\n      resulting disk can be attached to an Amazon Lightsail instance in the same Availability Zone\n      (e.g., <code>us-east-2a</code>).</p>\n         <p>The <code>create disk from snapshot</code> operation supports tag-based access control\n      via request tags and resource tags applied to the resource identified by <code>disk snapshot\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a block storage disk from a manual or automatic snapshot of a disk. The\n      resulting disk can be attached to an Amazon Lightsail instance in the same Availability Zone\n      (e.g., <code>us-east-2a</code>).</p>\n         <p>The <code>create disk from snapshot</code> operation supports tag-based access control\n      via request tags and resource tags applied to the resource identified by <code>disk snapshot\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateDiskFromSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateDiskFromSnapshotRequest": {
@@ -1340,7 +1392,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a snapshot of a block storage disk. You can use snapshots for backups, to make\n      copies of disks, and to save data before shutting down a Lightsail instance.</p>\n         <p>You can take a snapshot of an attached disk that is in use; however, snapshots only\n      capture data that has been written to your disk at the time the snapshot command is issued.\n      This may exclude any data that has been cached by any applications or the operating system. If\n      you can pause any file systems on the disk long enough to take a snapshot, your snapshot\n      should be complete. Nevertheless, if you cannot pause all file writes to the disk, you should\n      unmount the disk from within the Lightsail instance, issue the create disk snapshot command,\n      and then remount the disk to ensure a consistent and complete snapshot. You may remount and\n      use your disk while the snapshot status is pending.</p>\n         <p>You can also use this operation to create a snapshot of an instance's system volume. You\n      might want to do this, for example, to recover data from the system volume of a botched\n      instance or to create a backup of the system volume like you would for a block storage disk.\n      To create a snapshot of a system volume, just define the <code>instance name</code> parameter\n      when issuing the snapshot command, and a snapshot of the defined instance's system volume will\n      be created. After the snapshot is available, you can create a block storage disk from the\n      snapshot and attach it to a running instance to access the data on the disk.</p>\n      \n         <p>The <code>create disk snapshot</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a snapshot of a block storage disk. You can use snapshots for backups, to make\n      copies of disks, and to save data before shutting down a Lightsail instance.</p>\n         <p>You can take a snapshot of an attached disk that is in use; however, snapshots only\n      capture data that has been written to your disk at the time the snapshot command is issued.\n      This may exclude any data that has been cached by any applications or the operating system. If\n      you can pause any file systems on the disk long enough to take a snapshot, your snapshot\n      should be complete. Nevertheless, if you cannot pause all file writes to the disk, you should\n      unmount the disk from within the Lightsail instance, issue the create disk snapshot command,\n      and then remount the disk to ensure a consistent and complete snapshot. You may remount and\n      use your disk while the snapshot status is pending.</p>\n         <p>You can also use this operation to create a snapshot of an instance's system volume. You\n      might want to do this, for example, to recover data from the system volume of a botched\n      instance or to create a backup of the system volume like you would for a block storage disk.\n      To create a snapshot of a system volume, just define the <code>instance name</code> parameter\n      when issuing the snapshot command, and a snapshot of the defined instance's system volume will\n      be created. After the snapshot is available, you can create a block storage disk from the\n      snapshot and attach it to a running instance to access the data on the disk.</p>\n      \n         <p>The <code>create disk snapshot</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateDiskSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateDiskSnapshotRequest": {
@@ -1416,7 +1473,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a domain resource for the specified domain (e.g., example.com).</p>\n         <p>The <code>create domain</code> operation supports tag-based access control via request\n      tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a domain resource for the specified domain (e.g., example.com).</p>\n         <p>The <code>create domain</code> operation supports tag-based access control via request\n      tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateDomain",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateDomainEntry": {
@@ -1451,7 +1513,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates one of the following entry records associated with the domain: Address (A),\n      canonical name (CNAME), mail exchanger (MX), name server (NS), start of authority (SOA),\n      service locator (SRV), or text (TXT).</p>\n         <p>The <code>create domain entry</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>domain name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates one of the following entry records associated with the domain: Address (A),\n      canonical name (CNAME), mail exchanger (MX), name server (NS), start of authority (SOA),\n      service locator (SRV), or text (TXT).</p>\n         <p>The <code>create domain entry</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>domain name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateDomainEntry",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateDomainEntryRequest": {
@@ -1545,7 +1612,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a snapshot of a specific virtual private server, or\n        <i>instance</i>. You can use a snapshot to create a new instance that is based\n      on that snapshot.</p>\n         <p>The <code>create instance snapshot</code> operation supports tag-based access control\n      via request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a snapshot of a specific virtual private server, or\n        <i>instance</i>. You can use a snapshot to create a new instance that is based\n      on that snapshot.</p>\n         <p>The <code>create instance snapshot</code> operation supports tag-based access control\n      via request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateInstanceSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateInstanceSnapshotRequest": {
@@ -1616,7 +1688,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates one or more Amazon Lightsail instances.</p>\n         <p>The <code>create instances</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates one or more Amazon Lightsail instances.</p>\n         <p>The <code>create instances</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateInstances",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateInstancesFromSnapshot": {
@@ -1651,7 +1728,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates one or more new instances from a manual or automatic snapshot of an\n      instance.</p>\n         <p>The <code>create instances from snapshot</code> operation supports tag-based access\n      control via request tags and resource tags applied to the resource identified by\n        <code>instance snapshot name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates one or more new instances from a manual or automatic snapshot of an\n      instance.</p>\n         <p>The <code>create instances from snapshot</code> operation supports tag-based access\n      control via request tags and resource tags applied to the resource identified by\n        <code>instance snapshot name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateInstancesFromSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateInstancesFromSnapshotRequest": {
@@ -1852,7 +1934,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates an SSH key pair.</p>\n         <p>The <code>create key pair</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates an SSH key pair.</p>\n         <p>The <code>create key pair</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateKeyPair",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateKeyPairRequest": {
@@ -1934,7 +2021,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a Lightsail load balancer. To learn more about deciding whether to load\n      balance your application, see <a href=\"https://lightsail.aws.amazon.com/ls/docs/how-to/article/configure-lightsail-instances-for-load-balancing\">Configure your Lightsail instances for load balancing</a>. You can create up to 5\n      load balancers per AWS Region in your account.</p>\n         <p>When you create a load balancer, you can specify a unique name and port settings. To\n      change additional load balancer settings, use the <code>UpdateLoadBalancerAttribute</code>\n      operation.</p>\n         <p>The <code>create load balancer</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a Lightsail load balancer. To learn more about deciding whether to load\n      balance your application, see <a href=\"https://lightsail.aws.amazon.com/ls/docs/how-to/article/configure-lightsail-instances-for-load-balancing\">Configure your Lightsail instances for load balancing</a>. You can create up to 5\n      load balancers per AWS Region in your account.</p>\n         <p>When you create a load balancer, you can specify a unique name and port settings. To\n      change additional load balancer settings, use the <code>UpdateLoadBalancerAttribute</code>\n      operation.</p>\n         <p>The <code>create load balancer</code> operation supports tag-based access control via\n      request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateLoadBalancer",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateLoadBalancerRequest": {
@@ -2029,7 +2121,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a Lightsail load balancer TLS certificate.</p>\n         <p>TLS is just an updated, more secure version of Secure Socket Layer (SSL).</p>\n         <p>The <code>create load balancer tls certificate</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a Lightsail load balancer TLS certificate.</p>\n         <p>TLS is just an updated, more secure version of Secure Socket Layer (SSL).</p>\n         <p>The <code>create load balancer tls certificate</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateLoadBalancerTlsCertificate",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateLoadBalancerTlsCertificateRequest": {
@@ -2113,7 +2210,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a new database in Amazon Lightsail.</p>\n         <p>The <code>create relational database</code> operation supports tag-based access control\n      via request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a new database in Amazon Lightsail.</p>\n         <p>The <code>create relational database</code> operation supports tag-based access control\n      via request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateRelationalDatabase",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateRelationalDatabaseFromSnapshot": {
@@ -2148,7 +2250,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a new database from an existing database snapshot in Amazon Lightsail.</p>\n         <p>You can create a new database from a snapshot in if something goes wrong with your\n      original database, or to change it to a different plan, such as a high availability or\n      standard plan.</p>\n         <p>The <code>create relational database from snapshot</code> operation supports tag-based\n      access control via request tags and resource tags applied to the resource identified by\n      relationalDatabaseSnapshotName. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a new database from an existing database snapshot in Amazon Lightsail.</p>\n         <p>You can create a new database from a snapshot in if something goes wrong with your\n      original database, or to change it to a different plan, such as a high availability or\n      standard plan.</p>\n         <p>The <code>create relational database from snapshot</code> operation supports tag-based\n      access control via request tags and resource tags applied to the resource identified by\n      relationalDatabaseSnapshotName. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateRelationalDatabaseFromSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateRelationalDatabaseFromSnapshotRequest": {
@@ -2341,7 +2448,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Creates a snapshot of your database in Amazon Lightsail. You can use snapshots for\n      backups, to make copies of a database, and to save data before deleting a database.</p>\n         <p>The <code>create relational database snapshot</code> operation supports tag-based\n      access control via request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Creates a snapshot of your database in Amazon Lightsail. You can use snapshots for\n      backups, to make copies of a database, and to save data before deleting a database.</p>\n         <p>The <code>create relational database snapshot</code> operation supports tag-based\n      access control via request tags. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/CreateRelationalDatabaseSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#CreateRelationalDatabaseSnapshotRequest": {
@@ -2409,7 +2521,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes an automatic snapshot for an instance or disk.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes an automatic snapshot for an instance or disk.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteAutoSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteAutoSnapshotRequest": {
@@ -2474,7 +2591,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes the specified block storage disk. The disk must be in the\n        <code>available</code> state (not attached to a Lightsail instance).</p>\n         <note>\n            <p>The disk may remain in the <code>deleting</code> state for several minutes.</p>\n\n         </note>\n         <p>The <code>delete disk</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>disk name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes the specified block storage disk. The disk must be in the\n        <code>available</code> state (not attached to a Lightsail instance).</p>\n         <note>\n            <p>The disk may remain in the <code>deleting</code> state for several minutes.</p>\n\n         </note>\n         <p>The <code>delete disk</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>disk name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteDisk",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteDiskRequest": {
@@ -2538,7 +2660,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes the specified disk snapshot.</p>\n         <p>When you make periodic snapshots of a disk, the snapshots are incremental, and only the\n      blocks on the device that have changed since your last snapshot are saved in the new snapshot.\n      When you delete a snapshot, only the data not needed for any other snapshot is removed. So\n      regardless of which prior snapshots have been deleted, all active snapshots will have access\n      to all the information needed to restore the disk.</p>\n         <p>The <code>delete disk snapshot</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>disk snapshot name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes the specified disk snapshot.</p>\n         <p>When you make periodic snapshots of a disk, the snapshots are incremental, and only the\n      blocks on the device that have changed since your last snapshot are saved in the new snapshot.\n      When you delete a snapshot, only the data not needed for any other snapshot is removed. So\n      regardless of which prior snapshots have been deleted, all active snapshots will have access\n      to all the information needed to restore the disk.</p>\n         <p>The <code>delete disk snapshot</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>disk snapshot name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteDiskSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteDiskSnapshotRequest": {
@@ -2596,7 +2723,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes the specified domain recordset and all of its domain records.</p>\n         <p>The <code>delete domain</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>domain name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes the specified domain recordset and all of its domain records.</p>\n         <p>The <code>delete domain</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>domain name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteDomain",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteDomainEntry": {
@@ -2631,7 +2763,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes a specific domain entry.</p>\n         <p>The <code>delete domain entry</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>domain name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes a specific domain entry.</p>\n         <p>The <code>delete domain entry</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>domain name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteDomainEntry",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteDomainEntryRequest": {
@@ -2719,7 +2856,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes an Amazon Lightsail instance.</p>\n         <p>The <code>delete instance</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes an Amazon Lightsail instance.</p>\n         <p>The <code>delete instance</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteInstance",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteInstanceRequest": {
@@ -2783,7 +2925,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes a specific snapshot of a virtual private server (or\n        <i>instance</i>).</p>\n         <p>The <code>delete instance snapshot</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by <code>instance snapshot name</code>.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes a specific snapshot of a virtual private server (or\n        <i>instance</i>).</p>\n         <p>The <code>delete instance snapshot</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by <code>instance snapshot name</code>.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteInstanceSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteInstanceSnapshotRequest": {
@@ -2841,7 +2988,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes a specific SSH key pair.</p>\n         <p>The <code>delete key pair</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>key pair name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes a specific SSH key pair.</p>\n         <p>The <code>delete key pair</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>key pair name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteKeyPair",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteKeyPairRequest": {
@@ -2899,7 +3051,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes the known host key or certificate used by the Amazon Lightsail browser-based SSH or\n      RDP clients to authenticate an instance. This operation enables the Lightsail browser-based\n      SSH or RDP clients to connect to the instance after a host key mismatch.</p>\n         <important>\n            <p>Perform this operation only if you were expecting the host key or certificate mismatch\n        or if you are familiar with the new host key or certificate on the instance. For more\n        information, see <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-troubleshooting-browser-based-ssh-rdp-client-connection\">Troubleshooting connection issues when using the Amazon Lightsail browser-based SSH or RDP\n          client</a>.</p>\n         </important>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes the known host key or certificate used by the Amazon Lightsail browser-based SSH or\n      RDP clients to authenticate an instance. This operation enables the Lightsail browser-based\n      SSH or RDP clients to connect to the instance after a host key mismatch.</p>\n         <important>\n            <p>Perform this operation only if you were expecting the host key or certificate mismatch\n        or if you are familiar with the new host key or certificate on the instance. For more\n        information, see <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-troubleshooting-browser-based-ssh-rdp-client-connection\">Troubleshooting connection issues when using the Amazon Lightsail browser-based SSH or RDP\n          client</a>.</p>\n         </important>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteKnownHostKeys",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteKnownHostKeysRequest": {
@@ -2957,7 +3114,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes a Lightsail load balancer and all its associated SSL/TLS certificates. Once\n      the load balancer is deleted, you will need to create a new load balancer, create a new\n      certificate, and verify domain ownership again.</p>\n         <p>The <code>delete load balancer</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>load balancer name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes a Lightsail load balancer and all its associated SSL/TLS certificates. Once\n      the load balancer is deleted, you will need to create a new load balancer, create a new\n      certificate, and verify domain ownership again.</p>\n         <p>The <code>delete load balancer</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>load balancer name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteLoadBalancer",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteLoadBalancerRequest": {
@@ -3015,7 +3177,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes an SSL/TLS certificate associated with a Lightsail load balancer.</p>\n         <p>The <code>delete load balancer tls certificate</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes an SSL/TLS certificate associated with a Lightsail load balancer.</p>\n         <p>The <code>delete load balancer tls certificate</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteLoadBalancerTlsCertificate",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteLoadBalancerTlsCertificateRequest": {
@@ -3086,7 +3253,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes a database in Amazon Lightsail.</p>\n         <p>The <code>delete relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes a database in Amazon Lightsail.</p>\n         <p>The <code>delete relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteRelationalDatabase",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteRelationalDatabaseRequest": {
@@ -3156,7 +3328,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes a database snapshot in Amazon Lightsail.</p>\n         <p>The <code>delete relational database snapshot</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by relationalDatabaseName.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes a database snapshot in Amazon Lightsail.</p>\n         <p>The <code>delete relational database snapshot</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by relationalDatabaseName.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DeleteRelationalDatabaseSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DeleteRelationalDatabaseSnapshotRequest": {
@@ -3234,7 +3411,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Detaches a stopped block storage disk from a Lightsail instance. Make sure to unmount\n      any file systems on the device within your operating system before stopping the instance and\n      detaching the disk.</p>\n         <p>The <code>detach disk</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>disk name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Detaches a stopped block storage disk from a Lightsail instance. Make sure to unmount\n      any file systems on the device within your operating system before stopping the instance and\n      detaching the disk.</p>\n         <p>The <code>detach disk</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>disk name</code>. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DetachDisk",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DetachDiskRequest": {
@@ -3292,7 +3474,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Detaches the specified instances from a Lightsail load balancer.</p>\n         <p>This operation waits until the instances are no longer needed before they are detached\n      from the load balancer.</p>\n         <p>The <code>detach instances from load balancer</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Detaches the specified instances from a Lightsail load balancer.</p>\n         <p>This operation waits until the instances are no longer needed before they are detached\n      from the load balancer.</p>\n         <p>The <code>detach instances from load balancer</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DetachInstancesFromLoadBalancer",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DetachInstancesFromLoadBalancerRequest": {
@@ -3357,7 +3544,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Detaches a static IP from the Amazon Lightsail instance to which it is\n      attached.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Detaches a static IP from the Amazon Lightsail instance to which it is\n      attached.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DetachStaticIp",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DetachStaticIpRequest": {
@@ -3412,7 +3604,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Disables an add-on for an Amazon Lightsail resource. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-configuring-automatic-snapshots\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Disables an add-on for an Amazon Lightsail resource. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-configuring-automatic-snapshots\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DisableAddOn",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DisableAddOnRequest": {
@@ -3955,7 +4152,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Downloads the default SSH key pair from the user's account.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Downloads the default SSH key pair from the user's account.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/DownloadDefaultKeyPair",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#DownloadDefaultKeyPairRequest": {
@@ -4008,7 +4210,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Enables or modifies an add-on for an Amazon Lightsail resource. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-configuring-automatic-snapshots\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Enables or modifies an add-on for an Amazon Lightsail resource. For more information, see\n      the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-configuring-automatic-snapshots\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/EnableAddOn",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#EnableAddOnRequest": {
@@ -4073,7 +4280,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Exports an Amazon Lightsail instance or block storage disk snapshot to Amazon Elastic Compute Cloud (Amazon EC2).\n      This operation results in an export snapshot record that can be used with the <code>create\n        cloud formation stack</code> operation to create new Amazon EC2 instances.</p>\n         <p>Exported instance snapshots appear in Amazon EC2 as Amazon Machine Images (AMIs), and the\n      instance system disk appears as an Amazon Elastic Block Store (Amazon EBS) volume. Exported disk snapshots appear in\n      Amazon EC2 as Amazon EBS volumes. Snapshots are exported to the same Amazon Web Services Region in Amazon EC2 as the\n      source Lightsail snapshot.</p>\n         <p></p>\n         <p>The <code>export snapshot</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>source snapshot name</code>. For\n      more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n         <note>\n            <p>Use the <code>get instance snapshots</code> or <code>get disk snapshots</code>\n        operations to get a list of snapshots that you can export to Amazon EC2.</p>\n         </note>\n      "
+        "smithy.api#documentation": "\n         <p>Exports an Amazon Lightsail instance or block storage disk snapshot to Amazon Elastic Compute Cloud (Amazon EC2).\n      This operation results in an export snapshot record that can be used with the <code>create\n        cloud formation stack</code> operation to create new Amazon EC2 instances.</p>\n         <p>Exported instance snapshots appear in Amazon EC2 as Amazon Machine Images (AMIs), and the\n      instance system disk appears as an Amazon Elastic Block Store (Amazon EBS) volume. Exported disk snapshots appear in\n      Amazon EC2 as Amazon EBS volumes. Snapshots are exported to the same Amazon Web Services Region in Amazon EC2 as the\n      source Lightsail snapshot.</p>\n         <p></p>\n         <p>The <code>export snapshot</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>source snapshot name</code>. For\n      more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n         <note>\n            <p>Use the <code>get instance snapshots</code> or <code>get disk snapshots</code>\n        operations to get a list of snapshots that you can export to Amazon EC2.</p>\n         </note>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/ExportSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#ExportSnapshotRecord": {
@@ -4262,7 +4474,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the names of all active (not deleted) resources.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the names of all active (not deleted) resources.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetActiveNames",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetActiveNamesRequest": {
@@ -4322,7 +4539,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the available automatic snapshots for the specified resource name. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-configuring-automatic-snapshots\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the available automatic snapshots for the specified resource name. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-configuring-automatic-snapshots\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetAutoSnapshots",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetAutoSnapshotsRequest": {
@@ -4392,7 +4614,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the list of available instance images, or <i>blueprints</i>. You\n      can use a blueprint to create a new instance already running a specific operating system, as\n      well as a preinstalled app or development stack. The software each instance is running depends\n      on the blueprint image you choose.</p>\n         <note>\n            <p>Use active blueprints when creating new instances. Inactive blueprints are listed to\n        support customers with existing instances and are not necessarily available to create new\n        instances. Blueprints are marked inactive when they become outdated due to operating system\n        updates or new application releases.</p>\n         </note>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the list of available instance images, or <i>blueprints</i>. You\n      can use a blueprint to create a new instance already running a specific operating system, as\n      well as a preinstalled app or development stack. The software each instance is running depends\n      on the blueprint image you choose.</p>\n         <note>\n            <p>Use active blueprints when creating new instances. Inactive blueprints are listed to\n        support customers with existing instances and are not necessarily available to create new\n        instances. Blueprints are marked inactive when they become outdated due to operating system\n        updates or new application releases.</p>\n         </note>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetBlueprints",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetBlueprintsRequest": {
@@ -4461,7 +4688,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the list of bundles that are available for purchase. A bundle describes the\n      specs for your virtual private server (or <i>instance</i>).</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the list of bundles that are available for purchase. A bundle describes the\n      specs for your virtual private server (or <i>instance</i>).</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetBundles",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetBundlesRequest": {
@@ -4530,7 +4762,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the CloudFormation stack record created as a result of the <code>create cloud\n        formation stack</code> operation.</p>\n         <p>An AWS CloudFormation stack is used to create a new Amazon EC2 instance from an exported Lightsail\n      snapshot.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the CloudFormation stack record created as a result of the <code>create cloud\n        formation stack</code> operation.</p>\n         <p>An AWS CloudFormation stack is used to create a new Amazon EC2 instance from an exported Lightsail\n      snapshot.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetCloudFormationStackRecords",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetCloudFormationStackRecordsRequest": {
@@ -4593,7 +4830,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific block storage disk.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific block storage disk.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetDisk",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetDiskRequest": {
@@ -4651,7 +4893,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific block storage disk snapshot.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific block storage disk snapshot.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetDiskSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetDiskSnapshotRequest": {
@@ -4709,7 +4956,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all block storage disk snapshots in your AWS account and\n      region.</p>\n         <p>If you are describing a long list of disk snapshots, you can paginate the output to\n      make the list more manageable. You can use the pageToken and nextPageToken values to retrieve\n      the next items in the list.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all block storage disk snapshots in your AWS account and\n      region.</p>\n         <p>If you are describing a long list of disk snapshots, you can paginate the output to\n      make the list more manageable. You can use the pageToken and nextPageToken values to retrieve\n      the next items in the list.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetDiskSnapshots",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetDiskSnapshotsRequest": {
@@ -4772,7 +5024,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all block storage disks in your AWS account and\n      region.</p>\n         <p>If you are describing a long list of disks, you can paginate the output to make the\n      list more manageable. You can use the pageToken and nextPageToken values to retrieve the next\n      items in the list.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all block storage disks in your AWS account and\n      region.</p>\n         <p>If you are describing a long list of disks, you can paginate the output to make the\n      list more manageable. You can use the pageToken and nextPageToken values to retrieve the next\n      items in the list.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetDisks",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetDisksRequest": {
@@ -4835,7 +5092,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific domain recordset.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific domain recordset.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetDomain",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetDomainRequest": {
@@ -4893,7 +5155,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns a list of all domains in the user's account.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns a list of all domains in the user's account.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetDomains",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetDomainsRequest": {
@@ -4956,7 +5223,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the export snapshot record created as a result of the <code>export snapshot</code>\n      operation.</p>\n         <p>An export snapshot record can be used to create a new Amazon EC2 instance and its related\n      resources with the <code>create cloud formation stack</code> operation.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the export snapshot record created as a result of the <code>export snapshot</code>\n      operation.</p>\n         <p>An export snapshot record can be used to create a new Amazon EC2 instance and its related\n      resources with the <code>create cloud formation stack</code> operation.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetExportSnapshotRecords",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetExportSnapshotRecordsRequest": {
@@ -5019,7 +5291,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific Amazon Lightsail instance, which is a virtual\n      private server.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific Amazon Lightsail instance, which is a virtual\n      private server.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstance",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstanceAccessDetails": {
@@ -5054,7 +5331,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns temporary SSH keys you can use to connect to a specific virtual private server,\n      or <i>instance</i>.</p>\n         <p>The <code>get instance access details</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>instance name</code>.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns temporary SSH keys you can use to connect to a specific virtual private server,\n      or <i>instance</i>.</p>\n         <p>The <code>get instance access details</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>instance name</code>.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstanceAccessDetails",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstanceAccessDetailsRequest": {
@@ -5118,7 +5400,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the data points for the specified Amazon Lightsail instance metric, given an\n      instance name.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the data points for the specified Amazon Lightsail instance metric, given an\n      instance name.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstanceMetricData",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstanceMetricDataRequest": {
@@ -5224,7 +5511,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the port states for a specific virtual private server, or\n        <i>instance</i>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the port states for a specific virtual private server, or\n        <i>instance</i>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstancePortStates",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstancePortStatesRequest": {
@@ -5305,7 +5597,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific instance snapshot.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific instance snapshot.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstanceSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstanceSnapshotRequest": {
@@ -5363,7 +5660,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns all instance snapshots for the user's account.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns all instance snapshots for the user's account.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstanceSnapshots",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstanceSnapshotsRequest": {
@@ -5426,7 +5728,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the state of a specific instance. Works on one instance at a time.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the state of a specific instance. Works on one instance at a time.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstanceState",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstanceStateRequest": {
@@ -5484,7 +5791,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all Amazon Lightsail virtual private servers, or\n        <i>instances</i>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all Amazon Lightsail virtual private servers, or\n        <i>instances</i>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetInstances",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetInstancesRequest": {
@@ -5547,7 +5859,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific key pair.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific key pair.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetKeyPair",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetKeyPairRequest": {
@@ -5605,7 +5922,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all key pairs in the user's account.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all key pairs in the user's account.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetKeyPairs",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetKeyPairsRequest": {
@@ -5668,7 +5990,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about the specified Lightsail load balancer.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about the specified Lightsail load balancer.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetLoadBalancer",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetLoadBalancerMetricData": {
@@ -5703,7 +6030,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about health metrics for your Lightsail load balancer.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about health metrics for your Lightsail load balancer.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetLoadBalancerMetricData",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetLoadBalancerMetricDataRequest": {
@@ -5832,7 +6164,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about the TLS certificates that are associated with the specified\n      Lightsail load balancer.</p>\n         <p>TLS is just an updated, more secure version of Secure Socket Layer (SSL).</p>\n         <p>You can have a maximum of 2 certificates associated with a Lightsail load balancer.\n      One is active and the other is inactive.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about the TLS certificates that are associated with the specified\n      Lightsail load balancer.</p>\n         <p>TLS is just an updated, more secure version of Secure Socket Layer (SSL).</p>\n         <p>You can have a maximum of 2 certificates associated with a Lightsail load balancer.\n      One is active and the other is inactive.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetLoadBalancerTlsCertificates",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetLoadBalancerTlsCertificatesRequest": {
@@ -5890,7 +6227,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all load balancers in an account.</p>\n         <p>If you are describing a long list of load balancers, you can paginate the output to\n      make the list more manageable. You can use the pageToken and nextPageToken values to retrieve\n      the next items in the list.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all load balancers in an account.</p>\n         <p>If you are describing a long list of load balancers, you can paginate the output to\n      make the list more manageable. You can use the pageToken and nextPageToken values to retrieve\n      the next items in the list.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetLoadBalancers",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetLoadBalancersRequest": {
@@ -5953,7 +6295,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific operation. Operations include events such as when\n      you create an instance, allocate a static IP, attach a static IP, and so on.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific operation. Operations include events such as when\n      you create an instance, allocate a static IP, attach a static IP, and so on.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetOperation",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetOperationRequest": {
@@ -6011,7 +6358,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all operations.</p>\n         <p>Results are returned from oldest to newest, up to a maximum of 200. Results can be\n      paged by making each subsequent call to <code>GetOperations</code> use the maximum (last)\n        <code>statusChangedAt</code> value from the previous request.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all operations.</p>\n         <p>Results are returned from oldest to newest, up to a maximum of 200. Results can be\n      paged by making each subsequent call to <code>GetOperations</code> use the maximum (last)\n        <code>statusChangedAt</code> value from the previous request.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetOperations",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetOperationsForResource": {
@@ -6046,7 +6398,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Gets operations for a specific resource (e.g., an instance or a static IP).</p>\n      "
+        "smithy.api#documentation": "\n         <p>Gets operations for a specific resource (e.g., an instance or a static IP).</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetOperationsForResource",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetOperationsForResourceRequest": {
@@ -6151,7 +6508,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns a list of all valid regions for Amazon Lightsail. Use the <code>include\n        availability zones</code> parameter to also return the Availability Zones in a\n      region.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns a list of all valid regions for Amazon Lightsail. Use the <code>include\n        availability zones</code> parameter to also return the Availability Zones in a\n      region.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRegions",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRegionsRequest": {
@@ -6214,7 +6576,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific database in Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific database in Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabase",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseBlueprints": {
@@ -6249,7 +6616,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns a list of available database blueprints in Amazon Lightsail. A blueprint\n      describes the major engine version of a database.</p>\n         <p>You can use a blueprint ID to create a new database that runs a specific database\n      engine.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns a list of available database blueprints in Amazon Lightsail. A blueprint\n      describes the major engine version of a database.</p>\n         <p>You can use a blueprint ID to create a new database that runs a specific database\n      engine.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseBlueprints",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseBlueprintsRequest": {
@@ -6312,7 +6684,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the list of bundles that are available in Amazon Lightsail. A bundle describes\n      the performance specifications for a database.</p>\n         <p>You can use a bundle ID to create a new database with explicit performance\n      specifications.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the list of bundles that are available in Amazon Lightsail. A bundle describes\n      the performance specifications for a database.</p>\n         <p>You can use a bundle ID to create a new database with explicit performance\n      specifications.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseBundles",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseBundlesRequest": {
@@ -6375,7 +6752,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns a list of events for a specific database in Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns a list of events for a specific database in Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseEvents",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseEventsRequest": {
@@ -6451,7 +6833,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns a list of log events for a database in Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns a list of log events for a database in Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseLogEvents",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseLogEventsRequest": {
@@ -6552,7 +6939,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns a list of available log streams for a specific database in\n      Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns a list of available log streams for a specific database in\n      Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseLogStreams",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseLogStreamsRequest": {
@@ -6610,7 +7002,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the current, previous, or pending versions of the master user password for a\n      Lightsail database.</p>\n         <p>The <code>GetRelationalDatabaseMasterUserPassword</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by\n      relationalDatabaseName.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the current, previous, or pending versions of the master user password for a\n      Lightsail database.</p>\n         <p>The <code>GetRelationalDatabaseMasterUserPassword</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by\n      relationalDatabaseName.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseMasterUserPassword",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseMasterUserPasswordRequest": {
@@ -6680,7 +7077,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns the data points of the specified metric for a database in\n      Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns the data points of the specified metric for a database in\n      Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseMetricData",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseMetricDataRequest": {
@@ -6786,7 +7188,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns all of the runtime parameters offered by the underlying database software, or\n      engine, for a specific database in Amazon Lightsail.</p>\n         <p>In addition to the parameter names and values, this operation returns other information\n      about each parameter. This information includes whether changes require a reboot, whether the\n      parameter is modifiable, the allowed values, and the data types.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns all of the runtime parameters offered by the underlying database software, or\n      engine, for a specific database in Amazon Lightsail.</p>\n         <p>In addition to the parameter names and values, this operation returns other information\n      about each parameter. This information includes whether changes require a reboot, whether the\n      parameter is modifiable, the allowed values, and the data types.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseParameters",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseParametersRequest": {
@@ -6879,7 +7286,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific database snapshot in Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific database snapshot in Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseSnapshot",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseSnapshotRequest": {
@@ -6937,7 +7349,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all of your database snapshots in Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all of your database snapshots in Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabaseSnapshots",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabaseSnapshotsRequest": {
@@ -7000,7 +7417,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all of your databases in Amazon Lightsail.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all of your databases in Amazon Lightsail.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetRelationalDatabases",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetRelationalDatabasesRequest": {
@@ -7063,7 +7485,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about a specific static IP.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about a specific static IP.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetStaticIp",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetStaticIpRequest": {
@@ -7121,7 +7548,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns information about all static IPs in the user's account.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns information about all static IPs in the user's account.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/GetStaticIps",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#GetStaticIpsRequest": {
@@ -7240,7 +7672,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Imports a public SSH key from a specific key pair.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Imports a public SSH key from a specific key pair.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/ImportKeyPair",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#ImportKeyPairRequest": {
@@ -8007,7 +8444,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Lightsail throws this exception when user input does not conform to the validation\n      rules of an input field.</p>\n         <note>\n            <p>Domain-related APIs are only available in the N. Virginia (us-east-1) Region. Please\n        set your AWS Region configuration to us-east-1 to create, view, or edit these\n        resources.</p>\n         </note>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.lightsail#IpAddress": {
@@ -8054,7 +8492,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Returns a Boolean value indicating whether your Lightsail VPC is peered.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Returns a Boolean value indicating whether your Lightsail VPC is peered.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/IsVpcPeered",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#IsVpcPeeredRequest": {
@@ -9355,7 +9798,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Lightsail throws this exception when it cannot find a resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.lightsail#OpenInstancePublicPorts": {
@@ -9390,7 +9834,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Adds public ports to an Amazon Lightsail instance.</p>\n         <p>The <code>open instance public ports</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Adds public ports to an Amazon Lightsail instance.</p>\n         <p>The <code>open instance public ports</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/OpenInstancePublicPorts",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#OpenInstancePublicPortsRequest": {
@@ -9521,7 +9970,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Lightsail throws this exception when an operation fails to execute.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.lightsail#OperationList": {
@@ -9752,7 +10202,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Tries to peer the Lightsail VPC with the user's default VPC.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Tries to peer the Lightsail VPC with the user's default VPC.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/PeerVpc",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#PeerVpcRequest": {
@@ -9952,7 +10407,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Sets the specified open ports for an Amazon Lightsail instance, and closes all ports for\n      every protocol not included in the current request.</p>\n         <p>The <code>put instance public ports</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Sets the specified open ports for an Amazon Lightsail instance, and closes all ports for\n      every protocol not included in the current request.</p>\n         <p>The <code>put instance public ports</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/PutInstancePublicPorts",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#PutInstancePublicPortsRequest": {
@@ -10017,7 +10477,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Restarts a specific instance.</p>\n         <p>The <code>reboot instance</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Restarts a specific instance.</p>\n         <p>The <code>reboot instance</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/RebootInstance",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#RebootInstanceRequest": {
@@ -10075,7 +10540,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Restarts a specific database in Amazon Lightsail.</p>\n         <p>The <code>reboot relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Restarts a specific database in Amazon Lightsail.</p>\n         <p>The <code>reboot relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/RebootRelationalDatabase",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#RebootRelationalDatabaseRequest": {
@@ -10831,7 +11301,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes a specific static IP from your account.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes a specific static IP from your account.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/ReleaseStaticIp",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#ReleaseStaticIpRequest": {
@@ -10968,7 +11443,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A general service exception.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.lightsail#StartInstance": {
@@ -11003,7 +11479,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Starts a specific Amazon Lightsail instance from a stopped state. To restart an\n      instance, use the <code>reboot instance</code> operation.</p>\n         <note>\n            <p>When you start a stopped instance, Lightsail assigns a new public IP address to the\n        instance. To use the same IP address after stopping and starting an instance, create a\n        static IP address and attach it to the instance. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/lightsail-create-static-ip\">Lightsail Dev Guide</a>.</p>\n         </note>\n         <p>The <code>start instance</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Starts a specific Amazon Lightsail instance from a stopped state. To restart an\n      instance, use the <code>reboot instance</code> operation.</p>\n         <note>\n            <p>When you start a stopped instance, Lightsail assigns a new public IP address to the\n        instance. To use the same IP address after stopping and starting an instance, create a\n        static IP address and attach it to the instance. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/lightsail-create-static-ip\">Lightsail Dev Guide</a>.</p>\n         </note>\n         <p>The <code>start instance</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>instance name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/StartInstance",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#StartInstanceRequest": {
@@ -11061,7 +11542,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Starts a specific database from a stopped state in Amazon Lightsail. To restart a\n      database, use the <code>reboot relational database</code> operation.</p>\n         <p>The <code>start relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Starts a specific database from a stopped state in Amazon Lightsail. To restart a\n      database, use the <code>reboot relational database</code> operation.</p>\n         <p>The <code>start relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/StartRelationalDatabase",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#StartRelationalDatabaseRequest": {
@@ -11187,7 +11673,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Stops a specific Amazon Lightsail instance that is currently running.</p>\n         <note>\n            <p>When you start a stopped instance, Lightsail assigns a new public IP address to the\n        instance. To use the same IP address after stopping and starting an instance, create a\n        static IP address and attach it to the instance. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/lightsail-create-static-ip\">Lightsail Dev Guide</a>.</p>\n         </note>\n         <p>The <code>stop instance</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>instance name</code>. For more information,\n      see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Stops a specific Amazon Lightsail instance that is currently running.</p>\n         <note>\n            <p>When you start a stopped instance, Lightsail assigns a new public IP address to the\n        instance. To use the same IP address after stopping and starting an instance, create a\n        static IP address and attach it to the instance. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/lightsail-create-static-ip\">Lightsail Dev Guide</a>.</p>\n         </note>\n         <p>The <code>stop instance</code> operation supports tag-based access control via resource\n      tags applied to the resource identified by <code>instance name</code>. For more information,\n      see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/StopInstance",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#StopInstanceRequest": {
@@ -11251,7 +11742,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Stops a specific database that is currently running in Amazon Lightsail.</p>\n         <p>The <code>stop relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Stops a specific database that is currently running in Amazon Lightsail.</p>\n         <p>The <code>stop relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/StopRelationalDatabase",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#StopRelationalDatabaseRequest": {
@@ -11365,7 +11861,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Adds one or more tags to the specified Amazon Lightsail resource. Each resource can have a\n      maximum of 50 tags. Each tag consists of a key and an optional value. Tag keys must be unique\n      per resource. For more information about tags, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-tags\">Lightsail\n        Dev Guide</a>.</p>\n         <p>The <code>tag resource</code> operation supports tag-based access control via request tags\n      and resource tags applied to the resource identified by <code>resource name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Adds one or more tags to the specified Amazon Lightsail resource. Each resource can have a\n      maximum of 50 tags. Each tag consists of a key and an optional value. Tag keys must be unique\n      per resource. For more information about tags, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-tags\">Lightsail\n        Dev Guide</a>.</p>\n         <p>The <code>tag resource</code> operation supports tag-based access control via request tags\n      and resource tags applied to the resource identified by <code>resource name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/TagResource",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#TagResourceRequest": {
@@ -11431,7 +11932,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Lightsail throws this exception when the user has not been authenticated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 401
       }
     },
     "com.amazonaws.lightsail#UnpeerVpc": {
@@ -11466,7 +11968,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Attempts to unpeer the Lightsail VPC from the user's default VPC.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Attempts to unpeer the Lightsail VPC from the user's default VPC.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/UnpeerVpc",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#UnpeerVpcRequest": {
@@ -11516,7 +12023,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Deletes the specified set of tag keys and their values from the specified Amazon Lightsail\n      resource.</p>\n         <p>The <code>untag resource</code> operation supports tag-based access control via request\n      tags and resource tags applied to the resource identified by <code>resource name</code>. For\n      more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Deletes the specified set of tag keys and their values from the specified Amazon Lightsail\n      resource.</p>\n         <p>The <code>untag resource</code> operation supports tag-based access control via request\n      tags and resource tags applied to the resource identified by <code>resource name</code>. For\n      more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/UntagResource",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#UntagResourceRequest": {
@@ -11587,7 +12099,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Updates a domain recordset after it is created.</p>\n         <p>The <code>update domain entry</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>domain name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Updates a domain recordset after it is created.</p>\n         <p>The <code>update domain entry</code> operation supports tag-based access control via\n      resource tags applied to the resource identified by <code>domain name</code>. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/UpdateDomainEntry",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#UpdateDomainEntryRequest": {
@@ -11652,7 +12169,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Updates the specified attribute for a load balancer. You can only update one attribute\n      at a time.</p>\n         <p>The <code>update load balancer attribute</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Updates the specified attribute for a load balancer. You can only update one attribute\n      at a time.</p>\n         <p>The <code>update load balancer attribute</code> operation supports tag-based access\n      control via resource tags applied to the resource identified by <code>load balancer\n        name</code>. For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/UpdateLoadBalancerAttribute",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#UpdateLoadBalancerAttributeRequest": {
@@ -11724,7 +12246,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Allows the update of one or more attributes of a database in Amazon Lightsail.</p>\n         <p>Updates are applied immediately, or in cases where the updates could result in an\n      outage, are applied during the database's predefined maintenance window.</p>\n         <p>The <code>update relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Allows the update of one or more attributes of a database in Amazon Lightsail.</p>\n         <p>Updates are applied immediately, or in cases where the updates could result in an\n      outage, are applied during the database's predefined maintenance window.</p>\n         <p>The <code>update relational database</code> operation supports tag-based access control\n      via resource tags applied to the resource identified by relationalDatabaseName. For more\n      information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/UpdateRelationalDatabase",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#UpdateRelationalDatabaseParameters": {
@@ -11759,7 +12286,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n         <p>Allows the update of one or more parameters of a database in Amazon Lightsail.</p>\n         <p>Parameter updates don't cause outages; therefore, their application is not subject to\n      the preferred maintenance window. However, there are two ways in which paramater updates are\n      applied: <code>dynamic</code> or <code>pending-reboot</code>. Parameters marked with a\n        <code>dynamic</code> apply type are applied immediately. Parameters marked with a\n        <code>pending-reboot</code> apply type are applied only after the database is rebooted using\n      the <code>reboot relational database</code> operation.</p>\n         <p>The <code>update relational database parameters</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by relationalDatabaseName.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      "
+        "smithy.api#documentation": "\n         <p>Allows the update of one or more parameters of a database in Amazon Lightsail.</p>\n         <p>Parameter updates don't cause outages; therefore, their application is not subject to\n      the preferred maintenance window. However, there are two ways in which paramater updates are\n      applied: <code>dynamic</code> or <code>pending-reboot</code>. Parameters marked with a\n        <code>dynamic</code> apply type are applied immediately. Parameters marked with a\n        <code>pending-reboot</code> apply type are applied only after the database is rebooted using\n      the <code>reboot relational database</code> operation.</p>\n         <p>The <code>update relational database parameters</code> operation supports tag-based\n      access control via resource tags applied to the resource identified by relationalDatabaseName.\n      For more information, see the <a href=\"https://lightsail.aws.amazon.com/ls/docs/en/articles/amazon-lightsail-controlling-access-using-tags\">Lightsail Dev Guide</a>.</p>\n      ",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/ls/api/2016-11-28/UpdateRelationalDatabaseParameters",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.lightsail#UpdateRelationalDatabaseParametersRequest": {

--- a/codegen/sdk-codegen/aws-models/machine-learning.2014-12-12.json
+++ b/codegen/sdk-codegen/aws-models/machine-learning.2014-12-12.json
@@ -216,7 +216,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Machine Learning"
+        "smithy.api#title": "Amazon Machine Learning",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://machinelearning.amazonaws.com/doc/2014-12-12/"
+        }
       }
     },
     "com.amazon.eml.v20141212#AwsUserArn": {
@@ -2764,7 +2767,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.eml.v20141212#IntegerType": {
@@ -2785,7 +2789,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An error on the server occurred when trying to process a request.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.eml.v20141212#InvalidInputException": {
@@ -2800,7 +2805,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.eml.v20141212#InvalidTagException": {
@@ -2835,7 +2841,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The subscriber exceeded the maximum number of operations. This exception can occur when listing objects such as <code>DataSource</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 417
       }
     },
     "com.amazon.eml.v20141212#LongType": {
@@ -3169,7 +3176,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The exception is thrown when a predict request is made to an unmounted <code>MLModel</code>.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.eml.v20141212#PresignedS3Url": {
@@ -3637,7 +3645,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A specified resource cannot be located.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.eml.v20141212#RoleARN": {

--- a/codegen/sdk-codegen/aws-models/mediaconnect.2018-11-14.json
+++ b/codegen/sdk-codegen/aws-models/mediaconnect.2018-11-14.json
@@ -1,0 +1,2600 @@
+{
+  "smithy": "0.5.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "ids": [
+          "HttpMethodSemantics"
+        ]
+      },
+      {
+        "ids": [
+          "HttpResponseCodeSemantics"
+        ]
+      },
+      {
+        "ids": [
+          "PaginatedTrait"
+        ]
+      },
+      {
+        "ids": [
+          "HttpHeaderTrait"
+        ]
+      },
+      {
+        "ids": [
+          "HttpUriConflict"
+        ]
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.mediaconnect#AddFlowOutputs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#AddFlowOutputsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#AddFlowOutputsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#AddFlowOutputs420Exception"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Adds outputs to an existing flow. You can create up to 20 outputs per flow.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/flows/{FlowArn}/outputs",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#AddFlowOutputs420Exception": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 420
+      }
+    },
+    "com.amazonaws.mediaconnect#AddFlowOutputsRequest": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The flow that you want to add outputs to.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#pattern": "^arn:.*",
+            "smithy.api#required": true
+          }
+        },
+        "Outputs": {
+          "target": "com.amazonaws.mediaconnect#__listOfAddOutputRequest",
+          "traits": {
+            "smithy.api#documentation": "A list of outputs that you want to add.",
+            "smithy.api#jsonName": "outputs",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A request to add outputs to the specified flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#AddFlowOutputsResponse": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that these outputs were added to.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        },
+        "Outputs": {
+          "target": "com.amazonaws.mediaconnect#__listOfOutput",
+          "traits": {
+            "smithy.api#documentation": "The details of the newly added outputs.",
+            "smithy.api#jsonName": "outputs"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#AddOutputRequest": {
+      "type": "structure",
+      "members": {
+        "CidrAllowList": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "The range of IP addresses that should be allowed to initiate output requests to this flow. These IP addresses should be in the form of a Classless Inter-Domain Routing (CIDR) block; for example, 10.0.0.0/16.",
+            "smithy.api#jsonName": "cidrAllowList"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the output. This description appears only on the AWS Elemental MediaConnect console and will not be seen by the end user.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "Destination": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The IP address from which video will be sent to output destinations.",
+            "smithy.api#jsonName": "destination"
+          }
+        },
+        "Encryption": {
+          "target": "com.amazonaws.mediaconnect#Encryption",
+          "traits": {
+            "smithy.api#documentation": "The type of key used for the encryption. If no keyType is provided, the service will use the default setting (static-key).",
+            "smithy.api#jsonName": "encryption"
+          }
+        },
+        "MaxLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The maximum latency in milliseconds for Zixi-based streams.",
+            "smithy.api#jsonName": "maxLatency"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the output. This value must be unique within the current flow.",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "Port": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The port to use when content is distributed to this output.",
+            "smithy.api#jsonName": "port"
+          }
+        },
+        "Protocol": {
+          "target": "com.amazonaws.mediaconnect#Protocol",
+          "traits": {
+            "smithy.api#documentation": "The protocol to use for the output.",
+            "smithy.api#jsonName": "protocol",
+            "smithy.api#required": true
+          }
+        },
+        "RemoteId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The remote ID for the Zixi-pull output stream.",
+            "smithy.api#jsonName": "remoteId"
+          }
+        },
+        "SmoothingLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The smoothing latency in milliseconds for RIST, RTP, and RTP-FEC streams.",
+            "smithy.api#jsonName": "smoothingLatency"
+          }
+        },
+        "StreamId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The stream ID that you want to use for this transport. This parameter applies only to Zixi-based streams.",
+            "smithy.api#jsonName": "streamId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The output that you want to add to this flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#Algorithm": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "aes128": {
+            "name": "aes128"
+          },
+          "aes192": {
+            "name": "aes192"
+          },
+          "aes256": {
+            "name": "aes256"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#BadRequestException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.mediaconnect#CreateFlow": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#CreateFlowRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#CreateFlowResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#CreateFlow420Exception"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a new flow. The request must include one source. The request optionally can include outputs (up to 20) and entitlements (up to 50).",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/flows",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#CreateFlow420Exception": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 420
+      }
+    },
+    "com.amazonaws.mediaconnect#CreateFlowRequest": {
+      "type": "structure",
+      "members": {
+        "AvailabilityZone": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The Availability Zone that you want to create the flow in. These options are limited to the Availability Zones within the current AWS Region.",
+            "smithy.api#jsonName": "availabilityZone"
+          }
+        },
+        "Entitlements": {
+          "target": "com.amazonaws.mediaconnect#__listOfGrantEntitlementRequest",
+          "traits": {
+            "smithy.api#documentation": "The entitlements that you want to grant on a flow.",
+            "smithy.api#jsonName": "entitlements"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the flow.",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": true
+          }
+        },
+        "Outputs": {
+          "target": "com.amazonaws.mediaconnect#__listOfAddOutputRequest",
+          "traits": {
+            "smithy.api#documentation": "The outputs that you want to add to this flow.",
+            "smithy.api#jsonName": "outputs"
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.mediaconnect#SetSourceRequest",
+          "traits": {
+            "smithy.api#jsonName": "source",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Creates a new flow. The request must include one source. The request optionally can include outputs (up to 20) and entitlements (up to 50)."
+      }
+    },
+    "com.amazonaws.mediaconnect#CreateFlowResponse": {
+      "type": "structure",
+      "members": {
+        "Flow": {
+          "target": "com.amazonaws.mediaconnect#Flow",
+          "traits": {
+            "smithy.api#jsonName": "flow"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#DeleteFlow": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#DeleteFlowRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#DeleteFlowResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes a flow. Before you can delete a flow, you must stop the flow.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v1/flows/{FlowArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#DeleteFlowRequest": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that you want to delete.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#DeleteFlowResponse": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that was deleted.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.mediaconnect#Status",
+          "traits": {
+            "smithy.api#documentation": "The status of the flow when the DeleteFlow process begins.",
+            "smithy.api#jsonName": "status"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#DescribeFlow": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#DescribeFlowRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#DescribeFlowResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Displays the details of a flow. The response includes the flow ARN, name, and Availability Zone, as well as details about the source, outputs, and entitlements.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v1/flows/{FlowArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#DescribeFlowRequest": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that you want to describe.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#DescribeFlowResponse": {
+      "type": "structure",
+      "members": {
+        "Flow": {
+          "target": "com.amazonaws.mediaconnect#Flow",
+          "traits": {
+            "smithy.api#jsonName": "flow"
+          }
+        },
+        "Messages": {
+          "target": "com.amazonaws.mediaconnect#Messages",
+          "traits": {
+            "smithy.api#jsonName": "messages"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#Encryption": {
+      "type": "structure",
+      "members": {
+        "Algorithm": {
+          "target": "com.amazonaws.mediaconnect#Algorithm",
+          "traits": {
+            "smithy.api#documentation": "The type of algorithm that is used for the encryption (such as aes128, aes192, or aes256).",
+            "smithy.api#jsonName": "algorithm",
+            "smithy.api#required": true
+          }
+        },
+        "ConstantInitializationVector": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A 128-bit, 16-byte hex value represented by a 32-character string, to be used with the key for encrypting content. This parameter is not valid for static key encryption.",
+            "smithy.api#jsonName": "constantInitializationVector"
+          }
+        },
+        "DeviceId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The value of one of the devices that you configured with your digital rights management (DRM) platform key provider. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "deviceId"
+          }
+        },
+        "KeyType": {
+          "target": "com.amazonaws.mediaconnect#KeyType",
+          "traits": {
+            "smithy.api#documentation": "The type of key that is used for the encryption. If no keyType is provided, the service will use the default setting (static-key).",
+            "smithy.api#jsonName": "keyType"
+          }
+        },
+        "Region": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The AWS Region that the API Gateway proxy endpoint was created in. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "region"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "An identifier for the content. The service sends this value to the key server to identify the current endpoint. The resource ID is also known as the content ID. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "resourceId"
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the role that you created during setup (when you set up AWS Elemental MediaConnect as a trusted entity).",
+            "smithy.api#jsonName": "roleArn",
+            "smithy.api#required": true
+          }
+        },
+        "SecretArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the secret that you created in AWS Secrets Manager to store the encryption key. This parameter is required for static key encryption and is not valid for SPEKE encryption.",
+            "smithy.api#jsonName": "secretArn"
+          }
+        },
+        "Url": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The URL from the API Gateway proxy that you set up to talk to your key server. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "url"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about the encryption of the flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#Entitlement": {
+      "type": "structure",
+      "members": {
+        "DataTransferSubscriberFeePercent": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "Percentage from 0-100 of the data transfer cost to be billed to the subscriber.",
+            "smithy.api#jsonName": "dataTransferSubscriberFeePercent"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the entitlement.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "Encryption": {
+          "target": "com.amazonaws.mediaconnect#Encryption",
+          "traits": {
+            "smithy.api#documentation": "The type of encryption that will be used on the output that is associated with this entitlement.",
+            "smithy.api#jsonName": "encryption"
+          }
+        },
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement.",
+            "smithy.api#jsonName": "entitlementArn",
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the entitlement.",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": true
+          }
+        },
+        "Subscribers": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "The AWS account IDs that you want to share your content with. The receiving accounts (subscribers) will be allowed to create their own flow using your content as the source.",
+            "smithy.api#jsonName": "subscribers",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The settings for a flow entitlement."
+      }
+    },
+    "com.amazonaws.mediaconnect#Flow": {
+      "type": "structure",
+      "members": {
+        "AvailabilityZone": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The Availability Zone that you want to create the flow in. These options are limited to the Availability Zones within the current AWS.",
+            "smithy.api#jsonName": "availabilityZone",
+            "smithy.api#required": true
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the flow. This value is not used or seen outside of the current AWS Elemental MediaConnect account.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "EgressIp": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The IP address from which video will be sent to output destinations.",
+            "smithy.api#jsonName": "egressIp"
+          }
+        },
+        "Entitlements": {
+          "target": "com.amazonaws.mediaconnect#__listOfEntitlement",
+          "traits": {
+            "smithy.api#documentation": "The entitlements in this flow.",
+            "smithy.api#jsonName": "entitlements",
+            "smithy.api#required": true
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The Amazon Resource Name (ARN), a unique identifier for any AWS resource, of the flow.",
+            "smithy.api#jsonName": "flowArn",
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the flow.",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": true
+          }
+        },
+        "Outputs": {
+          "target": "com.amazonaws.mediaconnect#__listOfOutput",
+          "traits": {
+            "smithy.api#documentation": "The outputs in this flow.",
+            "smithy.api#jsonName": "outputs",
+            "smithy.api#required": true
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.mediaconnect#Source",
+          "traits": {
+            "smithy.api#jsonName": "source",
+            "smithy.api#required": true
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.mediaconnect#Status",
+          "traits": {
+            "smithy.api#documentation": "The current status of the flow.",
+            "smithy.api#jsonName": "status",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The settings for a flow, including its source, outputs, and entitlements."
+      }
+    },
+    "com.amazonaws.mediaconnect#ForbiddenException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
+      }
+    },
+    "com.amazonaws.mediaconnect#GrantEntitlementRequest": {
+      "type": "structure",
+      "members": {
+        "DataTransferSubscriberFeePercent": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "Percentage from 0-100 of the data transfer cost to be billed to the subscriber.",
+            "smithy.api#jsonName": "dataTransferSubscriberFeePercent"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the entitlement. This description appears only on the AWS Elemental MediaConnect console and will not be seen by the subscriber or end user.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "Encryption": {
+          "target": "com.amazonaws.mediaconnect#Encryption",
+          "traits": {
+            "smithy.api#documentation": "The type of encryption that will be used on the output that is associated with this entitlement.",
+            "smithy.api#jsonName": "encryption"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the entitlement. This value must be unique within the current flow.",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "Subscribers": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "The AWS account IDs that you want to share your content with. The receiving accounts (subscribers) will be allowed to create their own flows using your content as the source.",
+            "smithy.api#jsonName": "subscribers",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The entitlements that you want to grant on a flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#GrantFlowEntitlements": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#GrantFlowEntitlementsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#GrantFlowEntitlementsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#GrantFlowEntitlements420Exception"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Grants entitlements to an existing flow.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/flows/{FlowArn}/entitlements",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#GrantFlowEntitlements420Exception": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 420
+      }
+    },
+    "com.amazonaws.mediaconnect#GrantFlowEntitlementsRequest": {
+      "type": "structure",
+      "members": {
+        "Entitlements": {
+          "target": "com.amazonaws.mediaconnect#__listOfGrantEntitlementRequest",
+          "traits": {
+            "smithy.api#documentation": "The list of entitlements that you want to grant.",
+            "smithy.api#jsonName": "entitlements",
+            "smithy.api#required": true
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The flow that you want to grant entitlements on.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#pattern": "^arn:.*",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A request to grant entitlements on a flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#GrantFlowEntitlementsResponse": {
+      "type": "structure",
+      "members": {
+        "Entitlements": {
+          "target": "com.amazonaws.mediaconnect#__listOfEntitlement",
+          "traits": {
+            "smithy.api#documentation": "The entitlements that were just granted.",
+            "smithy.api#jsonName": "entitlements"
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that these entitlements were granted to.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#InternalServerErrorException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.mediaconnect#KeyType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "speke": {
+            "name": "speke"
+          },
+          "static-key": {
+            "name": "static_key"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListEntitlements": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#ListEntitlementsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#ListEntitlementsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Displays a list of all entitlements that have been granted to this account. This request returns 20 results per page.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v1/entitlements",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListEntitlementsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.mediaconnect#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to return per API request. For example, you submit a ListEntitlements request with MaxResults set at 5. Although 20 items match your request, the service returns no more than the first 5 items. (The service also returns a NextToken value that you can use to fetch the next batch of results.) The service might return fewer results than the MaxResults value. If MaxResults is not included in the request, the service defaults to pagination with a maximum of 20 results per page.",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The token that identifies which batch of results that you want to see. For example, you submit a ListEntitlements request with MaxResults set at 5. The service returns the first batch of results (up to 5) and a NextToken value. To see the next batch of results, you can submit the ListEntitlements request a second time and specify the NextToken value.",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListEntitlementsResponse": {
+      "type": "structure",
+      "members": {
+        "Entitlements": {
+          "target": "com.amazonaws.mediaconnect#__listOfListedEntitlement",
+          "traits": {
+            "smithy.api#documentation": "A list of entitlements that have been granted to you from other AWS accounts.",
+            "smithy.api#jsonName": "entitlements"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The token that identifies which batch of results that you want to see. For example, you submit a ListEntitlements request with MaxResults set at 5. The service returns the first batch of results (up to 5) and a NextToken value. To see the next batch of results, you can submit the ListEntitlements request a second time and specify the NextToken value.",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListFlows": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#ListFlowsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#ListFlowsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Displays a list of flows that are associated with this account. This request returns a paginated result.",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v1/flows",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListFlowsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.mediaconnect#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "The maximum number of results to return per API request. For example, you submit a ListFlows request with MaxResults set at 5. Although 20 items match your request, the service returns no more than the first 5 items. (The service also returns a NextToken value that you can use to fetch the next batch of results.) The service might return fewer results than the MaxResults value. If MaxResults is not included in the request, the service defaults to pagination with a maximum of 10 results per page.",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The token that identifies which batch of results that you want to see. For example, you submit a ListFlows request with MaxResults set at 5. The service returns the first batch of results (up to 5) and a NextToken value. To see the next batch of results, you can submit the ListFlows request a second time and specify the NextToken value.",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListFlowsResponse": {
+      "type": "structure",
+      "members": {
+        "Flows": {
+          "target": "com.amazonaws.mediaconnect#__listOfListedFlow",
+          "traits": {
+            "smithy.api#documentation": "A list of flow summaries.",
+            "smithy.api#jsonName": "flows"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The token that identifies which batch of results that you want to see. For example, you submit a ListFlows request with MaxResults set at 5. The service returns the first batch of results (up to 5) and a NextToken value. To see the next batch of results, you can submit the ListFlows request a second time and specify the NextToken value.",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "List all tags on an AWS Elemental MediaConnect resource",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/tags/{ResourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The Amazon Resource Name (ARN) that identifies the AWS Elemental MediaConnect resource for which to list the tags.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.mediaconnect#__mapOf__string",
+          "traits": {
+            "smithy.api#documentation": "A map from tag keys to values. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters.",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ListedEntitlement": {
+      "type": "structure",
+      "members": {
+        "DataTransferSubscriberFeePercent": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "Percentage from 0-100 of the data transfer cost to be billed to the subscriber.",
+            "smithy.api#jsonName": "dataTransferSubscriberFeePercent"
+          }
+        },
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement.",
+            "smithy.api#jsonName": "entitlementArn",
+            "smithy.api#required": true
+          }
+        },
+        "EntitlementName": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the entitlement.",
+            "smithy.api#jsonName": "entitlementName",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An entitlement that has been granted to you from other AWS accounts."
+      }
+    },
+    "com.amazonaws.mediaconnect#ListedFlow": {
+      "type": "structure",
+      "members": {
+        "AvailabilityZone": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The Availability Zone that the flow was created in.",
+            "smithy.api#jsonName": "availabilityZone",
+            "smithy.api#required": true
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the flow.",
+            "smithy.api#jsonName": "description",
+            "smithy.api#required": true
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow.",
+            "smithy.api#jsonName": "flowArn",
+            "smithy.api#required": true
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the flow.",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": true
+          }
+        },
+        "SourceType": {
+          "target": "com.amazonaws.mediaconnect#SourceType",
+          "traits": {
+            "smithy.api#documentation": "The type of source. This value is either owned (originated somewhere other than an AWS Elemental MediaConnect flow owned by another AWS account) or entitled (originated at an AWS Elemental MediaConnect flow owned by another AWS account).",
+            "smithy.api#jsonName": "sourceType",
+            "smithy.api#required": true
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.mediaconnect#Status",
+          "traits": {
+            "smithy.api#documentation": "The current status of the flow.",
+            "smithy.api#jsonName": "status",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Provides a summary of a flow, including its ARN, Availability Zone, and source type."
+      }
+    },
+    "com.amazonaws.mediaconnect#MaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#MediaConnect": {
+      "type": "service",
+      "version": "2018-11-14",
+      "operations": [
+        {
+          "target": "com.amazonaws.mediaconnect#AddFlowOutputs"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#CreateFlow"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#DeleteFlow"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#DescribeFlow"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#GrantFlowEntitlements"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ListEntitlements"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ListFlows"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#RemoveFlowOutput"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#RevokeFlowEntitlement"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#StartFlow"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#StopFlow"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TagResource"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#UpdateFlowEntitlement"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#UpdateFlowOutput"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#UpdateFlowSource"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "MediaConnect",
+          "arnNamespace": "mediaconnect",
+          "cloudFormationName": "MediaConnect",
+          "cloudTrailEventSource": "mediaconnect.amazonaws.com"
+        },
+        "smithy.api#documentation": "API for AWS Elemental MediaConnect",
+        "smithy.api#protocols": [
+          {
+            "name": "aws.rest-json-1.1",
+            "auth": [
+              "aws.v4"
+            ]
+          }
+        ],
+        "smithy.api#title": "AWS MediaConnect"
+      }
+    },
+    "com.amazonaws.mediaconnect#Messages": {
+      "type": "structure",
+      "members": {
+        "Errors": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "A list of errors that might have been generated from processes on this flow.",
+            "smithy.api#jsonName": "errors",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Messages that provide the state of the flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#NotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.mediaconnect#Output": {
+      "type": "structure",
+      "members": {
+        "DataTransferSubscriberFeePercent": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "Percentage from 0-100 of the data transfer cost to be billed to the subscriber.",
+            "smithy.api#jsonName": "dataTransferSubscriberFeePercent"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the output.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "Destination": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The address where you want to send the output.",
+            "smithy.api#jsonName": "destination"
+          }
+        },
+        "Encryption": {
+          "target": "com.amazonaws.mediaconnect#Encryption",
+          "traits": {
+            "smithy.api#documentation": "The type of key used for the encryption. If no keyType is provided, the service will use the default setting (static-key).",
+            "smithy.api#jsonName": "encryption"
+          }
+        },
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement on the originator''s flow. This value is relevant only on entitled flows.",
+            "smithy.api#jsonName": "entitlementArn"
+          }
+        },
+        "MediaLiveInputArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The input ARN of the AWS Elemental MediaLive channel. This parameter is relevant only for outputs that were added by creating a MediaLive input.",
+            "smithy.api#jsonName": "mediaLiveInputArn"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the output. This value must be unique within the current flow.",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": true
+          }
+        },
+        "OutputArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the output.",
+            "smithy.api#jsonName": "outputArn",
+            "smithy.api#required": true
+          }
+        },
+        "Port": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The port to use when content is distributed to this output.",
+            "smithy.api#jsonName": "port"
+          }
+        },
+        "Transport": {
+          "target": "com.amazonaws.mediaconnect#Transport",
+          "traits": {
+            "smithy.api#documentation": "Attributes related to the transport stream that are used in the output.",
+            "smithy.api#jsonName": "transport"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The settings for an output."
+      }
+    },
+    "com.amazonaws.mediaconnect#Protocol": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "zixi-push": {
+            "name": "zixi_push"
+          },
+          "rtp-fec": {
+            "name": "rtp_fec"
+          },
+          "rtp": {
+            "name": "rtp"
+          },
+          "zixi-pull": {
+            "name": "zixi_pull"
+          },
+          "rist": {
+            "name": "rist"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#RemoveFlowOutput": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#RemoveFlowOutputRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#RemoveFlowOutputResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Removes an output from an existing flow. This request can be made only on an output that does not have an entitlement associated with it. If the output has an entitlement, you must revoke the entitlement instead. When an entitlement is revoked from a flow, the service automatically removes the associated output.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v1/flows/{FlowArn}/outputs/{OutputArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#RemoveFlowOutputRequest": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The flow that you want to remove an output from.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "OutputArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the output that you want to remove.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#RemoveFlowOutputResponse": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that is associated with the output you removed.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        },
+        "OutputArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the output that was removed.",
+            "smithy.api#jsonName": "outputArn"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#RevokeFlowEntitlement": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#RevokeFlowEntitlementRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#RevokeFlowEntitlementResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Revokes an entitlement from a flow. Once an entitlement is revoked, the content becomes unavailable to the subscriber and the associated output is removed.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v1/flows/{FlowArn}/entitlements/{EntitlementArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#RevokeFlowEntitlementRequest": {
+      "type": "structure",
+      "members": {
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement that you want to revoke.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The flow that you want to revoke an entitlement from.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#RevokeFlowEntitlementResponse": {
+      "type": "structure",
+      "members": {
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement that was revoked.",
+            "smithy.api#jsonName": "entitlementArn"
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that the entitlement was revoked from.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#ServiceUnavailableException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
+      }
+    },
+    "com.amazonaws.mediaconnect#SetSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Decryption": {
+          "target": "com.amazonaws.mediaconnect#Encryption",
+          "traits": {
+            "smithy.api#documentation": "The type of encryption that is used on the content ingested from this source.",
+            "smithy.api#jsonName": "decryption"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description for the source. This value is not used or seen outside of the current AWS Elemental MediaConnect account.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement that allows you to subscribe to this flow. The entitlement is set by the flow originator, and the ARN is generated as part of the originator's flow.",
+            "smithy.api#jsonName": "entitlementArn"
+          }
+        },
+        "IngestPort": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The port that the flow will be listening on for incoming content.",
+            "smithy.api#jsonName": "ingestPort"
+          }
+        },
+        "MaxBitrate": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The smoothing max bitrate for RIST, RTP, and RTP-FEC streams.",
+            "smithy.api#jsonName": "maxBitrate"
+          }
+        },
+        "MaxLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
+            "smithy.api#jsonName": "maxLatency"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the source.",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "Protocol": {
+          "target": "com.amazonaws.mediaconnect#Protocol",
+          "traits": {
+            "smithy.api#documentation": "The protocol that is used by the source.",
+            "smithy.api#jsonName": "protocol"
+          }
+        },
+        "StreamId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The stream ID that you want to use for this transport. This parameter applies only to Zixi-based streams.",
+            "smithy.api#jsonName": "streamId"
+          }
+        },
+        "WhitelistCidr": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The range of IP addresses that should be allowed to contribute content to your source. These IP addresses should be in the form of a Classless Inter-Domain Routing (CIDR) block; for example, 10.0.0.0/16.",
+            "smithy.api#jsonName": "whitelistCidr"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The settings for the source of the flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#Source": {
+      "type": "structure",
+      "members": {
+        "DataTransferSubscriberFeePercent": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "Percentage from 0-100 of the data transfer cost to be billed to the subscriber.",
+            "smithy.api#jsonName": "dataTransferSubscriberFeePercent"
+          }
+        },
+        "Decryption": {
+          "target": "com.amazonaws.mediaconnect#Encryption",
+          "traits": {
+            "smithy.api#documentation": "The type of encryption that is used on the content ingested from this source.",
+            "smithy.api#jsonName": "decryption"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description for the source. This value is not used or seen outside of the current AWS Elemental MediaConnect account.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement that allows you to subscribe to content that comes from another AWS account. The entitlement is set by the content originator and the ARN is generated as part of the originator's flow.",
+            "smithy.api#jsonName": "entitlementArn"
+          }
+        },
+        "IngestIp": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The IP address that the flow will be listening on for incoming content.",
+            "smithy.api#jsonName": "ingestIp"
+          }
+        },
+        "IngestPort": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The port that the flow will be listening on for incoming content.",
+            "smithy.api#jsonName": "ingestPort"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The name of the source.",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": true
+          }
+        },
+        "SourceArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the source.",
+            "smithy.api#jsonName": "sourceArn",
+            "smithy.api#required": true
+          }
+        },
+        "Transport": {
+          "target": "com.amazonaws.mediaconnect#Transport",
+          "traits": {
+            "smithy.api#documentation": "Attributes related to the transport stream that are used in the source.",
+            "smithy.api#jsonName": "transport"
+          }
+        },
+        "WhitelistCidr": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The range of IP addresses that should be allowed to contribute content to your source. These IP addresses should be in the form of a Classless Inter-Domain Routing (CIDR) block; for example, 10.0.0.0/16.",
+            "smithy.api#jsonName": "whitelistCidr"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The settings for the source of the flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#SourceType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "OWNED": {
+            "name": "OWNED"
+          },
+          "ENTITLED": {
+            "name": "ENTITLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#StartFlow": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#StartFlowRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#StartFlowResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Starts a flow.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/flows/start/{FlowArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#StartFlowRequest": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that you want to start.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#pattern": "^arn:.*",
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#StartFlowResponse": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that you started.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.mediaconnect#Status",
+          "traits": {
+            "smithy.api#documentation": "The status of the flow when the StartFlow process begins.",
+            "smithy.api#jsonName": "status"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#Status": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": {
+          "STANDBY": {
+            "name": "STANDBY"
+          },
+          "ACTIVE": {
+            "name": "ACTIVE"
+          },
+          "UPDATING": {
+            "name": "UPDATING"
+          },
+          "DELETING": {
+            "name": "DELETING"
+          },
+          "STARTING": {
+            "name": "STARTING"
+          },
+          "STOPPING": {
+            "name": "STOPPING"
+          },
+          "ERROR": {
+            "name": "ERROR"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#StopFlow": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#StopFlowRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#StopFlowResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Stops a flow.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v1/flows/stop/{FlowArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#StopFlowRequest": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that you want to stop.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#pattern": "^arn:.*",
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#StopFlowResponse": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that you stopped.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.mediaconnect#Status",
+          "traits": {
+            "smithy.api#documentation": "The status of the flow when the StopFlow process begins.",
+            "smithy.api#jsonName": "status"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#TagResourceRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Associates the specified tags to a resource with the specified resourceArn. If existing tags on a resource are not specified in the request parameters, they are not changed. When a resource is deleted, the tags associated with that resource are deleted as well.",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/tags/{ResourceArn}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The Amazon Resource Name (ARN) that identifies the AWS Elemental MediaConnect resource to which to add tags.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.mediaconnect#__mapOf__string",
+          "traits": {
+            "smithy.api#documentation": "A map from tag keys to values. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters.",
+            "smithy.api#jsonName": "tags",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The tags to add to the resource. A tag is an array of key-value pairs. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters."
+      }
+    },
+    "com.amazonaws.mediaconnect#TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The error message returned by AWS Elemental MediaConnect.",
+            "smithy.api#jsonName": "message",
+            "smithy.api#required": true
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.mediaconnect#Transport": {
+      "type": "structure",
+      "members": {
+        "CidrAllowList": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "The range of IP addresses that should be allowed to initiate output requests to this flow. These IP addresses should be in the form of a Classless Inter-Domain Routing (CIDR) block; for example, 10.0.0.0/16.",
+            "smithy.api#jsonName": "cidrAllowList"
+          }
+        },
+        "MaxBitrate": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The smoothing max bitrate for RIST, RTP, and RTP-FEC streams.",
+            "smithy.api#jsonName": "maxBitrate"
+          }
+        },
+        "MaxLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
+            "smithy.api#jsonName": "maxLatency"
+          }
+        },
+        "Protocol": {
+          "target": "com.amazonaws.mediaconnect#Protocol",
+          "traits": {
+            "smithy.api#documentation": "The protocol that is used by the source or output.",
+            "smithy.api#jsonName": "protocol",
+            "smithy.api#required": true
+          }
+        },
+        "RemoteId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The remote ID for the Zixi-pull stream.",
+            "smithy.api#jsonName": "remoteId"
+          }
+        },
+        "SmoothingLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The smoothing latency in milliseconds for RIST, RTP, and RTP-FEC streams.",
+            "smithy.api#jsonName": "smoothingLatency"
+          }
+        },
+        "StreamId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The stream ID that you want to use for this transport. This parameter applies only to Zixi-based streams.",
+            "smithy.api#jsonName": "streamId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Attributes related to the transport stream that are used in a source or output."
+      }
+    },
+    "com.amazonaws.mediaconnect#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#UntagResourceRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes specified tags from a resource.",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/tags/{ResourceArn}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The Amazon Resource Name (ARN) that identifies the AWS Elemental MediaConnect resource from which to delete tags.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "The keys of the tags to be removed.",
+            "smithy.api#httpQuery": "tagKeys",
+            "smithy.api#required": true
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateEncryption": {
+      "type": "structure",
+      "members": {
+        "Algorithm": {
+          "target": "com.amazonaws.mediaconnect#Algorithm",
+          "traits": {
+            "smithy.api#documentation": "The type of algorithm that is used for the encryption (such as aes128, aes192, or aes256).",
+            "smithy.api#jsonName": "algorithm"
+          }
+        },
+        "ConstantInitializationVector": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A 128-bit, 16-byte hex value represented by a 32-character string, to be used with the key for encrypting content. This parameter is not valid for static key encryption.",
+            "smithy.api#jsonName": "constantInitializationVector"
+          }
+        },
+        "DeviceId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The value of one of the devices that you configured with your digital rights management (DRM) platform key provider. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "deviceId"
+          }
+        },
+        "KeyType": {
+          "target": "com.amazonaws.mediaconnect#KeyType",
+          "traits": {
+            "smithy.api#documentation": "The type of key that is used for the encryption. If no keyType is provided, the service will use the default setting (static-key).",
+            "smithy.api#jsonName": "keyType"
+          }
+        },
+        "Region": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The AWS Region that the API Gateway proxy endpoint was created in. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "region"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "An identifier for the content. The service sends this value to the key server to identify the current endpoint. The resource ID is also known as the content ID. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "resourceId"
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the role that you created during setup (when you set up AWS Elemental MediaConnect as a trusted entity).",
+            "smithy.api#jsonName": "roleArn"
+          }
+        },
+        "SecretArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the secret that you created in AWS Secrets Manager to store the encryption key. This parameter is required for static key encryption and is not valid for SPEKE encryption.",
+            "smithy.api#jsonName": "secretArn"
+          }
+        },
+        "Url": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The URL from the API Gateway proxy that you set up to talk to your key server. This parameter is required for SPEKE encryption and is not valid for static key encryption.",
+            "smithy.api#jsonName": "url"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Information about the encryption of the flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowEntitlement": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#UpdateFlowEntitlementRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#UpdateFlowEntitlementResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "You can change an entitlement's description, subscribers, and encryption. If you change the subscribers, the service will remove the outputs that are are used by the subscribers that are removed.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v1/flows/{FlowArn}/entitlements/{EntitlementArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowEntitlementRequest": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the entitlement. This description appears only on the AWS Elemental MediaConnect console and will not be seen by the subscriber or end user.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "Encryption": {
+          "target": "com.amazonaws.mediaconnect#UpdateEncryption",
+          "traits": {
+            "smithy.api#documentation": "The type of encryption that will be used on the output associated with this entitlement.",
+            "smithy.api#jsonName": "encryption"
+          }
+        },
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement that you want to update.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The flow that is associated with the entitlement that you want to update.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Subscribers": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "The AWS account IDs that you want to share your content with. The receiving accounts (subscribers) will be allowed to create their own flow using your content as the source.",
+            "smithy.api#jsonName": "subscribers"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The entitlement fields that you want to update."
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowEntitlementResponse": {
+      "type": "structure",
+      "members": {
+        "Entitlement": {
+          "target": "com.amazonaws.mediaconnect#Entitlement",
+          "traits": {
+            "smithy.api#jsonName": "entitlement"
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that this entitlement was granted on.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowOutput": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#UpdateFlowOutputRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#UpdateFlowOutputResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates an existing flow output.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v1/flows/{FlowArn}/outputs/{OutputArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowOutputRequest": {
+      "type": "structure",
+      "members": {
+        "CidrAllowList": {
+          "target": "com.amazonaws.mediaconnect#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "The range of IP addresses that should be allowed to initiate output requests to this flow. These IP addresses should be in the form of a Classless Inter-Domain Routing (CIDR) block; for example, 10.0.0.0/16.",
+            "smithy.api#jsonName": "cidrAllowList"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description of the output. This description appears only on the AWS Elemental MediaConnect console and will not be seen by the end user.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "Destination": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The IP address where you want to send the output.",
+            "smithy.api#jsonName": "destination"
+          }
+        },
+        "Encryption": {
+          "target": "com.amazonaws.mediaconnect#UpdateEncryption",
+          "traits": {
+            "smithy.api#documentation": "The type of key used for the encryption. If no keyType is provided, the service will use the default setting (static-key).",
+            "smithy.api#jsonName": "encryption"
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The flow that is associated with the output that you want to update.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "MaxLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The maximum latency in milliseconds for Zixi-based streams.",
+            "smithy.api#jsonName": "maxLatency"
+          }
+        },
+        "OutputArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the output that you want to update.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "Port": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The port to use when content is distributed to this output.",
+            "smithy.api#jsonName": "port"
+          }
+        },
+        "Protocol": {
+          "target": "com.amazonaws.mediaconnect#Protocol",
+          "traits": {
+            "smithy.api#documentation": "The protocol to use for the output.",
+            "smithy.api#jsonName": "protocol"
+          }
+        },
+        "RemoteId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The remote ID for the Zixi-pull stream.",
+            "smithy.api#jsonName": "remoteId"
+          }
+        },
+        "SmoothingLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The smoothing latency in milliseconds for RIST, RTP, and RTP-FEC streams.",
+            "smithy.api#jsonName": "smoothingLatency"
+          }
+        },
+        "StreamId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The stream ID that you want to use for this transport. This parameter applies only to Zixi-based streams.",
+            "smithy.api#jsonName": "streamId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The fields that you want to update in the output."
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowOutputResponse": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that is associated with the updated output.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        },
+        "Output": {
+          "target": "com.amazonaws.mediaconnect#Output",
+          "traits": {
+            "smithy.api#jsonName": "output"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowSource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.mediaconnect#UpdateFlowSourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.mediaconnect#UpdateFlowSourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.mediaconnect#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ForbiddenException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#InternalServerErrorException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.mediaconnect#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Updates the source of a flow.",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v1/flows/{FlowArn}/source/{SourceArn}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Decryption": {
+          "target": "com.amazonaws.mediaconnect#UpdateEncryption",
+          "traits": {
+            "smithy.api#documentation": "The type of encryption used on the content ingested from this source.",
+            "smithy.api#jsonName": "decryption"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "A description for the source. This value is not used or seen outside of the current AWS Elemental MediaConnect account.",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "EntitlementArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the entitlement that allows you to subscribe to this flow. The entitlement is set by the flow originator, and the ARN is generated as part of the originator's flow.",
+            "smithy.api#jsonName": "entitlementArn"
+          }
+        },
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The flow that is associated with the source that you want to update.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "IngestPort": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The port that the flow will be listening on for incoming content.",
+            "smithy.api#jsonName": "ingestPort"
+          }
+        },
+        "MaxBitrate": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The smoothing max bitrate for RIST, RTP, and RTP-FEC streams.",
+            "smithy.api#jsonName": "maxBitrate"
+          }
+        },
+        "MaxLatency": {
+          "target": "com.amazonaws.mediaconnect#__integer",
+          "traits": {
+            "smithy.api#documentation": "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
+            "smithy.api#jsonName": "maxLatency"
+          }
+        },
+        "Protocol": {
+          "target": "com.amazonaws.mediaconnect#Protocol",
+          "traits": {
+            "smithy.api#documentation": "The protocol that is used by the source.",
+            "smithy.api#jsonName": "protocol"
+          }
+        },
+        "SourceArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the source that you want to update.",
+            "smithy.api#httpLabel": true,
+            "smithy.api#required": true
+          }
+        },
+        "StreamId": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The stream ID that you want to use for this transport. This parameter applies only to Zixi-based streams.",
+            "smithy.api#jsonName": "streamId"
+          }
+        },
+        "WhitelistCidr": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The range of IP addresses that should be allowed to contribute content to your source. These IP addresses should be in the form of a Classless Inter-Domain Routing (CIDR) block; for example, 10.0.0.0/16.",
+            "smithy.api#jsonName": "whitelistCidr"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A request to update the source of a flow."
+      }
+    },
+    "com.amazonaws.mediaconnect#UpdateFlowSourceResponse": {
+      "type": "structure",
+      "members": {
+        "FlowArn": {
+          "target": "com.amazonaws.mediaconnect#__string",
+          "traits": {
+            "smithy.api#documentation": "The ARN of the flow that you want to update.",
+            "smithy.api#jsonName": "flowArn"
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.mediaconnect#Source",
+          "traits": {
+            "smithy.api#documentation": "The settings for the source of the flow.",
+            "smithy.api#jsonName": "source"
+          }
+        }
+      }
+    },
+    "com.amazonaws.mediaconnect#__integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.mediaconnect#__listOfAddOutputRequest": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.mediaconnect#AddOutputRequest"
+      }
+    },
+    "com.amazonaws.mediaconnect#__listOfEntitlement": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.mediaconnect#Entitlement"
+      }
+    },
+    "com.amazonaws.mediaconnect#__listOfGrantEntitlementRequest": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.mediaconnect#GrantEntitlementRequest"
+      }
+    },
+    "com.amazonaws.mediaconnect#__listOfListedEntitlement": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.mediaconnect#ListedEntitlement"
+      }
+    },
+    "com.amazonaws.mediaconnect#__listOfListedFlow": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.mediaconnect#ListedFlow"
+      }
+    },
+    "com.amazonaws.mediaconnect#__listOfOutput": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.mediaconnect#Output"
+      }
+    },
+    "com.amazonaws.mediaconnect#__listOf__string": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.mediaconnect#__string"
+      }
+    },
+    "com.amazonaws.mediaconnect#__mapOf__string": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.mediaconnect#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.mediaconnect#__string"
+      }
+    },
+    "com.amazonaws.mediaconnect#__string": {
+      "type": "string"
+    }
+  }
+}

--- a/codegen/sdk-codegen/aws-models/mediastore-data.2017-09-01.json
+++ b/codegen/sdk-codegen/aws-models/mediastore-data.2017-09-01.json
@@ -507,7 +507,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Elemental MediaStore Data Plane"
+        "smithy.api#title": "AWS Elemental MediaStore Data Plane",
+        "smithy.api#xmlNamespace": {
+          "uri": "https://object.mediastore.amazonaws.com/doc/2017-09-01"
+        }
       }
     },
     "com.amazonaws.mediastore.object#NonNegativeLong": {

--- a/codegen/sdk-codegen/aws-models/mediastore.2017-09-01.json
+++ b/codegen/sdk-codegen/aws-models/mediastore.2017-09-01.json
@@ -939,7 +939,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Elemental MediaStore"
+        "smithy.api#title": "AWS Elemental MediaStore",
+        "smithy.api#xmlNamespace": {
+          "uri": "https://mediastore.amazonaws.com/doc/2017-09-01"
+        }
       }
     },
     "com.amazonaws.mediastore#MethodName": {

--- a/codegen/sdk-codegen/aws-models/mobile.2017-07-01.json
+++ b/codegen/sdk-codegen/aws-models/mobile.2017-07-01.json
@@ -73,7 +73,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Mobile"
+        "smithy.api#title": "AWS Mobile",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://mobile.amazonaws.com"
+        }
       }
     },
     "com.amazonaws.services.mobile.model#AccountActionRequiredException": {

--- a/codegen/sdk-codegen/aws-models/mturk.2017-01-17.json
+++ b/codegen/sdk-codegen/aws-models/mturk.2017-01-17.json
@@ -2559,7 +2559,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Mechanical Turk"
+        "smithy.api#title": "Amazon Mechanical Turk",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://requester.mturk.com/2017-01-17/"
+        }
       }
     },
     "com.amazonaws.services.mturk.requester.V20170117#NotificationSpecification": {
@@ -3150,7 +3153,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Your request is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.mturk.requester.V20170117#ResultSize": {
@@ -3485,7 +3489,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Amazon Mechanical Turk is temporarily unable to process your request. Try your call again.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.services.mturk.requester.V20170117#String": {

--- a/codegen/sdk-codegen/aws-models/neptune.2014-10-31.json
+++ b/codegen/sdk-codegen/aws-models/neptune.2014-10-31.json
@@ -416,7 +416,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Specified CIDRIP or EC2 security group is not authorized for the specified DB security group.</p>\n         <p>Neptune may not also be authorized via IAM to perform necessary actions on your behalf.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#AvailabilityZone": {
@@ -472,7 +473,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>CertificateIdentifier</i> does not refer to an existing certificate.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#CharacterSet": {
@@ -1772,7 +1774,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>User already has a DB cluster with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterList": {
@@ -1854,7 +1857,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBClusterIdentifier</i> does not refer to an existing DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBClusterOptionGroupMemberships": {
@@ -1967,7 +1971,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBClusterParameterGroupName</i> does not refer to an\n      existing DB Cluster parameter group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBClusterParameterGroupsMessage": {
@@ -1999,7 +2004,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>User attempted to create a new DB cluster and the user has already reached the maximum allowed DB cluster quota.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "rds.admin.v20141031#DBClusterRole": {
@@ -2034,7 +2040,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified IAM role Amazon Resource Name (ARN) is already associated with the specified DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBClusterRoleNotFoundFault": {
@@ -2049,7 +2056,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified IAM role Amazon Resource Name (ARN) is not associated with the specified DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBClusterRoleQuotaExceededFault": {
@@ -2064,7 +2072,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded the maximum number of IAM roles that can be associated with the specified DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterRoles": {
@@ -2216,7 +2225,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>User already has a DB cluster snapshot with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterSnapshotAttribute": {
@@ -2306,7 +2316,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBClusterSnapshotIdentifier</i> does not refer to an existing\n      DB cluster snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBEngineVersion": {
@@ -2748,7 +2759,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>User already has a DB instance with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBInstanceList": {
@@ -2789,7 +2801,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBInstanceIdentifier</i> does not refer to an existing DB instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBInstanceStatusInfo": {
@@ -2877,7 +2890,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A DB parameter group with the same name exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBParameterGroupDetails": {
@@ -2929,7 +2943,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBParameterGroupName</i> does not refer to an\n      existing DB parameter group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBParameterGroupQuotaExceededFault": {
@@ -2944,7 +2959,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Request would result in user exceeding the allowed number of DB parameter groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBParameterGroupStatus": {
@@ -3043,7 +3059,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBSecurityGroupName</i> does not refer\n      to an existing DB security group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBSnapshotAlreadyExistsFault": {
@@ -3058,7 +3075,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBSnapshotIdentifier</i> is already used by an existing snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSnapshotNotFoundFault": {
@@ -3073,7 +3091,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBSnapshotIdentifier</i> does not refer to an existing DB snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBSubnetGroup": {
@@ -3132,7 +3151,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBSubnetGroupName</i> is already used by an existing DB subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSubnetGroupDoesNotCoverEnoughAZs": {
@@ -3147,7 +3167,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Subnets in the DB subnet group should cover at least two Availability\n      Zones unless there is only one Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSubnetGroupMessage": {
@@ -3179,7 +3200,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>DBSubnetGroupName</i> does not refer to an\n      existing DB subnet group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBSubnetGroupQuotaExceededFault": {
@@ -3194,7 +3216,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Request would result in user exceeding the allowed number of DB subnet groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSubnetGroups": {
@@ -3218,7 +3241,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Request would result in user exceeding the allowed number of subnets in a DB subnet groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBUpgradeDependencyFailureFault": {
@@ -3233,7 +3257,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The DB upgrade failed because a resource the DB depends on could not be modified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DeleteDBCluster": {
@@ -4477,7 +4502,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>Domain</i> does not refer to an existing Active Directory Domain.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#Double": {
@@ -4752,7 +4778,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded the number of events you can subscribe to.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#EventSubscriptionsList": {
@@ -4893,7 +4920,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Request would result in user exceeding the allowed number of DB instances.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InsufficientDBClusterCapacityFault": {
@@ -4908,7 +4936,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The DB cluster does not have enough capacity for the current operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "rds.admin#InsufficientDBInstanceCapacityFault": {
@@ -4923,7 +4952,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Specified DB instance class is not available in the specified Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InsufficientStorageClusterCapacityFault": {
@@ -4938,7 +4968,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>There is insufficient storage available for the current action. You may\n       be able to resolve this error by updating your subnet group to use different\n       Availability Zones that have more storage available.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#Integer": {
@@ -4962,7 +4993,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The supplied value is not a valid DB cluster snapshot state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBClusterStateFault": {
@@ -4977,7 +5009,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The DB cluster is not in a valid state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBInstanceStateFault": {
@@ -4992,7 +5025,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified DB instance is not in the <i>available</i> state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBParameterGroupStateFault": {
@@ -5007,7 +5041,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The DB parameter group is in use or is in an invalid state. If you are attempting to\n      delete the parameter group, you cannot delete it when the parameter group is in this state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSecurityGroupStateFault": {
@@ -5022,7 +5057,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The state of the DB security group does not allow deletion.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSnapshotStateFault": {
@@ -5037,7 +5073,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The state of the DB snapshot does not allow deletion.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSubnetGroupStateFault": {
@@ -5052,7 +5089,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The DB subnet group cannot be deleted because it is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSubnetStateFault": {
@@ -5067,7 +5105,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The DB subnet is not in the <i>available</i> state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidEventSubscriptionStateFault": {
@@ -5082,7 +5121,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The event subscription is in an invalid state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidRestoreFault": {
@@ -5097,7 +5137,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Cannot restore from vpc backup to non-vpc DB instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidSubnet": {
@@ -5112,7 +5153,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested subnet is invalid, or multiple subnets were requested that are\n      not all in a common VPC.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidVPCNetworkStateFault": {
@@ -5127,7 +5169,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>DB subnet group does not cover all Availability Zones after it is created\n      because users' change.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#KMSKeyNotAccessibleFault": {
@@ -5142,7 +5185,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error accessing KMS key.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#KeyList": {
@@ -5915,7 +5959,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The designated option group could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#OrderableDBInstanceOption": {
@@ -6384,7 +6429,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Provisioned IOPS not available in the specified Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#Range": {
@@ -6704,7 +6750,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource ID was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#ResourcePendingMaintenanceActions": {
@@ -7055,7 +7102,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The SNS topic is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SNSNoAuthorizationFault": {
@@ -7070,7 +7118,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>There is no SNS authorization.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SNSTopicArnNotFoundFault": {
@@ -7085,7 +7134,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The ARN of the SNS topic could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#SharedSnapshotQuotaExceededFault": {
@@ -7100,7 +7150,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded the maximum number of accounts that you can share a manual DB snapshot with.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SnapshotQuotaExceededFault": {
@@ -7115,7 +7166,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Request would result in user exceeding the allowed number of DB snapshots.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#SourceIdsList": {
@@ -7139,7 +7191,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The source could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#SourceType": {
@@ -7167,7 +7220,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Request would result in user exceeding the allowed amount of storage available across all DB instances.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#StorageTypeNotSupportedFault": {
@@ -7182,7 +7236,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>\n            <i>StorageType</i> specified cannot be associated with the DB Instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#String": {
@@ -7226,7 +7281,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The DB subnet is already in use in the Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#SubnetIdentifierList": {
@@ -7259,7 +7315,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This subscription already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SubscriptionCategoryNotFoundFault": {
@@ -7274,7 +7331,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The designated subscription category could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#SubscriptionNotFoundFault": {
@@ -7289,7 +7347,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The designated subscription could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#SupportedCharacterSetsList": {

--- a/codegen/sdk-codegen/aws-models/opsworks.2013-02-18.json
+++ b/codegen/sdk-codegen/aws-models/opsworks.2013-02-18.json
@@ -4714,7 +4714,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS OpsWorks"
+        "smithy.api#title": "AWS OpsWorks",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://opsworks.amazonaws.com/doc/2013-02-18/"
+        }
       }
     },
     "com.amazonaws.opsworks#Parameters": {

--- a/codegen/sdk-codegen/aws-models/opsworkscm.2016-11-01.json
+++ b/codegen/sdk-codegen/aws-models/opsworkscm.2016-11-01.json
@@ -1347,7 +1347,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS OpsWorks CM"
+        "smithy.api#title": "AWS OpsWorks CM",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://opsworks-cm.amazonaws.com/doc/2016-11-01/"
+        }
       }
     },
     "com.amazonaws.opsworkscm#ResourceAlreadyExistsException": {

--- a/codegen/sdk-codegen/aws-models/organizations.2016-11-28.json
+++ b/codegen/sdk-codegen/aws-models/organizations.2016-11-28.json
@@ -34,7 +34,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Your account isn't a member of an organization. To make this request, you must use the\n      credentials of an account that belongs to an organization.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#AWSOrganizationsV20161128": {
@@ -199,7 +200,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Organizations"
+        "smithy.api#title": "AWS Organizations",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://organizations.amazonaws.com/doc/2016-11-28/"
+        }
       }
     },
     "com.amazon.awsorganizations.v20161128#AcceptHandshake": {
@@ -281,7 +285,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You don't have permissions to perform the requested operation. The user or role that is\n      making the request must have at least one IAM permissions policy attached that grants the\n      required permissions. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html\">Access Management</a> in the\n        <i>IAM User Guide.</i>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.awsorganizations.v20161128#AccessDeniedForDependencyException": {
@@ -296,7 +301,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The operation that you attempted requires you to have the\n        <code>iam:CreateServiceLinkedRole</code> for <code>organizations.amazonaws.com</code>\n      permission so that AWS Organizations can create the required service-linked role. You don't have that\n      permission.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.awsorganizations.v20161128#AccessDeniedForDependencyExceptionReason": {
@@ -404,7 +410,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> We can't find an AWS account with the <code>AccountId</code> that you specified. Or the\n      account whose credentials you used to make this request isn't a member of an\n      organization.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#AccountOwnerNotVerifiedException": {
@@ -416,7 +423,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can't invite an existing account to your organization until you verify that you own\n      the email address associated with the master account. For more information, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_create.html#about-email-verification\">Email Address\n        Verification</a> in the <i>AWS Organizations User Guide.</i>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.awsorganizations.v20161128#AccountStatus": {
@@ -466,7 +474,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This account is already a member of an organization. An account can belong to only one\n      organization at a time.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#AttachPolicy": {
@@ -637,7 +646,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find an organizational unit (OU) or AWS account with the <code>ChildId</code>\n      that you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#ChildType": {
@@ -668,7 +678,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The target of the operation is currently being modified by a different request. Try again\n      later.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#ConstraintViolationException": {
@@ -683,7 +694,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Performing this operation violates a minimum or maximum value limit. Examples include\n      attempting to remove the last service control policy (SCP) from an OU or root, or  attaching\n      too many policies to an account, OU, or root. This exception includes a reason that contains\n      additional information about the violated limit.</p>\n         <p>Some of the reasons in the following list might not be applicable to this specific API or\n      operation:</p>\n         <ul>\n            <li>\n               <p>ACCOUNT_CANNOT_LEAVE_WITHOUT_EULA: You attempted to remove an account from the\n          organization that doesn't yet have enough information to exist as a standalone account.\n          This account requires you to first agree to the AWS Customer Agreement. Follow the steps\n          at <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html#leave-without-all-info\">To\n            leave an organization when all required account information has not yet been\n            provided</a> in the <i>AWS Organizations User Guide.</i>\n               </p>\n            </li>\n            <li>\n               <p>ACCOUNT_CANNOT_LEAVE_WITHOUT_PHONE_VERIFICATION: You attempted to remove an account\n          from the organization that doesn't yet have enough information to exist as a standalone\n          account. This account requires you to first complete phone verification. Follow the steps\n          at <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html#leave-without-all-info\">To\n            leave an organization when all required account information has not yet been\n            provided</a> in the <i>AWS Organizations User Guide.</i>\n               </p>\n            </li>\n            <li>\n               <p>ACCOUNT_CREATION_RATE_LIMIT_EXCEEDED: You attempted to exceed the number of accounts\n          that you can create in one day.</p>\n            </li>\n            <li>\n               <p>ACCOUNT_NUMBER_LIMIT_EXCEEDED: You attempted to exceed the limit on the number of\n          accounts in an organization. If you need more accounts, contact <a href=\"https://console.aws.amazon.com/support/home#/\">AWS Support</a> to request an increase in your\n          limit. </p>\n               <p>Or the number of invitations that you tried to send would cause you to exceed the\n          limit of accounts in your organization. Send fewer invitations or contact AWS Support to\n          request an increase in the number of accounts.</p>\n               <note>\n                  <p>Deleted and closed accounts still count toward your limit.</p>\n               </note>\n               <important>\n                  <p>If you get receive this exception when running a command immediately after creating\n            the organization, wait one hour and try again. If after an hour it continues to fail\n            with this error, contact <a href=\"https://console.aws.amazon.com/support/home#/\">AWS\n            Support</a>.</p>\n               </important>\n            </li>\n            <li>\n               <p>HANDSHAKE_RATE_LIMIT_EXCEEDED: You attempted to exceed the number of handshakes that\n          you can send in one day.</p>\n            </li>\n            <li>\n               <p>MASTER_ACCOUNT_ADDRESS_DOES_NOT_MATCH_MARKETPLACE: To create an account in this\n          organization, you first must migrate the organization's master account to the marketplace\n          that corresponds to the master account's address. For example, accounts with India\n          addresses must be associated with the AISPL marketplace. All accounts in an organization\n          must be associated with the same marketplace.</p>\n            </li>\n            <li>\n               <p>MASTER_ACCOUNT_MISSING_CONTACT_INFO: To complete this operation, you must first\n          provide contact a valid address and phone number for the master account. Then try the\n          operation again.</p>\n            </li>\n            <li>\n               <p>MASTER_ACCOUNT_NOT_GOVCLOUD_ENABLED: To complete this operation, the master account\n          must have an associated account in the AWS GovCloud (US-West) Region. For more\n          information, see <a href=\"http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-organizations.html\">AWS Organizations</a> in the \n          <i>AWS GovCloud User Guide.</i>\n               </p>\n            </li>\n            <li>\n               <p>MASTER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED: To create an organization with this master\n          account, you first must associate a valid payment instrument, such as a credit card, with\n          the account. Follow the steps at <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html#leave-without-all-info\">To leave an\n            organization when all required account information has not yet been provided</a> in\n          the <i>AWS Organizations User Guide.</i>\n               </p>\n            </li>\n            <li>\n               <p>MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED: You attempted to exceed the number of\n          policies of a certain type that can be attached to an entity at one time.</p>\n            </li>\n            <li>\n               <p>MAX_TAG_LIMIT_EXCEEDED: You have exceeded the number of tags allowed on this resource.\n        </p>\n            </li>\n            <li>\n               <p>MEMBER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED: To complete this operation with this\n          member account, you first must associate a valid payment instrument, such as a credit\n          card, with the account. Follow the steps at <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html#leave-without-all-info\">To leave an\n            organization when all required account information has not yet been provided</a> in\n          the <i>AWS Organizations User Guide.</i>\n               </p>\n            </li>\n            <li>\n               <p>MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED: You attempted to detach a policy from an\n          entity, which would cause the entity to have fewer than the minimum number of policies of\n          the required type.</p>\n            </li>\n            <li>\n               <p>OU_DEPTH_LIMIT_EXCEEDED: You attempted to create an OU tree that is too many levels\n          deep.</p>\n            </li>\n            <li>\n               <p>ORGANIZATION_NOT_IN_ALL_FEATURES_MODE: You attempted to perform an operation that\n          requires the organization to be configured to support all features. An organization that\n          supports only consolidated billing features can't perform this operation.</p>\n            </li>\n            <li>\n               <p>OU_NUMBER_LIMIT_EXCEEDED: You attempted to exceed the number of OUs that you can have\n          in an organization.</p>\n            </li>\n            <li>\n               <p>POLICY_NUMBER_LIMIT_EXCEEDED. You attempted to exceed the number of policies that you\n          can have in an organization.</p>\n            </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#ConstraintViolationExceptionReason": {
@@ -966,7 +978,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find a create account request with the <code>CreateAccountRequestId</code> that\n      you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#CreateAccountStatuses": {
@@ -1861,7 +1874,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find the destination container (a root or OU) with the <code>ParentId</code> that\n      you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#DetachPolicy": {
@@ -2060,7 +2074,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>That account is already present in the specified destination.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#DuplicateHandshakeException": {
@@ -2072,7 +2087,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A handshake with the same action and target already exists. For example, if you invited an\n      account to join your organization, the invited account might already have a pending invitation\n      from this organization. If you intend to resend an invitation to an account, ensure that\n      existing handshakes that might be considered duplicates are canceled or declined.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#DuplicateOrganizationalUnitException": {
@@ -2084,7 +2100,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An OU with the same name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#DuplicatePolicyAttachmentException": {
@@ -2096,7 +2113,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The selected policy is already attached to the specified target.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#DuplicatePolicyException": {
@@ -2108,7 +2126,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A policy with the same name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#EffectivePolicy": {
@@ -2391,7 +2410,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>AWS Organizations couldn't perform the operation because your organization hasn't finished\n      initializing. This can take up to an hour. Try again later. If after one hour you continue to\n      receive this error, contact <a href=\"https://console.aws.amazon.com/support/home#/\">AWS\n      Support</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#GenericArn": {
@@ -2465,7 +2485,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified handshake is already in the requested state. For example, you can't accept a\n      handshake that was already accepted.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#HandshakeArn": {
@@ -2486,7 +2507,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested operation would violate the constraint identified in the reason code.</p>\n         <note>\n            <p>Some of the reasons in the following list might not be applicable to this specific API\n        or operation:</p>\n         </note>\n         <ul>\n            <li>\n               <p>ACCOUNT_NUMBER_LIMIT_EXCEEDED: You attempted to exceed the limit on the number of\n          accounts in an organization. Note that deleted and closed accounts still count toward your\n          limit.</p>\n               <important>\n                  <p>If you get this exception immediately after creating the organization, wait one hour\n            and try again. If after an hour it continues to fail with this error, contact <a href=\"https://console.aws.amazon.com/support/home#/\">AWS Support</a>.</p>\n               </important>\n            </li>\n            <li>\n               <p>ALREADY_IN_AN_ORGANIZATION: The handshake request is invalid because the invited\n          account is already a member of an organization.</p>\n            </li>\n            <li>\n               <p>HANDSHAKE_RATE_LIMIT_EXCEEDED: You attempted to exceed the number of handshakes that\n          you can send in one day.</p>\n            </li>\n            <li>\n               <p>INVITE_DISABLED_DURING_ENABLE_ALL_FEATURES: You can't issue new invitations to join an\n          organization while it's in the process of enabling all features. You can resume inviting\n          accounts after you finalize the process when all accounts have agreed to the\n          change.</p>\n            </li>\n            <li>\n               <p>ORGANIZATION_ALREADY_HAS_ALL_FEATURES: The handshake request is invalid because the\n          organization has already enabled all features.</p>\n            </li>\n            <li>\n               <p>ORGANIZATION_FROM_DIFFERENT_SELLER_OF_RECORD: The request failed because the account\n          is from a different marketplace than the accounts in the organization. For example,\n          accounts with India addresses must be associated with the AISPL marketplace. All accounts\n          in an organization must be from the same marketplace.</p>\n            </li>\n            <li>\n               <p>ORGANIZATION_MEMBERSHIP_CHANGE_RATE_LIMIT_EXCEEDED: You attempted to change the\n          membership of an account too quickly after its previous change.</p>\n            </li>\n            <li>\n               <p>PAYMENT_INSTRUMENT_REQUIRED: You can't complete the operation with an account that\n          doesn't have a payment instrument, such as a credit card, associated with it.</p>\n            </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#HandshakeConstraintViolationExceptionReason": {
@@ -2555,7 +2577,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find a handshake with the <code>HandshakeId</code> that you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#HandshakeNotes": {
@@ -2744,7 +2767,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can't perform the operation on the handshake in its current state. For example, you\n      can't cancel a handshake that was already accepted or accept a handshake that was already\n      declined.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#InvalidInputException": {
@@ -2759,7 +2783,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested operation failed because you provided invalid values for one or more of the\n      request parameters. This exception includes a reason that contains additional information\n      about the violated limit:</p>\n         <note>\n            <p>Some of the reasons in the following list might not be applicable to this specific API\n        or operation:</p>\n         </note>\n         <ul>\n            <li>\n               <p>IMMUTABLE_POLICY: You specified a policy that is managed by AWS and can't be\n          modified.</p>\n            </li>\n            <li>\n               <p>INPUT_REQUIRED: You must include a value for all required parameters.</p>\n            </li>\n            <li>\n               <p>INVALID_ENUM: You specified an invalid value.</p>\n            </li>\n            <li>\n               <p>INVALID_ENUM_POLICY_TYPE: You specified an invalid policy type.</p>\n            </li>\n            <li>\n               <p>INVALID_FULL_NAME_TARGET: You specified a full name that contains invalid\n          characters.</p>\n            </li>\n            <li>\n               <p>INVALID_LIST_MEMBER: You provided a list to a parameter that contains at least one\n          invalid value.</p>\n            </li>\n            <li>\n               <p>INVALID_PAGINATION_TOKEN: Get the value for the <code>NextToken</code> parameter from\n          the response to a previous call of the operation.</p>\n            </li>\n            <li>\n               <p>INVALID_PARTY_TYPE_TARGET: You specified the wrong type of entity (account,\n          organization, or email) as a party.</p>\n            </li>\n            <li>\n               <p>INVALID_PATTERN: You provided a value that doesn't match the required pattern.</p>\n            </li>\n            <li>\n               <p>INVALID_PATTERN_TARGET_ID: You specified a policy target ID that doesn't match the\n          required pattern.</p>\n            </li>\n            <li>\n               <p>INVALID_ROLE_NAME: You provided a role name that isn't valid. A role name can't begin\n          with the reserved prefix <code>AWSServiceRoleFor</code>.</p>\n            </li>\n            <li>\n               <p>INVALID_SYNTAX_ORGANIZATION_ARN: You specified an invalid Amazon Resource Name (ARN)\n          for the organization.</p>\n            </li>\n            <li>\n               <p>INVALID_SYNTAX_POLICY_ID: You specified an invalid policy ID. </p>\n            </li>\n            <li>\n               <p>INVALID_SYSTEM_TAGS_PARAMETER: You specified a tag key that is a system tag. You can’t\n          add, edit, or delete system tag keys because they're reserved for AWS use. System tags\n          don’t count against your tags per resource limit.</p>\n            </li>\n            <li>\n               <p>MAX_FILTER_LIMIT_EXCEEDED: You can specify only one filter parameter for the\n          operation.</p>\n            </li>\n            <li>\n               <p>MAX_LENGTH_EXCEEDED: You provided a string parameter that is longer than\n          allowed.</p>\n            </li>\n            <li>\n               <p>MAX_VALUE_EXCEEDED: You provided a numeric parameter that has a larger value than\n          allowed.</p>\n            </li>\n            <li>\n               <p>MIN_LENGTH_EXCEEDED: You provided a string parameter that is shorter than\n          allowed.</p>\n            </li>\n            <li>\n               <p>MIN_VALUE_EXCEEDED: You provided a numeric parameter that has a smaller value than\n          allowed.</p>\n            </li>\n            <li>\n               <p>MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS: You can move an account only between entities\n          in the same root.</p>\n            </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.awsorganizations.v20161128#InvalidInputExceptionReason": {
@@ -4025,7 +4050,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The provided policy document doesn't meet the requirements of the specified policy type.\n      For example, the syntax might be incorrect. For details about service control policy syntax,\n      see <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html\">Service\n        Control Policy Syntax</a> in the <i>AWS Organizations User Guide.</i>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.awsorganizations.v20161128#MasterCannotLeaveOrganizationException": {
@@ -4037,7 +4063,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can't remove a master account from an organization. If you want the master account to\n      become a member account in another organization, you must first delete the current\n      organization of the master account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#MaxResults": {
@@ -4204,7 +4231,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The organization isn't empty. To delete an organization, you must first remove all\n      accounts except the master account, delete all OUs, and delete all policies.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#OrganizationalUnit": {
@@ -4263,7 +4291,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified OU is not empty. Move all accounts to another root or to other OUs, remove\n      all child OUs, and try the operation again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#OrganizationalUnitNotFoundException": {
@@ -4275,7 +4304,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find an OU with the <code>OrganizationalUnitId</code> that you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#OrganizationalUnits": {
@@ -4319,7 +4349,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find a root or OU with the <code>ParentId</code> that you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#ParentType": {
@@ -4418,7 +4449,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The policy is attached to one or more entities. You must detach it from all roots, OUs,\n      and accounts before performing this operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#PolicyName": {
@@ -4439,7 +4471,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The policy isn't attached to the specified target in the specified root.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#PolicyNotFoundException": {
@@ -4451,7 +4484,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find a policy with the <code>PolicyId</code> that you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#PolicySummary": {
@@ -4564,7 +4598,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified policy type is already enabled in the specified root.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#PolicyTypeNotAvailableForOrganizationException": {
@@ -4576,7 +4611,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can't use the specified policy type with the feature set currently enabled for this\n      organization. For example, you can enable SCPs only after you enable all features in the\n      organization. For more information, see <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies.html#enable_policies_on_root\">Enabling and Disabling\n        a Policy Type on a Root</a> in the <i>AWS Organizations User Guide.</i>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#PolicyTypeNotEnabledException": {
@@ -4588,7 +4624,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified policy type isn't currently enabled in this root. You can't attach policies\n      of the specified type to entities in a root until you enable that type in the root. For more\n      information, see <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_org_support-all-features.html\">Enabling All Features in Your\n        Organization</a> in the <i>AWS Organizations User Guide.</i>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazon.awsorganizations.v20161128#PolicyTypeStatus": {
@@ -4751,7 +4788,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find a root with the <code>RootId</code> that you specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#Roots": {
@@ -4769,7 +4807,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>AWS Organizations can't complete your request because of an internal service error. Try again\n      later.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.awsorganizations.v20161128#ServicePrincipal": {
@@ -4791,7 +4830,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find a source root or OU with the <code>ParentId</code> that you\n      specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#Tag": {
@@ -4926,7 +4966,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>We can't find a root, OU, or account with the <code>TargetId</code> that you\n      specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.awsorganizations.v20161128#TargetType": {
@@ -4960,7 +5001,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have sent too many requests in too short a period of time. The limit helps protect\n      against denial-of-service attacks. Try again later.</p>\n         <p>For information on limits that affect AWS Organizations, see <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html\">Limits of AWS Organizations</a> in the\n        <i>AWS Organizations User Guide.</i>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazon.awsorganizations.v20161128#UnsupportedAPIEndpointException": {
@@ -4972,7 +5014,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This action isn't available in the current Region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.awsorganizations.v20161128#UntagResource": {

--- a/codegen/sdk-codegen/aws-models/personalize.2018-05-22.json
+++ b/codegen/sdk-codegen/aws-models/personalize.2018-05-22.json
@@ -3158,7 +3158,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Provide a valid value for the field or parameter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.personalize.exceptions#InvalidNextTokenException": {
@@ -3170,7 +3171,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The token is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.personalize#KmsKeyArn": {
@@ -3185,7 +3187,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The limit on the number of requests per second has been exceeded.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.services.personalize#ListBatchInferenceJobs": {
@@ -4075,7 +4078,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.services.personalize#ResourceConfig": {
@@ -4102,7 +4106,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.services.personalize.exceptions#ResourceNotFoundException": {
@@ -4114,7 +4119,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Could not find the specified resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.personalize#RoleArn": {

--- a/codegen/sdk-codegen/aws-models/pi.2018-02-27.json
+++ b/codegen/sdk-codegen/aws-models/pi.2018-02-27.json
@@ -550,7 +550,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Performance Insights"
+        "smithy.api#title": "AWS Performance Insights",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://pi.amazonaws.com/doc/2018-02-27/"
+        }
       }
     },
     "amazonaws.pi.v20180227#ResponsePartitionKey": {

--- a/codegen/sdk-codegen/aws-models/polly.2016-06-10.json
+++ b/codegen/sdk-codegen/aws-models/polly.2016-06-10.json
@@ -884,7 +884,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Polly"
+        "smithy.api#title": "Amazon Polly",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://polly.amazonaws.com/doc/v1"
+        }
       }
     },
     "com.amazonaws.parrot.v1#PutLexicon": {

--- a/codegen/sdk-codegen/aws-models/pricing.2017-10-15.json
+++ b/codegen/sdk-codegen/aws-models/pricing.2017-10-15.json
@@ -189,7 +189,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The pagination token expired. Try again without a pagination token.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awspricelistservice#Filter": {
@@ -422,7 +423,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An error on the server occurred during the processing of your request. Try again later.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.awspricelistservice#InvalidNextTokenException": {
@@ -434,7 +436,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The pagination token is invalid. Try again without a pagination token.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awspricelistservice#InvalidParameterException": {
@@ -446,7 +449,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>One or more parameters had an invalid value.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awspricelistservice#NotFoundException": {
@@ -458,7 +462,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested resource can't be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awspricelistservice#PriceList": {

--- a/codegen/sdk-codegen/aws-models/qldb.2019-01-02.json
+++ b/codegen/sdk-codegen/aws-models/qldb.2019-01-02.json
@@ -91,7 +91,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon QLDB"
+        "smithy.api#title": "Amazon QLDB",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ledger.amazonaws.com/doc/2019-01-02/"
+        }
       }
     },
     "com.amazonaws.ledger.v20190102#Arn": {

--- a/codegen/sdk-codegen/aws-models/ram.2018-01-04.json
+++ b/codegen/sdk-codegen/aws-models/ram.2018-01-04.json
@@ -590,7 +590,8 @@
         "returnValue": {
           "target": "com.amazonaws.resourcesharing.V2018_01_04#Boolean",
           "traits": {
-            "smithy.api#documentation": "\n         <p>Indicates whether the request succeeded.</p>\n      "
+            "smithy.api#documentation": "\n         <p>Indicates whether the request succeeded.</p>\n      ",
+            "smithy.api#xmlName": "return"
           }
         }
       }
@@ -811,7 +812,8 @@
         "returnValue": {
           "target": "com.amazonaws.resourcesharing.V2018_01_04#Boolean",
           "traits": {
-            "smithy.api#documentation": "\n   \t     <p>Indicates whether the request succeeded.</p>\n      "
+            "smithy.api#documentation": "\n   \t     <p>Indicates whether the request succeeded.</p>\n      ",
+            "smithy.api#xmlName": "return"
           }
         }
       }
@@ -1919,7 +1921,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#PermissionArnList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#String"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#String",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#Policy": {
@@ -1928,7 +1933,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#PolicyList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#Policy"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#Policy",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#Principal": {
@@ -1972,13 +1980,19 @@
     "com.amazonaws.resourcesharing.V2018_01_04#PrincipalArnOrIdList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#String"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#String",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#PrincipalList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#Principal"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#Principal",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#PromoteResourceShareCreatedFromPolicy": {
@@ -2037,7 +2051,8 @@
         "returnValue": {
           "target": "com.amazonaws.resourcesharing.V2018_01_04#Boolean",
           "traits": {
-            "smithy.api#documentation": "\n\t        <p>Indicates whether the request succeeded.</p>\n      "
+            "smithy.api#documentation": "\n\t        <p>Indicates whether the request succeeded.</p>\n      ",
+            "smithy.api#xmlName": "return"
           }
         }
       }
@@ -2185,7 +2200,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceArnList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#String"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#String",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceArnNotFoundException": {
@@ -2207,7 +2225,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#Resource"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#Resource",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceOwner": {
@@ -2294,7 +2315,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareArnList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#String"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#String",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareAssociation": {
@@ -2362,7 +2386,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareAssociationList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareAssociation"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareAssociation",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareAssociationStatus": {
@@ -2490,7 +2517,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareInvitationArnList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#String"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#String",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareInvitationArnNotFoundException": {
@@ -2528,7 +2558,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareInvitationList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareInvitation"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareInvitation",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareInvitationStatus": {
@@ -2561,7 +2594,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceShareList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceShare"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceShare",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceSharePermissionDetail": {
@@ -2623,7 +2659,10 @@
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceSharePermissionList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceSharePermissionSummary"
+        "target": "com.amazonaws.resourcesharing.V2018_01_04#ResourceSharePermissionSummary",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.resourcesharing.V2018_01_04#ResourceSharePermissionSummary": {

--- a/codegen/sdk-codegen/aws-models/rds.2014-10-31.json
+++ b/codegen/sdk-codegen/aws-models/rds.2014-10-31.json
@@ -769,7 +769,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified CIDR IP range or Amazon EC2 security group is already authorized for\n            the specified DB security group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#AuthorizationNotFoundFault": {
@@ -781,7 +782,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified CIDR IP range or Amazon EC2 security group might not be authorized\n            for the specified DB security group.</p>\n        <p>Or, RDS might not be authorized to perform necessary actions using IAM on your\n            behalf.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#AuthorizationQuotaExceededFault": {
@@ -793,7 +795,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB security group authorization quota has been reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#AuthorizeDBSecurityGroupIngress": {
@@ -993,7 +996,8 @@
         "smithy.api#deprecated": {
           "message": "Please avoid using this fault"
         },
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#Boolean": {
@@ -1087,7 +1091,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>CertificateIdentifier</code> doesn't refer to an\n        existing certificate.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#CharacterSet": {
@@ -3221,7 +3226,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>CustomAvailabilityZoneName</code> is already used by an existing custom\n            Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#CustomAvailabilityZoneList": {
@@ -3259,7 +3265,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>CustomAvailabilityZoneId</code> doesn't refer to an existing custom\n            Availability Zone identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#CustomAvailabilityZoneQuotaExceededFault": {
@@ -3271,7 +3278,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the maximum number of custom Availability Zones.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBCluster": {
@@ -3594,7 +3602,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The user already has a DB cluster with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterBacktrack": {
@@ -3679,7 +3688,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>BacktrackIdentifier</code> doesn't refer to an existing backtrack. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBClusterCapacityInfo": {
@@ -3794,7 +3804,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified custom endpoint can't be created because it already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterEndpointList": {
@@ -3832,7 +3843,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified custom endpoint doesn't exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBClusterEndpointQuotaExceededFault": {
@@ -3844,7 +3856,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The cluster already has the maximum number of custom endpoints.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "rds.admin.v20141031#DBClusterList": {
@@ -3926,7 +3939,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBClusterIdentifier</code> doesn't refer to an existing DB cluster.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBClusterOptionGroupMemberships": {
@@ -4042,7 +4056,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBClusterParameterGroupName</code> doesn't refer to an existing DB\n            cluster parameter group. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBClusterParameterGroupsMessage": {
@@ -4074,7 +4089,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The user attempted to create a new DB cluster and the user has already reached the\n            maximum allowed DB cluster quota.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "rds.admin.v20141031#DBClusterRole": {
@@ -4112,7 +4128,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified IAM role Amazon Resource Name (ARN) is already associated with the specified DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBClusterRoleNotFoundFault": {
@@ -4124,7 +4141,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified IAM role Amazon Resource Name (ARN) isn't associated with the specified DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBClusterRoleQuotaExceededFault": {
@@ -4136,7 +4154,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the maximum number of IAM roles that can be associated with the specified DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterRoles": {
@@ -4285,7 +4304,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The user already has a DB cluster snapshot with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBClusterSnapshotAttribute": {
@@ -4375,7 +4395,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBClusterSnapshotIdentifier</code> doesn't refer to an existing DB cluster snapshot.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBEngineVersion": {
@@ -4870,7 +4891,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The user already has a DB instance with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBInstanceAutomatedBackup": {
@@ -5057,7 +5079,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n    \t    <p>No automated backup for this DB instance was found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBInstanceAutomatedBackupQuotaExceededFault": {
@@ -5069,7 +5092,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The quota for retained automated backups was exceeded. This prevents you\n            from retaining any additional automated backups. The retained automated backups \n            quota is the same as your DB Instance quota.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBInstanceList": {
@@ -5110,7 +5134,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBInstanceIdentifier</code> doesn't refer to an existing DB instance.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBInstanceRole": {
@@ -5148,7 +5173,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified <code>RoleArn</code> or <code>FeatureName</code> value is already associated with the DB instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBInstanceRoleNotFoundFault": {
@@ -5160,7 +5186,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified <code>RoleArn</code> value doesn't match the specified feature for\n            the DB instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBInstanceRoleQuotaExceededFault": {
@@ -5172,7 +5199,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You can't associate any more AWS Identity and Access Management (IAM) roles with the DB instance because the quota has been reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBInstanceRoles": {
@@ -5234,7 +5262,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>LogFileName</code> doesn't refer to an existing DB log file.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBParameterGroup": {
@@ -5278,7 +5307,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A DB parameter group with the same name exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBParameterGroupDetails": {
@@ -5333,7 +5363,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBParameterGroupName</code> doesn't refer to an\n        existing DB parameter group.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBParameterGroupQuotaExceededFault": {
@@ -5345,7 +5376,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of DB parameter\n            groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBParameterGroupStatus": {
@@ -5498,7 +5530,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified proxy name must be unique for all proxies owned by your AWS account in the specified AWS Region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBProxyList": {
@@ -5516,7 +5549,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified proxy name doesn't correspond to a proxy owned by your AWS accoutn in the specified AWS Region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBProxyQuotaExceededFault": {
@@ -5528,7 +5562,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Your AWS account already has the maximum number of proxies in the specified AWS Region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBProxyStatus": {
@@ -5609,7 +5644,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The proxy is already associated with the specified RDS DB instance or Aurora DB cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBProxyTargetGroup": {
@@ -5677,7 +5713,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified target group isn't available for a proxy owned by your AWS account in the specified AWS Region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBProxyTargetNotFoundFault": {
@@ -5689,7 +5726,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified RDS DB instance or Aurora DB cluster isn't available for a proxy owned by your AWS account in the specified AWS Region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBSecurityGroup": {
@@ -5751,7 +5789,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n        A DB security group with the name specified in\n        <code>DBSecurityGroupName</code> already exists.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSecurityGroupMembership": {
@@ -5821,7 +5860,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSecurityGroupName</code> doesn't refer to an existing DB security group.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBSecurityGroupNotSupportedFault": {
@@ -5833,7 +5873,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A DB security group isn't allowed for this action.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSecurityGroupQuotaExceededFault": {
@@ -5845,7 +5886,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of DB security\n            groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSecurityGroups": {
@@ -6042,7 +6084,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSnapshotIdentifier</code> is already used by an existing snapshot.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSnapshotAttribute": {
@@ -6132,7 +6175,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSnapshotIdentifier</code> doesn't refer to an existing DB snapshot.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#DBSubnetGroup": {
@@ -6188,7 +6232,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSubnetGroupName</code> is already used by an existing DB subnet group.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSubnetGroupDoesNotCoverEnoughAZs": {
@@ -6200,7 +6245,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Subnets in the DB subnet group should cover at least two Availability Zones unless there is only one Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSubnetGroupMessage": {
@@ -6232,7 +6278,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DBSubnetGroup shouldn't be specified while creating read replicas that lie\n            in the same region as the source instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBSubnetGroupNotFoundFault": {
@@ -6244,7 +6291,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>DBSubnetGroupName</code> doesn't refer to an existing DB subnet group.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#DBSubnetGroupQuotaExceededFault": {
@@ -6256,7 +6304,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of DB subnet\n            groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DBSubnetGroups": {
@@ -6277,7 +6326,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of subnets in a\n            DB subnet groups.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#DBUpgradeDependencyFailureFault": {
@@ -6289,7 +6339,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB upgrade failed because a resource the DB depends on can't be\n            modified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#DeleteCustomAvailabilityZone": {
@@ -9265,7 +9316,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>Domain</code> doesn't refer to an existing Active Directory domain.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#Double": {
@@ -9677,7 +9729,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have reached the maximum number of event subscriptions.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#EventSubscriptionsList": {
@@ -9899,7 +9952,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#GlobalClusterList": {
@@ -9955,7 +10009,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#GlobalClusterQuotaExceededFault": {
@@ -9967,7 +10022,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#GlobalClustersMessage": {
@@ -10154,7 +10210,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified installation medium has already been imported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#InstallationMediaFailureCause": {
@@ -10206,7 +10263,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>InstallationMediaID</code> doesn't refer to an existing installation medium.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#InstanceQuotaExceededFault": {
@@ -10218,7 +10276,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of DB\n            instances.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InsufficientDBClusterCapacityFault": {
@@ -10230,7 +10289,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB cluster doesn't have enough capacity for the current operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "rds.admin#InsufficientDBInstanceCapacityFault": {
@@ -10242,7 +10302,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified DB instance class isn't available in the specified Availability\n            Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InsufficientStorageClusterCapacityFault": {
@@ -10254,7 +10315,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>There is insufficient storage available for the current action. You might be able to\n            resolve this error by updating your subnet group to use different Availability Zones\n            that have more storage available.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#Integer": {
@@ -10275,7 +10337,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>Capacity</code> isn't a valid Aurora Serverless DB cluster\n            capacity. Valid capacity values are <code>2</code>, <code>4</code>, <code>8</code>, <code>16</code>, \n            <code>32</code>, <code>64</code>, <code>128</code>, and <code>256</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBClusterEndpointStateFault": {
@@ -10287,7 +10350,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested operation can't be performed on the endpoint while the endpoint is in this state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBClusterSnapshotStateFault": {
@@ -10299,7 +10363,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The supplied value isn't a valid DB cluster snapshot state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBClusterStateFault": {
@@ -10311,7 +10376,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested operation can't be performed while the cluster is in this state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBInstanceAutomatedBackupStateFault": {
@@ -10323,7 +10389,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n    \t    <p>The automated backup is in an invalid state. \n    \t    For example, this automated backup is associated with an active instance. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBInstanceStateFault": {
@@ -10335,7 +10402,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB instance isn't in a valid state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBParameterGroupStateFault": {
@@ -10347,7 +10415,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB parameter group is in use or is in an invalid state. If you are attempting\n            to delete the parameter group, you can't delete it when the parameter group is in\n            this state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBProxyStateFault": {
@@ -10359,7 +10428,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested operation can't be performed while the proxy is in this state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSecurityGroupStateFault": {
@@ -10371,7 +10441,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The state of the DB security group doesn't allow deletion.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSnapshotStateFault": {
@@ -10383,7 +10454,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The state of the DB snapshot doesn't allow deletion.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSubnetGroupFault": {
@@ -10395,7 +10467,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DBSubnetGroup doesn't belong to the same VPC as that of an existing\n            cross-region read replica of the same source instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSubnetGroupStateFault": {
@@ -10407,7 +10480,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB subnet group cannot be deleted because it's in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidDBSubnetStateFault": {
@@ -10419,7 +10493,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            The DB subnet isn't in the <i>available</i> state.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidEventSubscriptionStateFault": {
@@ -10431,7 +10506,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This error can occur if someone else is modifying a subscription. You should retry the action.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidGlobalClusterStateFault": {
@@ -10443,7 +10519,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p></p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidOptionGroupStateFault": {
@@ -10455,7 +10532,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            The option group isn't in the <i>available</i> state.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidRestoreFault": {
@@ -10467,7 +10545,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Cannot restore from VPC backup to non-VPC DB instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidS3BucketFault": {
@@ -10479,7 +10558,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified Amazon S3 bucket name can't be found or Amazon RDS isn't\n            authorized to access the specified Amazon S3 bucket. Verify the <b>SourceS3BucketName</b> and <b>S3IngestionRoleArn</b> values and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidSubnet": {
@@ -10491,7 +10571,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested subnet is invalid, or multiple subnets were requested that are not all in a common VPC.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#InvalidVPCNetworkStateFault": {
@@ -10503,7 +10584,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB subnet group doesn't cover all Availability Zones after it's\n            created because of users' change.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#KMSKeyNotAccessibleFault": {
@@ -10515,7 +10597,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An error occurred accessing an AWS KMS key.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#KeyList": {
@@ -12033,7 +12116,8 @@
       },
       "traits": {
         "smithy.api#documentation": "   \n        <p>The option group you are trying to create already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#OptionGroupMembership": {
@@ -12074,7 +12158,8 @@
       },
       "traits": {
         "smithy.api#documentation": "   \n        <p>The specified option group could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#OptionGroupOption": {
@@ -12293,7 +12378,8 @@
       },
       "traits": {
         "smithy.api#documentation": "   \n        <p>The quota of 20 option groups was exceeded for this AWS account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#OptionGroups": {
@@ -12928,7 +13014,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>\n            <code>SourceDBInstanceIdentifier</code>\n        refers to a DB instance with\n        <code>BackupRetentionPeriod</code> equal to 0.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#ProcessorFeature": {
@@ -13051,7 +13138,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Provisioned IOPS not available in the specified Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#PurchaseReservedDBInstancesOffering": {
@@ -13649,7 +13737,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>User already has a reservation with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#ReservedDBInstanceList": {
@@ -13690,7 +13779,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified reserved DB Instance not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#ReservedDBInstanceQuotaExceededFault": {
@@ -13702,7 +13792,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Request would exceed the user's DB Instance quota.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#ReservedDBInstancesOffering": {
@@ -13811,7 +13902,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Specified offering does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#ResetDBClusterParameterGroup": {
@@ -13917,7 +14009,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified resource ID was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#ResourcePendingMaintenanceActions": {
@@ -15500,7 +15593,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>SNS has responded that there is a problem with the SND topic specified.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SNSNoAuthorizationFault": {
@@ -15512,7 +15606,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You do not have permission to publish to the SNS topic ARN.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SNSTopicArnNotFoundFault": {
@@ -15524,7 +15619,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The SNS topic ARN does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#ScalingConfiguration": {
@@ -15612,7 +15708,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the maximum number of accounts that you can share a manual DB snapshot with.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SnapshotQuotaExceededFault": {
@@ -15624,7 +15721,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of DB\n            snapshots.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#SourceIdsList": {
@@ -15645,7 +15743,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested source could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#SourceRegion": {
@@ -16070,7 +16169,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed amount of storage\n            available across all DB instances.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#StorageTypeNotSupportedFault": {
@@ -16082,7 +16182,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Storage of the <code>StorageType</code> specified can't be associated\n            with the DB instance. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#String": {
@@ -16132,7 +16233,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The DB subnet is already in use in the Availability Zone.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin.v20141031#SubnetIdentifierList": {
@@ -16162,7 +16264,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The supplied subscription name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "rds.admin#SubscriptionCategoryNotFoundFault": {
@@ -16174,7 +16277,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The supplied category does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin#SubscriptionNotFoundFault": {
@@ -16186,7 +16290,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The subscription name does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "rds.admin.v20141031#SupportedCharacterSetsList": {

--- a/codegen/sdk-codegen/aws-models/redshift.2012-12-01.json
+++ b/codegen/sdk-codegen/aws-models/redshift.2012-12-01.json
@@ -99,7 +99,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The owner of the specified snapshot has not authorized your account to access the\n            snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#AccountAttribute": {
@@ -234,7 +235,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified CIDR block or EC2 security group is already authorized for the\n            specified cluster security group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#AuthorizationNotFoundFault": {
@@ -246,7 +248,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified CIDR IP range or EC2 security group is not authorized for the\n            specified cluster security group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#AuthorizationQuotaExceededFault": {
@@ -258,7 +261,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The authorization quota for the cluster security group has been reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#AuthorizeClusterSecurityGroupIngress": {
@@ -464,7 +468,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The maximum number for a batch delete of snapshots has been reached. The limit is\n            100. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#BatchModifyClusterSnapshots": {
@@ -496,7 +501,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The maximum number for snapshot identifiers has been reached. The limit is 100.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#BatchModifyClusterSnapshotsMessage": {
@@ -576,7 +582,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Could not find the specified S3 bucket.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#CancelResize": {
@@ -910,7 +917,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The account already has a cluster with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterAssociatedToSchedule": {
@@ -1096,7 +1104,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The <code>ClusterIdentifier</code> parameter does not refer to an existing cluster.\n        </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#ClusterOnLatestRevisionFault": {
@@ -1108,7 +1117,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Cluster is already on the latest database revision.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterParameterGroup": {
@@ -1152,7 +1162,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A cluster parameter group with the same name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterParameterGroupDetails": {
@@ -1204,7 +1215,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The parameter group name does not refer to an existing parameter group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#ClusterParameterGroupQuotaExceededFault": {
@@ -1216,7 +1228,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of cluster\n            parameter groups. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterParameterGroupStatus": {
@@ -1315,7 +1328,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would exceed the allowed number of cluster instances for this account.\n            \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterSecurityGroup": {
@@ -1365,7 +1379,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A cluster security group with the same name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterSecurityGroupMembership": {
@@ -1435,7 +1450,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster security group name does not refer to an existing cluster security\n            group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#ClusterSecurityGroupQuotaExceededFault": {
@@ -1447,7 +1463,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of cluster\n            security groups. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterSecurityGroups": {
@@ -1468,7 +1485,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The value specified as a snapshot identifier is already used by an existing\n            snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterSnapshotCopyStatus": {
@@ -1512,7 +1530,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The snapshot identifier does not refer to an existing cluster snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#ClusterSnapshotQuotaExceededFault": {
@@ -1524,7 +1543,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in the user exceeding the allowed number of cluster\n            snapshots.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterSubnetGroup": {
@@ -1580,7 +1600,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A <i>ClusterSubnetGroupName</i> is already used by an existing\n            cluster subnet group. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterSubnetGroupMessage": {
@@ -1612,7 +1633,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster subnet group name does not refer to an existing cluster subnet\n            group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#ClusterSubnetGroupQuotaExceededFault": {
@@ -1624,7 +1646,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in user exceeding the allowed number of cluster subnet\n            groups. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterSubnetGroups": {
@@ -1645,7 +1668,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would result in user exceeding the allowed number of subnets in a\n            cluster subnet groups. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ClusterVersion": {
@@ -1795,7 +1819,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Cross-region snapshot copy was temporarily disabled. Try your request\n            again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#CreateCluster": {
@@ -3397,7 +3422,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request cannot be completed because a dependent service is throttling requests\n            made by Amazon Redshift on your behalf. Wait and retry the request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#DependentServiceUnavailableFault": {
@@ -3409,7 +3435,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Your request cannot be completed because a dependent internal service is\n            temporarily unavailable. Wait 30 to 60 seconds and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#DescribeAccountAttributes": {
@@ -5505,7 +5532,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request would exceed the allowed number of event subscriptions for this\n            account. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#EventSubscriptionsList": {
@@ -5737,7 +5765,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There is already an existing Amazon Redshift HSM client certificate with the specified\n            identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#HsmClientCertificateList": {
@@ -5778,7 +5807,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There is no Amazon Redshift HSM client certificate with the specified\n            identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#HsmClientCertificateQuotaExceededFault": {
@@ -5790,7 +5820,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The quota for HSM client certificates has been reached. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#HsmConfiguration": {
@@ -5840,7 +5871,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There is already an existing Amazon Redshift HSM configuration with the specified\n            identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#HsmConfigurationList": {
@@ -5881,7 +5913,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There is no Amazon Redshift HSM configuration with the specified identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#HsmConfigurationQuotaExceededFault": {
@@ -5893,7 +5926,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The quota for HSM configurations has been reached. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#HsmStatus": {
@@ -5993,7 +6027,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the allowed number of table restore requests. Wait for your\n            current table restore requests to complete before making a new request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#IncompatibleOrderableOptions": {
@@ -6005,7 +6040,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified options are incompatible.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InsufficientClusterCapacityFault": {
@@ -6017,7 +6053,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The number of nodes specified exceeds the allotted capacity of the\n            cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InsufficientS3BucketPolicyFault": {
@@ -6029,7 +6066,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster does not have read bucket or put object permissions on the S3 bucket\n            specified when enabling logging.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#Integer": {
@@ -6050,7 +6088,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster parameter group action can not be completed because another task is in\n            progress that involves the parameter group. Wait a few moments and try the operation\n            again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidClusterSecurityGroupStateFault": {
@@ -6062,7 +6101,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The state of the cluster security group is not <code>available</code>. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidClusterSnapshotScheduleStateFault": {
@@ -6074,7 +6114,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster snapshot schedule state is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidClusterSnapshotStateFault": {
@@ -6086,7 +6127,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified cluster snapshot is not in the <code>available</code> state, or other\n            accounts are authorized to access the snapshot. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidClusterStateFault": {
@@ -6098,7 +6140,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified cluster is not in the <code>available</code> state. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidClusterSubnetGroupStateFault": {
@@ -6110,7 +6153,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster subnet group cannot be deleted because it is in use.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidClusterSubnetStateFault": {
@@ -6122,7 +6166,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The state of the subnet is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidClusterTrackFault": {
@@ -6134,7 +6179,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The provided cluster track name is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidElasticIpFault": {
@@ -6146,7 +6192,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The Elastic IP (EIP) is invalid or cannot be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidHsmClientCertificateStateFault": {
@@ -6158,7 +6205,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified HSM client certificate is not in the <code>available</code> state, or\n            it is still in use by one or more Amazon Redshift clusters.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidHsmConfigurationStateFault": {
@@ -6170,7 +6218,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified HSM configuration is not in the <code>available</code> state, or it\n            is still in use by one or more Amazon Redshift clusters.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidReservedNodeStateFault": {
@@ -6182,7 +6231,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the Reserved Node being exchanged is not in an active state.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidRestoreFault": {
@@ -6194,7 +6244,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The restore is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 406
       }
     },
     "redshift.admin#InvalidRetentionPeriodFault": {
@@ -6206,7 +6257,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The retention period specified is either in the past or is not a valid value.</p>\n\n        <p>The value must be either -1 or an integer between 1 and 3,653.</p>\n\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidS3BucketNameFault": {
@@ -6218,7 +6270,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\n        <p>The S3 bucket name is invalid. For more information about naming rules, go to\n                <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html\">Bucket\n                Restrictions and Limitations</a> in the Amazon Simple Storage Service (S3)\n            Developer Guide.</p>\n\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidS3KeyPrefixFault": {
@@ -6230,7 +6283,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The string specified for the logging S3 key prefix does not comply with the\n            documented constraints.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidScheduleFault": {
@@ -6242,7 +6296,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The schedule you submitted isn't valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidScheduledActionFault": {
@@ -6254,7 +6309,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The scheduled action is not valid. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidSnapshotCopyGrantStateFault": {
@@ -6266,7 +6322,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The snapshot copy grant can't be deleted because it is used by one or more\n            clusters.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidSubnet": {
@@ -6278,7 +6335,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested subnet is not valid, or not all of the subnets are in the same\n            VPC.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidSubscriptionStateFault": {
@@ -6290,7 +6348,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The subscription request is invalid because it is a duplicate request. This\n            subscription request is already in progress.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidTableRestoreArgumentFault": {
@@ -6302,7 +6361,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The value specified for the <code>sourceDatabaseName</code>,\n                <code>sourceSchemaName</code>, or <code>sourceTableName</code> parameter, or a\n            combination of these, doesn't exist in the snapshot.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidTagFault": {
@@ -6314,7 +6374,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The tag is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#InvalidVPCNetworkStateFault": {
@@ -6326,7 +6387,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster subnet group does not cover all Availability Zones.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#LimitExceededFault": {
@@ -6338,7 +6400,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The encryption key has exceeded its grant limit in AWS KMS.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#LoggingStatus": {
@@ -7382,7 +7445,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The operation would exceed the number of nodes allowed for a cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#NumberOfNodesQuotaExceededFault": {
@@ -7394,7 +7458,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The operation would exceed the number of nodes allotted to the account.\n            \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#OperatorType": {
@@ -8146,7 +8211,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>User already has a reservation with the given identifier.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#ReservedNodeAlreadyMigratedFault": {
@@ -8158,7 +8224,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the reserved node has already been exchanged.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ReservedNodeList": {
@@ -8179,7 +8246,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified reserved compute node not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin.v20121201#ReservedNodeOffering": {
@@ -8262,7 +8330,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Specified offering does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin.v20121201#ReservedNodeOfferingType": {
@@ -8303,7 +8372,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Request would exceed the user's compute node quota. \nFor information about increasing your quota, go to <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> \nin the <i>Amazon Redshift Cluster Management Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ReservedNodesMessage": {
@@ -8480,7 +8550,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A resize operation for the specified cluster is not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin.v20121201#ResizeProgressMessage": {
@@ -8596,7 +8667,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The resource could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin.v20121201#RestorableNodeTypeList": {
@@ -9192,7 +9264,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Amazon SNS has responded that there is a problem with the specified Amazon SNS\n            topic.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SNSNoAuthorizationFault": {
@@ -9204,7 +9277,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You do not have permission to publish to the specified Amazon SNS topic.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SNSTopicArnNotFoundFault": {
@@ -9216,7 +9290,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An Amazon SNS topic with the specified Amazon Resource Name (ARN) does not\n            exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin.v20121201#ScheduleDefinitionList": {
@@ -9237,7 +9312,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The definition you submitted is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ScheduleState": {
@@ -9321,7 +9397,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The scheduled action already exists. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ScheduledActionFilter": {
@@ -9386,7 +9463,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The scheduled action cannot be found. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#ScheduledActionQuotaExceededFault": {
@@ -9398,7 +9476,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The quota for scheduled actions exceeded. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ScheduledActionState": {
@@ -9446,7 +9525,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The action type specified for a scheduled action is not supported. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#ScheduledActionTypeValues": {
@@ -9722,7 +9802,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster already has cross-region snapshot copy disabled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SnapshotCopyAlreadyEnabledFault": {
@@ -9734,7 +9815,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The cluster already has cross-region snapshot copy enabled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SnapshotCopyDisabledFault": {
@@ -9746,7 +9828,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Cross-region snapshot copy was temporarily disabled. Try your request\n            again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#SnapshotCopyGrant": {
@@ -9784,7 +9867,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The snapshot copy grant can't be created because a grant with the same name already\n            exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#SnapshotCopyGrantList": {
@@ -9825,7 +9909,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified snapshot copy grant can't be found. Make sure that the name is typed\n            correctly and that the grant exists in the destination region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SnapshotCopyGrantQuotaExceededFault": {
@@ -9837,7 +9922,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The AWS account has exceeded the maximum number of snapshot copy grants in this\n            region.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#SnapshotErrorMessage": {
@@ -9969,7 +10055,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified snapshot schedule already exists. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#SnapshotScheduleList": {
@@ -9990,7 +10077,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>We could not find the specified snapshot schedule. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SnapshotScheduleQuotaExceededFault": {
@@ -10002,7 +10090,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the quota of snapshot schedules. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SnapshotScheduleUpdateInProgressFault": {
@@ -10014,7 +10103,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified snapshot schedule is already being updated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#SnapshotSortingEntity": {
@@ -10078,7 +10168,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified Amazon Redshift event source could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin.v20121201#SourceType": {
@@ -10131,7 +10222,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A specified subnet is already in use by another cluster.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#SubnetIdentifierList": {
@@ -10161,7 +10253,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There is already an existing event notification subscription with the specified\n            name.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#SubscriptionCategoryNotFoundFault": {
@@ -10173,7 +10266,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The value specified for the event category was not one of the allowed values, or it\n            specified a category that does not apply to the specified source type. The allowed\n            values are Configuration, Management, Monitoring, and Security.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#SubscriptionEventIdNotFoundFault": {
@@ -10185,7 +10279,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An Amazon Redshift event with the specified event ID does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#SubscriptionNotFoundFault": {
@@ -10197,7 +10292,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An Amazon Redshift event notification subscription with the specified name does not\n            exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#SubscriptionSeverityNotFoundFault": {
@@ -10209,7 +10305,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The value specified for the event severity was not one of the allowed values, or it\n            specified a severity that does not apply to the specified source type. The allowed\n            values are ERROR and INFO.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin.v20121201#SupportedOperation": {
@@ -10270,7 +10367,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The number of tables in the cluster exceeds the limit for the requested new cluster\n            node type. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#TableRestoreNotFoundFault": {
@@ -10282,7 +10380,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified <code>TableRestoreRequestId</code> value was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#TableRestoreStatus": {
@@ -10456,7 +10555,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the number of tags allowed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#TagList": {
@@ -10567,7 +10667,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Your account is not authorized to perform the requested operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#UnknownSnapshotCopyRegionFault": {
@@ -10579,7 +10680,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified region is incorrect or does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "redshift.admin#UnsupportedOperationFault": {
@@ -10591,7 +10693,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The requested operation isn't supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin#UnsupportedOptionFault": {
@@ -10603,7 +10706,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A request option was specified that is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "redshift.admin.v20121201#UpdateTarget": {

--- a/codegen/sdk-codegen/aws-models/rekognition.2016-06-27.json
+++ b/codegen/sdk-codegen/aws-models/rekognition.2016-06-27.json
@@ -3149,7 +3149,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The number of in-progress human reviews you have has exceeded the number allowed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
       }
     },
     "com.amazonaws.rekognitionservice#IdempotentParameterMismatchException": {

--- a/codegen/sdk-codegen/aws-models/route-53-domains.2014-05-15.json
+++ b/codegen/sdk-codegen/aws-models/route-53-domains.2014-05-15.json
@@ -751,7 +751,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The number of domains has exceeded the allowed threshold for the account.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53domains.v20140515#DomainName": {
@@ -860,7 +861,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The request is already in progress for the domain.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53domains.v20140515#DurationInYears": {
@@ -1506,7 +1508,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The requested item is not acceptable. For example, for an OperationId it might refer to the ID of an operation \n\t\t\tthat is already completed. For a domain name, it might not be a valid domain name or belong to the requester account.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53domains.v20140515#InvoiceId": {
@@ -1756,7 +1759,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The number of operations or jobs running exceeded the allowed threshold for the account.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53domains.v20140515#OperationStatus": {
@@ -2309,7 +2313,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Route 53 Domains"
+        "smithy.api#title": "Amazon Route 53 Domains",
+        "smithy.api#xmlNamespace": {
+          "uri": "https://route53domains.amazonaws.com/doc/2014-05-15/"
+        }
       }
     },
     "com.amazonaws.route53domains.v20140515#State": {
@@ -2336,7 +2343,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The top-level domain does not support this operation.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53domains.v20140515#Tag": {
@@ -2541,7 +2549,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>Amazon Route 53 does not support this top-level domain (TLD).</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53domains.v20140515#UpdateDomainContact": {

--- a/codegen/sdk-codegen/aws-models/s3.2006-03-01.json
+++ b/codegen/sdk-codegen/aws-models/s3.2006-03-01.json
@@ -179,9 +179,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#AllowedHeader"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#AllowedMethod": {
@@ -191,9 +188,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#AllowedMethod"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#AllowedOrigin": {
@@ -203,9 +197,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#AllowedOrigin"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#AmazonS3": {
@@ -541,9 +532,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#AnalyticsConfiguration"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#AnalyticsExportDestination": {
@@ -699,6 +687,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>A lifecycle rule for individual objects in an Amazon S3 bucket.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Rule"
           }
         }
@@ -787,6 +776,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "CORSRule"
           }
         }
@@ -802,6 +792,7 @@
           "target": "com.amazonaws.s3#AllowedHeaders",
           "traits": {
             "smithy.api#documentation": "\n         <p>Headers that are specified in the <code>Access-Control-Request-Headers</code>\n      header. These headers are allowed in a preflight OPTIONS request. In response to\n      any preflight OPTIONS request, Amazon S3 returns any requested headers that are\n      allowed.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "AllowedHeader"
           }
         },
@@ -810,6 +801,7 @@
           "traits": {
             "smithy.api#documentation": " \n         <p>An HTTP method that you allow the origin to execute. Valid values are\n      <code>GET</code>, <code>PUT</code>, <code>HEAD</code>, <code>POST</code>, and\n      <code>DELETE</code>.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "AllowedMethod"
           }
         },
@@ -818,6 +810,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>One or more origins you want customers to be able to access the bucket from.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "AllowedOrigin"
           }
         },
@@ -825,6 +818,7 @@
           "target": "com.amazonaws.s3#ExposeHeaders",
           "traits": {
             "smithy.api#documentation": "\n         <p>One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript <code>XMLHttpRequest</code> object).</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "ExposeHeader"
           }
         },
@@ -843,9 +837,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#CORSRule"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#CSVInput": {
@@ -963,9 +954,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#CommonPrefix"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#CompleteMultipartUpload": {
@@ -1098,6 +1086,7 @@
           "target": "com.amazonaws.s3#CompletedPartList",
           "traits": {
             "smithy.api#documentation": "\n         <p>Array of CompletedPart data types.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Part"
           }
         }
@@ -1130,9 +1119,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#CompletedPart"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#CompressionType": {
@@ -2094,6 +2080,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>The objects to delete.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Object"
           }
         },
@@ -2500,9 +2487,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#DeleteMarkerEntry"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#DeleteObject": {
@@ -2675,13 +2659,15 @@
         "Deleted": {
           "target": "com.amazonaws.s3#DeletedObjects",
           "traits": {
-            "smithy.api#documentation": "\n         <p>Container element for a successful delete. It identifies the object that was successfully deleted.</p>\n      "
+            "smithy.api#documentation": "\n         <p>Container element for a successful delete. It identifies the object that was successfully deleted.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "Errors": {
           "target": "com.amazonaws.s3#Errors",
           "traits": {
             "smithy.api#documentation": "\n         <p>Container for a failed delete operation that describes the object that Amazon S3 attempted to delete and the error it encountered.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Error"
           }
         },
@@ -2797,9 +2783,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#DeletedObject"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#Delimiter": {
@@ -2982,9 +2965,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#Error"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#Event": {
@@ -3016,9 +2996,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#Event"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#ExistingObjectReplication": {
@@ -3070,9 +3047,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#ExposeHeader"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#Expression": {
@@ -3136,8 +3110,7 @@
         "target": "com.amazonaws.s3#FilterRule"
       },
       "traits": {
-        "smithy.api#documentation": "\n         <p>A list of containers for the key-value pair that defines the criteria for the filter\n         rule.</p>\n      ",
-        "smithy.api#xmlFlattened": true
+        "smithy.api#documentation": "\n         <p>A list of containers for the key-value pair that defines the criteria for the filter\n         rule.</p>\n      "
       }
     },
     "com.amazonaws.s3#FilterRuleName": {
@@ -3315,6 +3288,7 @@
           "target": "com.amazonaws.s3#CORSRules",
           "traits": {
             "smithy.api#documentation": "\n         <p>A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "CORSRule"
           }
         }
@@ -3448,6 +3422,7 @@
           "target": "com.amazonaws.s3#LifecycleRules",
           "traits": {
             "smithy.api#documentation": "\n         <p>Container for a lifecycle rule.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Rule"
           }
         }
@@ -5347,9 +5322,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#InventoryConfiguration"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#InventoryDestination": {
@@ -5593,6 +5565,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>The Amazon S3 bucket event for which to invoke the AWS Lambda function.\n         For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Supported Event Types</a> in the\n         <i>Amazon Simple Storage Service Developer Guide</i>.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Event"
           }
         },
@@ -5619,9 +5592,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#LambdaFunctionConfiguration"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#LastModified": {
@@ -5681,6 +5651,7 @@
           "target": "com.amazonaws.s3#NoncurrentVersionTransitionList",
           "traits": {
             "smithy.api#documentation": "\n         <p> Specifies the transition rule for the lifecycle rule that describes when noncurrent\n         objects transition to a specific storage class. If your bucket is versioning-enabled (or\n         versioning is suspended), you can set this action to request that Amazon S3 transition\n         noncurrent object versions to a specific storage class at a set period in the object's\n         lifetime. </p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "NoncurrentVersionTransition"
           }
         },
@@ -5702,6 +5673,7 @@
           "target": "com.amazonaws.s3#TransitionList",
           "traits": {
             "smithy.api#documentation": "\n         <p>Specifies when an Amazon S3 object transitions to a specified storage class.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Transition"
           }
         }
@@ -5759,9 +5731,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#LifecycleRule"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#ListBucketAnalyticsConfigurations": {
@@ -5788,6 +5757,7 @@
           "target": "com.amazonaws.s3#AnalyticsConfigurationList",
           "traits": {
             "smithy.api#documentation": "\n         <p>The list of analytics configurations for a bucket.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "AnalyticsConfiguration"
           }
         },
@@ -5861,6 +5831,7 @@
           "target": "com.amazonaws.s3#InventoryConfigurationList",
           "traits": {
             "smithy.api#documentation": "\n         <p>The list of inventory configurations for a bucket.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "InventoryConfiguration"
           }
         },
@@ -5934,6 +5905,7 @@
           "target": "com.amazonaws.s3#MetricsConfigurationList",
           "traits": {
             "smithy.api#documentation": "\n         <p>The list of metrics configurations for a bucket.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "MetricsConfiguration"
           }
         },
@@ -6025,7 +5997,8 @@
         "CommonPrefixes": {
           "target": "com.amazonaws.s3#CommonPrefixList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>If you specify a delimiter in the request, then the result returns each distinct key\n         prefix containing the delimiter in a <code>CommonPrefixes</code> element. The distinct key\n         prefixes are returned in the <code>Prefix</code> child element.</p>\n      "
+            "smithy.api#documentation": "\n         <p>If you specify a delimiter in the request, then the result returns each distinct key\n         prefix containing the delimiter in a <code>CommonPrefixes</code> element. The distinct key\n         prefixes are returned in the <code>Prefix</code> child element.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "Delimiter": {
@@ -6086,6 +6059,7 @@
           "target": "com.amazonaws.s3#MultipartUploadList",
           "traits": {
             "smithy.api#documentation": "\n         <p>Container for elements related to a particular multipart upload. A response can contain\n         zero or more <code>Upload</code> elements.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Upload"
           }
         }
@@ -6168,13 +6142,15 @@
         "CommonPrefixes": {
           "target": "com.amazonaws.s3#CommonPrefixList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>All of the keys rolled up into a common prefix count as a single return when calculating the number of returns.</p>\n      "
+            "smithy.api#documentation": "\n         <p>All of the keys rolled up into a common prefix count as a single return when calculating the number of returns.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "DeleteMarkers": {
           "target": "com.amazonaws.s3#DeleteMarkers",
           "traits": {
             "smithy.api#documentation": "\n         <p>Container for an object that is a delete marker.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "DeleteMarker"
           }
         },
@@ -6242,6 +6218,7 @@
           "target": "com.amazonaws.s3#ObjectVersionList",
           "traits": {
             "smithy.api#documentation": "\n         <p>Container for version information.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Version"
           }
         }
@@ -6329,13 +6306,15 @@
         "CommonPrefixes": {
           "target": "com.amazonaws.s3#CommonPrefixList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>All of the keys rolled up in a common prefix count as a single return when calculating the number of returns. </p>\n         \n         <p>A response can contain CommonPrefixes only if you specify a delimiter.</p>\n         \n         <p>CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by the delimiter.</p>\n         \n        <p> CommonPrefixes lists keys that act like subdirectories in the directory specified by Prefix.</p>\n         \n         <p>For example, if the prefix is notes/ and the delimiter is a slash (/) as in notes/summer/july, the common prefix is notes/summer/. All of the keys that roll up into a common prefix count as a single return when calculating the number of returns.</p>\n      "
+            "smithy.api#documentation": "\n         <p>All of the keys rolled up in a common prefix count as a single return when calculating the number of returns. </p>\n         \n         <p>A response can contain CommonPrefixes only if you specify a delimiter.</p>\n         \n         <p>CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by the delimiter.</p>\n         \n        <p> CommonPrefixes lists keys that act like subdirectories in the directory specified by Prefix.</p>\n         \n         <p>For example, if the prefix is notes/ and the delimiter is a slash (/) as in notes/summer/july, the common prefix is notes/summer/. All of the keys that roll up into a common prefix count as a single return when calculating the number of returns.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "Contents": {
           "target": "com.amazonaws.s3#ObjectList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>Metadata about each object returned.</p>\n      "
+            "smithy.api#documentation": "\n         <p>Metadata about each object returned.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "Delimiter": {
@@ -6470,13 +6449,15 @@
         "CommonPrefixes": {
           "target": "com.amazonaws.s3#CommonPrefixList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>All of the keys rolled up into a common prefix count as a single return when calculating the number of returns.</p>\n      \n         <p>A response can contain <code>CommonPrefixes</code> only if you specify a delimiter.</p>\n      \n         <p>\n            <code>CommonPrefixes</code> contains all (if there are any) keys between <code>Prefix</code> and the next occurrence of the string specified by a delimiter.</p>\n      \n         <p>\n            <code>CommonPrefixes</code> lists keys that act like subdirectories in the directory specified by <code>Prefix</code>.</p>\n      \n         <p>For example, if the prefix is <code>notes/</code> and the delimiter is a slash (<code>/</code>) as in <code>notes/summer/july</code>, the common prefix is <code>notes/summer/</code>. All of the keys that roll up into a common prefix count as a single return when calculating the number of returns. </p>\n   \n      "
+            "smithy.api#documentation": "\n         <p>All of the keys rolled up into a common prefix count as a single return when calculating the number of returns.</p>\n      \n         <p>A response can contain <code>CommonPrefixes</code> only if you specify a delimiter.</p>\n      \n         <p>\n            <code>CommonPrefixes</code> contains all (if there are any) keys between <code>Prefix</code> and the next occurrence of the string specified by a delimiter.</p>\n      \n         <p>\n            <code>CommonPrefixes</code> lists keys that act like subdirectories in the directory specified by <code>Prefix</code>.</p>\n      \n         <p>For example, if the prefix is <code>notes/</code> and the delimiter is a slash (<code>/</code>) as in <code>notes/summer/july</code>, the common prefix is <code>notes/summer/</code>. All of the keys that roll up into a common prefix count as a single return when calculating the number of returns. </p>\n   \n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "Contents": {
           "target": "com.amazonaws.s3#ObjectList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>Metadata about each object returned.</p>\n      "
+            "smithy.api#documentation": "\n         <p>Metadata about each object returned.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "ContinuationToken": {
@@ -6696,6 +6677,7 @@
           "target": "com.amazonaws.s3#Parts",
           "traits": {
             "smithy.api#documentation": "\n         <p> Container for elements related to a particular part. A response can contain zero or\n         more <code>Part</code> elements.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Part"
           }
         },
@@ -6954,9 +6936,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#MetricsConfiguration"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#MetricsFilter": {
@@ -7054,9 +7033,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#MultipartUpload"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#NextKeyMarker": {
@@ -7139,9 +7115,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#NoncurrentVersionTransition"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#NotificationConfiguration": {
@@ -7151,6 +7124,7 @@
           "target": "com.amazonaws.s3#LambdaFunctionConfigurationList",
           "traits": {
             "smithy.api#documentation": "\n         <p>Describes the AWS Lambda functions to invoke and the events for which to invoke them.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "CloudFunctionConfiguration"
           }
         },
@@ -7158,6 +7132,7 @@
           "target": "com.amazonaws.s3#QueueConfigurationList",
           "traits": {
             "smithy.api#documentation": "\n         <p>The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "QueueConfiguration"
           }
         },
@@ -7165,6 +7140,7 @@
           "target": "com.amazonaws.s3#TopicConfigurationList",
           "traits": {
             "smithy.api#documentation": "\n         <p>The topic to which notifications are sent and the events for which notifications are generated.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "TopicConfiguration"
           }
         }
@@ -7284,9 +7260,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#ObjectIdentifier"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#ObjectKey": {
@@ -7301,9 +7274,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#Object"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#ObjectLockConfiguration": {
@@ -7506,9 +7476,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#ObjectVersion"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#ObjectVersionStorageClass": {
@@ -7630,9 +7597,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#Part"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#PartsCount": {
@@ -9256,6 +9220,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>A collection of bucket events for which to send notifications</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Event"
           }
         },
@@ -9282,9 +9247,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#QueueConfiguration"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#Quiet": {
@@ -9413,6 +9375,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>A container for one or more replication rules. A replication configuration must have at\n      least one rule and can contain a maximum of 1,000 rules. </p>\n \n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Rule"
           }
         }
@@ -9541,9 +9504,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#ReplicationRule"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#ReplicationStatus": {
@@ -9852,6 +9812,7 @@
         "FilterRules": {
           "target": "com.amazonaws.s3#FilterRuleList",
           "traits": {
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "FilterRule"
           }
         }
@@ -10210,6 +10171,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>Container for information about a particular server-side encryption configuration rule.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Rule"
           }
         }
@@ -10236,9 +10198,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#ServerSideEncryptionRule"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#Setting": {
@@ -10513,6 +10472,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>The Amazon S3 bucket event about which to send notifications. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Supported Event\n            Types</a> in the <i>Amazon Simple Storage Service Developer Guide</i>.</p>\n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Event"
           }
         },
@@ -10539,9 +10499,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#TopicConfiguration"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#Transition": {
@@ -10574,9 +10531,6 @@
       "type": "list",
       "member": {
         "target": "com.amazonaws.s3#Transition"
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.s3#TransitionStorageClass": {

--- a/codegen/sdk-codegen/aws-models/sagemaker.2017-07-24.json
+++ b/codegen/sdk-codegen/aws-models/sagemaker.2017-07-24.json
@@ -17868,7 +17868,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon SageMaker Service"
+        "smithy.api#title": "Amazon SageMaker Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://sagemaker.amazonaws.com/doc/2017-05-13/"
+        }
       }
     },
     "com.amazonaws.sagemaker.api#SamplingPercentage": {

--- a/codegen/sdk-codegen/aws-models/service-catalog.2015-12-10.json
+++ b/codegen/sdk-codegen/aws-models/service-catalog.2015-12-10.json
@@ -2210,6 +2210,7 @@
           "target": "com.amazonaws.aws242.library#TagOptionId",
           "traits": {
             "smithy.api#documentation": "\n         <p>The TagOption identifier.</p>\n      ",
+            "smithy.api#httpQuery": "id",
             "smithy.api#required": true
           }
         }
@@ -3125,6 +3126,7 @@
           "target": "com.amazonaws.aws242.library#TagOptionId",
           "traits": {
             "smithy.api#documentation": "\n         <p>The TagOption identifier.</p>\n      ",
+            "smithy.api#httpQuery": "id",
             "smithy.api#required": true
           }
         }
@@ -3399,6 +3401,7 @@
           "target": "com.amazonaws.aws242.library#ResourceId",
           "traits": {
             "smithy.api#documentation": "\n         <p>The resource identifier.</p>\n      ",
+            "smithy.api#httpQuery": "resourceId",
             "smithy.api#required": true
           }
         },
@@ -3406,6 +3409,7 @@
           "target": "com.amazonaws.aws242.library#TagOptionId",
           "traits": {
             "smithy.api#documentation": "\n         <p>The TagOption identifier.</p>\n      ",
+            "smithy.api#httpQuery": "tagOptionId",
             "smithy.api#required": true
           }
         }
@@ -4842,25 +4846,29 @@
         "PageSize": {
           "target": "com.amazonaws.aws242.library#PageSize",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The maximum number of items to return with this call.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The maximum number of items to return with this call.</p>\n      ",
+            "smithy.api#httpQuery": "pageSize"
           }
         },
         "PageToken": {
           "target": "com.amazonaws.aws242.servicecatalog.v20151210#PageToken",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The page token for the next set of results. To retrieve the first set of results, use null.</p>\n      "
+            "smithy.api#documentation": "\n         <p>The page token for the next set of results. To retrieve the first set of results, use null.</p>\n      ",
+            "smithy.api#httpQuery": "pageToken"
           }
         },
         "ResourceType": {
           "target": "com.amazonaws.aws242.library#ResourceType",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The resource type.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Portfolio</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>Product</code>\n               </p>\n            </li>\n         </ul>\n      "
+            "smithy.api#documentation": "\n         <p>The resource type.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Portfolio</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>Product</code>\n               </p>\n            </li>\n         </ul>\n      ",
+            "smithy.api#httpQuery": "resourceType"
           }
         },
         "TagOptionId": {
           "target": "com.amazonaws.aws242.library#TagOptionId",
           "traits": {
             "smithy.api#documentation": "\n         <p>The TagOption identifier.</p>\n      ",
+            "smithy.api#httpQuery": "tagOptionId",
             "smithy.api#required": true
           }
         }

--- a/codegen/sdk-codegen/aws-models/service-quotas.2019-06-24.json
+++ b/codegen/sdk-codegen/aws-models/service-quotas.2019-06-24.json
@@ -34,7 +34,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The action you attempted is not allowed unless Service Access with Service Quotas is\n      enabled in your organization. To enable, call <a>AssociateServiceQuotaTemplate</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.servicequotas#AccessDeniedException": {
@@ -46,7 +47,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You do not have sufficient access to perform this action.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.servicequotas#AssociateServiceQuotaTemplate": {
@@ -191,7 +193,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can't perform this action because a dependency does not have access.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.servicequotas#DisassociateServiceQuotaTemplate": {
@@ -598,7 +601,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Invalid input was provided. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servicequotas#InvalidPaginationTokenException": {
@@ -610,7 +614,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Invalid input was provided.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servicequotas#InvalidResourceStateException": {
@@ -622,7 +627,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Invalid input was provided for the . </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 405
       }
     },
     "com.amazonaws.servicequotas#ListAWSDefaultServiceQuotas": {
@@ -1200,7 +1206,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The account making this call is not a member of an organization.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.servicequotas#NoSuchResourceException": {
@@ -1212,7 +1219,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.servicequotas#OrganizationNotInAllFeaturesModeException": {
@@ -1224,7 +1232,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The organization that your account belongs to, is not in All Features mode. To enable all\n      features mode, see <a href=\"https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAllFeatures.html\">EnableAllFeatures</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servicequotas#PeriodUnit": {
@@ -1374,7 +1383,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded your service quota. To perform the requested action, remove some of the\n      relevant resources, or use Service Quotas to request a service quota increase.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.servicequotas#QuotaMetricName": {
@@ -1639,7 +1649,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified resource already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servicequotas#ServiceCode": {
@@ -1661,7 +1672,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Something went wrong. </p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.servicequotas#ServiceInfo": {
@@ -1863,7 +1875,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The quota request template is not associated with your organization. </p>\n         <p>To use the template, call <a>AssociateServiceQuotaTemplate</a>. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servicequotas#ServiceQuotasV20190624": {
@@ -1957,7 +1970,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The Service Quotas template is not available in the Region where you are making the\n      request. Please make the request in us-east-1. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.servicequotas#TooManyRequestsException": {
@@ -1969,7 +1983,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Due to throttling, the request was denied. Slow down the rate of request calls, or request\n      an increase for this quota. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     }
   }

--- a/codegen/sdk-codegen/aws-models/servicediscovery.2017-03-14.json
+++ b/codegen/sdk-codegen/aws-models/servicediscovery.2017-03-14.json
@@ -352,7 +352,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The health check for the instance that is specified by <code>ServiceId</code> and <code>InstanceId</code> is not a custom health check. </p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#CustomHealthStatus": {
@@ -691,7 +692,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The operation is already in progress.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#ErrorMessage": {
@@ -735,7 +737,10 @@
     "com.amazonaws.route53.autonaming.v20170314#FilterValues": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.route53.autonaming.v20170314#FilterValue"
+        "target": "com.amazonaws.route53.autonaming.v20170314#FilterValue",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#GetInstance": {
@@ -1181,7 +1186,10 @@
     "com.amazonaws.route53.autonaming.v20170314#InstanceIdList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.route53.autonaming.v20170314#ResourceId"
+        "target": "com.amazonaws.route53.autonaming.v20170314#ResourceId",
+        "traits": {
+          "smithy.api#xmlName": "InstanceId"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -1198,7 +1206,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>No instance exists with the specified ID, or the instance was recently registered, and information about the instance hasn't propagated yet.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#InstanceSummary": {
@@ -1224,7 +1233,10 @@
     "com.amazonaws.route53.autonaming.v20170314#InstanceSummaryList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.route53.autonaming.v20170314#InstanceSummary"
+        "target": "com.amazonaws.route53.autonaming.v20170314#InstanceSummary",
+        "traits": {
+          "smithy.api#xmlName": "InstanceSummary"
+        }
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#InvalidInput": {
@@ -1236,7 +1248,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>One or more specified values aren't valid. For example, a required value might be missing, a numeric value might be outside the allowed range, \n\t\t\tor a string value might exceed length constraints.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#ListInstances": {
@@ -1587,7 +1600,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The namespace that you're trying to create already exists.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#NamespaceFilter": {
@@ -1631,7 +1645,10 @@
     "com.amazonaws.route53.autonaming.v20170314#NamespaceFilters": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.route53.autonaming.v20170314#NamespaceFilter"
+        "target": "com.amazonaws.route53.autonaming.v20170314#NamespaceFilter",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#NamespaceName": {
@@ -1652,7 +1669,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>No namespace exists with the specified ID.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#NamespaceProperties": {
@@ -1868,7 +1886,10 @@
     "com.amazonaws.route53.autonaming.v20170314#OperationFilters": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.route53.autonaming.v20170314#OperationFilter"
+        "target": "com.amazonaws.route53.autonaming.v20170314#OperationFilter",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#OperationId": {
@@ -1889,7 +1910,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>No operation exists with the specified ID.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#OperationStatus": {
@@ -1934,7 +1956,10 @@
     "com.amazonaws.route53.autonaming.v20170314#OperationSummaryList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.route53.autonaming.v20170314#OperationSummary"
+        "target": "com.amazonaws.route53.autonaming.v20170314#OperationSummary",
+        "traits": {
+          "smithy.api#xmlName": "OperationSummary"
+        }
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#OperationTargetType": {
@@ -2119,7 +2144,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The specified resource can't be deleted because it contains other resources. For example, you can't delete a service that \n\t\t\tcontains any instances.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#ResourceLimitExceeded": {
@@ -2131,7 +2157,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The resource can't be created because you've reached the limit on the number of resources.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#ResourcePath": {
@@ -2335,7 +2362,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>The service can't be created because a service with the same name already exists.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#ServiceChange": {
@@ -2403,7 +2431,10 @@
     "com.amazonaws.route53.autonaming.v20170314#ServiceFilters": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.route53.autonaming.v20170314#ServiceFilter"
+        "target": "com.amazonaws.route53.autonaming.v20170314#ServiceFilter",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#ServiceName": {
@@ -2421,7 +2452,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\t\t       <p>No service exists with the specified ID.</p>\n\t     ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.route53.autonaming.v20170314#ServiceSummariesList": {

--- a/codegen/sdk-codegen/aws-models/ses.2010-12-01.json
+++ b/codegen/sdk-codegen/aws-models/ses.2010-12-01.json
@@ -34,7 +34,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that email sending is disabled for your entire Amazon SES account.</p>\n        <p>You can enable or disable email sending for your Amazon SES account using <a>UpdateAccountSendingEnabled</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#AddHeaderAction": {
@@ -83,7 +84,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that a resource could not be created because of a naming conflict.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#AmazonResourceName": {
@@ -367,7 +369,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the delete operation could not be completed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#Charset": {
@@ -508,7 +511,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the configuration set could not be created because of a naming\n            conflict.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#ConfigurationSetAttribute": {
@@ -551,7 +555,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the configuration set does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#ConfigurationSetName": {
@@ -572,7 +577,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that email sending is disabled for the configuration set.</p>\n        <p>You can enable or disable email sending for a configuration set using <a>UpdateConfigurationSetSendingEnabled</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#ConfigurationSets": {
@@ -1062,7 +1068,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that custom verification email template provided content is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#CustomVerificationEmailTemplate": {
@@ -1118,7 +1125,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that a custom verification email template with the name you specified\n            already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#CustomVerificationEmailTemplateDoesNotExistException": {
@@ -1136,7 +1144,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that a custom verification email template with the name you specified does\n            not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#CustomVerificationEmailTemplates": {
@@ -1946,7 +1955,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the event destination could not be created because of a naming\n            conflict.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#EventDestinationDoesNotExistException": {
@@ -1970,7 +1980,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the event destination does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#EventDestinationName": {
@@ -2077,7 +2088,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the sender address specified for a custom verification email is not\n            verified, and is therefore not eligible to send the custom verification email. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc#GetAccountSendingEnabled": {
@@ -2671,7 +2683,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the Amazon CloudWatch destination is invalid. See the error message for\n            details.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidConfigurationSetException": {
@@ -2683,7 +2696,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the configuration set is invalid. See the error message for\n            details.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidDeliveryOptionsException": {
@@ -2695,7 +2709,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that provided delivery option is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidFirehoseDestinationException": {
@@ -2719,7 +2734,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the Amazon Kinesis Firehose destination is invalid. See the error\n            message for details.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidLambdaFunctionException": {
@@ -2737,7 +2753,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the provided AWS Lambda function is invalid, or that Amazon SES could\n            not execute the provided function, possibly due to permissions issues. For information\n            about giving permissions, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\">Amazon SES\n                Developer Guide</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidPolicyException": {
@@ -2749,7 +2766,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the provided policy is invalid. Check the error stack for more\n            information about what caused the error.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidRenderingParameterException": {
@@ -2764,7 +2782,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that one or more of the replacement values you provided is invalid. This\n            error may occur when the TemplateData object contains invalid JSON.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidS3ConfigurationException": {
@@ -2782,7 +2801,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the provided Amazon S3 bucket or AWS KMS encryption key is invalid, or\n            that Amazon SES could not publish to the bucket, possibly due to permissions issues. For\n            information about giving permissions, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\">Amazon SES\n                Developer Guide</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidSNSDestinationException": {
@@ -2806,7 +2826,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the Amazon Simple Notification Service (Amazon SNS) destination is\n            invalid. See the error message for details.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidSnsTopicException": {
@@ -2824,7 +2845,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the provided Amazon SNS topic is invalid, or that Amazon SES could not\n            publish to the topic, possibly due to permissions issues. For information about giving\n            permissions, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\">Amazon SES\n                Developer Guide</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidTemplateException": {
@@ -2839,7 +2861,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the template that you specified could not be rendered. This issue may\n            occur when a template refers to a partial that does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvalidTrackingOptionsException": {
@@ -2851,7 +2874,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the custom domain to be used for open and click tracking redirects is\n            invalid. This error appears most often in the following situations:</p>\n        <ul>\n            <li>\n                <p>When the tracking domain you specified is not verified in Amazon SES.</p>\n            </li>\n            <li>\n                <p>When the tracking domain you specified is not a valid domain or\n                    subdomain.</p>\n            </li>\n         </ul>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#InvocationType": {
@@ -2927,7 +2951,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that a resource could not be created because of service limits. For a list\n            of Amazon SES limits, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/limits.html\">Amazon SES Developer\n            Guide</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc#ListConfigurationSets": {
@@ -3315,7 +3340,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p> Indicates that the message could not be sent because Amazon SES could not read the MX\n            record required to use the specified MAIL FROM domain. For information about editing the\n            custom MAIL FROM domain settings for an identity, see the <a href=\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-edit.html\">Amazon SES Developer\n                Guide</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#Max24HourSend": {
@@ -3404,7 +3430,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the action failed, and the message could not be sent. Check the error\n            stack for more information about what caused the error.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.common.svc#MessageTag": {
@@ -3453,7 +3480,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that one or more of the replacement values for the specified template was\n            not specified. Ensure that the TemplateData object contains references to all of the\n            replacement tags in the specified template.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#NextToken": {
@@ -3522,7 +3550,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the account has not been granted production access.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc#PutConfigurationSetDeliveryOptions": {
@@ -4015,7 +4044,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the provided receipt rule does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#RuleOrRuleSetName": {
@@ -4036,7 +4066,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the provided receipt rule set does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#S3Action": {
@@ -5429,7 +5460,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the Template object you specified does not exist in your Amazon SES\n            account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#TemplateMetadata": {
@@ -5562,7 +5594,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the configuration set you specified already contains a TrackingOptions\n            object.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc.common#TrackingOptionsDoesNotExistException": {
@@ -5580,7 +5613,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the TrackingOptions object you specified does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.bacon.frontend.svc#UpdateAccountSendingEnabled": {

--- a/codegen/sdk-codegen/aws-models/sfn.2016-11-23.json
+++ b/codegen/sdk-codegen/aws-models/sfn.2016-11-23.json
@@ -112,7 +112,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Step Functions"
+        "smithy.api#title": "AWS Step Functions",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://swf.amazonaws.com/doc/2015-07-20/"
+        }
       }
     },
     "com.amazonaws.swf.service.v2.model#ActivityDoesNotExist": {
@@ -2090,7 +2093,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Could not find the referenced resource. Only state machine and activity ARNs are\n      supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.swf.service.v2.model#ReverseOrder": {
@@ -2974,7 +2978,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've exceeded the number of tags allowed for a resource. See the <a href=\"https://docs.aws.amazon.com/step-functions/latest/dg/limits.html\"> Limits Topic</a> in the\n      AWS Step Functions Developer Guide.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.swf.base.model#UnsignedInteger": {

--- a/codegen/sdk-codegen/aws-models/shield.2016-06-02.json
+++ b/codegen/sdk-codegen/aws-models/shield.2016-06-02.json
@@ -100,7 +100,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Shield"
+        "smithy.api#title": "AWS Shield",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ddp.amazonaws.com/doc/2016-06-02/"
+        }
       }
     },
     "com.amazonaws.bardockcustomerapiservice.v20160616#AccessDeniedException": {

--- a/codegen/sdk-codegen/aws-models/sms.2016-10-24.json
+++ b/codegen/sdk-codegen/aws-models/sms.2016-10-24.json
@@ -130,7 +130,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Server Migration Service"
+        "smithy.api#title": "AWS Server Migration Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ec2.amazon.com/servermigration/2016-10-24/"
+        }
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#AmiId": {
@@ -498,7 +501,10 @@
     "com.amazonaws.servermigration.V2016_10_24#ConnectorCapabilityList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.servermigration.V2016_10_24#ConnectorCapability"
+        "target": "com.amazonaws.servermigration.V2016_10_24#ConnectorCapability",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ConnectorId": {
@@ -507,7 +513,10 @@
     "com.amazonaws.servermigration.V2016_10_24#ConnectorList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.servermigration.V2016_10_24#Connector"
+        "target": "com.amazonaws.servermigration.V2016_10_24#Connector",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ConnectorStatus": {
@@ -1653,7 +1662,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>An internal error occurred.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#InvalidParameterException": {
@@ -1665,7 +1675,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A specified parameter is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#IpAddress": {
@@ -1856,7 +1867,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A required parameter is missing.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#NextToken": {
@@ -1871,7 +1883,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There are no connectors available.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 430
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#NumberOfRecentAmisToKeep": {
@@ -1889,7 +1902,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>This operation is not allowed.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#OutputFormat": {
@@ -2136,7 +2150,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified replication job already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ReplicationJobId": {
@@ -2145,7 +2160,10 @@
     "com.amazonaws.servermigration.V2016_10_24#ReplicationJobList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.servermigration.V2016_10_24#ReplicationJob"
+        "target": "com.amazonaws.servermigration.V2016_10_24#ReplicationJob",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ReplicationJobNotFoundException": {
@@ -2157,7 +2175,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified replication job does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ReplicationJobState": {
@@ -2286,13 +2305,17 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You have exceeded the number of on-demand replication runs you can request in a\n            24-hour period.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ReplicationRunList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.servermigration.V2016_10_24#ReplicationRun"
+        "target": "com.amazonaws.servermigration.V2016_10_24#ReplicationRun",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ReplicationRunStage": {
@@ -2444,7 +2467,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The specified server cannot be replicated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ServerCatalogStatus": {
@@ -2639,7 +2663,10 @@
     "com.amazonaws.servermigration.V2016_10_24#ServerList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.servermigration.V2016_10_24#Server"
+        "target": "com.amazonaws.servermigration.V2016_10_24#Server",
+        "traits": {
+          "smithy.api#xmlName": "item"
+        }
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#ServerReplicationConfiguration": {
@@ -2920,7 +2947,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n        <p>The service is temporarily unavailable.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#TerminateApp": {
@@ -2991,7 +3019,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>You lack permissions needed to perform this operation. Check your IAM policies, and\n            ensure that you are using the correct access keys.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.servermigration.V2016_10_24#UpdateApp": {

--- a/codegen/sdk-codegen/aws-models/sns.2010-03-31.json
+++ b/codegen/sdk-codegen/aws-models/sns.2010-03-31.json
@@ -231,7 +231,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the user has been denied access to the requested resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.cloudcast.onlines#Binary": {
@@ -301,7 +302,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Can't perform multiple operations on a tag simultaneously. Perform the operations\n            sequentially.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#ConfirmSubscription": {
@@ -755,7 +757,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Exception error indicating endpoint disabled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#FilterPolicyLimitExceededException": {
@@ -767,7 +770,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the number of filter polices in your AWS account exceeds the limit. To\n            add more filter polices, submit an SNS Limit Increase case in the AWS Support\n            Center.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.cloudcast.onlines#GetEndpointAttributes": {
@@ -1056,7 +1060,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates an internal service error.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazon.cloudcast.onlines#InvalidParameterException": {
@@ -1068,7 +1073,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that a request parameter does not comply with the associated\n            constraints.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#InvalidParameterValueException": {
@@ -1083,7 +1089,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that a request parameter does not comply with the associated\n            constraints.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#InvalidSecurityException": {
@@ -1095,7 +1102,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The credential signature isn't valid. You must use an HTTPS endpoint and sign your\n            request using Signature Version 4.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.cloudcast.onlines#KMSAccessDeniedException": {
@@ -1107,7 +1115,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The ciphertext references a key that doesn't exist or that you don't have access\n            to.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#KMSDisabledException": {
@@ -1119,7 +1128,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request was rejected because the specified customer master key (CMK) isn't\n            enabled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#KMSInvalidStateException": {
@@ -1131,7 +1141,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request was rejected because the state of the specified resource isn't valid for\n            this request. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">How Key State Affects Use of a\n                Customer Master Key</a> in the <i>AWS Key Management Service Developer\n                Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#KMSNotFoundException": {
@@ -1143,7 +1154,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request was rejected because the specified entity or resource can't be\n            found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#KMSOptInRequired": {
@@ -1155,7 +1167,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The AWS access key ID needs a subscription for the service.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.cloudcast.onlines#KMSThrottlingException": {
@@ -1167,7 +1180,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request was denied due to request throttling. For more information about\n            throttling, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#requests-per-second\">Limits</a> in\n            the <i>AWS Key Management Service Developer Guide.</i>\n         </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#ListEndpointsByPlatformApplication": {
@@ -1687,7 +1701,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the requested resource does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.cloudcast.onlines#OptInPhoneNumber": {
@@ -1779,7 +1794,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Exception error indicating platform application disabled.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#Publish": {
@@ -1957,7 +1973,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Can't tag resource. Verify that the topic exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazon.cloudcast.onlines#SetEndpointAttributes": {
@@ -2215,7 +2232,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>A tag has been added to a resource with the same ARN as a deleted resource.\n            Wait a short while and then retry the operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#String": {
@@ -2366,7 +2384,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the customer already owns the maximum allowed number of\n            subscriptions.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.cloudcast.onlines#SubscriptionsList": {
@@ -2421,7 +2440,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Can't add more than 50 tags to a topic.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#TagList": {
@@ -2439,7 +2459,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request doesn't comply with the IAM tag policy. Correct your request and then\n            retry it.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.cloudcast.onlines#TagResource": {
@@ -2521,7 +2542,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the rate at which requests have been submitted for this action exceeds\n            the limit for your account.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazon.cloudcast.onlines#Topic": {
@@ -2556,7 +2578,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Indicates that the customer already owns the maximum allowed number of topics.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.cloudcast.onlines#TopicsList": {

--- a/codegen/sdk-codegen/aws-models/sqs.2012-11-05.json
+++ b/codegen/sdk-codegen/aws-models/sqs.2012-11-05.json
@@ -32,9 +32,6 @@
         "traits": {
           "smithy.api#xmlName": "AWSAccountId"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#ActionNameList": {
@@ -44,9 +41,6 @@
         "traits": {
           "smithy.api#xmlName": "ActionName"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#AddPermission": {
@@ -70,14 +64,16 @@
           "target": "com.amazonaws.sqs#AWSAccountIdList",
           "traits": {
             "smithy.api#documentation": "\n         <p>The AWS account number of the <a href=\"https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#P\">principal</a> who is given permission. The principal must have an AWS account, but does not need to be signed up for Amazon SQS. For information about locating the AWS\n          account identification, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-making-api-requests.html#sqs-api-request-authentication\">Your AWS Identifiers</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "Actions": {
           "target": "com.amazonaws.sqs#ActionNameList",
           "traits": {
             "smithy.api#documentation": "\n         <p>The action the client wants to allow for the specified principal. Valid values: the name of any action or <code>*</code>.</p>\n         <p>For more information about these actions, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-overview-of-managing-access.html\">Overview of Managing Access Permissions to Your Amazon Simple Queue Service Resource</a> \n          in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n         <p>Specifying <code>SendMessage</code>, <code>DeleteMessage</code>, or <code>ChangeMessageVisibility</code> for <code>ActionName.n</code> also grants permissions for the corresponding batch versions of those actions: <code>SendMessageBatch</code>,\n        <code>DeleteMessageBatch</code>, and <code>ChangeMessageVisibilityBatch</code>.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "Label": {
@@ -193,9 +189,6 @@
         "traits": {
           "smithy.api#xmlName": "AttributeName"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#BatchEntryIdsNotDistinct": {
@@ -203,7 +196,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>Two or more batch entries in the request have the same <code>Id</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#BatchRequestTooLong": {
@@ -211,7 +205,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The length of all the messages put together is more than the limit.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#BatchResultErrorEntry": {
@@ -256,9 +251,6 @@
         "traits": {
           "smithy.api#xmlName": "BatchResultErrorEntry"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#Binary": {
@@ -326,7 +318,8 @@
           "target": "com.amazonaws.sqs#ChangeMessageVisibilityBatchRequestEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of receipt handles of the messages for which the visibility timeout must be changed.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "QueueUrl": {
@@ -376,9 +369,6 @@
         "traits": {
           "smithy.api#xmlName": "ChangeMessageVisibilityBatchRequestEntry"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#ChangeMessageVisibilityBatchResult": {
@@ -388,14 +378,16 @@
           "target": "com.amazonaws.sqs#BatchResultErrorEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of <code>\n               <a>BatchResultErrorEntry</a>\n            </code> items.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "Successful": {
           "target": "com.amazonaws.sqs#ChangeMessageVisibilityBatchResultEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of <code>\n               <a>ChangeMessageVisibilityBatchResultEntry</a>\n            </code> items.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         }
       },
@@ -425,9 +417,6 @@
         "traits": {
           "smithy.api#xmlName": "ChangeMessageVisibilityBatchResultEntry"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#ChangeMessageVisibilityRequest": {
@@ -483,6 +472,7 @@
           "target": "com.amazonaws.sqs#QueueAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>A map of attributes with their corresponding values.</p>\n         <p>The following lists the names, descriptions, and values of the special request parameters that the <code>CreateQueue</code> action uses:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DelaySeconds</code> - The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Valid values: An integer from 0 to 900 seconds (15 minutes). Default: 0.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <code>MaximumMessageSize</code> - The limit of how many bytes a message can contain before Amazon SQS rejects it. Valid values: An integer from 1,024 bytes (1 KiB) to 262,144 bytes (256 KiB). Default: 262,144 (256 KiB).\n            </p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageRetentionPeriod</code> - The length of time, in seconds, for which Amazon SQS retains a message. Valid values: An integer from 60 seconds (1 minute) to 1,209,600 seconds (14 days). Default: 345,600 (4 days).\n            </p>\n            </li>\n            <li>\n               <p>\n                  <code>Policy</code> - The queue's policy. A valid AWS policy. For more information about policy structure, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html\">Overview of AWS IAM Policies</a> in the <i>Amazon IAM User Guide</i>.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <code>ReceiveMessageWaitTimeSeconds</code> - The length of time, in seconds, for which a <code>\n                     <a>ReceiveMessage</a>\n                  </code> action waits for a message to arrive. Valid values: An integer from 0 to 20 (seconds). Default: 0.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <code>RedrivePolicy</code> - The string that includes the parameters for the dead-letter queue functionality of the source queue.\n                For more information about the redrive policy and dead-letter queues, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html\">Using Amazon SQS Dead-Letter Queues</a> \n                in the <i>Amazon Simple Queue Service Developer Guide</i>.    \n            </p>\n                        <ul>\n                  <li>\n                    <p>\n                        <code>deadLetterTargetArn</code> - The Amazon Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves messages after the value of <code>maxReceiveCount</code> is exceeded.</p>\n                  </li>\n                  <li>\n                    <p>\n                        <code>maxReceiveCount</code> - The number of times a message is delivered to the source queue before being moved to the dead-letter queue.\n                        When the <code>ReceiveCount</code> for a message exceeds the <code>maxReceiveCount</code> for a queue, Amazon SQS moves the message to the dead-letter-queue.</p>\n                  </li>\n               </ul>\n               <note>\n                  <p>The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly, the dead-letter queue of a standard queue must also be a standard queue.</p>\n               </note>\n            </li>\n            <li>\n               <p>\n                  <code>VisibilityTimeout</code> - The visibility timeout for the queue, in seconds. Valid values: An integer from 0 to 43,200 (12 hours). Default: 30. For more information about the visibility timeout, see \n                    <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n            </li>\n         </ul>\n      \n         <p>The following attributes apply only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html\">server-side-encryption</a>:</p>\n         <ul>\n            <li>\n              <p>\n                  <code>KmsMasterKeyId</code> - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms\">Key Terms</a>.\n                  While the alias of the AWS-managed CMK for Amazon SQS is always <code>alias/aws/sqs</code>, the alias of a custom CMK can, for example, be <code>alias/<i>MyAlias</i>\n                  </code>.\n                  For more examples, see <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters\">KeyId</a> in the <i>AWS Key Management Service API Reference</i>.\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>KmsDataKeyReusePeriodSeconds</code> - The length of time, in seconds, for which Amazon SQS can reuse a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys\">data key</a> to encrypt \n                  or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). Default: 300 (5 minutes). A shorter time period provides better security \n                  but results in more calls to KMS which might incur charges after Free Tier. For more information, see \n                  <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work\">How Does the Data Key Reuse Period Work?</a>.\n              </p>\n            </li>\n         </ul>\n      \n      \n         <p>The following attributes apply only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO (first-in-first-out) queues</a>:</p>\n         <ul>\n            <li>\n              <p>\n                  <code>FifoQueue</code> - Designates a queue as FIFO. Valid values: <code>true</code>, <code>false</code>. If you don't specify the <code>FifoQueue</code> attribute, Amazon SQS creates a standard queue. \n                  You can provide this attribute only during queue creation. You can't change it for an existing queue. \n                  When you set this attribute, you must also provide the <code>MessageGroupId</code> for your messages explicitly.</p> \n               <p>For more information, see \n                  <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic\">FIFO Queue Logic</a> \n                  in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n            </li>\n            <li>\n              <p>\n                  <code>ContentBasedDeduplication</code> - Enables content-based deduplication. Valid values: <code>true</code>, <code>false</code>. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\">Exactly-Once Processing</a> in the \n                      <i>Amazon Simple Queue Service Developer Guide</i>.\n              </p>\n              <ul>\n                  <li>\n                      <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p>\n                      <ul>\n                        <li>\n                              <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p>\n                          </li>\n                        <li>\n                              <p>If you aren't able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, \n                                  Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message).\n                              </p>\n                          </li>\n                        <li>\n                              <p>If you don't provide a <code>MessageDeduplicationId</code> and the queue doesn't have <code>ContentBasedDeduplication</code> set,\n                                  the action fails with an error.</p>\n                          </li>\n                        <li>\n                              <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p>\n                          </li>\n                     </ul>\n                  </li>\n                  <li>\n                      <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates \n                          and only one copy of the message is delivered.</p>\n                  </li>\n                  <li>\n                      <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same \n                          as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered.\n                      </p>\n                  </li>\n               </ul> \n            </li>\n         </ul>\n      \n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Attribute"
           }
         },
@@ -497,6 +487,7 @@
           "target": "com.amazonaws.sqs#TagMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>Add cost allocation tags to the specified Amazon SQS queue. For an overview, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-tags.html\">Tagging Your Amazon SQS Queues</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n      \n         <p>When you use queue tags, keep the following guidelines in mind:</p>\n         <ul>\n            <li>\n               <p>Adding more than 50 tags to a queue isn't recommended.</p>\n            </li>\n            <li>\n               <p>Tags don't have any semantic meaning. Amazon SQS interprets tags as character strings.</p>\n            </li>\n            <li>\n               <p>Tags are case-sensitive.</p>\n            </li>\n            <li>\n               <p>A new tag with a key identical to that of an existing tag overwrites the existing tag.</p>\n            </li>\n         </ul>\n         <p>For a full list of tag restrictions, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-limits.html#limits-queues\">Limits Related to Queues</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n         <note>\n            <p>To be able to tag a queue on creation, you must have the\n                    <code>sqs:CreateQueue</code> and <code>sqs:TagQueue</code> permissions.</p>\n            <p>Cross-account permissions don't apply to this action. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-customer-managed-policy-examples.html#grant-cross-account-permissions-to-role-and-user-name\">Grant Cross-Account Permissions to a Role and a User Name</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n         </note>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Tag"
           }
         }
@@ -569,7 +560,8 @@
           "target": "com.amazonaws.sqs#DeleteMessageBatchRequestEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of receipt handles for the messages to be deleted.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "QueueUrl": {
@@ -613,9 +605,6 @@
         "traits": {
           "smithy.api#xmlName": "DeleteMessageBatchRequestEntry"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#DeleteMessageBatchResult": {
@@ -625,14 +614,16 @@
           "target": "com.amazonaws.sqs#BatchResultErrorEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of <code>\n               <a>BatchResultErrorEntry</a>\n            </code> items.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "Successful": {
           "target": "com.amazonaws.sqs#DeleteMessageBatchResultEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of <code>\n               <a>DeleteMessageBatchResultEntry</a>\n            </code> items.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         }
       },
@@ -662,9 +653,6 @@
         "traits": {
           "smithy.api#xmlName": "DeleteMessageBatchResultEntry"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#DeleteMessageRequest": {
@@ -718,7 +706,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The batch request doesn't contain any entries.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#GetQueueAttributes": {
@@ -744,7 +733,8 @@
         "AttributeNames": {
           "target": "com.amazonaws.sqs#AttributeNameList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>A list of attributes for which to retrieve information.</p>\n         <note>\n            <p>In the future, new attributes might be added. If you write code that calls this action, we recommend that you structure your code so that it can handle new attributes gracefully.</p>\n         </note>\n         <p>The following attributes are supported:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>All</code> - Returns all values. </p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateNumberOfMessages</code> - Returns the approximate number of\n                    messages available for retrieval from the queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateNumberOfMessagesDelayed</code> - Returns the approximate number\n                    of messages in the queue that are delayed and not available for reading\n                    immediately. This can happen when the queue is configured as a delay queue or\n                    when a message has been sent with a delay parameter.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateNumberOfMessagesNotVisible</code> - Returns the approximate\n                    number of messages that are in flight. Messages are considered to be\n                        <i>in flight</i> if they have been sent to a client but have\n                    not yet been deleted or have not yet reached the end of their visibility window. </p>\n            </li>\n            <li>\n               <p>\n                  <code>CreatedTimestamp</code> - Returns the time when the queue was created in\n                    seconds (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch\n                    time</a>).</p>\n            </li>\n            <li>\n               <p>\n                  <code>DelaySeconds</code> - Returns the default delay on the queue in\n                    seconds.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LastModifiedTimestamp</code> - Returns the time when the queue was last\n                    changed in seconds (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch\n                        time</a>).</p>\n            </li>\n            <li>\n               <p>\n                  <code>MaximumMessageSize</code> - Returns the limit of how many bytes a message\n                    can contain before Amazon SQS rejects it.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageRetentionPeriod</code> - Returns the length of time, in seconds,\n                    for which Amazon SQS retains a message.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Policy</code> - Returns the policy of the queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>QueueArn</code> - Returns the Amazon resource name (ARN) of the\n                    queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ReceiveMessageWaitTimeSeconds</code> - Returns the length of time, in\n                    seconds, for which the <code>ReceiveMessage</code> action waits for a message to\n                    arrive. </p>\n            </li>\n            <li>\n               <p>\n                  <code>RedrivePolicy</code> - Returns the string that includes the parameters\n                    for dead-letter queue functionality of the source queue. For more information\n                    about the redrive policy and dead-letter queues, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html\">Using Amazon SQS Dead-Letter Queues</a> in the\n                        <i>Amazon Simple Queue Service Developer Guide</i>. </p>\n                        <ul>\n                  <li>\n                    <p>\n                        <code>deadLetterTargetArn</code> - The Amazon Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves messages after the value of <code>maxReceiveCount</code> is exceeded.</p>\n                  </li>\n                  <li>\n                    <p>\n                        <code>maxReceiveCount</code> - The number of times a message is delivered to the source queue before being moved to the dead-letter queue.\n                        When the <code>ReceiveCount</code> for a message exceeds the <code>maxReceiveCount</code> for a queue, Amazon SQS moves the message to the dead-letter-queue.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>VisibilityTimeout</code> - Returns the visibility timeout for the queue. For more information about the visibility timeout, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.\n            </p>\n            </li>\n         </ul>\n      \n         <p>The following attributes apply only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html\">server-side-encryption</a>:</p>\n         <ul>\n            <li>\n              <p>\n                  <code>KmsMasterKeyId</code> - Returns the ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms\">Key Terms</a>.\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>KmsDataKeyReusePeriodSeconds</code> - Returns the length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again.\n                  For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work\">How Does the Data Key Reuse Period Work?</a>.\n              </p>\n            </li>\n         </ul>\n      \n      \n         <p>The following attributes apply only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO (first-in-first-out) queues</a>:</p>\n         <ul>\n            <li>\n              <p>\n                  <code>FifoQueue</code> - Returns whether the queue is FIFO. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic\">FIFO Queue Logic</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n              <note>\n                  <p>To determine whether a queue is <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a>, you can check whether <code>QueueName</code> ends with the <code>.fifo</code> suffix.</p>\n               </note>\n            </li>\n            <li>\n              <p>\n                  <code>ContentBasedDeduplication</code> - Returns whether content-based deduplication is enabled for the queue. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\">Exactly-Once Processing</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.\n              </p>\n            </li>\n         </ul>\n      \n      "
+            "smithy.api#documentation": "\n         <p>A list of attributes for which to retrieve information.</p>\n         <note>\n            <p>In the future, new attributes might be added. If you write code that calls this action, we recommend that you structure your code so that it can handle new attributes gracefully.</p>\n         </note>\n         <p>The following attributes are supported:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>All</code> - Returns all values. </p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateNumberOfMessages</code> - Returns the approximate number of\n                    messages available for retrieval from the queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateNumberOfMessagesDelayed</code> - Returns the approximate number\n                    of messages in the queue that are delayed and not available for reading\n                    immediately. This can happen when the queue is configured as a delay queue or\n                    when a message has been sent with a delay parameter.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateNumberOfMessagesNotVisible</code> - Returns the approximate\n                    number of messages that are in flight. Messages are considered to be\n                        <i>in flight</i> if they have been sent to a client but have\n                    not yet been deleted or have not yet reached the end of their visibility window. </p>\n            </li>\n            <li>\n               <p>\n                  <code>CreatedTimestamp</code> - Returns the time when the queue was created in\n                    seconds (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch\n                    time</a>).</p>\n            </li>\n            <li>\n               <p>\n                  <code>DelaySeconds</code> - Returns the default delay on the queue in\n                    seconds.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LastModifiedTimestamp</code> - Returns the time when the queue was last\n                    changed in seconds (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch\n                        time</a>).</p>\n            </li>\n            <li>\n               <p>\n                  <code>MaximumMessageSize</code> - Returns the limit of how many bytes a message\n                    can contain before Amazon SQS rejects it.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageRetentionPeriod</code> - Returns the length of time, in seconds,\n                    for which Amazon SQS retains a message.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Policy</code> - Returns the policy of the queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>QueueArn</code> - Returns the Amazon resource name (ARN) of the\n                    queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ReceiveMessageWaitTimeSeconds</code> - Returns the length of time, in\n                    seconds, for which the <code>ReceiveMessage</code> action waits for a message to\n                    arrive. </p>\n            </li>\n            <li>\n               <p>\n                  <code>RedrivePolicy</code> - Returns the string that includes the parameters\n                    for dead-letter queue functionality of the source queue. For more information\n                    about the redrive policy and dead-letter queues, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html\">Using Amazon SQS Dead-Letter Queues</a> in the\n                        <i>Amazon Simple Queue Service Developer Guide</i>. </p>\n                        <ul>\n                  <li>\n                    <p>\n                        <code>deadLetterTargetArn</code> - The Amazon Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves messages after the value of <code>maxReceiveCount</code> is exceeded.</p>\n                  </li>\n                  <li>\n                    <p>\n                        <code>maxReceiveCount</code> - The number of times a message is delivered to the source queue before being moved to the dead-letter queue.\n                        When the <code>ReceiveCount</code> for a message exceeds the <code>maxReceiveCount</code> for a queue, Amazon SQS moves the message to the dead-letter-queue.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>VisibilityTimeout</code> - Returns the visibility timeout for the queue. For more information about the visibility timeout, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.\n            </p>\n            </li>\n         </ul>\n      \n         <p>The following attributes apply only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html\">server-side-encryption</a>:</p>\n         <ul>\n            <li>\n              <p>\n                  <code>KmsMasterKeyId</code> - Returns the ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms\">Key Terms</a>.\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>KmsDataKeyReusePeriodSeconds</code> - Returns the length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again.\n                  For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work\">How Does the Data Key Reuse Period Work?</a>.\n              </p>\n            </li>\n         </ul>\n      \n      \n         <p>The following attributes apply only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO (first-in-first-out) queues</a>:</p>\n         <ul>\n            <li>\n              <p>\n                  <code>FifoQueue</code> - Returns whether the queue is FIFO. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic\">FIFO Queue Logic</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n              <note>\n                  <p>To determine whether a queue is <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a>, you can check whether <code>QueueName</code> ends with the <code>.fifo</code> suffix.</p>\n               </note>\n            </li>\n            <li>\n              <p>\n                  <code>ContentBasedDeduplication</code> - Returns whether content-based deduplication is enabled for the queue. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\">Exactly-Once Processing</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.\n              </p>\n            </li>\n         </ul>\n      \n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "QueueUrl": {
@@ -766,6 +756,7 @@
           "target": "com.amazonaws.sqs#QueueAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>A map of attributes to their respective values.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Attribute"
           }
         }
@@ -842,7 +833,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The <code>Id</code> of a batch entry in a batch request doesn't abide by the specification.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#InvalidIdFormat": {
@@ -900,7 +892,8 @@
           "target": "com.amazonaws.sqs#QueueUrlList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of source queue URLs that have the <code>RedrivePolicy</code> queue attribute configured with a dead-letter queue.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         }
       },
@@ -939,6 +932,7 @@
           "target": "com.amazonaws.sqs#TagMap",
           "traits": {
             "smithy.api#documentation": "\n        <p>The list of all tags added to the specified queue.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Tag"
           }
         }
@@ -976,7 +970,8 @@
         "QueueUrls": {
           "target": "com.amazonaws.sqs#QueueUrlList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>A list of queue URLs, up to 1,000 entries.</p>\n      "
+            "smithy.api#documentation": "\n         <p>A list of queue URLs, up to 1,000 entries.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         }
       },
@@ -991,6 +986,7 @@
           "target": "com.amazonaws.sqs#MessageSystemAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>A map of the attributes requested in <code>\n               <a>ReceiveMessage</a>\n            </code> to their respective values. \n          Supported attributes:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ApproximateReceiveCount</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateFirstReceiveTimestamp</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageDeduplicationId</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageGroupId</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SenderId</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SentTimestamp</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SequenceNumber</code>\n               </p>\n            </li>\n         </ul>\n         <p>\n            <code>ApproximateFirstReceiveTimestamp</code> and <code>SentTimestamp</code> are each returned as an integer representing the \n        <a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Attribute"
           }
         },
@@ -1016,6 +1012,7 @@
           "target": "com.amazonaws.sqs#MessageBodyAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>Each message attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html\">Amazon SQS Message Attributes</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "MessageAttribute"
           }
         },
@@ -1046,9 +1043,6 @@
         "traits": {
           "smithy.api#xmlName": "MessageAttributeName"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#MessageAttributeValue": {
@@ -1107,9 +1101,6 @@
         "traits": {
           "smithy.api#xmlName": "Value"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#MessageBodySystemAttributeMap": {
@@ -1125,9 +1116,6 @@
         "traits": {
           "smithy.api#xmlName": "Value"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#MessageList": {
@@ -1137,9 +1125,6 @@
         "traits": {
           "smithy.api#xmlName": "Message"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#MessageNotInflight": {
@@ -1147,7 +1132,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified message isn't in flight.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#MessageSystemAttributeMap": {
@@ -1163,10 +1149,6 @@
         "traits": {
           "smithy.api#xmlName": "Value"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true,
-        "smithy.api#xmlName": "Attribute"
       }
     },
     "com.amazonaws.sqs#MessageSystemAttributeName": {
@@ -1240,7 +1222,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified action violates a limit. For example, <code>ReceiveMessage</code>\n            returns this error if the maximum number of inflight messages is reached and\n                <code>AddPermission</code> returns this error if the maximum number of permissions\n            for the queue is reached.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.sqs#PurgeQueue": {
@@ -1265,7 +1248,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>Indicates that the specified queue previously received a <code>PurgeQueue</code> request within the last 60 seconds (the time it can take to delete the messages in the queue).</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.sqs#PurgeQueueRequest": {
@@ -1296,10 +1280,6 @@
         "traits": {
           "smithy.api#xmlName": "Value"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true,
-        "smithy.api#xmlName": "Attribute"
       }
     },
     "com.amazonaws.sqs#QueueAttributeName": {
@@ -1332,7 +1312,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>You must wait 60 seconds after deleting a queue before you can create another queue\n            with the same name.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#QueueDoesNotExist": {
@@ -1340,7 +1321,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified queue doesn't exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#QueueNameExists": {
@@ -1348,7 +1330,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>A queue with this name already exists. Amazon SQS returns this error only if the request\n            includes attributes whose values differ from those of the existing queue.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#QueueUrlList": {
@@ -1358,9 +1341,6 @@
         "traits": {
           "smithy.api#xmlName": "QueueUrl"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#ReceiptHandleIsInvalid": {
@@ -1394,7 +1374,8 @@
         "AttributeNames": {
           "target": "com.amazonaws.sqs#AttributeNameList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>A list of attributes that need to be returned along with each message. These attributes\n            include:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>All</code> - Returns all values.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateFirstReceiveTimestamp</code> - Returns the time the message was first received from the queue (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds).</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateReceiveCount</code> - Returns the number of times a message has been received from the queue but not deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AWSTraceHeader</code> - Returns the AWS X-Ray trace header string.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <code>SenderId</code>\n               </p>\n               <ul>\n                  <li>\n                       <p>For an IAM user, returns the IAM user ID, for example <code>ABCDEFGHI1JKLMNOPQ23R</code>.</p>\n                   </li>\n                  <li>\n                       <p>For an IAM role, returns the IAM role ID, for example <code>ABCDE1F2GH3I4JK5LMNOP:i-a123b456</code>.</p>\n                   </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>SentTimestamp</code> - Returns the time the message was sent to the queue (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds).</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageDeduplicationId</code> - Returns the value provided by the\n                    producer that calls the <code>\n                     <a>SendMessage</a>\n                  </code>\n                    action.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageGroupId</code> - Returns the value provided by the producer that\n                    calls the <code>\n                     <a>SendMessage</a>\n                  </code> action. Messages with the\n                    same <code>MessageGroupId</code> are returned in sequence.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SequenceNumber</code> - Returns the value provided by Amazon SQS.</p>\n            </li>\n         </ul>\n      "
+            "smithy.api#documentation": "\n         <p>A list of attributes that need to be returned along with each message. These attributes\n            include:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>All</code> - Returns all values.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateFirstReceiveTimestamp</code> - Returns the time the message was first received from the queue (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds).</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateReceiveCount</code> - Returns the number of times a message has been received from the queue but not deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AWSTraceHeader</code> - Returns the AWS X-Ray trace header string.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <code>SenderId</code>\n               </p>\n               <ul>\n                  <li>\n                       <p>For an IAM user, returns the IAM user ID, for example <code>ABCDEFGHI1JKLMNOPQ23R</code>.</p>\n                   </li>\n                  <li>\n                       <p>For an IAM role, returns the IAM role ID, for example <code>ABCDE1F2GH3I4JK5LMNOP:i-a123b456</code>.</p>\n                   </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>SentTimestamp</code> - Returns the time the message was sent to the queue (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds).</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageDeduplicationId</code> - Returns the value provided by the\n                    producer that calls the <code>\n                     <a>SendMessage</a>\n                  </code>\n                    action.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageGroupId</code> - Returns the value provided by the producer that\n                    calls the <code>\n                     <a>SendMessage</a>\n                  </code> action. Messages with the\n                    same <code>MessageGroupId</code> are returned in sequence.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SequenceNumber</code> - Returns the value provided by Amazon SQS.</p>\n            </li>\n         </ul>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "MaxNumberOfMessages": {
@@ -1406,7 +1387,8 @@
         "MessageAttributeNames": {
           "target": "com.amazonaws.sqs#MessageAttributeNameList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>The name of the message attribute, where <i>N</i> is the index.</p>\n         <ul>\n            <li>\n               <p>The name can contain alphanumeric characters and the underscore (<code>_</code>), hyphen (<code>-</code>), and period (<code>.</code>).</p>\n            </li>\n            <li>\n               <p>The name is case-sensitive and must be unique among all attribute names for the message.</p>\n            </li>\n            <li>\n               <p>The name must not start with AWS-reserved prefixes such as <code>AWS.</code> or <code>Amazon.</code> (or any casing variants).</p>\n            </li>\n            <li>\n               <p>The name must not start or end with a period (<code>.</code>), and it should not have periods in succession (<code>..</code>).</p>\n            </li>\n            <li>\n               <p>The name can be up to 256 characters long.</p>\n            </li>\n         </ul>\n          \n         <p>When using <code>ReceiveMessage</code>, you can send a list of attribute names to receive, or you can return all of the attributes by specifying <code>All</code> or <code>.*</code> in your request. \n          You can also use all message attributes starting with a prefix, for example <code>bar.*</code>.</p>\n    \n      "
+            "smithy.api#documentation": "\n         <p>The name of the message attribute, where <i>N</i> is the index.</p>\n         <ul>\n            <li>\n               <p>The name can contain alphanumeric characters and the underscore (<code>_</code>), hyphen (<code>-</code>), and period (<code>.</code>).</p>\n            </li>\n            <li>\n               <p>The name is case-sensitive and must be unique among all attribute names for the message.</p>\n            </li>\n            <li>\n               <p>The name must not start with AWS-reserved prefixes such as <code>AWS.</code> or <code>Amazon.</code> (or any casing variants).</p>\n            </li>\n            <li>\n               <p>The name must not start or end with a period (<code>.</code>), and it should not have periods in succession (<code>..</code>).</p>\n            </li>\n            <li>\n               <p>The name can be up to 256 characters long.</p>\n            </li>\n         </ul>\n          \n         <p>When using <code>ReceiveMessage</code>, you can send a list of attribute names to receive, or you can return all of the attributes by specifying <code>All</code> or <code>.*</code> in your request. \n          You can also use all message attributes starting with a prefix, for example <code>bar.*</code>.</p>\n    \n      ",
+            "smithy.api#xmlFlattened": true
           }
         },
         "QueueUrl": {
@@ -1445,7 +1427,8 @@
         "Messages": {
           "target": "com.amazonaws.sqs#MessageList",
           "traits": {
-            "smithy.api#documentation": "\n         <p>A list of messages.</p>\n      "
+            "smithy.api#documentation": "\n         <p>A list of messages.</p>\n      ",
+            "smithy.api#xmlFlattened": true
           }
         }
       },
@@ -1543,7 +1526,8 @@
           "target": "com.amazonaws.sqs#SendMessageBatchRequestEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of <code>\n               <a>SendMessageBatchRequestEntry</a>\n            </code> items.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "QueueUrl": {
@@ -1578,6 +1562,7 @@
           "target": "com.amazonaws.sqs#MessageBodyAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>Each message attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html\">Amazon SQS Message Attributes</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "MessageAttribute"
           }
         },
@@ -1604,6 +1589,7 @@
           "target": "com.amazonaws.sqs#MessageBodySystemAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>The message system attribute to send Each message system attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>.</p>\n         <important>\n            <ul>\n               <li>\n                  <p>Currently, the only supported message system attribute is <code>AWSTraceHeader</code>.\n                    Its type must be <code>String</code> and its value must be a correctly formatted\n                    AWS X-Ray trace string.</p>\n              </li>\n               <li>\n                  <p>The size of a message system attribute doesn't count towards the total size of a message.</p>\n              </li>\n            </ul>\n         </important>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "MessageSystemAttribute"
           }
         }
@@ -1619,9 +1605,6 @@
         "traits": {
           "smithy.api#xmlName": "SendMessageBatchRequestEntry"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#SendMessageBatchResult": {
@@ -1631,14 +1614,16 @@
           "target": "com.amazonaws.sqs#BatchResultErrorEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of <code>\n               <a>BatchResultErrorEntry</a>\n            </code> items with error details about each message that can't be enqueued.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         },
         "Successful": {
           "target": "com.amazonaws.sqs#SendMessageBatchResultEntryList",
           "traits": {
             "smithy.api#documentation": "\n         <p>A list of <code>\n               <a>SendMessageBatchResultEntry</a>\n            </code> items.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         }
       },
@@ -1700,9 +1685,6 @@
         "traits": {
           "smithy.api#xmlName": "SendMessageBatchResultEntry"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#SendMessageRequest": {
@@ -1718,6 +1700,7 @@
           "target": "com.amazonaws.sqs#MessageBodyAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>Each message attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html\">Amazon SQS Message Attributes</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "MessageAttribute"
           }
         },
@@ -1744,6 +1727,7 @@
           "target": "com.amazonaws.sqs#MessageBodySystemAttributeMap",
           "traits": {
             "smithy.api#documentation": "\n         <p>The message system attribute to send. Each message system attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>.</p>\n         <important>\n            <ul>\n               <li>\n                  <p>Currently, the only supported message system attribute is <code>AWSTraceHeader</code>.\n                    Its type must be <code>String</code> and its value must be a correctly formatted\n                    AWS X-Ray trace string.</p>\n              </li>\n               <li>\n                  <p>The size of a message system attribute doesn't count towards the total size of a message.</p>\n              </li>\n            </ul>\n         </important>\n      ",
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "MessageSystemAttribute"
           }
         },
@@ -1819,6 +1803,7 @@
           "traits": {
             "smithy.api#documentation": "\n         <p>A map of attributes to set.</p>\n         <p>The following lists the names, descriptions, and values of the special request parameters that the <code>SetQueueAttributes</code> action uses:</p>      \n         <ul>\n            <li>\n              <p>\n                  <code>DelaySeconds</code> - The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Valid values: An integer from 0 to 900 (15 minutes). Default: 0.\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>MaximumMessageSize</code> - The limit of how many bytes a message can contain before Amazon SQS rejects it. Valid values: An integer from 1,024 bytes (1 KiB) up to 262,144 bytes (256 KiB). Default: 262,144 (256 KiB).\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>MessageRetentionPeriod</code> - The length of time, in seconds, for which Amazon SQS retains a message. Valid values: An integer representing seconds, from 60 (1 minute) to 1,209,600 (14 days). Default: 345,600 (4 days).\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>Policy</code> - The queue's policy. A valid AWS policy. For more information about policy structure, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html\">Overview of AWS IAM Policies</a> \n                  in the <i>Amazon IAM User Guide</i>.\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>ReceiveMessageWaitTimeSeconds</code> - The length of time, in seconds, for which a <code>\n                     <a>ReceiveMessage</a>\n                  </code> action waits for a message to arrive. Valid values: an integer from 0 to 20 (seconds). Default: 0.\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>RedrivePolicy</code> - The string that includes the parameters for the dead-letter queue functionality of the source queue.\n                  For more information about the redrive policy and dead-letter queues, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html\">Using Amazon SQS Dead-Letter Queues</a> \n                  in the <i>Amazon Simple Queue Service Developer Guide</i>.    \n              </p>\n                          <ul>\n                  <li>\n                    <p>\n                        <code>deadLetterTargetArn</code> - The Amazon Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves messages after the value of <code>maxReceiveCount</code> is exceeded.</p>\n                  </li>\n                  <li>\n                    <p>\n                        <code>maxReceiveCount</code> - The number of times a message is delivered to the source queue before being moved to the dead-letter queue.\n                        When the <code>ReceiveCount</code> for a message exceeds the <code>maxReceiveCount</code> for a queue, Amazon SQS moves the message to the dead-letter-queue.</p>\n                  </li>\n               </ul>\n              <note>\n                  <p>The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly, the dead-letter queue of a standard queue must also be a standard queue.</p>\n              </note>\n            </li>\n            <li>\n              <p>\n                  <code>VisibilityTimeout</code> - The visibility timeout for the queue, in seconds. Valid values: an integer from 0 to 43,200 (12 hours). Default: 30. For more information about the visibility timeout,\n                  see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>\n            </li>\n         </ul>\n      \n         <p>The following attributes apply only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html\">server-side-encryption</a>:</p>     \n         <ul>\n            <li>\n              <p>\n                  <code>KmsMasterKeyId</code> - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms\">Key Terms</a>.\n                  While the alias of the AWS-managed CMK for Amazon SQS is always <code>alias/aws/sqs</code>, the alias of a custom CMK can, for example, be <code>alias/<i>MyAlias</i>\n                  </code>.\n                  For more examples, see <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters\">KeyId</a> in the <i>AWS Key Management Service API Reference</i>.\n              </p>\n            </li>\n            <li>\n              <p>\n                  <code>KmsDataKeyReusePeriodSeconds</code> - The length of time, in seconds, for which Amazon SQS can reuse a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys\">data key</a> to encrypt \n                  or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). Default: 300 (5 minutes). A shorter time period provides better security \n                  but results in more calls to KMS which might incur charges after Free Tier. For more information, see \n                  <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work\">How Does the Data Key Reuse Period Work?</a>.\n              </p>\n            </li>\n         </ul>\n      \n      \n         <p>The following attribute applies only to <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO (first-in-first-out) queues</a>:</p>\n         <ul>\n            <li>\n              <p>\n                  <code>ContentBasedDeduplication</code> - Enables content-based deduplication. For more information, see <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\">Exactly-Once Processing</a> in the \n                  <i>Amazon Simple Queue Service Developer Guide</i>.\n              </p>\n              <ul>\n                  <li>\n                      <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p>\n                      <ul>\n                        <li>\n                              <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p>\n                          </li>\n                        <li>\n                              <p>If you aren't able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, \n                                  Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message).\n                              </p>\n                          </li>\n                        <li>\n                              <p>If you don't provide a <code>MessageDeduplicationId</code> and the queue doesn't have <code>ContentBasedDeduplication</code> set,\n                                  the action fails with an error.</p>\n                          </li>\n                        <li>\n                              <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p>\n                          </li>\n                     </ul>\n                  </li>\n                  <li>\n                      <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates \n                          and only one copy of the message is delivered.</p>\n                  </li>\n                  <li>\n                      <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same \n                          as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered.\n                      </p>\n                  </li>\n               </ul>  \n            </li>\n         </ul>\n      \n      ",
             "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
             "smithy.api#xmlName": "Attribute"
           }
         },
@@ -1856,9 +1841,6 @@
         "traits": {
           "smithy.api#xmlName": "TagKey"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true
       }
     },
     "com.amazonaws.sqs#TagMap": {
@@ -1874,10 +1856,6 @@
         "traits": {
           "smithy.api#xmlName": "Value"
         }
-      },
-      "traits": {
-        "smithy.api#xmlFlattened": true,
-        "smithy.api#xmlName": "Tag"
       }
     },
     "com.amazonaws.sqs#TagQueue": {
@@ -1903,7 +1881,9 @@
           "target": "com.amazonaws.sqs#TagMap",
           "traits": {
             "smithy.api#documentation": "\n        <p>The list of tags to be added to the specified queue.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true,
+            "smithy.api#xmlName": "Tag"
           }
         }
       }
@@ -1916,7 +1896,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The batch request contains more entries than permissible.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#UnsupportedOperation": {
@@ -1924,7 +1905,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error code 400. Unsupported operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.sqs#UntagQueue": {
@@ -1950,7 +1932,8 @@
           "target": "com.amazonaws.sqs#TagKeyList",
           "traits": {
             "smithy.api#documentation": "\n        <p>The list of tags to be removed from the specified queue.</p>\n      ",
-            "smithy.api#required": true
+            "smithy.api#required": true,
+            "smithy.api#xmlFlattened": true
           }
         }
       }

--- a/codegen/sdk-codegen/aws-models/ssm.2014-11-06.json
+++ b/codegen/sdk-codegen/aws-models/ssm.2014-11-06.json
@@ -37,7 +37,10 @@
     "com.amazonaws.services.ssm#AccountIdList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AccountId"
+        "target": "com.amazonaws.services.ssm#AccountId",
+        "traits": {
+          "smithy.api#xmlName": "AccountId"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -69,7 +72,10 @@
     "com.amazonaws.services.ssm#AccountSharingInfoList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AccountSharingInfo"
+        "target": "com.amazonaws.services.ssm#AccountSharingInfo",
+        "traits": {
+          "smithy.api#xmlName": "AccountSharingInfo"
+        }
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A list of of AWS accounts where the current document is shared and the version shared with each account.</p>\n      "
@@ -274,7 +280,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error returned if an attempt is made to register a patch group with a patch baseline that is\n   already registered with a different patch baseline.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#AmazonSSM": {
@@ -661,7 +668,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Simple Systems Manager (SSM)"
+        "smithy.api#title": "Amazon Simple Systems Manager (SSM)",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ssm.amazonaws.com/doc/2014-11-06/"
+        }
       }
     },
     "com.amazonaws.services.ssm#ApproveAfterDays": {
@@ -678,7 +688,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>You must disassociate a document from all instances before you can delete it.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#Association": {
@@ -754,7 +765,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified association already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#AssociationComplianceSeverity": {
@@ -910,7 +922,10 @@
     "com.amazonaws.services.ssm#AssociationDescriptionList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AssociationDescription"
+        "target": "com.amazonaws.services.ssm#AssociationDescription",
+        "traits": {
+          "smithy.api#xmlName": "AssociationDescription"
+        }
       }
     },
     "com.amazonaws.services.ssm#AssociationDoesNotExist": {
@@ -922,7 +937,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified association does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#AssociationExecution": {
@@ -990,7 +1006,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified execution ID does not exist. Verify the ID number and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#AssociationExecutionFilter": {
@@ -1041,7 +1058,10 @@
     "com.amazonaws.services.ssm#AssociationExecutionFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AssociationExecutionFilter"
+        "target": "com.amazonaws.services.ssm#AssociationExecutionFilter",
+        "traits": {
+          "smithy.api#xmlName": "AssociationExecutionFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -1166,7 +1186,10 @@
     "com.amazonaws.services.ssm#AssociationExecutionTargetsFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AssociationExecutionTargetsFilter"
+        "target": "com.amazonaws.services.ssm#AssociationExecutionTargetsFilter",
+        "traits": {
+          "smithy.api#xmlName": "AssociationExecutionTargetsFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -1185,13 +1208,19 @@
     "com.amazonaws.services.ssm#AssociationExecutionTargetsList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AssociationExecutionTarget"
+        "target": "com.amazonaws.services.ssm#AssociationExecutionTarget",
+        "traits": {
+          "smithy.api#xmlName": "AssociationExecutionTarget"
+        }
       }
     },
     "com.amazonaws.services.ssm#AssociationExecutionsList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AssociationExecution"
+        "target": "com.amazonaws.services.ssm#AssociationExecution",
+        "traits": {
+          "smithy.api#xmlName": "AssociationExecution"
+        }
       }
     },
     "com.amazonaws.services.ssm#AssociationFilter": {
@@ -1247,7 +1276,10 @@
     "com.amazonaws.services.ssm#AssociationFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AssociationFilter"
+        "target": "com.amazonaws.services.ssm#AssociationFilter",
+        "traits": {
+          "smithy.api#xmlName": "AssociationFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -1302,13 +1334,17 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can have at most 2,000 active associations.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#AssociationList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#Association"
+        "target": "com.amazonaws.services.ssm#Association",
+        "traits": {
+          "smithy.api#xmlName": "Association"
+        }
       }
     },
     "com.amazonaws.services.ssm#AssociationName": {
@@ -1522,7 +1558,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have reached the maximum number versions allowed for an association. Each association\n   has a limit of 1,000 versions. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#AssociationVersionList": {
@@ -1577,7 +1614,10 @@
     "com.amazonaws.services.ssm#AttachmentContentList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AttachmentContent"
+        "target": "com.amazonaws.services.ssm#AttachmentContent",
+        "traits": {
+          "smithy.api#xmlName": "AttachmentContent"
+        }
       }
     },
     "com.amazonaws.services.ssm#AttachmentHash": {
@@ -1622,7 +1662,10 @@
     "com.amazonaws.services.ssm#AttachmentInformationList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#AttachmentInformation"
+        "target": "com.amazonaws.services.ssm#AttachmentInformation",
+        "traits": {
+          "smithy.api#xmlName": "AttachmentInformation"
+        }
       }
     },
     "com.amazonaws.services.ssm#AttachmentName": {
@@ -1739,7 +1782,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An Automation document with the specified name could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#AutomationDefinitionVersionNotFoundException": {
@@ -1751,7 +1795,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An Automation document with the specified name and version could not be found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#AutomationExecution": {
@@ -2016,7 +2061,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The number of simultaneously running Automation executions exceeded the allowable\n   limit.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.services.ssm#AutomationExecutionMetadata": {
@@ -2174,7 +2220,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>There is no automation execution information for the requested automation execution\n   ID.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#AutomationExecutionStatus": {
@@ -2262,7 +2309,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified step name and execution ID don't exist. Verify the information and try\n   again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#AutomationTargetParameterName": {
@@ -3194,7 +3242,10 @@
     "com.amazonaws.services.ssm#ComplianceItemList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#ComplianceItem"
+        "target": "com.amazonaws.services.ssm#ComplianceItem",
+        "traits": {
+          "smithy.api#xmlName": "Item"
+        }
       }
     },
     "com.amazonaws.services.ssm#ComplianceItemTitle": {
@@ -3344,13 +3395,19 @@
     "com.amazonaws.services.ssm#ComplianceStringFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#ComplianceStringFilter"
+        "target": "com.amazonaws.services.ssm#ComplianceStringFilter",
+        "traits": {
+          "smithy.api#xmlName": "ComplianceFilter"
+        }
       }
     },
     "com.amazonaws.services.ssm#ComplianceStringFilterValueList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#ComplianceFilterValue"
+        "target": "com.amazonaws.services.ssm#ComplianceFilterValue",
+        "traits": {
+          "smithy.api#xmlName": "FilterValue"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -3391,7 +3448,10 @@
     "com.amazonaws.services.ssm#ComplianceSummaryItemList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#ComplianceSummaryItem"
+        "target": "com.amazonaws.services.ssm#ComplianceSummaryItem",
+        "traits": {
+          "smithy.api#xmlName": "Item"
+        }
       }
     },
     "com.amazonaws.services.ssm#ComplianceTypeCountLimitExceededException": {
@@ -3403,7 +3463,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You specified too many custom compliance types. You can specify a maximum of 10 different\n   types. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ComplianceTypeName": {
@@ -3647,7 +3708,10 @@
     "com.amazonaws.services.ssm#CreateAssociationBatchRequestEntries": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#CreateAssociationBatchRequestEntry"
+        "target": "com.amazonaws.services.ssm#CreateAssociationBatchRequestEntry",
+        "traits": {
+          "smithy.api#xmlName": "entries"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -4354,7 +4418,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded the limit for custom schemas. Delete one or more custom schemas and try\n   again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#DateTime": {
@@ -7307,7 +7372,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified document already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#DocumentContent": {
@@ -7528,7 +7594,10 @@
     "com.amazonaws.services.ssm#DocumentFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#DocumentFilter"
+        "target": "com.amazonaws.services.ssm#DocumentFilter",
+        "traits": {
+          "smithy.api#xmlName": "DocumentFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -7656,7 +7725,10 @@
     "com.amazonaws.services.ssm#DocumentIdentifierList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#DocumentIdentifier"
+        "target": "com.amazonaws.services.ssm#DocumentIdentifier",
+        "traits": {
+          "smithy.api#xmlName": "DocumentIdentifier"
+        }
       }
     },
     "com.amazonaws.services.ssm#DocumentKeyValuesFilter": {
@@ -7724,7 +7796,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You can have at most 500 active Systems Manager documents.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#DocumentName": {
@@ -7777,7 +7850,10 @@
     "com.amazonaws.services.ssm#DocumentParameterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#DocumentParameter"
+        "target": "com.amazonaws.services.ssm#DocumentParameter",
+        "traits": {
+          "smithy.api#xmlName": "DocumentParameter"
+        }
       }
     },
     "com.amazonaws.services.ssm#DocumentParameterName": {
@@ -7801,7 +7877,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The document cannot be shared with more AWS user accounts. You can share a document with a\n   maximum of 20 accounts. You can publicly share up to five documents. If you need to increase this\n   limit, contact AWS Support.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#DocumentPermissionType": {
@@ -7983,7 +8060,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The document has too many versions. Delete one or more document versions and try\n   again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#DocumentVersionList": {
@@ -8018,7 +8096,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error returned when the ID specified for a resource, such as a maintenance window or Patch\n   baseline, doesn't exist.</p>\n         <p>For information about resource limits in Systems Manager, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_ssm\">AWS Systems Manager Limits</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#DryRun": {
@@ -8033,7 +8112,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The content of the association document matches another document. Change the content of the\n   document and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#DuplicateDocumentVersionName": {
@@ -8045,7 +8125,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The version name has already been used in this document. Specify a different version name,\n   and then try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#DuplicateInstanceId": {
@@ -8053,7 +8134,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>You cannot specify an instance ID in more than one association.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#EffectiveInstanceAssociationMaxResults": {
@@ -8148,7 +8230,10 @@
     "com.amazonaws.services.ssm#FailedCreateAssociationList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#FailedCreateAssociation"
+        "target": "com.amazonaws.services.ssm#FailedCreateAssociation",
+        "traits": {
+          "smithy.api#xmlName": "FailedCreateAssociationEntry"
+        }
       }
     },
     "com.amazonaws.services.ssm#FailureDetails": {
@@ -8196,7 +8281,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You attempted to register a LAMBDA or STEP_FUNCTIONS task in a region where the\n   corresponding service is not available. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#GetAutomationExecution": {
@@ -10108,7 +10194,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A hierarchy can have a maximum of 15 levels. For more information, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html\">Requirements and Constraints for\n    Parameter Names</a> in the <i>AWS Systems Manager User Guide</i>. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#HierarchyTypeMismatchException": {
@@ -10123,7 +10210,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Parameter Store does not support changing a parameter type in a hierarchy. For example, you\n   can't change a parameter from a String type to a SecureString type. You must create a new, unique\n   parameter.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#IPAddress": {
@@ -10163,7 +10251,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error returned when an idempotent operation is retried and the parameters don't match the\n   original call to the API with the same idempotency token. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#IncompatiblePolicyException": {
@@ -10175,7 +10264,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>There is a conflict in the policies specified for this parameter. You can't, for example,\n   specify two Expiration policies for a parameter. Review your policies, and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InstallOverrideList": {
@@ -10578,7 +10668,10 @@
     "com.amazonaws.services.ssm#InstanceInformationFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InstanceInformationFilter"
+        "target": "com.amazonaws.services.ssm#InstanceInformationFilter",
+        "traits": {
+          "smithy.api#xmlName": "InstanceInformationFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -10597,7 +10690,10 @@
     "com.amazonaws.services.ssm#InstanceInformationFilterValueSet": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InstanceInformationFilterValue"
+        "target": "com.amazonaws.services.ssm#InstanceInformationFilterValue",
+        "traits": {
+          "smithy.api#xmlName": "InstanceInformationFilterValue"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -10609,7 +10705,10 @@
     "com.amazonaws.services.ssm#InstanceInformationList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InstanceInformation"
+        "target": "com.amazonaws.services.ssm#InstanceInformation",
+        "traits": {
+          "smithy.api#xmlName": "InstanceInformation"
+        }
       }
     },
     "com.amazonaws.services.ssm#InstanceInformationStringFilter": {
@@ -10645,7 +10744,10 @@
     "com.amazonaws.services.ssm#InstanceInformationStringFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InstanceInformationStringFilter"
+        "target": "com.amazonaws.services.ssm#InstanceInformationStringFilter",
+        "traits": {
+          "smithy.api#xmlName": "InstanceInformationStringFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -10910,7 +11012,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An error occurred on the server side.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.services.ssm#InvalidActivation": {
@@ -10922,7 +11025,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The activation is not valid. The activation might have been deleted, or the ActivationId and\n   the ActivationCode do not match.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#InvalidActivationId": {
@@ -10934,7 +11038,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The activation ID is not valid. Verify the you entered the correct ActivationId or\n   ActivationCode and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#InvalidAggregatorException": {
@@ -10946,7 +11051,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified aggregator is not valid for inventory groups. Verify that the aggregator uses\n   a valid inventory type such as <code>AWS:Application</code> or\n    <code>AWS:InstanceInformation</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidAllowedPatternException": {
@@ -10961,7 +11067,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request does not meet the regular expression requirement.</p>\n\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidAssociation": {
@@ -10973,7 +11080,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The association is not valid or does not exist. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidAssociationVersion": {
@@ -10985,7 +11093,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The version you specified is not valid. Use ListAssociationVersions to view all versions of\n   an association according to the association ID. Or, use the <code>$LATEST</code> parameter to\n   view the latest version of the association.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidAutomationExecutionParametersException": {
@@ -10997,7 +11106,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The supplied parameters for invoking the specified Automation document are incorrect. For\n   example, they may not match the set of parameters permitted for the specified Automation\n   document.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidAutomationSignalException": {
@@ -11009,7 +11119,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The signal is not valid for the current Automation execution.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidAutomationStatusUpdateException": {
@@ -11021,14 +11132,16 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified update status operation is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidCommandId": {
       "type": "structure",
       "members": { },
       "traits": {
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#InvalidDeleteInventoryParametersException": {
@@ -11040,7 +11153,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>One or more of the parameters specified for the delete operation is not valid. Verify all\n   parameters and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidDeletionIdException": {
@@ -11052,7 +11166,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The ID specified for the delete operation does not exist or is not valid. Verify the ID and\n   try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidDocument": {
@@ -11067,7 +11182,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified document does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#InvalidDocumentContent": {
@@ -11082,7 +11198,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The content for the document is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidDocumentOperation": {
@@ -11094,7 +11211,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You attempted to delete a document while it is still shared. You must stop sharing the\n   document before you can delete it.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazonaws.services.ssm#InvalidDocumentSchemaVersion": {
@@ -11106,7 +11224,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The version of the document schema is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidDocumentVersion": {
@@ -11118,7 +11237,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The document version is not valid or does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidFilter": {
@@ -11130,7 +11250,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The filter name is not valid. Verify the you entered the correct name and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 441
       }
     },
     "com.amazonaws.services.ssm#InvalidFilterKey": {
@@ -11138,7 +11259,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified key is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidFilterOption": {
@@ -11153,7 +11275,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified filter option is not valid. Valid options are Equals and BeginsWith. For Path\n   filter, valid options are Recursive and OneLevel.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidFilterValue": {
@@ -11165,7 +11288,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The filter value is not valid. Verify the value and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidInstanceId": {
@@ -11177,7 +11301,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The following problems can cause this exception:</p>\n         <p>You do not have permission to access the instance.</p>\n         <p>SSM Agent is not running. Verify that SSM Agent is running.</p>\n         <p>SSM Agent is not registered with the SSM endpoint. Try reinstalling SSM Agent.</p>\n         <p>The instance is not in valid state. Valid states are: Running, Pending, Stopped, Stopping.\n   Invalid states are: Shutting-down and Terminated.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#InvalidInstanceInformationFilterValue": {
@@ -11189,7 +11314,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified filter value is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidInventoryGroupException": {
@@ -11201,7 +11327,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified inventory group is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidInventoryItemContextException": {
@@ -11213,7 +11340,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You specified invalid keys or values in the <code>Context</code> attribute for\n    <code>InventoryItem</code>. Verify the keys and values, and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidInventoryRequestException": {
@@ -11225,7 +11353,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidItemContentException": {
@@ -11240,7 +11369,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>One or more content items is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidKeyId": {
@@ -11252,7 +11382,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The query key ID is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidNextToken": {
@@ -11264,7 +11395,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified token is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidNotificationConfig": {
@@ -11276,7 +11408,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>One or more configuration items is not valid. Verify that a valid Amazon Resource Name (ARN)\n   was provided for an Amazon SNS topic.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidOptionException": {
@@ -11288,7 +11421,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The delete inventory option specified is not valid. Verify the option and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidOutputFolder": {
@@ -11296,7 +11430,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The S3 bucket does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidOutputLocation": {
@@ -11304,7 +11439,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The output location is not valid or does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidParameters": {
@@ -11316,7 +11452,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You must specify values for all required parameters in the Systems Manager document. You can only\n   supply values to parameters defined in the Systems Manager document.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidPermissionType": {
@@ -11328,7 +11465,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The permission type is not supported. <i>Share</i> is the only supported\n   permission type.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidPluginName": {
@@ -11336,7 +11474,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The plugin name is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#InvalidPolicyAttributeException": {
@@ -11348,7 +11487,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A policy attribute or its value is invalid. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidPolicyTypeException": {
@@ -11360,7 +11500,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The policy type is not supported. Parameter Store supports the following policy types:\n   Expiration, ExpirationNotification, and NoChangeNotification.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidResourceId": {
@@ -11368,7 +11509,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The resource ID is not valid. Verify that you entered the correct ID and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidResourceType": {
@@ -11376,7 +11518,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The resource type is not valid. For example, if you are attempting to tag an instance, the\n   instance must be a registered, managed instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidResultAttributeException": {
@@ -11388,7 +11531,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified inventory item result attribute is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidRole": {
@@ -11400,7 +11544,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The role name can't contain invalid characters. Also verify that you specified an IAM role\n   for notifications that includes the required trust policy. For information about configuring the\n   IAM role for Run Command notifications, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/rc-sns-notifications.html\">Configuring Amazon SNS Notifications for Run Command</a> in the\n    <i>AWS Systems Manager User Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidSchedule": {
@@ -11412,7 +11557,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The schedule is invalid. Verify your cron or rate expression and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidTarget": {
@@ -11424,7 +11570,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The target is not valid or does not exist. It might not be configured for EC2 Systems\n   Manager or you might not have permission to perform the operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidTypeNameException": {
@@ -11436,7 +11583,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The parameter type name is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvalidUpdate": {
@@ -11448,7 +11596,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The update is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InventoryAggregator": {
@@ -11489,7 +11638,10 @@
     "com.amazonaws.services.ssm#InventoryAggregatorList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InventoryAggregator"
+        "target": "com.amazonaws.services.ssm#InventoryAggregator",
+        "traits": {
+          "smithy.api#xmlName": "Aggregator"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -11690,7 +11842,10 @@
     "com.amazonaws.services.ssm#InventoryFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InventoryFilter"
+        "target": "com.amazonaws.services.ssm#InventoryFilter",
+        "traits": {
+          "smithy.api#xmlName": "InventoryFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -11705,7 +11860,10 @@
     "com.amazonaws.services.ssm#InventoryFilterValueList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InventoryFilterValue"
+        "target": "com.amazonaws.services.ssm#InventoryFilterValue",
+        "traits": {
+          "smithy.api#xmlName": "FilterValue"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -11739,7 +11897,10 @@
     "com.amazonaws.services.ssm#InventoryGroupList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InventoryGroup"
+        "target": "com.amazonaws.services.ssm#InventoryGroup",
+        "traits": {
+          "smithy.api#xmlName": "InventoryGroup"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -11829,7 +11990,10 @@
     "com.amazonaws.services.ssm#InventoryItemAttributeList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InventoryItemAttribute"
+        "target": "com.amazonaws.services.ssm#InventoryItemAttribute",
+        "traits": {
+          "smithy.api#xmlName": "Attribute"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -11901,7 +12065,10 @@
     "com.amazonaws.services.ssm#InventoryItemList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InventoryItem"
+        "target": "com.amazonaws.services.ssm#InventoryItem",
+        "traits": {
+          "smithy.api#xmlName": "Item"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -12026,7 +12193,10 @@
     "com.amazonaws.services.ssm#InventoryResultEntityList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#InventoryResultEntity"
+        "target": "com.amazonaws.services.ssm#InventoryResultEntity",
+        "traits": {
+          "smithy.api#xmlName": "Entity"
+        }
       }
     },
     "com.amazonaws.services.ssm#InventoryResultItem": {
@@ -12103,7 +12273,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The command ID and instance ID you specified did not match any invocations. Verify the\n   command ID and the instance ID and try again. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#InvocationTraceOutput": {
@@ -12130,7 +12301,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The inventory item has invalid content. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ItemSizeLimitExceededException": {
@@ -12145,7 +12317,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The inventory item size has exceeded the size limit.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#KeyList": {
@@ -14226,7 +14399,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The size limit of a document is 64 KB.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#MaxErrors": {
@@ -14507,7 +14681,10 @@
     "com.amazonaws.services.ssm#OpsAggregatorList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#OpsAggregator"
+        "target": "com.amazonaws.services.ssm#OpsAggregator",
+        "traits": {
+          "smithy.api#xmlName": "Aggregator"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -14663,7 +14840,10 @@
     "com.amazonaws.services.ssm#OpsEntityList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#OpsEntity"
+        "target": "com.amazonaws.services.ssm#OpsEntity",
+        "traits": {
+          "smithy.api#xmlName": "Entity"
+        }
       }
     },
     "com.amazonaws.services.ssm#OpsFilter": {
@@ -14706,7 +14886,10 @@
     "com.amazonaws.services.ssm#OpsFilterList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#OpsFilter"
+        "target": "com.amazonaws.services.ssm#OpsFilter",
+        "traits": {
+          "smithy.api#xmlName": "OpsFilter"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -14746,7 +14929,10 @@
     "com.amazonaws.services.ssm#OpsFilterValueList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#OpsFilterValue"
+        "target": "com.amazonaws.services.ssm#OpsFilterValue",
+        "traits": {
+          "smithy.api#xmlName": "FilterValue"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -14871,7 +15057,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The OpsItem already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#OpsItemCategory": {
@@ -15070,7 +15257,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A specified parameter argument isn't valid. Verify the available arguments and try\n   again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#OpsItemLimitExceededException": {
@@ -15091,7 +15279,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request caused OpsItems to exceed one or more limits. For information about OpsItem\n   limits, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-learn-more.html#OpsCenter-learn-more-limits\">What\n    are the resource limits for OpsCenter?</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#OpsItemMaxResults": {
@@ -15113,7 +15302,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified OpsItem ID doesn't exist. Verify the ID and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#OpsItemNotification": {
@@ -15314,7 +15504,10 @@
     "com.amazonaws.services.ssm#OpsResultAttributeList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#OpsResultAttribute"
+        "target": "com.amazonaws.services.ssm#OpsResultAttribute",
+        "traits": {
+          "smithy.api#xmlName": "OpsResultAttribute"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -15454,7 +15647,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The parameter already exists. You can't create duplicate parameters.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ParameterDescription": {
@@ -15618,7 +15812,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded the number of parameters for this AWS account. Delete one or more\n   parameters and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.services.ssm#ParameterList": {
@@ -15636,7 +15831,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The parameter exceeded the maximum number of allowed versions.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ParameterMetadata": {
@@ -15737,7 +15933,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The parameter could not be found. Verify the name and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#ParameterPatternMismatchException": {
@@ -15752,7 +15949,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The parameter name is not valid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ParameterPolicies": {
@@ -15893,7 +16091,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A parameter version can have a maximum of ten labels.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ParameterVersionNotFound": {
@@ -15905,7 +16104,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified parameter version was not found. Verify the parameter name and version, and\n   try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#Parameters": {
@@ -16825,7 +17025,10 @@
     "com.amazonaws.services.ssm#PlatformTypeList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#PlatformType"
+        "target": "com.amazonaws.services.ssm#PlatformType",
+        "traits": {
+          "smithy.api#xmlName": "PlatformType"
+        }
       }
     },
     "com.amazonaws.services.ssm#PoliciesLimitExceededException": {
@@ -16837,7 +17040,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You specified more than the maximum number of allowed policies for the parameter. The\n   maximum is 10.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#Product": {
@@ -17787,7 +17991,10 @@
     "com.amazonaws.services.ssm#ResourceComplianceSummaryItemList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#ResourceComplianceSummaryItem"
+        "target": "com.amazonaws.services.ssm#ResourceComplianceSummaryItem",
+        "traits": {
+          "smithy.api#xmlName": "Item"
+        }
       }
     },
     "com.amazonaws.services.ssm#ResourceCount": {
@@ -17815,7 +18022,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>A sync configuration with the same name already exists.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ResourceDataSyncAwsOrganizationsSource": {
@@ -17848,7 +18056,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Another <code>UpdateResourceDataSync</code> request is being processed. Wait a few minutes\n   and try again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.services.ssm#ResourceDataSyncCountExceededException": {
@@ -17860,7 +18069,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You have exceeded the allowed maximum sync configurations.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ResourceDataSyncCreatedTime": {
@@ -17878,7 +18088,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified sync configuration is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ResourceDataSyncItem": {
@@ -17982,7 +18193,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified sync name was not found.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.services.ssm#ResourceDataSyncOrganizationSourceType": {
@@ -18234,7 +18446,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error returned if an attempt is made to delete a patch baseline that is registered for a\n   patch group.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ResourceLimitExceededException": {
@@ -18246,7 +18459,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Error returned when the caller has exceeded the default resource limits. For example, too\n   many maintenance windows or patch baselines have been created.</p>\n         <p>For information about resource limits in Systems Manager, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_ssm\">AWS Systems Manager Limits</a>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ResourceType": {
@@ -18311,7 +18525,10 @@
     "com.amazonaws.services.ssm#ResultAttributeList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.services.ssm#ResultAttribute"
+        "target": "com.amazonaws.services.ssm#ResultAttribute",
+        "traits": {
+          "smithy.api#xmlName": "ResultAttribute"
+        }
       },
       "traits": {
         "smithy.api#length": {
@@ -18770,7 +18987,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified service setting was not found. Either the service name or the setting has not\n   been provisioned by the AWS service team.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#ServiceSettingValue": {
@@ -19436,7 +19654,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The updated status is the same as the current status.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#StepExecution": {
@@ -19754,7 +19973,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The sub-type count exceeded the limit for the inventory type.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#Tag": {
@@ -19843,7 +20063,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You specified the <code>Safe</code> option for the DeregisterTargetFromMaintenanceWindow\n   operation, but the target is still referenced in a task.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#TargetKey": {
@@ -19972,7 +20193,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified target instance for the session is not fully configured for use with Session Manager.\n   For more information, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started.html\">Getting\n    Started with Session Manager</a> in the <i>AWS Systems Manager User Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 430
       }
     },
     "com.amazonaws.services.ssm#TargetParameterList": {
@@ -20084,7 +20306,8 @@
       "members": { },
       "traits": {
         "smithy.api#documentation": "\n         <p>The <code>Targets</code> parameter includes too many tags. Remove one or more tags and try\n   the command again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#TooManyUpdates": {
@@ -20096,7 +20319,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>There are concurrent updates for a resource that supports one update at a time.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.services.ssm#TotalCount": {
@@ -20111,7 +20335,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The size of inventory data has exceeded the total size limit for the resource.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#UnsupportedFeatureRequiredException": {
@@ -20123,7 +20348,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Microsoft application patching is only available on EC2 instances and Advanced Instances. To\n   patch Microsoft applications on on-premises servers and VMs, you must enable Advanced Instances.\n   For more information, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-managedinstances-advanced.html\">Using the Advanced-Instances\n    Tier</a> in the <i>AWS Systems Manager User Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#UnsupportedInventoryItemContextException": {
@@ -20138,7 +20364,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The <code>Context</code> attribute that you specified for the <code>InventoryItem</code> is\n   not allowed for this inventory type. You can only use the <code>Context</code> attribute with\n   inventory types like <code>AWS:ComplianceItem</code>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#UnsupportedInventorySchemaVersionException": {
@@ -20150,7 +20377,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Inventory item type schema version has to match supported versions in the service. Check\n   output of GetInventorySchema to see the available schema version for each type.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#UnsupportedOperatingSystem": {
@@ -20162,7 +20390,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The operating systems you specified is not supported, or the operation is not supported for\n   the operating system. Valid operating systems include: Windows, AmazonLinux,\n   RedhatEnterpriseLinux, and Ubuntu.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#UnsupportedParameterType": {
@@ -20174,7 +20403,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The parameter type is not supported.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#UnsupportedPlatformType": {
@@ -20186,7 +20416,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The document does not support the platform type of the given instance ID(s). For example,\n   you sent an document for a Windows instance to a Linux instance.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.services.ssm#UpdateAssociation": {

--- a/codegen/sdk-codegen/aws-models/storage-gateway.2013-06-30.json
+++ b/codegen/sdk-codegen/aws-models/storage-gateway.2013-06-30.json
@@ -3973,7 +3973,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An internal server error has occurred during the request. For more information, see\n         the error and message fields.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.awsappliancecontrolplaneapi#InvalidGatewayRequestException": {
@@ -3994,7 +3995,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An exception occurred because an invalid gateway request was issued to the service.\n         For more information, see the error and message fields.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.awsappliancecontrolplaneapi#IqnName": {
@@ -5409,7 +5411,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>An internal server error has occurred because the service is unavailable. For more\n         information, see the error and message fields.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.storagegateway.v20130630#SetLocalConsolePassword": {
@@ -5941,7 +5944,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Storage Gateway"
+        "smithy.api#title": "AWS Storage Gateway",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://storagegateway.amazonaws.com/doc/2013-06-30"
+        }
       }
     },
     "com.amazonaws.storagegateway.v20130630#StorediSCSIVolume": {

--- a/codegen/sdk-codegen/aws-models/sts.2011-06-15.json
+++ b/codegen/sdk-codegen/aws-models/sts.2011-06-15.json
@@ -566,7 +566,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The web identity token that was passed is expired or is not valid. Get a new identity\n            token from the identity provider and then retry the request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.its#FederatedUser": {
@@ -816,7 +817,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request could not be fulfilled because the identity provider (IDP) that\n            was asked to verify the incoming identity token could not be reached. This is often a\n            transient error caused by network conditions. Retry the request a limited number of\n            times so that you don't exceed the request rate. If the error persists, the\n            identity provider might be down or not responding.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.its#IDPRejectedClaimException": {
@@ -828,7 +830,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The identity provider (IdP) reported that authentication failed. This might be because\n            the claim is invalid.</p>\n        <p>If this error is returned for the <code>AssumeRoleWithWebIdentity</code> operation, it\n            can also mean that the claim has expired or has been explicitly revoked. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.its#InvalidAuthorizationMessageException": {
@@ -840,7 +843,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The error returned if the message passed to <code>DecodeAuthorizationMessage</code>\n            was invalid. This can happen if the token contains invalid characters, such as\n            linebreaks. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.its#InvalidIdentityTokenException": {
@@ -852,7 +856,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The web identity token that was passed could not be validated by AWS. Get a new\n            identity token from the identity provider and then retry the request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.its#Issuer": {
@@ -867,7 +872,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request was rejected because the policy document was malformed. The error message\n            describes the specific error.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.its#NameQualifier": {
@@ -882,7 +888,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>The request was rejected because the total packed size of the session policies and\n            session tags combined was too large. An AWS conversion compresses the session policy\n            document, session policy ARNs, and session tags into a packed binary format that has a\n            separate limit. The error message indicates by percentage how close the policies and\n            tags are to the upper size limit. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html\">Passing Session Tags in STS</a> in\n            the <i>IAM User Guide</i>.</p>\n        <p>You could receive this error even though you meet other defined session policy and\n            session tag limits. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">IAM and STS Entity\n                Character Limits</a> in the <i>IAM User Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazon.its#PolicyDescriptorType": {
@@ -908,7 +915,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>STS is not activated in the requested region for the account that is being asked to\n            generate credentials. The account administrator must use the IAM console to activate STS\n            in that region. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and\n                Deactivating AWS STS in an AWS Region</a> in the <i>IAM User\n                Guide</i>.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
       }
     },
     "com.amazon.its#SAMLAssertionType": {

--- a/codegen/sdk-codegen/aws-models/support.2013-04-15.json
+++ b/codegen/sdk-codegen/aws-models/support.2013-04-15.json
@@ -88,7 +88,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS Support"
+        "smithy.api#title": "AWS Support",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://support.amazonaws.com/doc/2013-04-15/"
+        }
       }
     },
     "com.amazon.awssupportapi.operation#AddAttachmentsToSet": {

--- a/codegen/sdk-codegen/aws-models/swf.2012-01-25.json
+++ b/codegen/sdk-codegen/aws-models/swf.2012-01-25.json
@@ -4843,7 +4843,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon Simple Workflow Service"
+        "smithy.api#title": "Amazon Simple Workflow Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://swf.amazonaws.com/doc/2012-01-25"
+        }
       }
     },
     "com.amazonaws.swf.base.model#StartChildWorkflowExecutionDecisionAttributes": {
@@ -5563,7 +5566,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>You've exceeded the number of tags allowed for a domain.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.swf.base.model#Truncated": {

--- a/codegen/sdk-codegen/aws-models/textract.2018-06-27.json
+++ b/codegen/sdk-codegen/aws-models/textract.2018-06-27.json
@@ -890,7 +890,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Indicates you have exceeded the maximum number of active human in the loop workflows available</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
       }
     },
     "com.amazonaws.textract#IdList": {

--- a/codegen/sdk-codegen/aws-models/transcribe.2017-10-26.json
+++ b/codegen/sdk-codegen/aws-models/transcribe.2017-10-26.json
@@ -34,7 +34,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n\n        <p>Your request didn't pass one or more validation tests. For example, if the\n            transcription you're trying to delete doesn't exist or if it is in a non-terminal state\n            (for example, it's \"in progress\"). See the exception <code>Message</code> field for more\n            information.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.transcribe#Boolean": {
@@ -52,7 +53,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>When you are using the <code>CreateVocabulary</code> operation, the\n                <code>JobName</code> field is a duplicate of a previously entered job name. Resend\n            your request with a different name.</p>\n        <p>When you are using the <code>UpdateVocabulary</code> operation, there are two jobs\n            running at the same time. Resend the second request later.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.transcribe#CreateVocabulary": {
@@ -78,7 +80,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n        <p>Creates a new custom vocabulary that you can use to change the way Amazon Transcribe handles\n            transcription of an audio file. </p>\n      "
+        "smithy.api#documentation": "\n        <p>Creates a new custom vocabulary that you can use to change the way Amazon Transcribe handles\n            transcription of an audio file. </p>\n      ",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.transcribe#CreateVocabularyRequest": {
@@ -107,6 +114,7 @@
           "target": "com.amazonaws.transcribe#VocabularyName",
           "traits": {
             "smithy.api#documentation": "\n        <p>The name of the vocabulary. The name must be unique within an AWS account. The name is\n            case-sensitive.</p>\n      ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -167,7 +175,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n\n        <p>Deletes a previously submitted transcription job along with any other generated\n            results such as the transcription, models, and so on.</p>\n      "
+        "smithy.api#documentation": "\n\n        <p>Deletes a previously submitted transcription job along with any other generated\n            results such as the transcription, models, and so on.</p>\n      ",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/transcriptionjobs/{TranscriptionJobName}",
+          "code": 204
+        }
       }
     },
     "com.amazonaws.transcribe#DeleteTranscriptionJobRequest": {
@@ -177,6 +190,7 @@
           "target": "com.amazonaws.transcribe#TranscriptionJobName",
           "traits": {
             "smithy.api#documentation": "\n        <p>The name of the transcription job to be deleted.</p>\n      ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -202,7 +216,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n        <p>Deletes a vocabulary from Amazon Transcribe. </p>\n      "
+        "smithy.api#documentation": "\n        <p>Deletes a vocabulary from Amazon Transcribe. </p>\n      ",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 204
+        }
       }
     },
     "com.amazonaws.transcribe#DeleteVocabularyRequest": {
@@ -212,6 +231,7 @@
           "target": "com.amazonaws.transcribe#VocabularyName",
           "traits": {
             "smithy.api#documentation": "\n        <p>The name of the vocabulary to delete. </p>\n      ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -243,7 +263,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n        <p>Returns information about a transcription job. To see the status of the job, check the\n                <code>TranscriptionJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished and you can find the results at the location specified in the\n                <code>TranscriptionFileUri</code> field.</p>\n      "
+        "smithy.api#documentation": "\n        <p>Returns information about a transcription job. To see the status of the job, check the\n                <code>TranscriptionJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished and you can find the results at the location specified in the\n                <code>TranscriptionFileUri</code> field.</p>\n      ",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/transcriptionjobs/{TranscriptionJobName}",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.transcribe#GetTranscriptionJobRequest": {
@@ -253,6 +278,7 @@
           "target": "com.amazonaws.transcribe#TranscriptionJobName",
           "traits": {
             "smithy.api#documentation": "\n        <p>The name of the job.</p>\n      ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -292,7 +318,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n        <p>Gets information about a vocabulary. </p>\n      "
+        "smithy.api#documentation": "\n        <p>Gets information about a vocabulary. </p>\n      ",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.transcribe#GetVocabularyRequest": {
@@ -302,6 +333,7 @@
           "target": "com.amazonaws.transcribe#VocabularyName",
           "traits": {
             "smithy.api#documentation": "\n        <p>The name of the vocabulary to return information about. The name is\n            case-sensitive.</p>\n      ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -357,7 +389,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>There was an internal error. Check the error message and try your request\n            again.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.transcribe#KMSKeyId": {
@@ -479,7 +512,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>Either you have sent too many requests or your input file is too long. Wait before you\n            resend your request, or use a smaller file and resend the request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.transcribe#ListTranscriptionJobs": {
@@ -503,6 +537,11 @@
       ],
       "traits": {
         "smithy.api#documentation": "\n        <p>Lists transcription jobs with the specified status.</p>\n      ",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/transcriptionjobs",
+          "code": 200
+        },
         "smithy.api#paginated": {
           "inputToken": "NextToken",
           "outputToken": "NextToken",
@@ -516,25 +555,29 @@
         "JobNameContains": {
           "target": "com.amazonaws.transcribe#TranscriptionJobName",
           "traits": {
-            "smithy.api#documentation": "\n        <p>When specified, the jobs returned in the list are limited to jobs whose name contains\n            the specified string.</p>\n      "
+            "smithy.api#documentation": "\n        <p>When specified, the jobs returned in the list are limited to jobs whose name contains\n            the specified string.</p>\n      ",
+            "smithy.api#httpQuery": "JobNameContains"
           }
         },
         "MaxResults": {
           "target": "com.amazonaws.transcribe#MaxResults",
           "traits": {
-            "smithy.api#documentation": "\n        <p>The maximum number of jobs to return in the response. If there are fewer results in\n            the list, this response contains only the actual results.</p>\n      "
+            "smithy.api#documentation": "\n        <p>The maximum number of jobs to return in the response. If there are fewer results in\n            the list, this response contains only the actual results.</p>\n      ",
+            "smithy.api#httpQuery": "MaxResults"
           }
         },
         "NextToken": {
           "target": "com.amazonaws.transcribe#NextToken",
           "traits": {
-            "smithy.api#documentation": "\n        <p>If the result of the previous request to <code>ListTranscriptionJobs</code> was\n            truncated, include the <code>NextToken</code> to fetch the next set of jobs.</p>\n      "
+            "smithy.api#documentation": "\n        <p>If the result of the previous request to <code>ListTranscriptionJobs</code> was\n            truncated, include the <code>NextToken</code> to fetch the next set of jobs.</p>\n      ",
+            "smithy.api#httpQuery": "NextToken"
           }
         },
         "Status": {
           "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
           "traits": {
-            "smithy.api#documentation": "\n        <p>When specified, returns only transcription jobs with the specified status. Jobs are\n            ordered by creation date, with the newest jobs returned first. If you don’t specify a\n            status, Amazon Transcribe returns all transcription jobs ordered by creation date. </p>\n      "
+            "smithy.api#documentation": "\n        <p>When specified, returns only transcription jobs with the specified status. Jobs are\n            ordered by creation date, with the newest jobs returned first. If you don’t specify a\n            status, Amazon Transcribe returns all transcription jobs ordered by creation date. </p>\n      ",
+            "smithy.api#httpQuery": "Status"
           }
         }
       }
@@ -583,6 +626,11 @@
       ],
       "traits": {
         "smithy.api#documentation": "\n        <p>Returns a list of vocabularies that match the specified criteria. If no criteria are\n            specified, returns the entire list of vocabularies.</p>\n      ",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/vocabularies",
+          "code": 200
+        },
         "smithy.api#paginated": {
           "inputToken": "NextToken",
           "outputToken": "NextToken",
@@ -596,25 +644,29 @@
         "MaxResults": {
           "target": "com.amazonaws.transcribe#MaxResults",
           "traits": {
-            "smithy.api#documentation": "\n        <p>The maximum number of vocabularies to return in the response. If there are fewer\n            results in the list, this response contains only the actual results.</p>\n      "
+            "smithy.api#documentation": "\n        <p>The maximum number of vocabularies to return in the response. If there are fewer\n            results in the list, this response contains only the actual results.</p>\n      ",
+            "smithy.api#httpQuery": "MaxResults"
           }
         },
         "NameContains": {
           "target": "com.amazonaws.transcribe#VocabularyName",
           "traits": {
-            "smithy.api#documentation": "\n        <p>When specified, the vocabularies returned in the list are limited to vocabularies\n            whose name contains the specified string. The search is case-insensitive,\n                <code>ListVocabularies</code> will return both \"vocabularyname\" and \"VocabularyName\"\n            in the response list.</p>\n      "
+            "smithy.api#documentation": "\n        <p>When specified, the vocabularies returned in the list are limited to vocabularies\n            whose name contains the specified string. The search is case-insensitive,\n                <code>ListVocabularies</code> will return both \"vocabularyname\" and \"VocabularyName\"\n            in the response list.</p>\n      ",
+            "smithy.api#httpQuery": "NameContains"
           }
         },
         "NextToken": {
           "target": "com.amazonaws.transcribe#NextToken",
           "traits": {
-            "smithy.api#documentation": "\n        <p>If the result of the previous request to <code>ListVocabularies</code> was truncated,\n            include the <code>NextToken</code> to fetch the next set of jobs.</p>\n      "
+            "smithy.api#documentation": "\n        <p>If the result of the previous request to <code>ListVocabularies</code> was truncated,\n            include the <code>NextToken</code> to fetch the next set of jobs.</p>\n      ",
+            "smithy.api#httpQuery": "NextToken"
           }
         },
         "StateEquals": {
           "target": "com.amazonaws.transcribe#VocabularyState",
           "traits": {
-            "smithy.api#documentation": "\n        <p>When specified, only returns vocabularies with the <code>VocabularyState</code> field\n            equal to the specified state.</p>\n      "
+            "smithy.api#documentation": "\n        <p>When specified, only returns vocabularies with the <code>VocabularyState</code> field\n            equal to the specified state.</p>\n      ",
+            "smithy.api#httpQuery": "StateEquals"
           }
         }
       }
@@ -734,7 +786,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n        <p>We can't find the requested resource. Check the name and try your request\n            again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.transcribe#OutputBucketName": {
@@ -843,7 +896,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n        <p>Starts an asynchronous job to transcribe speech to text. </p>\n      "
+        "smithy.api#documentation": "\n        <p>Starts an asynchronous job to transcribe speech to text. </p>\n      ",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/transcriptionjobs/{TranscriptionJobName}",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.transcribe#StartTranscriptionJobRequest": {
@@ -897,6 +955,7 @@
           "target": "com.amazonaws.transcribe#TranscriptionJobName",
           "traits": {
             "smithy.api#documentation": "\n        <p>The name of the job. Note that you can't use the strings \".\" or \"..\" by themselves as\n            the job name. The name must also be unique within an AWS account.</p>\n      ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }
@@ -1163,7 +1222,12 @@
         }
       ],
       "traits": {
-        "smithy.api#documentation": "\n        <p>Updates an existing vocabulary with new values. The <code>UpdateVocabulary</code>\n            operation overwrites all of the existing information with the values that you provide in\n            the request. </p>\n      "
+        "smithy.api#documentation": "\n        <p>Updates an existing vocabulary with new values. The <code>UpdateVocabulary</code>\n            operation overwrites all of the existing information with the values that you provide in\n            the request. </p>\n      ",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 200
+        }
       }
     },
     "com.amazonaws.transcribe#UpdateVocabularyRequest": {
@@ -1192,6 +1256,7 @@
           "target": "com.amazonaws.transcribe#VocabularyName",
           "traits": {
             "smithy.api#documentation": "\n        <p>The name of the vocabulary to update. The name is case-sensitive.</p>\n      ",
+            "smithy.api#httpLabel": true,
             "smithy.api#required": true
           }
         }

--- a/codegen/sdk-codegen/aws-models/transfer.2018-11-05.json
+++ b/codegen/sdk-codegen/aws-models/transfer.2018-11-05.json
@@ -844,7 +844,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when an error occurs in the AWS Transfer for SFTP service.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.necco.coral#InvalidNextTokenException": {
@@ -859,7 +860,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The <code>NextToken</code> parameter that was passed is invalid.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.necco.coral#InvalidRequestException": {
@@ -874,7 +876,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when the client submits a malformed request.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.necco.coral#ListServers": {
@@ -1300,7 +1303,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The requested resource does not exist.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
       }
     },
     "com.amazonaws.necco.coral#ResourceNotFoundException": {
@@ -1327,7 +1331,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>This exception is thrown when a resource is not found by the AWS Transfer for SFTP\n      service.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.necco.coral#ResourceType": {
@@ -1371,7 +1376,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request has failed because the AWS Transfer for SFTP service is not available.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.necco.coral#SshPublicKey": {
@@ -1738,12 +1744,16 @@
       "type": "structure",
       "members": {
         "RetryAfterSeconds": {
-          "target": "com.amazonaws.necco.coral#RetryAfterSeconds"
+          "target": "com.amazonaws.necco.coral#RetryAfterSeconds",
+          "traits": {
+            "smithy.api#httpHeader": "Retry-After"
+          }
         }
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The request was denied due to request throttling.</p>\n         <p> HTTP Status Code: 400</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.necco.coral#TransferService": {

--- a/codegen/sdk-codegen/aws-models/translate.2017-07-01.json
+++ b/codegen/sdk-codegen/aws-models/translate.2017-07-01.json
@@ -157,7 +157,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The confidence that Amazon Comprehend accurately detected the source language is low. If a low confidence level is acceptable for your application, you can use the language in the\n      exception to call Amazon Translate again. For more information, see the <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/API_DetectDominantLanguage.html\">DetectDominantLanguage</a> operation in the <i>Amazon Comprehend Developer\n        Guide</i>.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.shine#EncryptionKey": {
@@ -354,7 +355,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> An internal server error occurred. Retry your request.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
       }
     },
     "com.amazonaws.shine#InvalidParameterValueException": {
@@ -366,7 +368,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The value of the parameter is invalid. Review the value of the parameter you are using to correct it, and then retry your operation.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.shine#InvalidRequestException": {
@@ -378,7 +381,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> The request that you made is invalid. Check your request to determine why it's invalid and then retry the request.\n</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.shine#LanguageCodeString": {
@@ -405,7 +409,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The specified limit has been exceeded. Review your request and retry it with a quantity below the stated limit.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.shine#ListTerminologies": {
@@ -520,7 +525,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The resource you are looking for has not been found. Review the resource you're looking for and see if a different resource will accomplish your needs before retrying the revised request. .</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
       }
     },
     "com.amazonaws.shine#ServiceUnavailableException": {
@@ -532,7 +538,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>The Amazon Translate service is temporarily unavailable. Please wait a bit and then retry your request.</p>\n      ",
-        "smithy.api#error": "server"
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
       }
     },
     "com.amazonaws.shine#String": {
@@ -727,7 +734,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> The size of the text you submitted exceeds the size limit. Reduce the size of the text or use a smaller document and then retry your request.\n </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     },
     "com.amazonaws.shine#Timestamp": {
@@ -742,7 +750,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p> You have made too many requests within a short period of time. Wait for a short time and then try your request again.</p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
       }
     },
     "com.amazonaws.shine#TranslateText": {
@@ -868,7 +877,8 @@
       },
       "traits": {
         "smithy.api#documentation": "\n         <p>Amazon Translate does not support translation from the language of the source text into the requested target language. For\n      more information, see <a>how-to-error-msg</a>. </p>\n      ",
-        "smithy.api#error": "client"
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
       }
     }
   }

--- a/codegen/sdk-codegen/aws-models/waf-regional.2016-11-28.json
+++ b/codegen/sdk-codegen/aws-models/waf-regional.2016-11-28.json
@@ -286,7 +286,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS WAF Regional"
+        "smithy.api#title": "AWS WAF Regional",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://waf.amazonaws.com/doc/2015-08-24/"
+        }
       }
     },
     "com.amazonaws.gokucustomerapiservice.v20150409#Action": {

--- a/codegen/sdk-codegen/aws-models/waf.2015-08-24.json
+++ b/codegen/sdk-codegen/aws-models/waf.2015-08-24.json
@@ -274,7 +274,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS WAF"
+        "smithy.api#title": "AWS WAF",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://waf.amazonaws.com/doc/2015-08-24/"
+        }
       }
     },
     "com.amazonaws.gokucustomerapiservice.v20150409#Action": {

--- a/codegen/sdk-codegen/aws-models/wafv2.2019-07-29.json
+++ b/codegen/sdk-codegen/aws-models/wafv2.2019-07-29.json
@@ -154,7 +154,10 @@
             ]
           }
         ],
-        "smithy.api#title": "AWS WAFV2"
+        "smithy.api#title": "AWS WAFV2",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://waf.amazonaws.com/doc/2019-07-29/"
+        }
       }
     },
     "com.amazonaws.gokucustomerapiv2.v20190729#Action": {

--- a/codegen/sdk-codegen/aws-models/workdocs.2016-05-01.json
+++ b/codegen/sdk-codegen/aws-models/workdocs.2016-05-01.json
@@ -169,7 +169,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon WorkDocs"
+        "smithy.api#title": "Amazon WorkDocs",
+        "smithy.api#xmlNamespace": {
+          "uri": "https://aws.amazon.com/api/v1/"
+        }
       }
     },
     "com.amazon.aws.gorillaboy#AbortDocumentVersionUpload": {

--- a/codegen/sdk-codegen/aws-models/workspaces.2015-04-08.json
+++ b/codegen/sdk-codegen/aws-models/workspaces.2015-04-08.json
@@ -4258,7 +4258,10 @@
             ]
           }
         ],
-        "smithy.api#title": "Amazon WorkSpaces"
+        "smithy.api#title": "Amazon WorkSpaces",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://workspaces.amazonaws.com/api/v1"
+        }
       }
     }
   }


### PR DESCRIPTION
Changes in this update include:

* Added models for greengrass and mediaconnect.
* Traits that don't match the protocol are preserved.
* XML name and flattened traits are fixed up according to the updated spec.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
