### PR TITLE
fix: sort deps/devDeps by keys

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -48,6 +48,10 @@ const mergeManifest = (fromContent, toContent) => {
   for (const name of fromNames) {
     if (typeof toContent[name] === "object") {
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
+      if (name === "dependencies" || name === "devDependencies") {
+        // Sort dependencies as done by lerna
+        merged[name] = Object.fromEntries(Object.entries(merged[name]).sort());
+      }
     } else {
       // If key (say dependency) is present in both codegen and
       // package.json, we prefer latter


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/906

*Description of changes:*
* sort deps/devDeps by keys
* verified that the changes in https://github.com/aws/aws-sdk-js-v3/commit/09659dad03a38b0c15665b3279db8fa402789382 were undone after this code change, will verify again by running codegen after lerna releases `v1.0.0-alpha.21`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
