### PR TITLE
feat: Add support for the aws.query protocol

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
@@ -27,6 +27,7 @@ public class AddProtocols implements TypeScriptIntegration {
 
     @Override
     public List<ProtocolGenerator> getProtocolGenerators() {
-        return ListUtils.of(new AwsRestJson1_1(), new AwsJsonRpc1_0(), new AwsJsonRpc1_1(), new AwsRestXml());
+        return ListUtils.of(new AwsRestJson1_1(), new AwsJsonRpc1_0(), new AwsJsonRpc1_1(),
+                new AwsRestXml(), new AwsQuery());
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -101,6 +101,25 @@ final class AwsProtocolUtils {
         writer.write("");
     }
 
+    static void generateXmlParseBody(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Include an XML body parser used to deserialize documents from HTTP responses.
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.addDependency(AwsDependency.XML_PARSER);
+        writer.addDependency(AwsDependency.XML_PARSER_TYPES);
+        writer.addImport("parse", "pixlParse", "pixl-xml");
+        writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): any => {", "};", () -> {
+            writer.openBlock("return collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
+                writer.openBlock("if (encoded.length) {", "}", () -> {
+                    writer.write("return pixlParse(encoded);");
+                });
+                writer.write("return {};");
+            });
+        });
+        writer.write("");
+    }
+
     /**
      * Writes an attribute containing information about a Shape's optionally specified
      * XML namespace configuration to an attribute of the passed node name.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Set;
+import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
+
+/**
+ * Handles generating the aws.query protocol for services. It handles reading and
+ * writing from document bodies, including generating any functions needed for
+ * performing serde.
+ *
+ * This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle
+ * standard components of the HTTP requests and responses.
+ *
+ * A set of service-specific customizations exist for Amazon EC2:
+ *
+ * @see QueryShapeSerVisitor
+ * @see XmlShapeDeserVisitor
+ * @see QueryMemberSerVisitor
+ * @see XmlMemberDeserVisitor
+ * @see AwsProtocolUtils
+ * @see <a href="https://awslabs.github.io/smithy/spec/xml.html">Smithy XML traits.</a>
+ * @see <a href="https://awslabs.github.io/smithy/spec/aws-core.html#ec2QueryName-trait">Smithy EC2 Query Name trait.</a>
+ */
+final class AwsQuery extends HttpRpcProtocolGenerator {
+
+    AwsQuery() {
+        // AWS Query protocols will attempt to parse error codes from response bodies.
+        super(true);
+    }
+
+    @Override
+    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
+        return "/";
+    }
+
+    @Override
+    public String getName() {
+        return "aws.query";
+    }
+
+    @Override
+    protected String getDocumentContentType() {
+        return "application/x-www-form-urlencoded";
+    }
+
+    @Override
+    protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new QueryShapeSerVisitor(context));
+    }
+
+    @Override
+    protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new XmlShapeDeserVisitor(context));
+    }
+
+    @Override
+    public void generateSharedComponents(ProtocolGenerator.GenerationContext context) {
+        super.generateSharedComponents(context);
+        AwsProtocolUtils.generateXmlParseBody(context);
+
+        TypeScriptWriter writer = context.getWriter();
+
+        // Generate a function that handles the complex rules around deserializing
+        // an error code from a rest-xml error.
+        SymbolReference responseType = getApplicationProtocol().getResponseType();
+        writer.openBlock("const loadQueryErrorCode = (\n"
+                       + "  output: $T,\n"
+                       + "  data: any\n"
+                       + "): string => {", "};", responseType, () -> {
+
+            // Attempt to fetch the error code from the specific location.
+            writer.openBlock("if (data.Error.Code !== undefined) {", "}", () -> {
+                writer.write("return data.Error.Code;");
+            });
+
+            // Default a 404 status code to the NotFound code.
+            writer.openBlock("if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
+
+            // Default to an UnknownError code.
+            writer.write("return 'UnknownError';");
+        });
+        writer.write("");
+
+        // Write a single function to handle combining a map in to a valid query string.
+        writer.openBlock("const buildFormUrlencodedString = (entries: any): string => {", "}", () -> {
+            writer.write("return Object.keys(entries).map(key => key + '=' + entries[key]).join(\"&\");");
+        });
+    }
+
+    @Override
+    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
+        super.writeDefaultHeaders(context, operation);
+        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+    }
+
+    @Override
+    protected void serializeInputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            StructureShape inputStructure
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Gather all the explicit input entries.
+        writer.write("const entries = $L;",
+                inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
+
+        // Set the form encoded string.
+        writer.openBlock("body = buildFormUrlencodedString({", "});", () -> {
+            writer.write("...entries,");
+            // Set the protocol required values.
+            writer.write("Action: $S,", operation.getId().getName());
+            writer.write("Version: $S,", context.getService().getVersion());
+        });
+    }
+
+    @Override
+    protected void writeErrorCodeParser(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Outsource error code parsing since it's complex for this protocol.
+        writer.write("errorCode = loadQueryErrorCode(output, parsedOutput.body);");
+    }
+
+    @Override
+    protected void deserializeOutputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            StructureShape outputStructure
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+
+        String dataSource = "data." + operation.getId().getName() + "Result";
+        writer.write("contents = $L;",
+                outputStructure.accept(new XmlMemberDeserVisitor(context, dataSource, Format.DATE_TIME)));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -87,25 +87,10 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     @Override
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
+        AwsProtocolUtils.generateXmlParseBody(context);
 
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.XML_BUILDER);
-
-        // Include an XML body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
-        writer.addDependency(AwsDependency.XML_PARSER);
-        writer.addDependency(AwsDependency.XML_PARSER_TYPES);
-        writer.addImport("parse", "pixlParse", "pixl-xml");
-        writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): any => {", "};", () -> {
-            writer.openBlock("return collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
-                writer.openBlock("if (encoded.length) {", "}", () -> {
-                    writer.write("return pixlParse(encoded);");
-                });
-                writer.write("return {};");
-            });
-        });
-
-        writer.write("");
 
         // Generate a function that handles the complex rules around deserializing
         // an error code from a rest-xml error.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
 import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
