### PR TITLE
fix: check null locations

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -104,7 +104,8 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
             Shape target = context.getModel().expectShape(memberShape.getTarget());
 
             // Generate an if statement to set the bodyParam if the member is set.
-            writer.openBlock("if (output.$L !== undefined) {", "}", locationName, () -> {
+            writer.openBlock("if (output.$L !== undefined && output.$L !== null) {", "}", locationName, locationName,
+                    () -> {
                 writer.write("contents.$L = $L;", memberName,
                         // Dispatch to the output value provider for any additional handling.
                         target.accept(getMemberVisitor("output." + locationName)));
@@ -127,7 +128,8 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
             String locationName = memberShape.getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)
                     .orElse(memberName);
-            writer.openBlock("if (output.$L !== undefined) {", "}", locationName, () -> {
+            writer.openBlock("if (output.$L !== undefined && output.$L !== null) {", "}", locationName, locationName,
+                    () -> {
                 writer.openBlock("return {", "};", () -> {
                     // Dispatch to the output value provider for any additional handling.
                     writer.write("$L: $L", memberName, target.accept(getMemberVisitor("output." + locationName)));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -143,7 +143,8 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             String locationName = binding.getMember().getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)
                     .orElseGet(binding::getLocationName);
-            writer.openBlock("if (data.$L !== undefined) {", "}", locationName, () -> {
+            writer.openBlock("if (data.$L !== undefined && data.$L !== null) {", "}", locationName, locationName,
+                    () -> {
                 writer.write("contents.$L = $L;", memberName,
                         target.accept(getMemberDeserVisitor(context, "data." + locationName)));
             });


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/871

Need to check that locations are not null before attempting to deserialize.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
