### PR TITLE
Enable path escaping for all clients except S3

### DIFF
--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -437,6 +437,11 @@ export interface ClientDefaults
    * hash of the streamed value
    */
   streamHasher?: __StreamHasher<Readable> | __StreamHasher<Blob>;
+
+  /**
+   * Whether to escape request path when signing the request.
+   */
+  signingEscapePath?: boolean;
 }
 
 export type S3ClientConfig = Partial<

--- a/clients/client-s3/runtimeConfig.shared.ts
+++ b/clients/client-s3/runtimeConfig.shared.ts
@@ -4,5 +4,6 @@ export const ClientSharedValues = {
   apiVersion: "2006-03-01",
   disableHostPrefix: false,
   signingName: "s3",
-  regionInfoProvider: defaultRegionInfoProvider
+  regionInfoProvider: defaultRegionInfoProvider,
+  signingEscapePath: false
 };

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -60,10 +60,7 @@ public final class AddS3Config implements TypeScriptIntegration {
                 break;
             default:
                 //do nothing
-
         }
-
-
     }
 
     private static boolean needsS3Config(ServiceShape service) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -15,31 +15,19 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
+import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
-import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 
 /**
- * Generates an endpoint resolver from endpoints.json.
+ * AWS S3 client configuration.
  */
-public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegration {
-    @Override
-    public void writeAdditionalFiles(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory
-    ) {
-        writerFactory.accept("endpoints.ts", writer -> {
-            new EndpointGenerator(settings.getService(model), writer).run();
-        });
-    }
+public final class AddS3Config implements TypeScriptIntegration {
 
     @Override
     public void addConfigInterfaceFields(
@@ -48,9 +36,11 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             SymbolProvider symbolProvider,
             TypeScriptWriter writer
     ) {
-        writer.addImport("RegionInfoProvider", "RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.writeDocs("Fetch related hostname, signing name or signing region with given region.");
-        writer.write("regionInfoProvider?: RegionInfoProvider;\n");
+        if (!needsS3Config(settings.getService(model))) {
+            return;
+        }
+        writer.writeDocs("Whether to escape request path when signing the request.")
+                .write("signingEscapePath?: boolean;\n");
     }
 
     @Override
@@ -61,13 +51,23 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             TypeScriptWriter writer,
             LanguageTarget target
     ) {
+        if (!needsS3Config(settings.getService(model))) {
+            return;
+        }
         switch (target) {
             case SHARED:
-                writer.addImport("defaultRegionInfoProvider", "defaultRegionInfoProvider", "./endpoints");
-                writer.write("regionInfoProvider: defaultRegionInfoProvider,");
+                writer.write("signingEscapePath: false,");
                 break;
             default:
                 //do nothing
+
         }
+
+
+    }
+
+    private static boolean needsS3Config(ServiceShape service) {
+        String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
+        return serviceId.equals("S3");
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -7,3 +7,4 @@ software.amazon.smithy.aws.typescript.codegen.AwsPackageFixturesGeneratorIntegra
 software.amazon.smithy.aws.typescript.codegen.AddMd5HashDependency
 software.amazon.smithy.aws.typescript.codegen.AddStreamHasherDependency
 software.amazon.smithy.aws.typescript.codegen.AddBodyChecksumGeneratorDependency
+software.amazon.smithy.aws.typescript.codegen.AddS3Config

--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -55,7 +55,7 @@ export function resolveAwsAuthConfig<T>(
     input.credentials || input.credentialDefaultProvider(input as any);
   const normalizedCreds = normalizeProvider(credentials);
   const {
-    signingEscapePath = false,
+    signingEscapePath = true,
     systemClockOffset = input.systemClockOffset || 0,
     sha256
   } = input;


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-js-v3/issues/845 and https://github.com/aws/aws-sdk-js-v3/issues/810

Enables escaping the path while signing for all clients and adds configuration to disable this for S3 only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
