### PR TITLE
feat: migrate and apply copySnapshotPresignedUrlMiddleware

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -109,6 +109,12 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                         .servicePredicate((m, s) -> testServiceId(s, "Glacier"))
                         .build(),
                 RuntimeClientPlugin.builder()
+                        .withConventions(AwsDependency.EC2_MIDDLEWARE.dependency,
+                                         "CopySnapshotPresignedUrl", HAS_MIDDLEWARE)
+                        .operationPredicate((m, s, o) -> o.getId().getName().equals("CopySnapshot")
+                                            && testServiceId(s, "EC2"))
+                        .build(),
+                RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.SSEC_MIDDLEWARE.dependency, "Ssec", HAS_MIDDLEWARE)
                         .operationPredicate((m, s, o) -> testInputContainsMember(m, o, SSEC_OPERATIONS)
                                             && testServiceId(s, "S3"))

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -45,6 +45,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node", "^1.0.0-alpha.1"),
     STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser", "^1.0.0-alpha.1"),
     ROUTE53_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-route53", "^1.0.0-alpha.1"),
+    EC2_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-ec2", "^1.0.0-alpha.0g"),
     BUCKET_ENDPOINT_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-bucket-endpoint", "^1.0.0-alpha.1"),
     BODY_CHECKSUM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-apply-body-checksum", "^1.0.0-alpha.1"),
     MIDDLEWARE_HOST_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-host-header", "^1.0.0-alpha.1"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -45,7 +45,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node", "^1.0.0-alpha.1"),
     STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser", "^1.0.0-alpha.1"),
     ROUTE53_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-route53", "^1.0.0-alpha.1"),
-    EC2_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-ec2", "^1.0.0-alpha.0g"),
+    EC2_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-ec2", "^1.0.0-alpha.0"),
     BUCKET_ENDPOINT_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-bucket-endpoint", "^1.0.0-alpha.1"),
     BODY_CHECKSUM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-apply-body-checksum", "^1.0.0-alpha.1"),
     MIDDLEWARE_HOST_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-host-header", "^1.0.0-alpha.1"),

--- a/packages/middleware-sdk-ec2/.gitignore
+++ b/packages/middleware-sdk-ec2/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/middleware-sdk-ec2/.npmignore
+++ b/packages/middleware-sdk-ec2/.npmignore
@@ -1,0 +1,13 @@
+/src/
+/coverage/
+/docs/
+tsconfig.test.json
+*.tsbuildinfo
+
+*.spec.js
+*.spec.d.ts
+*.spec.js.map
+
+*.fixture.js
+*.fixture.d.ts
+*.fixture.js.map

