### PR TITLE
chore: manually bump @aws-sdk/client-personalize version again

### DIFF
--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-personalize",
   "description": "@aws-sdk/client-personalize client",
-  "version": "1.0.0-alpha.17",
+  "version": "1.0.0-alpha.18",
   "scripts": {
     "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
     "build-documentation": "npm run clean && typedoc ./",


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/886

*Description of changes:*
* Due to some issue appears to be with npmjs, we'd manually bumped `@aws-sdk/client-personalize` version in #886 and did an npm publish of `1.0.0-alpha.18` locally (which was successful)
* This PR bumps the version to `1.0.0-alpha.18`  in package.json so that release script can release `1.0.0-alpha.19`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
