### PR TITLE
fix: parse body only once for error response

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -88,8 +88,7 @@ final class AwsProtocolUtils {
         // Include a JSON body parser used to deserialize documents from HTTP responses.
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): any => {", "};", () -> {
-            writer.openBlock("return context.streamCollector(streamBody).then((body: any) => {", "});", () -> {
-                writer.write("const encoded = context.utf8Encoder(body);");
+            writer.openBlock("return collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
                 writer.openBlock("if (encoded.length) {", "}", () -> {
                     writer.write("return JSON.parse(encoded);");
                 });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -41,6 +41,13 @@ import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGene
  */
 abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
+    /**
+     * Creates a AWS JSON RPC protocol generator.
+     */
+    JsonRpcProtocolGenerator() {
+        super(true);
+    }
+
     protected Format getDocumentTimestampFormat() {
         return Format.EPOCH_SECONDS;
     }
@@ -96,8 +103,8 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     @Override
     protected void writeErrorCodeParser(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
-        writer.write("const errorTypeParts: String = data[\"__type\"].split('#');");
+        // parsedOutput is in scope because HttpRpcProtocolGenerator.isErrorCodeInBody is true
+        writer.write("const errorTypeParts: String = parsedOutput.body[\"__type\"].split('#');");
         writer.write("errorCode = (errorTypeParts[1] === undefined) ? errorTypeParts[0] : errorTypeParts[1];");
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -45,6 +45,12 @@ import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocol
  * @see <a href="https://awslabs.github.io/smithy/spec/http.html">Smithy HTTP protocol bindings.</a>
  */
 abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
+    /**
+     * Creates a AWS JSON RPC protocol generator.
+     */
+    RestJsonProtocolGenerator() {
+        super(false);
+    }
 
     @Override
     protected TimestampFormatTrait.Format getDocumentTimestampFormat() {


### PR DESCRIPTION
Paired with https://github.com/awslabs/smithy-typescript/pull/66



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
