### PR TITLE
fix: remove double query encoding

### DIFF
--- a/packages/querystring-builder/src/index.ts
+++ b/packages/querystring-builder/src/index.ts
@@ -5,15 +5,14 @@ export function buildQueryString(query: QueryParameterBag): string {
   const parts: string[] = [];
   for (let key of Object.keys(query).sort()) {
     const value = query[key];
-    key = escapeUri(key);
     if (Array.isArray(value)) {
       for (let i = 0, iLen = value.length; i < iLen; i++) {
-        parts.push(`${key}=${escapeUri(value[i])}`);
+        parts.push(`${key}=${value[i]}`);
       }
     } else {
       let qsEntry = key;
       if (value || typeof value === "string") {
-        qsEntry += `=${escapeUri(value)}`;
+        qsEntry += `=${value}`;
       }
       parts.push(qsEntry);
     }

--- a/packages/signature-v4/src/getCanonicalQuery.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.ts
@@ -15,18 +15,14 @@ export function getCanonicalQuery({ query = {} }: HttpRequest): string {
     keys.push(key);
     const value = query[key];
     if (typeof value === "string") {
-      serialized[key] = `${encodeURIComponent(key)}=${encodeURIComponent(
-        value
-      )}`;
+      serialized[key] = `${key}=${value}`;
     } else if (Array.isArray(value)) {
       serialized[key] = value
         .slice(0)
         .sort()
         .reduce(
           (encoded: Array<string>, value: string) =>
-            encoded.concat([
-              `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
-            ]),
+            encoded.concat([`${key}=${value}`]),
           []
         )
         .join("&");


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/930

Removes duplicate uri encoding that prevents ListObjects Prefix from being set properly.

Query params are properly encoded once during protocol serialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
