### PR TITLE
chore: manually bump @aws-sdk/client-personalize version

### DIFF
--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-personalize",
   "description": "@aws-sdk/client-personalize client",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",


### PR DESCRIPTION
*Issue #, if available:*
Discussed internally in JS-1639, the release scripts are failing with the following error
```console
@aws-sdk/client-personalize: Package publishing exception
{ Error: Command failed: npm publish
npm WARN lifecycle @aws-sdk/client-personalize@1.0.0-alpha.17~prepublishOnly: cannot run in wd @aws-sdk/client-personalize@1.0.0-alpha.17 yarn build (wd=.)
npm notice 
npm notice package: @aws-sdk/client-personalize@1.0.0-alpha.17
```

*Description of changes:*
* manually bump @aws-sdk/client-personalize
* this will skip `@aws-sdk/client-personalize@1.0.0-alpha.17` when release scripts are run, but release would succeed 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
