### PR TITLE
fix: accept header plugin name

### DIFF
--- a/packages/middleware-sdk-api-gateway/src/index.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.ts
@@ -35,7 +35,7 @@ export const acceptHeaderMiddlewareOptions: BuildHandlerOptions = {
   name: "acceptHeaderMiddleware"
 };
 
-export const getAcceptsHeaderPlugin = (unused: any): Pluggable<any, any> => ({
+export const getAcceptHeaderPlugin = (unused: any): Pluggable<any, any> => ({
   applyToStack: clientStack => {
     clientStack.add(acceptHeaderMiddleware(), acceptHeaderMiddlewareOptions);
   }


### PR DESCRIPTION
Fixes accept header plugin name
Error in https://github.com/aws/aws-sdk-js-v3/pull/710#issuecomment-572845853

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
