### PR TITLE
fix: uri escape presigned url

### DIFF
--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/signature-v4": "^1.0.0-alpha.7",
     "@aws-sdk/types": "^1.0.0-alpha.3",
     "@aws-sdk/util-format-url": "^1.0.0-alpha.3",
+    "@aws-sdk/util-uri-escape": "^1.0.0-alpha.2",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-rds/src/index.spec.ts
+++ b/packages/middleware-sdk-rds/src/index.spec.ts
@@ -38,17 +38,17 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
     expect(presignedUrl).toMatch(
-      /https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/
+      /https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/
     );
-    expect(presignedUrl).toMatch(/Action\=CopyDBSnapshot/);
-    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
+    expect(presignedUrl).toMatch(/Action%3DCopyDBSnapshot/);
+    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
   });
 
   it("should build CreateDBInstanceReadReplica cross origin presigned url correctly ", async () => {
@@ -69,17 +69,17 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
     expect(presignedUrl).toMatch(
-      /https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/
+      /https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/
     );
-    expect(presignedUrl).toMatch(/Action\=CreateDBInstanceReadReplica/);
-    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
+    expect(presignedUrl).toMatch(/Action%3DCreateDBInstanceReadReplica/);
+    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
   });
 
   it("should build CreateDBCluster cross origin presigned url correctly ", async () => {
@@ -100,17 +100,17 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
     expect(presignedUrl).toMatch(
-      /https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/
+      /https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/
     );
-    expect(presignedUrl).toMatch(/Action\=CreateDBCluster/);
-    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
+    expect(presignedUrl).toMatch(/Action%3DCreateDBCluster/);
+    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
   });
 
   it("should build CopyDBClusterSnapshot cross origin presigned url correctly ", async () => {
@@ -131,17 +131,17 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
     expect(presignedUrl).toMatch(
-      /https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/
+      /https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/
     );
-    expect(presignedUrl).toMatch(/Action\=CopyDBClusterSnapshot/);
-    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
+    expect(presignedUrl).toMatch(/Action%3DCopyDBClusterSnapshot/);
+    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
   });
 
   it("should not generate PreSignedUrl if source identifier is not ARN", async () => {

--- a/packages/middleware-sdk-rds/src/index.ts
+++ b/packages/middleware-sdk-rds/src/index.ts
@@ -15,6 +15,7 @@ import {
 import { formatUrl } from "@aws-sdk/util-format-url";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { SignatureV4 } from "@aws-sdk/signature-v4";
+import { escapeUri } from "@aws-sdk/util-uri-escape";
 
 const regARN = /arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=/,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?/;
 
@@ -104,7 +105,7 @@ export function crossRegionPresignedUrlMiddleware(
         ...args,
         input: {
           ...args.input,
-          PreSignedUrl: formatUrl(presignedRequest)
+          PreSignedUrl: escapeUri(formatUrl(presignedRequest))
         }
       };
     }


### PR DESCRIPTION
fix for invalid query string parameter: uri escape presigned url in request

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
