### PR TITLE
fix: check error header

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -110,8 +110,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     @Override
     protected void writeErrorCodeParser(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
-        writer.write("errorCode = output.headers[\"x-amzn-errortype\"].split(':')[0];");
+        writer.openBlock("if (output.headers[\"x-amzn-errortype\"]) {", "}", () -> {
+            writer.write("errorCode = output.headers[\"x-amzn-errortype\"].split(':')[0];");
+        });
     }
 
     @Override


### PR DESCRIPTION
Fixes parsing error returned without x-amzn-errortype header.

requires: https://github.com/awslabs/smithy-typescript/pull/83

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
