### PR TITLE
fix: Remove RPC getOperationPath implementations

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -47,11 +47,6 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
     }
 
     @Override
-    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
-        return "/";
-    }
-
-    @Override
     public String getName() {
         return "aws.ec2";
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -47,11 +47,6 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     }
 
     @Override
-    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
-        return "/";
-    }
-
-    @Override
     public String getName() {
         return "aws.query";
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
 import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
-import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Handles general components across the AWS JSON protocols that have do not have
@@ -48,11 +47,6 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     JsonRpcProtocolGenerator() {
         // AWS JSON RPC protocols will attempt to parse error codes from response bodies.
         super(true);
-    }
-
-    @Override
-    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
-        return "/" + StringUtils.capitalize(operationShape.getId().getName());
     }
 
     protected Format getDocumentTimestampFormat() {


### PR DESCRIPTION
Tandem PR with awslabs/smithy-typescript#115

Related to #792 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
