### PR TITLE
fix: ignore /dist

### DIFF
--- a/packages/credential-provider-cognito-identity/.gitignore
+++ b/packages/credential-provider-cognito-identity/.gitignore
@@ -1,6 +1,7 @@
 /node_modules/
 /build/
 /coverage/
+/dist/
 /docs/
 *.tsbuildinfo
 *.tgz


### PR DESCRIPTION
Adds /dist/ to .gitignore following es modules being generated starting with https://github.com/aws/aws-sdk-js-v3/pull/882

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