+import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Handles general components across the AWS JSON protocols that have do not have
@@ -45,7 +46,13 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
      * Creates a AWS JSON RPC protocol generator.
      */
     JsonRpcProtocolGenerator() {
+        // AWS JSON RPC protocols will attempt to parse error codes from response bodies.
         super(true);
+    }
+
+    @Override
+    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
+        return "/" + StringUtils.capitalize(operationShape.getId().getName());
     }
 
     protected Format getDocumentTimestampFormat() {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -36,8 +36,8 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * Visitor to generate serialization functions for shapes in AWS JSON protocol
  * document bodies.
  *
- * No standard visitation methods are overridden; function body generation for all
- * expected serializers is handled by this class.
+ * This class handles function body generation for all types expected by the {@code
+ * DocumentShapeSerVisitor}. No other shape type serialization is overridden.
  *
  * Timestamps are serialized to {@link Format}.EPOCH_SECONDS by default.
  */

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryMemberSerVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Overrides the default implementation of BigDecimal and BigInteger shape
+ * serialization to throw when encountered in the aws.query protocol.
+ *
+ * TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
+ */
+final class QueryMemberSerVisitor extends DocumentMemberSerVisitor {
+
+    QueryMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+        super(context, dataSource, defaultTimestampFormat);
+    }
+
+    boolean visitSuppliesEntryList(Shape shape) {
+        return shape.isStructureShape() || shape.isUnionShape()
+                || shape.isMapShape() || shape.isListShape() || shape.isSetShape();
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    private String unsupportedShape(Shape shape) {
+        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
+                shape.getType(), shape.getId()));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.model.traits.XmlFlattenedTrait;
+import software.amazon.smithy.model.traits.XmlNameTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Visitor to generate serialization functions for shapes in form-urlencoded
+ * based document bodies.
+ *
+ * This class handles function body generation for all types expected by the {@code
+ * DocumentShapeSerVisitor}. No other shape type serialization is overridden.
+ *
+ * Timestamps are serialized to {@link Format}.DATE_TIME by default.
+ */
+final class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
+
+    QueryShapeSerVisitor(GenerationContext context) {
+        super(context);
+    }
+
+    private QueryMemberSerVisitor getMemberVisitor(String dataSource) {
+        return new QueryMemberSerVisitor(getContext(), dataSource, Format.DATE_TIME);
+    }
+
+    @Override
+    protected void serializeCollection(GenerationContext context, CollectionShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        MemberShape memberShape = shape.getMember();
+        Shape target = context.getModel().expectShape(memberShape.getTarget());
+
+        // Use the @xmlName trait if present on the member, otherwise use "member".
+        String locationName = memberShape.getTrait(XmlNameTrait.class)
+                .map(XmlNameTrait::getValue)
+                .orElse("member");
+
+        // Set up a location to store all of the entry pairs.
+        writer.write("const entries: any = {};");
+        // Set up a counter to increment the member entries.
+        writer.write("let counter = 1;");
+        // Dispatch to the input value provider for any additional handling.
+        writer.openBlock("(input || []).map(entry => {", "});", () -> {
+            writer.write("const loc: string = \"$L.\" + counter;", locationName);
+            writer.write("entries[loc] = $L;", target.accept(getMemberVisitor("entry")));
+            writer.write("counter++;");
+        });
+
+        writer.write("return entries;");
+    }
+
+    @Override
+    protected void serializeDocument(GenerationContext context, DocumentShape shape) {
+        throw new CodegenException(String.format(
+                "Cannot serialize Document types on AWS Query protocols, shape: %s.", shape.getId()));
+    }
+
+    @Override
+    protected void serializeMap(GenerationContext context, MapShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+        Model model = context.getModel();
+
+        // Set up a location to store all of the entry pairs.
+        writer.write("const entries: any = {};");
+        // Set up a counter to increment the member entries.
+        writer.write("let counter = 1;");
+        // Use the keys as an iteration point to dispatch to the input value providers.
+        writer.openBlock("Object.keys(input).forEach(key => {", "});", () -> {
+            // Prepare the key's entry.
+            // Use the @xmlName trait if present on the member, otherwise use "key".
+            MemberShape keyMember = shape.getKey();
+            Shape keyTarget = model.expectShape(keyMember.getTarget());
+            String keyName = keyMember.getTrait(XmlNameTrait.class)
+                    .map(XmlNameTrait::getValue)
+                    .orElse("key");
+            writer.write("const keyLoc: string = \"entry.$L.\" + counter;", keyName);
+            writer.write("entries[keyLoc] = $L;", keyTarget.accept(getMemberVisitor("key")));
+
+
+            // Prepare the value's entry.
+            // Use the @xmlName trait if present on the member, otherwise use "value".
+            MemberShape valueMember = shape.getValue();
+            Shape valueTarget = model.expectShape(valueMember.getTarget());
+            String valueName = valueMember.getTrait(XmlNameTrait.class)
+                    .map(XmlNameTrait::getValue)
+                    .orElse("value");
+            writer.write("const valueLoc: string = \"entry.$L.\" + counter;", valueName);
+            writer.write("entries[valueLoc] = $L;", valueTarget.accept(getMemberVisitor("input[key]")));
+
+            writer.write("counter++;");
+        });
+
+        writer.write("return entries;");
+    }
+
+    @Override
+    protected void serializeStructure(GenerationContext context, StructureShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Set up a location to store all of the entry pairs.
+        writer.write("const entries: any = {};");
+
+        // Serialize every member of the structure if present.
+        shape.getAllMembers().forEach((memberName, memberShape) -> {
+            String inputLocation = "input." + memberName;
+            writer.openBlock("if ($L !== undefined) {", "}", inputLocation,
+                    () -> serializeNamedMember(context, memberName, memberShape, inputLocation));
+        });
+
+        writer.write("return entries");
+    }
+
+    private void serializeNamedMember(
+            GenerationContext context,
+            String memberName,
+            MemberShape memberShape,
+            String inputLocation
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+        // Grab the target shape so we can use a member serializer on it.
+        Shape target = context.getModel().expectShape(memberShape.getTarget());
+
+        // Use the @xmlName trait if present on the member, otherwise use the member name.
+        String locationName = memberShape.getTrait(XmlNameTrait.class)
+                .map(XmlNameTrait::getValue)
+                .orElse(memberName);
+
+        QueryMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation);
+        if (inputVisitor.visitSuppliesEntryList(target)) {
+            serializeNamedMemberEntryList(context, locationName, memberShape, target, inputVisitor);
+        } else {
+            writer.write("entries[$S] = $L", locationName, target.accept(inputVisitor));
+        }
+    }
+
+    private void serializeNamedMemberEntryList(
+            GenerationContext context,
+            String locationName,
+            MemberShape memberShape,
+            Shape target,
+            DocumentMemberSerVisitor inputVisitor
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Handle @xmlFlattened for collections and maps.
+        boolean isFlattened = memberShape.hasTrait(XmlFlattenedTrait.class);
+
+        // Set up a location to store all of the entry pairs.
+        writer.write("const memberEntries = $L;", target.accept(inputVisitor));
+
+        // Consolidate every entry in the list.
+        writer.openBlock("Object.keys(memberEntries).forEach(key => {", "});", () -> {
+            // Remove the last segment for any flattened entities.
+            if (isFlattened) {
+                writer.write("const loc = \"$L.\" + key.substring(key.indexOf('.') + 1);", locationName);
+            } else {
+                writer.write("const loc = \"$L.\" + key;", locationName);
+            }
+
+            writer.write("entries[loc] = memberEntries[key];");
+        });
+    }
+
+    @Override
+    protected void serializeUnion(GenerationContext context, UnionShape shape) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Set up a location to store the entry pair.
+        writer.write("const entries: any = {};");
+
+        // Visit over the union type, then get the right serialization for the member.
+        writer.openBlock("$L.visit(input, {", "});", shape.getId().getName(), () -> {
+            shape.getAllMembers().forEach((memberName, memberShape) -> {
+                writer.openBlock("$L: value => {", "},", memberName, () -> {
+                    serializeNamedMember(context, memberName, memberShape, "value");
+                });
+            });
+
+            // Handle the unknown property.
+            writer.openBlock("_: (name: string, value: any) => {", "}", () -> {
+                writer.write("entries[name] = value;");
+            });
+        });
+
+        writer.write("return entries;");
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
@@ -36,11 +36,11 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVis
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Visitor to generate deserialization functions for shapes in XML-document
+ * Visitor to generate serialization functions for shapes in XML-document
  * based document bodies.
  *
- * No standard visitation methods are overridden; function body generation for all
- * expected serializers is handled by this class.
+ * This class handles function body generation for all types expected by the {@code
+ * DocumentShapeSerVisitor}. No other shape type serialization is overridden.
  *
  * Timestamps are serialized to {@link Format}.DATE_TIME by default.
  *


### PR DESCRIPTION
This commit adds support for the `aws.query` protocol, building
on top of the `HttpRpcProtocolGenerator` and `Xml[Member|Shape]DeserVisitor`
for document serde.

Implementations of the `Document[Member|Shape]SerVisitor` have been
created that handle form-urlencoded bodies, respecting Smithy's `@xmlName`
trait.

Assorted minor updates for abstraction and in coordination with updates
to the base class have also been made.

Depends on awslabs/smithy-typescript#102

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
