### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+_Issue #, if available:_
+
+_Description of changes:_
+
+##### Checklist
+
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] This is a code generator change and I have run `yarn run generate-clients -m models`
+- [ ] I have run `yarn test:all` and passed
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
Add a PR template to enforce local testing and clients regenerating. When submit a change to codegen, contributor is required to regenerate the clients and preferrable to put clients update to the last commit. 

This is **important** because this enforces generating correct git diff thus clients will contain correct changelog reflecting the change introduced by particular codegen change. 

In the future, we can adopt different solutions to automate re-generate clients from codegen change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
