### PR TITLE
feat: rename calculateSha256 functions

### DIFF
--- a/clients/client-s3/runtimeConfig.browser.ts
+++ b/clients/client-s3/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { calculateSha256 as streamHasher } from "@aws-sdk/hash-blob-browser";
+import { blobHasher as streamHasher } from "@aws-sdk/hash-blob-browser";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
 import { Md5 } from "@aws-sdk/md5-js";
 import { Sha256 } from "@aws-crypto/sha256-browser";

--- a/clients/client-s3/runtimeConfig.ts
+++ b/clients/client-s3/runtimeConfig.ts
@@ -1,5 +1,5 @@
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
-import { calculateSha256 as streamHasher } from "@aws-sdk/hash-stream-node";
+import { fileStreamHasher as streamHasher } from "@aws-sdk/hash-stream-node";
 import { defaultProvider as regionDefaultProvider } from "@aws-sdk/region-provider";
 import { HashConstructor as __HashConstructor } from "@aws-sdk/types";
 import { Hash } from "@aws-sdk/hash-node";

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddStreamHasherDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddStreamHasherDependency.java
@@ -62,12 +62,12 @@ public class AddStreamHasherDependency implements TypeScriptIntegration {
         switch (target) {
             case NODE:
                 writer.addDependency(AwsDependency.STREAM_HASHER_NODE);
-                writer.addImport("calculateSha256", "streamHasher", AwsDependency.STREAM_HASHER_NODE.packageName);
+                writer.addImport("fileStreamHasher", "streamHasher", AwsDependency.STREAM_HASHER_NODE.packageName);
                 writer.write("streamHasher,");
                 break;
             case BROWSER:
                 writer.addDependency(AwsDependency.STREAM_HASHER_BROWSER);
-                writer.addImport("calculateSha256", "streamHasher", AwsDependency.STREAM_HASHER_BROWSER.packageName);
+                writer.addImport("blobHasher", "streamHasher", AwsDependency.STREAM_HASHER_BROWSER.packageName);
                 writer.write("streamHasher,");
                 break;
             default:

--- a/packages/hash-blob-browser/src/index.spec.ts
+++ b/packages/hash-blob-browser/src/index.spec.ts
@@ -1,14 +1,14 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { toHex } from "@aws-sdk/util-hex-encoding";
-import { calculateSha256 } from "./index";
+import { blobHasher } from "./index";
 
-describe("calculateSha256", () => {
+describe("blobHasher", () => {
   const blob = new Blob([
     "Shot through the bar, but you're too late bizzbuzz you give foo, a bad name."
   ]);
 
   it("calculates the SHA256 hash of a blob", async () => {
-    const result = await calculateSha256(Sha256, blob);
+    const result = await blobHasher(Sha256, blob);
 
     expect(result instanceof Uint8Array).toBe(true);
     expect(toHex(result)).toBe(

--- a/packages/hash-blob-browser/src/index.ts
+++ b/packages/hash-blob-browser/src/index.ts
@@ -2,7 +2,7 @@ import { Hash, HashConstructor, StreamHasher } from "@aws-sdk/types";
 
 import { blobReader } from "@aws-sdk/chunked-blob-reader";
 
-export const calculateSha256: StreamHasher<Blob> = async function calculateSha256(
+export const blobHasher: StreamHasher<Blob> = async function blobHasher(
   hashCtor: HashConstructor,
   blob: Blob
 ): Promise<Uint8Array> {

--- a/packages/hash-stream-node/src/index.spec.ts
+++ b/packages/hash-stream-node/src/index.spec.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "os";
 import { Readable } from "stream";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { toHex } from "@aws-sdk/util-hex-encoding";
-import { calculateSha256 } from "./index";
+import { fileStreamHasher } from "./index";
 
 function createTemporaryFile(contents: string): string {
   const folder = mkdtempSync(join(tmpdir(), "sha256-stream-node-"));
@@ -14,13 +14,13 @@ function createTemporaryFile(contents: string): string {
   return fileLoc;
 }
 
-describe("calculateSha256", () => {
+describe("fileStreamHasher", () => {
   const temporaryFile = createTemporaryFile(
     "Shot through the bar, but you're too late bizzbuzz you give foo, a bad name."
   );
 
   it("calculates the SHA256 hash of a stream", async () => {
-    const result = await calculateSha256(
+    const result = await fileStreamHasher(
       Sha256,
       createReadStream(temporaryFile)
     );
@@ -37,7 +37,7 @@ describe("calculateSha256", () => {
     const onSpy = jest.spyOn(inputStream, "on");
     const pipeSpy = jest.spyOn(inputStream, "pipe");
 
-    const result = await calculateSha256(Sha256, inputStream);
+    const result = await fileStreamHasher(Sha256, inputStream);
 
     expect(result instanceof Uint8Array).toBe(true);
     expect(toHex(result)).toBe(
@@ -51,7 +51,7 @@ describe("calculateSha256", () => {
     const inputStream = new Readable();
 
     await expect(
-      calculateSha256(Sha256, inputStream as any)
+      fileStreamHasher(Sha256, inputStream as any)
     ).rejects.toHaveProperty("message");
   });
 });

--- a/packages/hash-stream-node/src/index.ts
+++ b/packages/hash-stream-node/src/index.ts
@@ -3,7 +3,7 @@ import { HashCalculator } from "./hash-calculator";
 import { createReadStream, ReadStream } from "fs";
 import { Readable } from "stream";
 
-export const calculateSha256: StreamHasher<Readable> = function calculateSha256(
+export const fileStreamHasher: StreamHasher<Readable> = function fileStreamHasher(
   hashCtor: HashConstructor,
   fileStream: Readable
 ): Promise<Uint8Array> {


### PR DESCRIPTION
Renames calculateSha256 to fileStreamHasher and blobHasher.  Each function takes a Hash constructor and thus can return other hashes beyond Sha256.

Updates S3 Client where these functions are currently used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