--- a/packages/middleware-sdk-ec2/CHANGELOG.md
+++ b/packages/middleware-sdk-ec2/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.1.0-preview.7](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.3...@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.7) (2019-09-19)
+
+
+
+# 0.3.0 (2019-09-09)
+
+
+### Features
+
+* commit all clients ([#324](https://github.com/aws/aws-sdk-js-v3/issues/324)) ([cb268ed](https://github.com/aws/aws-sdk-js-v3/commit/cb268ed))
+
+
+
+# 0.2.0 (2019-07-12)
+
+
+### Features
+
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
+
+# 0.1.0 (2019-04-19)
+
+
+
+
+
+# [0.1.0-preview.6](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.3...@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.6) (2019-09-09)
+
+
+### Features
+
+* commit all clients ([#324](https://github.com/aws/aws-sdk-js-v3/issues/324)) ([cb268ed](https://github.com/aws/aws-sdk-js-v3/commit/cb268ed))
+
+
+
+# 0.2.0 (2019-07-12)
+
+
+### Features
+
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
+
+# 0.1.0 (2019-04-19)
+
+
+
+
+
+# [0.1.0-preview.5](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.3...@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.5) (2019-07-12)
+
+
+### Features
+
+* add npm badges for individual packages ([#251](https://github.com/aws/aws-sdk-js-v3/issues/251)) ([8adc10c](https://github.com/aws/aws-sdk-js-v3/commit/8adc10c))
+* update jest v20 to v24 ([#243](https://github.com/aws/aws-sdk-js-v3/issues/243)) ([1e156ab](https://github.com/aws/aws-sdk-js-v3/commit/1e156ab))
+
+
+
+# 0.1.0 (2019-04-19)
+
+
+
+
+
+# [0.1.0-preview.4](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.3...@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.4) (2019-04-19)
+
+**Note:** Version bump only for package @aws-sdk/middleware-ec2-copysnapshot
+
+# [0.1.0-preview.3](https://github.com/aws/aws-sdk-js-v3/compare/@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.2...@aws-sdk/middleware-ec2-copysnapshot@0.1.0-preview.3) (2019-03-27)
+
+**Note:** Version bump only for package @aws-sdk/middleware-ec2-copysnapshot

--- a/packages/middleware-sdk-ec2/LICENSE
+++ b/packages/middleware-sdk-ec2/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-sdk-ec2/LICENSE
+++ b/packages/middleware-sdk-ec2/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/middleware-sdk-ec2/README.md
+++ b/packages/middleware-sdk-ec2/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/middleware-sdk-ec2
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-sdk-ec2/preview.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-ec2)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-sdk-ec2.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-ec2)

--- a/packages/middleware-sdk-ec2/jest.config.js
+++ b/packages/middleware-sdk-ec2/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base
+};

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -17,6 +17,7 @@
     "@aws-sdk/signature-v4": "^1.0.0-alpha.3",
     "@aws-sdk/types": "^1.0.0-alpha.2",
     "@aws-sdk/util-format-url": "^1.0.0-alpha.2",
+    "@aws-sdk/util-uri-escape": "^1.0.0-alpha.2",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@aws-sdk/middleware-sdk-ec2",
+  "version": "1.0.0-alpha.0",
+  "scripts": {
+    "prepublishOnly": "tsc",
+    "pretest": "tsc -p tsconfig.test.json",
+    "test": "jest"
+  },
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/signature-v4": "^1.0.0-alpha.3",
+    "@aws-sdk/types": "^1.0.0-alpha.2",
+    "@aws-sdk/util-format-url": "^1.0.0-alpha.2",
+    "tslib": "^1.8.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.12",
+    "jest": "^24.7.1",
+    "typescript": "~3.4.0"
+  }
+}

--- a/packages/middleware-sdk-ec2/src/fixture.ts
+++ b/packages/middleware-sdk-ec2/src/fixture.ts
@@ -1,0 +1,25 @@
+import { SourceData } from "@aws-sdk/types";
+
+export class MockSha256 {
+  constructor(secret?: string | ArrayBuffer | ArrayBufferView) {}
+  update(data?: SourceData) {}
+  digest() {
+    return Promise.resolve(new Uint8Array(5));
+  }
+}
+
+export const region = () => Promise.resolve("mock-region");
+
+export const endpoint = () =>
+  Promise.resolve({
+    protocol: "https:",
+    path: "/",
+    hostname: "ec2.mock-region.amazonaws.com"
+  });
+
+export const credentials = () =>
+  Promise.resolve({
+    accessKeyId: "akid",
+    secretAccessKey: "secret",
+    sessionToken: "session"
+  });

--- a/packages/middleware-sdk-ec2/src/index.spec.ts
+++ b/packages/middleware-sdk-ec2/src/index.spec.ts
@@ -30,20 +30,20 @@ describe("middleware-sdk-ec2", () => {
     expect(middlewareOutput.input.DestinationRegion).toEqual(await region());
     const presignedUrl = middlewareOutput.input.PresignedUrl;
     expect(presignedUrl).toMatch(
-      /https\:\/\/ec2\.src\-region\.amazonaws\.com\/\?/
+      /https%3A%2F%2Fec2.src-region.amazonaws.com%2F%3F/
     );
-    expect(presignedUrl).toMatch(/Action\=CopySnapshot/);
-    expect(presignedUrl).toMatch(/Version\=2016\-11\-15/);
+    expect(presignedUrl).toMatch(/Action%3DCopySnapshot/);
+    expect(presignedUrl).toMatch(/Version%3D2016\-11\-15/);
     expect(presignedUrl).toMatch(
-      /DestinationRegion\=mock\-region\&SourceRegion\=src\-region\&SourceSnapshotId\=snap\-123456789/
+      /DestinationRegion%3Dmock\-region%26SourceRegion%3Dsrc\-region%26SourceSnapshotId%3Dsnap\-123456789/
     );
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
   });
 
   it("does not modify input if PresignedUrl has already  been set", async () => {

--- a/packages/middleware-sdk-ec2/src/index.spec.ts
+++ b/packages/middleware-sdk-ec2/src/index.spec.ts
@@ -1,0 +1,61 @@
+import { copySnapshotPresignedUrlMiddleware } from "./index";
+import { credentials, endpoint, region, MockSha256 } from "./fixture";
+
+const nextHandler = jest.fn();
+const handler = copySnapshotPresignedUrlMiddleware({
+  credentials,
+  endpoint,
+  region,
+  sha256: MockSha256,
+  signingEscapePath: true
+})(nextHandler, {} as any);
+
+describe("middleware-sdk-ec2", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("generates PresignedUrl and DestinationRegion parameters", async () => {
+    const params = {
+      SourceRegion: "src-region",
+      SourceSnapshotId: "snap-123456789"
+    };
+    await handler({ input: params });
+    expect(nextHandler.mock.calls.length).toBe(1);
+    const middlewareOutput = nextHandler.mock.calls[0][0];
+    expect(middlewareOutput.input.SourceRegion).toEqual(params.SourceRegion);
+    expect(middlewareOutput.input.SourceSnapshotId).toEqual(
+      params.SourceSnapshotId
+    );
+    expect(middlewareOutput.input.DestinationRegion).toEqual(await region());
+    const presignedUrl = middlewareOutput.input.PresignedUrl;
+    expect(presignedUrl).toMatch(
+      /https\:\/\/ec2\.src\-region\.amazonaws\.com\/\?/
+    );
+    expect(presignedUrl).toMatch(/Action\=CopySnapshot/);
+    expect(presignedUrl).toMatch(/Version\=2016\-11\-15/);
+    expect(presignedUrl).toMatch(
+      /DestinationRegion\=mock\-region\&SourceRegion\=src\-region\&SourceSnapshotId\=snap\-123456789/
+    );
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
+  });
+
+  it("does not modify input if PresignedUrl has already  been set", async () => {
+    const params = {
+      PresignedUrl: "provided",
+      SourceRegion: "src-region",
+      SourceSnapshotId: "snap-123456789"
+    };
+    await handler({ input: params });
+    expect(nextHandler.mock.calls.length).toBe(1);
+    const middlewareOutput = nextHandler.mock.calls[0][0];
+    expect(middlewareOutput.input.SourceRegion).toEqual(params.SourceRegion);
+    expect(middlewareOutput.input.PresignedUrl).toEqual(params.PresignedUrl);
+  });
+});

--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -1,0 +1,102 @@
+import {
+  Credentials,
+  DateInput,
+  Endpoint,
+  HashConstructor,
+  InitializeHandler,
+  InitializeMiddleware,
+  InitializeHandlerArguments,
+  InitializeHandlerOptions,
+  InitializeHandlerOutput,
+  MetadataBearer,
+  Pluggable,
+  Provider
+} from "@aws-sdk/types";
+import { SignatureV4 } from "@aws-sdk/signature-v4";
+import { formatUrl } from "@aws-sdk/util-format-url";
+import { HttpRequest } from "@aws-sdk/protocol-http";
+
+interface PreviouslyResolved {
+  credentials: Provider<Credentials>;
+  endpoint: Provider<Endpoint>;
+  region: Provider<string>;
+  sha256: HashConstructor;
+  signingEscapePath: boolean;
+}
+
+const version = "2016-11-15";
+
+//an initialize middleware to add PresignUrl to input
+export function copySnapshotPresignedUrlMiddleware(
+  options: PreviouslyResolved
+): InitializeMiddleware<any, any> {
+  return <Output extends MetadataBearer>(
+    next: InitializeHandler<any, Output>
+  ): InitializeHandler<any, Output> => async (
+    args: InitializeHandlerArguments<any>
+  ): Promise<InitializeHandlerOutput<Output>> => {
+    const { input } = args;
+    if (!input.PresignedUrl) {
+      const region = await options.region();
+      const resolvedEndpoint = await options.endpoint();
+      resolvedEndpoint.hostname = `ec2.${input.SourceRegion}.amazonaws.com`;
+      const request = new HttpRequest({
+        ...resolvedEndpoint,
+        protocol: "https",
+        headers: {
+          host: resolvedEndpoint.hostname
+        },
+        query: {
+          Action: "CopySnapshot",
+          Version: version,
+          SourceRegion: input.SourceRegion,
+          SourceSnapshotId: input.SourceSnapshotId,
+          DestinationRegion: region
+        }
+      });
+      const signer = new SignatureV4({
+        credentials: options.credentials,
+        region: input.SourceRegion,
+        service: "ec2",
+        sha256: options.sha256,
+        uriEscapePath: options.signingEscapePath
+      });
+      const presignedRequest = await signer.presignRequest(
+        request,
+        expirationTime(3600)
+      );
+
+      args = {
+        ...args,
+        input: {
+          ...args.input,
+          DestinationRegion: region,
+          PresignedUrl: formatUrl(presignedRequest)
+        }
+      };
+    }
+
+    return next(args);
+  };
+}
+
+function expirationTime(durationSeconds: number): DateInput {
+  return Math.round((new Date().valueOf() + durationSeconds * 1000) / 1000);
+}
+
+export const copySnapshotPresignedUrlMiddlewareOptions: InitializeHandlerOptions = {
+  step: "initialize",
+  tags: ["CROSS_REGION_PRESIGNED_URL"],
+  name: "crossRegionPresignedUrlMiddleware"
+};
+
+export const getCopySnapshotPresignedUrlMiddlewareOptionsPlugin = (
+  config: PreviouslyResolved
+): Pluggable<any, any> => ({
+  applyToStack: clientStack => {
+    clientStack.add(
+      copySnapshotPresignedUrlMiddleware(config),
+      copySnapshotPresignedUrlMiddlewareOptions
+    );
+  }
+});

--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -15,6 +15,7 @@ import {
 import { SignatureV4 } from "@aws-sdk/signature-v4";
 import { formatUrl } from "@aws-sdk/util-format-url";
 import { HttpRequest } from "@aws-sdk/protocol-http";
+import { escapeUri } from "@aws-sdk/util-uri-escape";
 
 interface PreviouslyResolved {
   credentials: Provider<Credentials>;
@@ -71,7 +72,7 @@ export function copySnapshotPresignedUrlMiddleware(
         input: {
           ...args.input,
           DestinationRegion: region,
-          PresignedUrl: formatUrl(presignedRequest)
+          PresignedUrl: escapeUri(formatUrl(presignedRequest))
         }
       };
     }
@@ -90,7 +91,7 @@ export const copySnapshotPresignedUrlMiddlewareOptions: InitializeHandlerOptions
   name: "crossRegionPresignedUrlMiddleware"
 };
 
-export const getCopySnapshotPresignedUrlMiddlewareOptionsPlugin = (
+export const getCopySnapshotPresignedUrlPlugin = (
   config: PreviouslyResolved
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {

--- a/packages/middleware-sdk-ec2/tsconfig.json
+++ b/packages/middleware-sdk-ec2/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "declaration": true,
+    "strict": true,
+    "sourceMap": true,
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "noEmitHelpers": true,
+    "lib": [
+      "es5",
+      "es2015.promise",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.symbol.wellknown"
+    ],
+    "rootDir": "./src",
+    "outDir": "./build",
+    "incremental": true
+  }
+}

--- a/packages/middleware-sdk-ec2/tsconfig.test.json
+++ b/packages/middleware-sdk-ec2/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "rootDir": "./src",
+    "outDir": "./build",
+    "incremental": true
+  }
+}


### PR DESCRIPTION
Migrates and applies copySnapshotPresignedUrlMiddleware for EC2 clients

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
