### PR TITLE
fix(util-create-request): fix creating undefined request

### DIFF
--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -20,7 +20,6 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/middleware-stack": "^1.0.0-alpha.1",
     "@aws-sdk/protocol-http": "^1.0.0-alpha.6",
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.3",

--- a/packages/util-create-request/src/foo.fixture.ts
+++ b/packages/util-create-request/src/foo.fixture.ts
@@ -53,7 +53,11 @@ export const operationCommand: Command<
     config: any,
     options: any
   ) => {
-    return () => Promise.resolve({ output, response: {} });
+    const concatStack = stack.concat(operationCommand.middlewareStack);
+    return concatStack.resolve(
+      () => Promise.resolve({ output, response: {} }),
+      {} as any
+    );
   }
 };
 

--- a/packages/util-create-request/src/index.spec.ts
+++ b/packages/util-create-request/src/index.spec.ts
@@ -116,7 +116,7 @@ describe("create-request", () => {
     );
     expect(request).toEqual({
       ...httpRequest,
-      body: "A1B2"
+      body: "A1B2C3"
     });
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
fix: #788 

*Description of changes:*

Use command.resolveMiddleware() to generate request instead of
concatenating middleware stacks manually. This fix
also includes `build` stage to creating request. Because build
stage sometimes contains necessary middleware to build a correct
request. For example, S3's bucket endpoint middleware is located
in build stage. Host header is also necessary, if users want to
sign the generated request directly.

Verify it works with s3 presigned url:
```js
const { createRequest } = require("@aws-sdk/util-create-request");
const {formatUrl} = require("@aws-sdk/util-format-url");
const {S3RequestPresigner} = require("@aws-sdk/s3-request-presigner");
const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");

(async () => {
  const client = new S3Client({region: "us-west-2"});
  const command = new GetObjectCommand({
    Bucket: "bucket",
    Key: "test"
  });

  try {
    const request = await createRequest(
      client,
      command
    );
    const presigner = new S3RequestPresigner({...client.config});
    const signed = await presigner.presignRequest(request, new Date(Date.now() + 900 * 1000));
    console.log(formatUrl(signed))
  } catch(e) {
    console.log(e)
  }
})();


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
