### PR TITLE
feat: add disableHostPrefix to serde context

### DIFF
--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -20,7 +20,7 @@ export interface StreamCollector {
 }
 
 /**
- * Request and Response serde util functions for AWS services
+ * Request and Response serde util functions and settings for AWS services
  */
 export interface SerdeContext extends EndpointBearer {
   base64Encoder: Encoder;
@@ -29,6 +29,7 @@ export interface SerdeContext extends EndpointBearer {
   utf8Decoder: Decoder;
   streamCollector: StreamCollector;
   requestHandler: RequestHandler<any, any>;
+  disableHostPrefix: boolean;
 }
 
 export interface RequestSerializer<


### PR DESCRIPTION
Updated serde context type for addition of endpoint and hostname prefix codegen.

Corresponds to changes in https://github.com/awslabs/smithy-typescript/pull/104

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
