### PR TITLE
fix: add missing middleware dep

### DIFF
--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/middleware-host-header": "^1.0.0-alpha.0",
     "@aws-sdk/middleware-retry": "^1.0.0-alpha.1",
     "@aws-sdk/middleware-serde": "^1.0.0-alpha.1",
+    "@aws-sdk/middleware-sdk-s3-control": "^1.0.0-alpha.0",
     "@aws-sdk/middleware-signing": "^1.0.0-alpha.0",
     "@aws-sdk/middleware-stack": "^1.0.0-alpha.1",
     "@aws-sdk/middleware-user-agent": "^1.0.0-alpha.1",


### PR DESCRIPTION
Adds missing package.json entry for s3-control middleware dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
