### PR TITLE
feat: x-amz-user-agent for browser

### DIFF
--- a/packages/middleware-user-agent/src/configurations.ts
+++ b/packages/middleware-user-agent/src/configurations.ts
@@ -6,10 +6,12 @@ export interface UserAgentInputConfig {
 }
 interface PreviouslyResolved {
   defaultUserAgent: string;
+  runtime: string;
 }
 export interface UserAgentResolvedConfig {
   defaultUserAgent: string;
   customUserAgent?: string;
+  runtime: string;
 }
 export function resolveUserAgentConfig<T>(
   input: T & PreviouslyResolved & UserAgentInputConfig

--- a/packages/middleware-user-agent/src/middleware.ts
+++ b/packages/middleware-user-agent/src/middleware.ts
@@ -9,8 +9,6 @@ import {
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { UserAgentResolvedConfig } from "./configurations";
 
-const userAgentHeader = "user-agent";
-
 export function userAgentMiddleware(options: UserAgentResolvedConfig) {
   return <Output extends MetadataBearer>(
     next: BuildHandler<any, any>
@@ -20,6 +18,8 @@ export function userAgentMiddleware(options: UserAgentResolvedConfig) {
     let { request } = args;
     if (!HttpRequest.isInstance(request)) return next(args);
     const { headers } = request;
+    const userAgentHeader =
+      options.runtime === "node" ? "user-agent" : "x-amz-user-agent";
     if (!headers[userAgentHeader]) {
       headers[userAgentHeader] = `${options.defaultUserAgent}`;
     } else {

--- a/packages/util-user-agent-browser/src/index.spec.ts
+++ b/packages/util-user-agent-browser/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { defaultUserAgent, appendToUserAgent } from ".";
+import { defaultUserAgent } from ".";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
 it("should response basic node default user agent", () => {
@@ -14,29 +14,4 @@ it("should response basic node default user agent", () => {
   expect(defaultUserAgent("client-s3-node", "0.1.0")).toBe(
     `aws-sdk-js-v3-client-s3-node/0.1.0 ${originUserAgent}`
   );
-});
-
-it("append to user agent", () => {
-  const defaultValue = defaultUserAgent("client-s3-node", "0.1.0");
-  const request = new HttpRequest({
-    headers: { "X-Amz-User-Agent": defaultValue },
-    method: "GET",
-    protocol: "json",
-    hostname: "foo.amazonaws.com",
-    path: "/"
-  });
-  appendToUserAgent(request, "http/2.0");
-  expect(request.headers["X-Amz-User-Agent"]).toBe(`${defaultValue} http/2.0`);
-});
-
-it("append custom user agent when existing user agent was undefined", () => {
-  const request = {
-    headers: { "X-Amz-User-Agent": undefined as any },
-    method: "GET",
-    protocol: "json",
-    hostname: "foo.amazonaws.com",
-    path: "/"
-  };
-  appendToUserAgent(request, "http/2.0");
-  expect(request.headers["X-Amz-User-Agent"]).toBe("http/2.0");
 });

--- a/packages/util-user-agent-browser/src/index.ts
+++ b/packages/util-user-agent-browser/src/index.ts
@@ -10,14 +10,3 @@ export function defaultUserAgent(
       : "";
   return `aws-sdk-js-v3-${packageName}/${packageVersion} ${originUserAgent}`;
 }
-
-export function appendToUserAgent(
-  request: HttpRequest,
-  userAgentPartial: string
-): void {
-  if (request.headers["X-Amz-User-Agent"]) {
-    request.headers["X-Amz-User-Agent"] += ` ${userAgentPartial}`;
-  } else {
-    request.headers["X-Amz-User-Agent"] = userAgentPartial;
-  }
-}

--- a/packages/util-user-agent-node/src/index.spec.ts
+++ b/packages/util-user-agent-node/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { defaultUserAgent, appendToUserAgent } from ".";
+import { defaultUserAgent } from ".";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import * as process from "process";
 
@@ -19,18 +19,5 @@ describe("defaultUserAgent", () => {
       `aws-sdk-nodejs-v3-client-s3-node/0.1.0 ${process.platform}/${process.version} exec-env/ecs`
     );
     if (originEnv) process.env.AWS_EXECUTION_ENV = originEnv;
-  });
-
-  it("append to user agent", () => {
-    const defaultValue = defaultUserAgent("client-s3-node", "0.1.0");
-    const request = new HttpRequest({
-      headers: { "User-Agent": defaultValue },
-      method: "GET",
-      protocol: "json",
-      hostname: "foo.amazonaws.com",
-      path: "/"
-    });
-    appendToUserAgent(request, "http/2.0");
-    expect(request.headers["User-Agent"]).toBe(`${defaultValue} http/2.0`);
   });
 });

--- a/packages/util-user-agent-node/src/index.ts
+++ b/packages/util-user-agent-node/src/index.ts
@@ -11,10 +11,3 @@ export function defaultUserAgent(
   }
   return `aws-sdk-nodejs-v3-${packageName}/${packageVersion} ${engine}`;
 }
-
-export function appendToUserAgent(
-  request: HttpRequest,
-  userAgentPartial: string
-): void {
-  request.headers["User-Agent"] += ` ${userAgentPartial}`;
-}


### PR DESCRIPTION
For browser runtime, switch to `x-amz-user-agent` for user-agent header instead of `user-agent`.

Fixes: #792

Also cleans up unused functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
