### PR TITLE
fix: multiple XML collection deserialization bugs

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -33,7 +33,7 @@ tasks.withType<Test> {
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-aws-traits:0.9.6")
+    api("software.amazon.smithy:smithy-aws-traits:0.9.7")
     api("software.amazon.smithy:smithy-typescript-codegen:0.1.0")
     testCompile("org.junit.jupiter:junit-jupiter-api:5.4.0")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -23,7 +23,6 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
-import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 
 /**
  * Handles generating the aws.query protocol for services. It handles reading and
@@ -33,15 +32,12 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
  * This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle
  * standard components of the HTTP requests and responses.
  *
- * A set of service-specific customizations exist for Amazon EC2:
- *
  * @see QueryShapeSerVisitor
  * @see XmlShapeDeserVisitor
  * @see QueryMemberSerVisitor
  * @see XmlMemberDeserVisitor
  * @see AwsProtocolUtils
  * @see <a href="https://awslabs.github.io/smithy/spec/xml.html">Smithy XML traits.</a>
- * @see <a href="https://awslabs.github.io/smithy/spec/aws-core.html#ec2QueryName-trait">Smithy EC2 Query Name trait.</a>
  */
 final class AwsQuery extends HttpRpcProtocolGenerator {
 
@@ -76,14 +72,14 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     }
 
     @Override
-    public void generateSharedComponents(ProtocolGenerator.GenerationContext context) {
+    public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateXmlParseBody(context);
 
         TypeScriptWriter writer = context.getWriter();
 
         // Generate a function that handles the complex rules around deserializing
-        // an error code from a rest-xml error.
+        // an error code from an xml error body.
         SymbolReference responseType = getApplicationProtocol().getResponseType();
         writer.openBlock("const loadQueryErrorCode = (\n"
                        + "  output: $T,\n"


### PR DESCRIPTION
This commit fixes a couple issues with generating code to deserialize
structure, union, or body members that target collection members.

1. Unflattened shapes that could return multiple entries in their
collection but only return one would result in an error at runtime
trying to iterate over an object like it was an Array.
2. Unflattened shapes that were not set in the provided output would
result in an error at runtime when trying to validate the entry exists
element without validating that its parent element existed.

This update also bumps the version of smithy-aws-traits to latest.

Fixes #765 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
