### PR TITLE
fix: prettify package.json before writing

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -8,6 +8,7 @@ const {
   writeFileSync
 } = require("fs");
 const { CODE_GEN_OUTPUT_DIR } = require("./code-gen-dir");
+const prettier = require("prettier");
 
 const getOverwritablePredicate = packageName => pathName => {
   const overwritablePathnames = [
@@ -87,7 +88,12 @@ async function copyToClients(clientsDir) {
           ? JSON.parse(readFileSync(destSubPath).toString())
           : {};
         const mergedManifest = mergeManifest(packageManifest, destManifest);
-        writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2));
+        writeFileSync(
+          destSubPath,
+          prettier.format(JSON.stringify(mergedManifest), {
+            parser: "json"
+          })
+        );
       } else if (
         overwritablePredicate(packageSub) ||
         !existsSync(destSubPath)


### PR DESCRIPTION
*Issue #, if available:*
Attempted fix for https://github.com/aws/aws-sdk-js-v3/issues/908

*Description of changes:*
* prettify package.json before writing
* we're not going ahead with this prettier CLI and prettier API prettifies JSON separately as shown in the screenshot below

![Screen Shot 2020-02-10 at 5 03 14 PM](https://user-images.githubusercontent.com/16024985/74204401-e2291480-4c27-11ea-989b-45d715fef455.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
