### PR TITLE
feat(signature-v4): unsign x-amz-user-agent header

### DIFF
--- a/packages/signature-v4/src/constants.ts
+++ b/packages/signature-v4/src/constants.ts
@@ -30,6 +30,7 @@ export const ALWAYS_UNSIGNABLE_HEADERS = {
   "transfer-encoding": true,
   upgrade: true,
   "user-agent": true,
+  "x-amz-user-agent": true,
   "x-amzn-trace-id": true
 };
 


### PR DESCRIPTION
`x-amz-user-agent` is equivalent to `user-agent` header but used only in browsers. If we don't sign `user-agent`, we shouldn't sign `x-amz-user-agent` either.

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/866#issuecomment-586481974

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
