### PR TITLE
fix: xml map serializer valueNode

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
@@ -115,10 +115,10 @@ final class XmlShapeSerVisitor extends DocumentShapeSerVisitor {
             Shape valueTarget = model.expectShape(valueMember.getTarget());
             String valueName = valueMember.getTrait(XmlNameTrait.class)
                     .map(XmlNameTrait::getValue)
-                    .orElse("key");
-            writer.write("const keyNode = new __XmlNode($S);", valueName);
-            writer.write("keyNode.addChildNode($L)", valueTarget.accept(getMemberVisitor("input[key]")));
-            writer.write("entryNode.addChildNode(keyNode);");
+                    .orElse("value");
+            writer.write("const valueNode = new __XmlNode($S);", valueName);
+            writer.write("valueNode.addChildNode($L)", valueTarget.accept(getMemberVisitor("input[key]")));
+            writer.write("entryNode.addChildNode(valueNode);");
 
             // Add the entry to the collection.
             writer.write("collectedNodes.push(entryNode);");


### PR DESCRIPTION
Fixes awslabs/smithy-typescript#97

Use valueNode instead of keyNode for value's node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
