### PR TITLE
fix: no LocationConstraint for us-east-1

### DIFF
--- a/packages/middleware-location-constraint/src/index.ts
+++ b/packages/middleware-location-constraint/src/index.ts
@@ -26,7 +26,15 @@ export function locationConstraintMiddleware(
     const { CreateBucketConfiguration } = args.input;
     //After region config resolution, region is a Provider<string>
     const region = await options.region();
-    if (
+    if (region === "us-east-1") {
+      args = {
+        ...args,
+        input: {
+          ...args.input,
+          CreateBucketConfiguration: undefined
+        }
+      };
+    } else if (
       !CreateBucketConfiguration ||
       !CreateBucketConfiguration.LocationConstraint
     ) {
@@ -35,14 +43,6 @@ export function locationConstraintMiddleware(
         input: {
           ...args.input,
           CreateBucketConfiguration: { LocationConstraint: region }
-        }
-      };
-    } else if (region === "us-east-1") {
-      args = {
-        ...args,
-        input: {
-          ...args.input,
-          CreateBucketConfiguration: undefined
         }
       };
     }


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-js-v3/issues/838

`LocationConstraint` should not be set for us-east-1 region.

Also requires updated codgen from https://github.com/awslabs/smithy-typescript/pull/118

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
