### PR TITLE
fix: prettify CODE_GEN_OUTPUT_DIR to improve performance

### DIFF
--- a/scripts/generate-clients/code-prettify.js
+++ b/scripts/generate-clients/code-prettify.js
@@ -1,25 +1,11 @@
-const path = require("path");
-const { readdirSync } = require("fs");
 const { spawnProcess } = require("./spawn-process");
 const { CODE_GEN_OUTPUT_DIR } = require("./code-gen-dir");
 
 const prettifyCode = async () => {
-  const spawnPromiseArray = [];
-  for (const modelName of readdirSync(CODE_GEN_OUTPUT_DIR)) {
-    if (modelName === "source") continue;
-    const artifactPath = path.join(
-      CODE_GEN_OUTPUT_DIR,
-      modelName,
-      "typescript-codegen"
-    );
-    spawnPromiseArray.push(
-      spawnProcess("./node_modules/.bin/prettier", [
-        "--write",
-        `${artifactPath}/**/*.{ts,md,json}`
-      ])
-    );
-  }
-  await Promise.all(spawnPromiseArray);
+  await spawnProcess("./node_modules/.bin/prettier", [
+    "--write",
+    `${CODE_GEN_OUTPUT_DIR}/**/*.{ts,js,md,json}`
+  ]);
 };
 
 module.exports = {

--- a/scripts/generate-clients/code-prettify.js
+++ b/scripts/generate-clients/code-prettify.js
@@ -4,6 +4,7 @@ const { spawnProcess } = require("./spawn-process");
 const { CODE_GEN_OUTPUT_DIR } = require("./code-gen-dir");
 
 const prettifyCode = async () => {
+  const spawnPromiseArray = [];
   for (const modelName of readdirSync(CODE_GEN_OUTPUT_DIR)) {
     if (modelName === "source") continue;
     const artifactPath = path.join(
@@ -11,11 +12,14 @@ const prettifyCode = async () => {
       modelName,
       "typescript-codegen"
     );
-    await spawnProcess("./node_modules/.bin/prettier", [
-      "--write",
-      `${artifactPath}/**/*.{ts,md,json}`
-    ]);
+    spawnPromiseArray.push(
+      spawnProcess("./node_modules/.bin/prettier", [
+        "--write",
+        `${artifactPath}/**/*.{ts,md,json}`
+      ])
+    );
   }
+  await Promise.all(spawnPromiseArray);
 };
 
 module.exports = {


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/aws-sdk-js-v3/issues/707

*Description of changes:*
* prettifies CODE_GEN_OUTPUT_DIR instead of each package to improve performance
* Tested on `c5.4xlarge` EC2 instance for generating 99 aws.json-1.1 clients:
  * without this code change:
  ```console
  $ time yarn generate-clients -m <dir-containing-json-1.1-models>
  ...
  ...
  Done in 205.55s.
  284.17s user 13.39s system 144% cpu 3:25.72 total
  ```
  * with this code change:
  ```console
  $ time yarn generate-clients -m <dir-containing-json-1.1-models>
  ...
  ...
  Done in 132.67s.
  177.20s user 7.31s system 138% cpu 2:12.84 total
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
