### PR TITLE
fix: accept header typo

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -82,7 +82,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                                          HAS_MIDDLEWARE)
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.ACCEPTS_HEADER.dependency, "AcceptsHeader",
+                        .withConventions(AwsDependency.ACCEPT_HEADER.dependency, "AcceptHeader",
                                          HAS_MIDDLEWARE)
                         .servicePredicate((m, s) -> testServiceId(s, "API Gateway"))
                         .build(),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -31,7 +31,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing", "^1.0.0-alpha.0"),
     CREDENTIAL_PROVIDER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/credential-provider-node", "^1.0.0-alpha.0"),
     REGION_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/region-provider", "^1.0.0-alpha.0"),
-    ACCEPTS_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-api-gateway", "^1.0.0-alpha.0"),
+    ACCEPT_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-api-gateway", "^1.0.0-alpha.0"),
     VALIDATE_BUCKET_NAME(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-s3", "^1.0.0-alpha.0"),
     ADD_EXPECT_CONTINUE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-expect-continue", "^1.0.0-alpha.0"),
     GLACIER_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-glacier", "^1.0.0-alpha.0"),

--- a/packages/middleware-sdk-api-gateway/src/index.spec.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.spec.ts
@@ -1,15 +1,15 @@
-import { acceptsHeaderMiddleware } from "./index";
+import { acceptHeaderMiddleware } from "./index";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
-describe("acceptsHeaderMiddleware", () => {
+describe("acceptHeaderMiddleware", () => {
   const next = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("sets Accepts header to application/json", async () => {
-    const handler = acceptsHeaderMiddleware()(next, {} as any);
+  it("sets Accept header to application/json", async () => {
+    const handler = acceptHeaderMiddleware()(next, {} as any);
     await handler({
       input: {},
       request: new HttpRequest({
@@ -20,6 +20,6 @@ describe("acceptsHeaderMiddleware", () => {
     const { calls } = (next as any).mock;
     expect(calls.length).toBe(1);
     const { request } = next.mock.calls[0][0];
-    expect(request.headers["accepts"]).toBe("application/json");
+    expect(request.headers["accept"]).toBe("application/json");
   });
 });

--- a/packages/middleware-sdk-api-gateway/src/index.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from "@aws-sdk/types";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
-export function acceptsHeaderMiddleware(): BuildMiddleware<any, any> {
+export function acceptHeaderMiddleware(): BuildMiddleware<any, any> {
   return <Output extends MetadataBearer>(
     next: BuildHandler<any, Output>
   ): BuildHandler<any, Output> => async (
@@ -19,7 +19,7 @@ export function acceptsHeaderMiddleware(): BuildMiddleware<any, any> {
     if (HttpRequest.isInstance(request)) {
       request.headers = {
         ...request.headers,
-        accepts: "application/json"
+        accept: "application/json"
       };
     }
     return next({
@@ -29,14 +29,14 @@ export function acceptsHeaderMiddleware(): BuildMiddleware<any, any> {
   };
 }
 
-export const acceptsHeaderMiddlewareOptions: BuildHandlerOptions = {
+export const acceptHeaderMiddlewareOptions: BuildHandlerOptions = {
   step: "build",
-  tags: ["SET_ACCEPTS_HEADER", "ACCEPTS_HEADER"],
-  name: "acceptsHeaderMiddleware"
+  tags: ["SET_ACCEPT_HEADER", "ACCEPT_HEADER"],
+  name: "acceptHeaderMiddleware"
 };
 
 export const getAcceptsHeaderPlugin = (unused: any): Pluggable<any, any> => ({
   applyToStack: clientStack => {
-    clientStack.add(acceptsHeaderMiddleware(), acceptsHeaderMiddlewareOptions);
+    clientStack.add(acceptHeaderMiddleware(), acceptHeaderMiddlewareOptions);
   }
 });


### PR DESCRIPTION
Fixes Middleware for API Gateway to set the "accept" header, required to return the necessary content-type.
MDN for Accept header https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
