### PR TITLE
fix: add bodies for undefined query/ec2 inputs

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -135,6 +135,11 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
     }
 
     @Override
+    protected boolean writeUndefinedInputBody(GenerationContext context, OperationShape operation) {
+        return AwsProtocolUtils.generateUndefinedQueryInputBody(context, operation);
+    }
+
+    @Override
     protected void writeErrorCodeParser(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -150,6 +150,27 @@ final class AwsProtocolUtils {
     }
 
     /**
+     * Writes a default body for query-based operations when the operation doesn't
+     * have an input defined.
+     *
+     * @param context The generation context.
+     * @param operation The operation being generated for.
+     * @return That a body variable was generated and should be set on the request.
+     */
+    static boolean generateUndefinedQueryInputBody(GenerationContext context, OperationShape operation) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Set the form encoded string.
+        writer.openBlock("const body = buildFormUrlencodedString({", "});", () -> {
+            // Set the protocol required values.
+            writer.write("Action: $S,", operation.getId().getName());
+            writer.write("Version: $S,", context.getService().getVersion());
+        });
+
+        return true;
+    }
+
+    /**
      * Writes an attribute containing information about a Shape's optionally specified
      * XML namespace configuration to an attribute of the passed node name.
      *

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -135,6 +135,11 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     }
 
     @Override
+    protected boolean writeUndefinedInputBody(GenerationContext context, OperationShape operation) {
+        return AwsProtocolUtils.generateUndefinedQueryInputBody(context, operation);
+    }
+
+    @Override
     protected void writeErrorCodeParser(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 


### PR DESCRIPTION
This commit serializes the Action and Version properties required
by `aws.query` and `aws.ec2` for operations that do not have input
shapes defined.

Depends on awslabs/smithy-typescript#131

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
