### PR TITLE
feat: Auto-fill idempotency token values

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -52,7 +52,9 @@ public enum AwsDependency implements SymbolDependencyContainer {
     SQS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-sqs", "^1.0.0-alpha.0"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder", "^1.0.0-alpha.1"),
     XML_PARSER(NORMAL_DEPENDENCY, "pixl-xml", "^1.0.13"),
-    XML_PARSER_TYPES(DEV_DEPENDENCY, "@types/pixl-xml", "^1.0.1");
+    XML_PARSER_TYPES(DEV_DEPENDENCY, "@types/pixl-xml", "^1.0.1"),
+    UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^3.4.0"),
+    UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^3.4.7");
 
     public final String packageName;
     public final String version;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -76,6 +76,7 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateXmlParseBody(context);
         AwsProtocolUtils.generateBuildFormUrlencodedString(context);
+        AwsProtocolUtils.addItempotencyAutofillImport(context);
 
         TypeScriptWriter writer = context.getWriter();
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -76,6 +76,7 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateXmlParseBody(context);
         AwsProtocolUtils.generateBuildFormUrlencodedString(context);
+        AwsProtocolUtils.addItempotencyAutofillImport(context);
 
         TypeScriptWriter writer = context.getWriter();
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -88,6 +88,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateXmlParseBody(context);
+        AwsProtocolUtils.addItempotencyAutofillImport(context);
 
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.XML_BUILDER);
@@ -159,8 +160,11 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             MemberShape memberShape = binding.getMember();
             // The name of the member to get from the input shape.
             String memberName = symbolProvider.toMemberName(memberShape);
-
             String inputLocation = "input." + memberName;
+
+            // Handle if the member is an idempotency token that should be auto-filled.
+            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+
             writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
                 shapeSerVisitor.serializeNamedMember(context, memberName, memberShape, () -> inputLocation);
             });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -73,6 +73,7 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateJsonParseBody(context);
+        AwsProtocolUtils.addItempotencyAutofillImport(context);
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -97,9 +97,13 @@ final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
                     .map(JsonNameTrait::getValue)
                     .orElse(memberName);
             Shape target = context.getModel().expectShape(memberShape.getTarget());
+            String inputLocation = "input." + memberName;
+
+            // Handle if the member is an idempotency token that should be auto-filled.
+            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
 
             // Generate an if statement to set the bodyParam if the member is set.
-            writer.openBlock("if (input.$L !== undefined) {", "}", memberName, () -> {
+            writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
                 // Dispatch to the input value provider for any additional handling.
                 writer.write("bodyParams['$L'] = $L;", locationName,
                         target.accept(getMemberVisitor("input." + memberName)));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -140,6 +140,10 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
         // Serialize every member of the structure if present.
         shape.getAllMembers().forEach((memberName, memberShape) -> {
             String inputLocation = "input." + memberName;
+
+            // Handle if the member is an idempotency token that should be auto-filled.
+            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+
             writer.openBlock("if ($L !== undefined) {", "}", inputLocation,
                     () -> serializeNamedMember(context, memberName, memberShape, inputLocation));
         });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
@@ -147,6 +147,10 @@ final class XmlShapeSerVisitor extends DocumentShapeSerVisitor {
         Map<String, MemberShape> members = shape.getAllMembers();
         members.forEach((memberName, memberShape) -> {
             String inputLocation = "input." + memberName;
+
+            // Handle if the member is an idempotency token that should be auto-filled.
+            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+
             writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
                 serializeNamedMember(context, memberName, memberShape, () -> inputLocation);
             });


### PR DESCRIPTION
This commit adds support for generating idempotency token values
when not set on input. These values are populated with a UUID v4
value provided by the `uuid` package.

This is done through setting the value on the provided input as to
not further complicate protocol specific member serialization.

-----

Related to awslabs/smithy-typescript#109

-----

Sample codegen:

```
import { v4 as generateIdempotencyToken } from "uuid";

if (input.ClientRequestToken === undefined) {
    input.ClientRequestToken = generateIdempotencyToken();
}
```

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
