### PR TITLE
feat: extended URI encoding

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -140,10 +140,11 @@ final class AwsProtocolUtils {
         TypeScriptWriter writer = context.getWriter();
 
         // Write a single function to handle combining a map in to a valid query string.
-        writer.addImport("extendedEncodeURI", "__extendedEncodeURI", "@aws-sdk/smithy-client");
+        writer.addImport("extendedEncodeURIComponent", "__extendedEncodeURIComponent", "@aws-sdk/smithy-client");
         writer.openBlock("const buildFormUrlencodedString = (entries: any): string => {", "}", () -> {
             writer.openBlock("return Object.keys(entries).map(", ").join(\"&\");", () ->
-                    writer.write("key => __extendedEncodeURI(key) + '=' + __extendedEncodeURI(entries[key])"));
+                    writer.write("key => __extendedEncodeURIComponent(key) + '=' + "
+                            + "__extendedEncodeURIComponent(entries[key])"));
         });
         writer.write("");
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -140,9 +140,10 @@ final class AwsProtocolUtils {
         TypeScriptWriter writer = context.getWriter();
 
         // Write a single function to handle combining a map in to a valid query string.
+        writer.addImport("extendedEncodeURI", "__extendedEncodeURI", "@aws-sdk/smithy-client");
         writer.openBlock("const buildFormUrlencodedString = (entries: any): string => {", "}", () -> {
             writer.openBlock("return Object.keys(entries).map(", ").join(\"&\");", () ->
-                    writer.write("key => encodeURIComponent(key) + '=' + encodeURIComponent(entries[key])"));
+                    writer.write("key => __extendedEncodeURI(key) + '=' + __extendedEncodeURI(entries[key])"));
         });
         writer.write("");
     }

--- a/packages/smithy-client/src/extended-encode-uri-component.ts
+++ b/packages/smithy-client/src/extended-encode-uri-component.ts
@@ -1,0 +1,8 @@
+/** Function that wraps encodeURIComponent to encode additional characters
+ * to fully adhere to RFC 3986.
+ */
+export function extendedEncodeURIComponent(str: string): string {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+    return "%" + c.charCodeAt(0).toString(16);
+  });
+}

--- a/packages/smithy-client/src/extended-encode-uri-component.ts
+++ b/packages/smithy-client/src/extended-encode-uri-component.ts
@@ -1,4 +1,5 @@
-/** Function that wraps encodeURIComponent to encode additional characters
+/**
+ * Function that wraps encodeURIComponent to encode additional characters
  * to fully adhere to RFC 3986.
  */
 export function extendedEncodeURIComponent(str: string): string {

--- a/packages/smithy-client/src/extended-encode-uri.ts
+++ b/packages/smithy-client/src/extended-encode-uri.ts
@@ -1,0 +1,5 @@
+export function extendedEncodeURI(str: string): string {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+    return "%" + c.charCodeAt(0).toString(16);
+  });
+}

--- a/packages/smithy-client/src/extended-encode-uri.ts
+++ b/packages/smithy-client/src/extended-encode-uri.ts
@@ -1,5 +1,0 @@
-export function extendedEncodeURI(str: string): string {
-  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
-    return "%" + c.charCodeAt(0).toString(16);
-  });
-}

--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -4,3 +4,4 @@ export * from "./document-type";
 export * from "./exception";
 export * from "./isa";
 export * from "./lazy-json";
+export * from "./extended-encode-uri";

--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -4,4 +4,4 @@ export * from "./document-type";
 export * from "./exception";
 export * from "./isa";
 export * from "./lazy-json";
-export * from "./extended-encode-uri";
+export * from "./extended-encode-uri-component";


### PR DESCRIPTION
Fixes: #866

Adds extendedEncodeURI function to wrap encodeURIComponent and encode additional characters, !, ', (, ), and *, to adhere to [RFC 3986](https://tools.ietf.org/html/rfc3986).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
