### PR TITLE
fix: remove duplicate signingName config

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -95,15 +95,16 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
             LanguageTarget target
     ) {
         ServiceShape service = settings.getService(model);
-        String signingName = service.getTrait(ServiceTrait.class)
-                .map(ServiceTrait::getArnNamespace)
-                .orElse(null);
-
-        if (signingName != null && target.equals(LanguageTarget.SHARED)) {
-            writer.write("signingName: $S,", signingName);
-        } else {
-            LOGGER.info("Cannot generate a signing name for the client because no aws.api#Service "
+        if (target.equals(LanguageTarget.SHARED)) {
+            String signingName = service.getTrait(ServiceTrait.class)
+                    .map(ServiceTrait::getArnNamespace)
+                    .orElse(null);
+            if (signingName != null) {
+                writer.write("signingName: $S,", signingName);
+            } else {
+                LOGGER.info("Cannot generate a signing name for the client because no aws.api#Service "
                         + "trait was found on " + service.getId());
+            }
         }
 
         getRuntimeConfig(writer, service, target);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -99,7 +99,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                 .map(ServiceTrait::getArnNamespace)
                 .orElse(null);
 
-        if (signingName != null) {
+        if (signingName != null && target.equals(LanguageTarget.SHARED)) {
             writer.write("signingName: $S,", signingName);
         } else {
             LOGGER.info("Cannot generate a signing name for the client because no aws.api#Service "


### PR DESCRIPTION
Currently, the same `signingName` is written to `runtimeConfig.ts` `runtimeConfig.browser.ts`, and `runtimeconfig.shared.ts`.

Since this is the same across runtimes, it only needs to be written to the `runtimeConfig.shared.ts`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
