### PR TITLE
Fix: XML body checksum

### DIFF
--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "jest": "^24.7.1",
-    "typescript": "~3.4.0"
+    "typescript": "~3.4.0",
+    "@aws-sdk/xml-builder": "1.0.0-alpha.2"
   }
 }

--- a/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
+++ b/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
@@ -34,6 +34,10 @@ export function applyMd5BodyChecksumMiddleware(
           const hash = new options.md5();
           hash.update(body || "");
           digest = hash.digest();
+        } else if (isXmlNode(body)) {
+          const hash = new options.md5();
+          hash.update(body.toString());
+          digest = hash.digest();
         } else {
           digest = options.streamHasher(options.md5, body);
         }
@@ -80,4 +84,15 @@ function hasHeader(soughtHeader: string, headers: HeaderBag): boolean {
   }
 
   return false;
+}
+
+function isXmlNode(arg: any) {
+  return (
+    typeof arg === "object" &&
+    typeof arg.toString === "function" &&
+    typeof arg.addAttribute === "function" &&
+    typeof arg.addChildNode === "function" &&
+    typeof arg.children === "object" &&
+    typeof arg.attributes === "object"
+  );
 }


### PR DESCRIPTION
Convert XmlNode to string before calculating checksum

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
