### PR TITLE
chore: switch global version to 1.0.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-sdk-js-v3",
   "private": true,
-  "version": "0.9.0",
+  "version": "1.0.0-alpha.0",
   "description": "AWS SDK for JavaScript from the future",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/690

*Description of changes:*
* switch global version to 1.0.0-alpha
* Confirmed in node that
  * `semver.inc("1.0.0-alpha.0", "prerelease")` returns `'1.0.0-alpha.1'`
  * `semver.inc("1.0.0-beta.0", "prerelease")` returns `'1.0.0-beta.1'`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
