### PR TITLE
fix: consistently encode query

### DIFF
--- a/packages/querystring-builder/src/index.ts
+++ b/packages/querystring-builder/src/index.ts
@@ -1,5 +1,5 @@
 import { QueryParameterBag } from "@aws-sdk/types";
-import { escapeUri, escapeUriPath } from "@aws-sdk/util-uri-escape";
+import { escapeUri } from "@aws-sdk/util-uri-escape";
 
 export function buildQueryString(query: QueryParameterBag): string {
   const parts: string[] = [];

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/is-array-buffer": "^1.0.0-alpha.2",
     "@aws-sdk/types": "^1.0.0-alpha.4",
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.2",
+    "@aws-sdk/util-uri-escape": "^1.0.0-alpha.2",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/signature-v4/src/getCanonicalQuery.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.ts
@@ -1,5 +1,6 @@
 import { SIGNATURE_HEADER } from "./constants";
 import { HttpRequest } from "@aws-sdk/types";
+import { escapeUri } from "@aws-sdk/util-uri-escape";
 
 /**
  * @internal
@@ -15,18 +16,14 @@ export function getCanonicalQuery({ query = {} }: HttpRequest): string {
     keys.push(key);
     const value = query[key];
     if (typeof value === "string") {
-      serialized[key] = `${encodeURIComponent(key)}=${encodeURIComponent(
-        value
-      )}`;
+      serialized[key] = `${escapeUri(key)}=${escapeUri(value)}`;
     } else if (Array.isArray(value)) {
       serialized[key] = value
         .slice(0)
         .sort()
         .reduce(
           (encoded: Array<string>, value: string) =>
-            encoded.concat([
-              `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
-            ]),
+            encoded.concat([`${escapeUri(key)}=${escapeUri(value)}`]),
           []
         )
         .join("&");


### PR DESCRIPTION
Fixes SignatureV4's `getCanonicalQuery` to use consistent query encoding via the `escapeUri` function used in the `querystring-builder` package.

The `querystring-builder` is used by each of the handler packages (node-http-handler, fetch-http-handler) to convert a HttpRequest query property into an encoded query string.  `getCanonicalQuery` in SignatureV4 must use the same enocding to assure that signatures are calculated properly.

Also, removes unused `escapeUriPath` from `querystring-builder`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
