### PR TITLE
fix: return empty array or map instead of undefined

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -162,6 +162,13 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
             sourceBuilder.append("['").append(targetLocation).append("']");
         }
 
+        // Handle self-closed xml parsed as an empty string.
+        if (deserializationReturnsArray) {
+            writer.openBlock("if ($L.$L === \"\") {", "}", inputLocation, locationName, () -> {
+                writer.write("contents.$L = [];", locationName);
+                writer.write("return contents");
+            });
+        }
         // Handle the response property.
         String source = sourceBuilder.toString();
         // Validate the resulting target element is set.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -165,7 +165,12 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
         // Handle self-closed xml parsed as an empty string.
         if (deserializationReturnsArray) {
             writer.openBlock("if ($L.$L === \"\") {", "}", inputLocation, locationName, () -> {
-                writer.write("contents.$L = [];", locationName);
+                if (target instanceof MapShape) {
+                    writer.write("contents.$L = {};", locationName);
+                }
+                if (target instanceof CollectionShape) {
+                    writer.write("contents.$L = [];", locationName);
+                }
                 writer.write("return contents");
             });
         }


### PR DESCRIPTION
Fixes: #766

Self-closed xml tags returned by service:
```
<DescribeDomainsResult>
  <DomainStatusList/>
</DescribeDomainsResult>
```
Will now result in the correct response:
```
{
  ...
  },
  __type: 'DescribeDomainsResponse',
  DomainStatusList: []
}
```

XML for an unflattened list:
```
<DescribeDomainsResult>
  <DomainStatusList>
    <member>
      ...
      <DomainName>foo</DomainName>
      ...
    </member>
  </DomainStatusList>
</DescribeDomainsResult>
```
Will still result in the correct list of Domains:
```
{
  ...
  },
  __type: 'DescribeDomainsResponse',
  DomainStatusList: [
    {
      __type: 'DomainStatus',
      ...
      DomainName: "foo".
      ...
    }
  ]
}
```

Self-closed tags for map:
```
<ListDomainNamesResult>
  <DomainNames/>
</ListDomainNamesResult>
```
Returned as correct, empty map:
```
{
  ...
  __type: 'ListDomainNamesResponse',
  DomainNames: {}
}
```
When an array or map is expected to be returned, deserialization should check first for an empty string and return the empty array/map before proceeding with additional deserialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
