### PR TITLE
fix: Update AWS protocol error body locations

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -87,10 +87,10 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
                        + "  output: $T,\n"
                        + "  data: any\n"
                        + "): string => {", "};", responseType, () -> {
-
-            // Attempt to fetch the error code from the specific location, including the wrapper.
-            writer.openBlock("if (data.Errors.Error.Code !== undefined) {", "}", () -> {
-                writer.write("return data.Errors.Error.Code;");
+            // Attempt to fetch the error code from the specific location.
+            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
+            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+                writer.write("return $L;", errorCodeLocation);
             });
 
             // Default a 404 status code to the NotFound code.
@@ -100,6 +100,11 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
             writer.write("return '';");
         });
         writer.write("");
+    }
+
+    @Override
+    protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
+        return outputLocation + ".Errors.Error";
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -143,6 +143,7 @@ final class AwsProtocolUtils {
             writer.openBlock("return Object.keys(entries).map(", ").join(\"&\");", () ->
                     writer.write("key => encodeURIComponent(key) + '=' + encodeURIComponent(entries[key])"));
         });
+        writer.write("");
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -87,10 +87,10 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
                        + "  output: $T,\n"
                        + "  data: any\n"
                        + "): string => {", "};", responseType, () -> {
-
             // Attempt to fetch the error code from the specific location.
-            writer.openBlock("if (data.Error.Code !== undefined) {", "}", () -> {
-                writer.write("return data.Error.Code;");
+            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
+            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+                writer.write("return $L;", errorCodeLocation);
             });
 
             // Default a 404 status code to the NotFound code.
@@ -100,6 +100,11 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
             writer.write("return '';");
         });
         writer.write("");
+    }
+
+    @Override
+    protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
+        return outputLocation + ".Error";
     }
 
     @Override


### PR DESCRIPTION
This commit updates some AWS protocols that wrap their error data
in additional elements.

Depends on awslabs/smithy-typescript#117
Fix for #763 

-----

Modeled error sample:

```
const deserializeAws_queryDBClusterEndpointNotFoundFaultResponse = async (
  parsedOutput: any,
  context: __SerdeContext
): Promise<DBClusterEndpointNotFoundFault> => {
  const body = parsedOutput.body
  const deserialized: any = deserializeAws_queryDBClusterEndpointNotFoundFault(body.Error, context); // <-- Note body.Error
  const contents: DBClusterEndpointNotFoundFault = {
    name: "DBClusterEndpointNotFoundFault",
    $fault: "client",
    $metadata: deserializeMetadata(parsedOutput),
    ...deserialized,
  };
  return contents;
};
```

Unmodeled error sample:

```
    default:
      const parsedBody = parsedOutput.body;
      errorCode = errorCode || "UnknownError";
      response = {
        ...parsedBody.Error,
        name: `${errorCode}`,
        message: parsedBody.Error.message || parsedBody.Error.Message || errorCode,
        $fault: "client",
        $metadata: deserializeMetadata(output)
      } as any;
```

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
