### PR TITLE
fix: handle flattened xml with self-closed tag

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -164,7 +164,7 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
 
         // Handle self-closed xml parsed as an empty string.
         if (deserializationReturnsArray) {
-            writer.openBlock("if ($L['$L'] === \"\") {", "}", inputLocation, locationName, () -> {
+            writer.openBlock("if ($L.$L === \"\") {", "}", inputLocation, locationName, () -> {
                 if (target instanceof MapShape) {
                     writer.write("contents.$L = {};", memberName);
                 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -164,16 +164,17 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
 
         // Handle self-closed xml parsed as an empty string.
         if (deserializationReturnsArray) {
-            writer.openBlock("if ($L.$L === \"\") {", "}", inputLocation, locationName, () -> {
+            writer.openBlock("if ($L[\"$L\"] === \"\") {", "}", inputLocation, locationName, () -> {
                 if (target instanceof MapShape) {
-                    writer.write("contents.$L = {};", locationName);
+                    writer.write("contents.$L = {};", memberName);
                 }
                 if (target instanceof CollectionShape) {
-                    writer.write("contents.$L = [];", locationName);
+                    writer.write("contents.$L = [];", memberName);
                 }
                 writer.write("return contents");
             });
         }
+
         // Handle the response property.
         String source = sourceBuilder.toString();
         // Validate the resulting target element is set.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -164,7 +164,7 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
 
         // Handle self-closed xml parsed as an empty string.
         if (deserializationReturnsArray) {
-            writer.openBlock("if ($L[\"$L\"] === \"\") {", "}", inputLocation, locationName, () -> {
+            writer.openBlock("if ($L['$L'] === \"\") {", "}", inputLocation, locationName, () -> {
                 if (target instanceof MapShape) {
                     writer.write("contents.$L = {};", memberName);
                 }


### PR DESCRIPTION
Fix for CI failure in https://github.com/aws/aws-sdk-js-v3/pull/914 by using correct location for flattened XML.

`CloudSearch.describeDomains` returns an empty `array` for `DomainStatusList`.  `SQS.listQueues` still returns `undefined` for `QueueUrls` since the  `QueueUrl` is not set in the XML.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
