### PR TITLE
chore: codegen for undo query encoding

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
@@ -218,9 +218,7 @@ export async function serializeAws_restJson1_1DeleteAnalyzerCommand(
   }
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("clientToken")
-    ] = __extendedEncodeURIComponent(input.clientToken);
+    query["clientToken"] = input.clientToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -267,9 +265,7 @@ export async function serializeAws_restJson1_1DeleteArchiveRuleCommand(
   }
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("clientToken")
-    ] = __extendedEncodeURIComponent(input.clientToken);
+    query["clientToken"] = input.clientToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -290,14 +286,10 @@ export async function serializeAws_restJson1_1GetAnalyzedResourceCommand(
   let resolvedPath = "/analyzed-resource";
   const query: any = {};
   if (input.analyzerArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("analyzerArn")
-    ] = __extendedEncodeURIComponent(input.analyzerArn);
+    query["analyzerArn"] = input.analyzerArn;
   }
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -402,9 +394,7 @@ export async function serializeAws_restJson1_1GetFindingCommand(
   }
   const query: any = {};
   if (input.analyzerArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("analyzerArn")
-    ] = __extendedEncodeURIComponent(input.analyzerArn);
+    query["analyzerArn"] = input.analyzerArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -457,19 +447,13 @@ export async function serializeAws_restJson1_1ListAnalyzersCommand(
   let resolvedPath = "/analyzer";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.type !== undefined) {
-    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
-      input.type
-    );
+    query["type"] = input.type;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -504,14 +488,10 @@ export async function serializeAws_restJson1_1ListArchiveRulesCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -680,9 +660,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-amplify/protocols/Aws_restJson1_1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1_1.ts
@@ -1069,14 +1069,10 @@ export async function serializeAws_restJson1_1ListAppsCommand(
   let resolvedPath = "/apps";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1134,14 +1130,10 @@ export async function serializeAws_restJson1_1ListArtifactsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1174,14 +1166,10 @@ export async function serializeAws_restJson1_1ListBackendEnvironmentsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   let body: any;
   const bodyParams: any = {};
@@ -1221,14 +1209,10 @@ export async function serializeAws_restJson1_1ListBranchesCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1261,14 +1245,10 @@ export async function serializeAws_restJson1_1ListDomainAssociationsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1313,14 +1293,10 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1383,14 +1359,10 @@ export async function serializeAws_restJson1_1ListWebhooksCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1626,9 +1598,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
@@ -2987,9 +2987,7 @@ export async function serializeAws_restJson1_1GetApiKeyCommand(
   }
   const query: any = {};
   if (input.includeValue !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeValue")
-    ] = __extendedEncodeURIComponent(input.includeValue.toString());
+    query["includeValue"] = input.includeValue.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -3029,29 +3027,19 @@ export async function serializeAws_restJson1_1GetApiKeysCommand(
   let resolvedPath = "/apikeys";
   const query: any = {};
   if (input.customerId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("customerId")
-    ] = __extendedEncodeURIComponent(input.customerId);
+    query["customerId"] = input.customerId;
   }
   if (input.includeValues !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeValues")
-    ] = __extendedEncodeURIComponent(input.includeValues.toString());
+    query["includeValues"] = input.includeValues.toString();
   }
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nameQuery !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.nameQuery
-    );
+    query["name"] = input.nameQuery;
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3164,14 +3152,10 @@ export async function serializeAws_restJson1_1GetAuthorizersCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3282,14 +3266,10 @@ export async function serializeAws_restJson1_1GetBasePathMappingsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3380,14 +3360,10 @@ export async function serializeAws_restJson1_1GetClientCertificatesCommand(
   let resolvedPath = "/clientcertificates";
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3453,9 +3429,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
   }
   const query: any = {};
   if (input.embed !== undefined) {
-    query[__extendedEncodeURIComponent("embed")] = input.embed.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["embed"] = input.embed;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3507,14 +3481,10 @@ export async function serializeAws_restJson1_1GetDeploymentsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3630,34 +3600,22 @@ export async function serializeAws_restJson1_1GetDocumentationPartsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.locationStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("locationStatus")
-    ] = __extendedEncodeURIComponent(input.locationStatus);
+    query["locationStatus"] = input.locationStatus;
   }
   if (input.nameQuery !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.nameQuery
-    );
+    query["name"] = input.nameQuery;
   }
   if (input.path !== undefined) {
-    query[__extendedEncodeURIComponent("path")] = __extendedEncodeURIComponent(
-      input.path
-    );
+    query["path"] = input.path;
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   if (input.type !== undefined) {
-    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
-      input.type
-    );
+    query["type"] = input.type;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3773,14 +3731,10 @@ export async function serializeAws_restJson1_1GetDocumentationVersionsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3867,14 +3821,10 @@ export async function serializeAws_restJson1_1GetDomainNamesCommand(
   let resolvedPath = "/domainnames";
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -4053,14 +4003,10 @@ export async function serializeAws_restJson1_1GetGatewayResponsesCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -4436,9 +4382,7 @@ export async function serializeAws_restJson1_1GetModelCommand(
   }
   const query: any = {};
   if (input.flatten !== undefined) {
-    query[
-      __extendedEncodeURIComponent("flatten")
-    ] = __extendedEncodeURIComponent(input.flatten.toString());
+    query["flatten"] = input.flatten.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -4550,14 +4494,10 @@ export async function serializeAws_restJson1_1GetModelsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -4673,14 +4613,10 @@ export async function serializeAws_restJson1_1GetRequestValidatorsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -4744,9 +4680,7 @@ export async function serializeAws_restJson1_1GetResourceCommand(
   }
   const query: any = {};
   if (input.embed !== undefined) {
-    query[__extendedEncodeURIComponent("embed")] = input.embed.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["embed"] = input.embed;
   }
   let body: any;
   const bodyParams: any = {};
@@ -4798,19 +4732,13 @@ export async function serializeAws_restJson1_1GetResourcesCommand(
   }
   const query: any = {};
   if (input.embed !== undefined) {
-    query[__extendedEncodeURIComponent("embed")] = input.embed.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["embed"] = input.embed;
   }
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -4897,14 +4825,10 @@ export async function serializeAws_restJson1_1GetRestApisCommand(
   let resolvedPath = "/restapis";
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5053,14 +4977,10 @@ export async function serializeAws_restJson1_1GetSdkTypesCommand(
   let resolvedPath = "/sdktypes";
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5171,9 +5091,7 @@ export async function serializeAws_restJson1_1GetStagesCommand(
   }
   const query: any = {};
   if (input.deploymentId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deploymentId")
-    ] = __extendedEncodeURIComponent(input.deploymentId);
+    query["deploymentId"] = input.deploymentId;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5227,14 +5145,10 @@ export async function serializeAws_restJson1_1GetTagsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5288,29 +5202,19 @@ export async function serializeAws_restJson1_1GetUsageCommand(
   }
   const query: any = {};
   if (input.endDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endDate")
-    ] = __extendedEncodeURIComponent(input.endDate);
+    query["endDate"] = input.endDate;
   }
   if (input.keyId !== undefined) {
-    query[__extendedEncodeURIComponent("keyId")] = __extendedEncodeURIComponent(
-      input.keyId
-    );
+    query["keyId"] = input.keyId;
   }
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   if (input.startDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startDate")
-    ] = __extendedEncodeURIComponent(input.startDate);
+    query["startDate"] = input.startDate;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5474,19 +5378,13 @@ export async function serializeAws_restJson1_1GetUsagePlanKeysCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nameQuery !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.nameQuery
-    );
+    query["name"] = input.nameQuery;
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5526,19 +5424,13 @@ export async function serializeAws_restJson1_1GetUsagePlansCommand(
   let resolvedPath = "/usageplans";
   const query: any = {};
   if (input.keyId !== undefined) {
-    query[__extendedEncodeURIComponent("keyId")] = __extendedEncodeURIComponent(
-      input.keyId
-    );
+    query["keyId"] = input.keyId;
   }
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5625,14 +5517,10 @@ export async function serializeAws_restJson1_1GetVpcLinksCommand(
   let resolvedPath = "/vpclinks";
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.position !== undefined) {
-    query[
-      __extendedEncodeURIComponent("position")
-    ] = __extendedEncodeURIComponent(input.position);
+    query["position"] = input.position;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5674,14 +5562,10 @@ export async function serializeAws_restJson1_1ImportApiKeysCommand(
     mode: "import"
   };
   if (input.failOnWarnings !== undefined) {
-    query[
-      __extendedEncodeURIComponent("failonwarnings")
-    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
+    query["failonwarnings"] = input.failOnWarnings.toString();
   }
   if (input.format !== undefined) {
-    query[
-      __extendedEncodeURIComponent("format")
-    ] = __extendedEncodeURIComponent(input.format);
+    query["format"] = input.format;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5733,14 +5617,10 @@ export async function serializeAws_restJson1_1ImportDocumentationPartsCommand(
   }
   const query: any = {};
   if (input.failOnWarnings !== undefined) {
-    query[
-      __extendedEncodeURIComponent("failonwarnings")
-    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
+    query["failonwarnings"] = input.failOnWarnings.toString();
   }
   if (input.mode !== undefined) {
-    query[__extendedEncodeURIComponent("mode")] = __extendedEncodeURIComponent(
-      input.mode
-    );
+    query["mode"] = input.mode;
   }
   let body: any;
   const bodyParams: any = {};
@@ -5782,9 +5662,7 @@ export async function serializeAws_restJson1_1ImportRestApiCommand(
     mode: "import"
   };
   if (input.failOnWarnings !== undefined) {
-    query[
-      __extendedEncodeURIComponent("failonwarnings")
-    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
+    query["failonwarnings"] = input.failOnWarnings.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -6357,14 +6235,10 @@ export async function serializeAws_restJson1_1PutRestApiCommand(
   }
   const query: any = {};
   if (input.failOnWarnings !== undefined) {
-    query[
-      __extendedEncodeURIComponent("failonwarnings")
-    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
+    query["failonwarnings"] = input.failOnWarnings.toString();
   }
   if (input.mode !== undefined) {
-    query[__extendedEncodeURIComponent("mode")] = __extendedEncodeURIComponent(
-      input.mode
-    );
+    query["mode"] = input.mode;
   }
   let body: any;
   const bodyParams: any = {};
@@ -6641,9 +6515,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   let body: any;
   const bodyParams: any = {};

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
@@ -1566,14 +1566,10 @@ export async function serializeAws_restJson1_1GetApiMappingsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1594,14 +1590,10 @@ export async function serializeAws_restJson1_1GetApisCommand(
   let resolvedPath = "/v2/apis";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1676,14 +1668,10 @@ export async function serializeAws_restJson1_1GetAuthorizersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1758,14 +1746,10 @@ export async function serializeAws_restJson1_1GetDeploymentsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1814,14 +1798,10 @@ export async function serializeAws_restJson1_1GetDomainNamesCommand(
   let resolvedPath = "/v2/domainnames";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1970,14 +1950,10 @@ export async function serializeAws_restJson1_1GetIntegrationResponsesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2010,14 +1986,10 @@ export async function serializeAws_restJson1_1GetIntegrationsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2130,14 +2102,10 @@ export async function serializeAws_restJson1_1GetModelsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2277,14 +2245,10 @@ export async function serializeAws_restJson1_1GetRouteResponsesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2317,14 +2281,10 @@ export async function serializeAws_restJson1_1GetRoutesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2397,14 +2357,10 @@ export async function serializeAws_restJson1_1GetStagesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2455,14 +2411,10 @@ export async function serializeAws_restJson1_1ImportApiCommand(
   let resolvedPath = "/v2/apis";
   const query: any = {};
   if (input.Basepath !== undefined) {
-    query[
-      __extendedEncodeURIComponent("basepath")
-    ] = __extendedEncodeURIComponent(input.Basepath);
+    query["basepath"] = input.Basepath;
   }
   if (input.FailOnWarnings !== undefined) {
-    query[
-      __extendedEncodeURIComponent("failOnWarnings")
-    ] = __extendedEncodeURIComponent(input.FailOnWarnings.toString());
+    query["failOnWarnings"] = input.FailOnWarnings.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -2502,14 +2454,10 @@ export async function serializeAws_restJson1_1ReimportApiCommand(
   }
   const query: any = {};
   if (input.Basepath !== undefined) {
-    query[
-      __extendedEncodeURIComponent("basepath")
-    ] = __extendedEncodeURIComponent(input.Basepath);
+    query["basepath"] = input.Basepath;
   }
   if (input.FailOnWarnings !== undefined) {
-    query[
-      __extendedEncodeURIComponent("failOnWarnings")
-    ] = __extendedEncodeURIComponent(input.FailOnWarnings.toString());
+    query["failOnWarnings"] = input.FailOnWarnings.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -2588,9 +2536,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
@@ -890,14 +890,10 @@ export async function serializeAws_restJson1_1ListMeshesCommand(
   let resolvedPath = "/v20190125/meshes";
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -947,14 +943,10 @@ export async function serializeAws_restJson1_1ListRoutesCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -975,19 +967,13 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/v20190125/tags";
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1020,14 +1006,10 @@ export async function serializeAws_restJson1_1ListVirtualNodesCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1060,14 +1042,10 @@ export async function serializeAws_restJson1_1ListVirtualRoutersCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1100,14 +1078,10 @@ export async function serializeAws_restJson1_1ListVirtualServicesCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit.toString()
-    );
+    query["limit"] = input.limit.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1128,9 +1102,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   let resolvedPath = "/v20190125/tag";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   let body: any;
   const bodyParams: any = {};
@@ -1158,9 +1130,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/v20190125/untag";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   let body: any;
   const bodyParams: any = {};

--- a/clients/client-appconfig/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1_1.ts
@@ -557,14 +557,10 @@ export async function serializeAws_restJson1_1GetConfigurationCommand(
   }
   const query: any = {};
   if (input.ClientConfigurationVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("client_configuration_version")
-    ] = __extendedEncodeURIComponent(input.ClientConfigurationVersion);
+    query["client_configuration_version"] = input.ClientConfigurationVersion;
   }
   if (input.ClientId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("client_id")
-    ] = __extendedEncodeURIComponent(input.ClientId);
+    query["client_id"] = input.ClientId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -770,14 +766,10 @@ export async function serializeAws_restJson1_1ListApplicationsCommand(
   let resolvedPath = "/applications";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -812,14 +804,10 @@ export async function serializeAws_restJson1_1ListConfigurationProfilesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -840,14 +828,10 @@ export async function serializeAws_restJson1_1ListDeploymentStrategiesCommand(
   let resolvedPath = "/deploymentstrategies";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -897,14 +881,10 @@ export async function serializeAws_restJson1_1ListDeploymentsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -939,14 +919,10 @@ export async function serializeAws_restJson1_1ListEnvironmentsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1173,9 +1149,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1446,9 +1420,7 @@ export async function serializeAws_restJson1_1ValidateConfigurationCommand(
   }
   const query: any = {};
   if (input.ConfigurationVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("configuration_version")
-    ] = __extendedEncodeURIComponent(input.ConfigurationVersion);
+    query["configuration_version"] = input.ConfigurationVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-appsync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1_1.ts
@@ -1055,14 +1055,10 @@ export async function serializeAws_restJson1_1GetIntrospectionSchemaCommand(
   }
   const query: any = {};
   if (input.format !== undefined) {
-    query[
-      __extendedEncodeURIComponent("format")
-    ] = __extendedEncodeURIComponent(input.format);
+    query["format"] = input.format;
   }
   if (input.includeDirectives !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeDirectives")
-    ] = __extendedEncodeURIComponent(input.includeDirectives.toString());
+    query["includeDirectives"] = input.includeDirectives.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1187,9 +1183,7 @@ export async function serializeAws_restJson1_1GetTypeCommand(
   }
   const query: any = {};
   if (input.format !== undefined) {
-    query[
-      __extendedEncodeURIComponent("format")
-    ] = __extendedEncodeURIComponent(input.format);
+    query["format"] = input.format;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1222,14 +1216,10 @@ export async function serializeAws_restJson1_1ListApiKeysCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1262,14 +1252,10 @@ export async function serializeAws_restJson1_1ListDataSourcesCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1302,14 +1288,10 @@ export async function serializeAws_restJson1_1ListFunctionsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1330,14 +1312,10 @@ export async function serializeAws_restJson1_1ListGraphqlApisCommand(
   let resolvedPath = "/apis";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1382,14 +1360,10 @@ export async function serializeAws_restJson1_1ListResolversCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1434,14 +1408,10 @@ export async function serializeAws_restJson1_1ListResolversByFunctionCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1504,19 +1474,13 @@ export async function serializeAws_restJson1_1ListTypesCommand(
   }
   const query: any = {};
   if (input.format !== undefined) {
-    query[
-      __extendedEncodeURIComponent("format")
-    ] = __extendedEncodeURIComponent(input.format);
+    query["format"] = input.format;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1623,9 +1587,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-backup/protocols/Aws_restJson1_1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1_1.ts
@@ -812,9 +812,7 @@ export async function serializeAws_restJson1_1GetBackupPlanCommand(
   }
   const query: any = {};
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1058,44 +1056,28 @@ export async function serializeAws_restJson1_1ListBackupJobsCommand(
   let resolvedPath = "/backup-jobs";
   const query: any = {};
   if (input.ByBackupVaultName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("backupVaultName")
-    ] = __extendedEncodeURIComponent(input.ByBackupVaultName);
+    query["backupVaultName"] = input.ByBackupVaultName;
   }
   if (input.ByCreatedAfter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("createdAfter")
-    ] = __extendedEncodeURIComponent(input.ByCreatedAfter.toISOString());
+    query["createdAfter"] = input.ByCreatedAfter.toISOString();
   }
   if (input.ByCreatedBefore !== undefined) {
-    query[
-      __extendedEncodeURIComponent("createdBefore")
-    ] = __extendedEncodeURIComponent(input.ByCreatedBefore.toISOString());
+    query["createdBefore"] = input.ByCreatedBefore.toISOString();
   }
   if (input.ByResourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.ByResourceArn);
+    query["resourceArn"] = input.ByResourceArn;
   }
   if (input.ByResourceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceType")
-    ] = __extendedEncodeURIComponent(input.ByResourceType);
+    query["resourceType"] = input.ByResourceType;
   }
   if (input.ByState !== undefined) {
-    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
-      input.ByState
-    );
+    query["state"] = input.ByState;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1116,14 +1098,10 @@ export async function serializeAws_restJson1_1ListBackupPlanTemplatesCommand(
   let resolvedPath = "/backup/template/plans";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1158,14 +1136,10 @@ export async function serializeAws_restJson1_1ListBackupPlanVersionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1186,19 +1160,13 @@ export async function serializeAws_restJson1_1ListBackupPlansCommand(
   let resolvedPath = "/backup/plans";
   const query: any = {};
   if (input.IncludeDeleted !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeDeleted")
-    ] = __extendedEncodeURIComponent(input.IncludeDeleted.toString());
+    query["includeDeleted"] = input.IncludeDeleted.toString();
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1233,14 +1201,10 @@ export async function serializeAws_restJson1_1ListBackupSelectionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1261,14 +1225,10 @@ export async function serializeAws_restJson1_1ListBackupVaultsCommand(
   let resolvedPath = "/backup-vaults";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1289,44 +1249,28 @@ export async function serializeAws_restJson1_1ListCopyJobsCommand(
   let resolvedPath = "/copy-jobs";
   const query: any = {};
   if (input.ByCreatedAfter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("createdAfter")
-    ] = __extendedEncodeURIComponent(input.ByCreatedAfter.toISOString());
+    query["createdAfter"] = input.ByCreatedAfter.toISOString();
   }
   if (input.ByCreatedBefore !== undefined) {
-    query[
-      __extendedEncodeURIComponent("createdBefore")
-    ] = __extendedEncodeURIComponent(input.ByCreatedBefore.toISOString());
+    query["createdBefore"] = input.ByCreatedBefore.toISOString();
   }
   if (input.ByDestinationVaultArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("destinationVaultArn")
-    ] = __extendedEncodeURIComponent(input.ByDestinationVaultArn);
+    query["destinationVaultArn"] = input.ByDestinationVaultArn;
   }
   if (input.ByResourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.ByResourceArn);
+    query["resourceArn"] = input.ByResourceArn;
   }
   if (input.ByResourceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceType")
-    ] = __extendedEncodeURIComponent(input.ByResourceType);
+    query["resourceType"] = input.ByResourceType;
   }
   if (input.ByState !== undefined) {
-    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
-      input.ByState
-    );
+    query["state"] = input.ByState;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1347,14 +1291,10 @@ export async function serializeAws_restJson1_1ListProtectedResourcesCommand(
   let resolvedPath = "/resources";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1389,39 +1329,25 @@ export async function serializeAws_restJson1_1ListRecoveryPointsByBackupVaultCom
   }
   const query: any = {};
   if (input.ByBackupPlanId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("backupPlanId")
-    ] = __extendedEncodeURIComponent(input.ByBackupPlanId);
+    query["backupPlanId"] = input.ByBackupPlanId;
   }
   if (input.ByCreatedAfter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("createdAfter")
-    ] = __extendedEncodeURIComponent(input.ByCreatedAfter.toISOString());
+    query["createdAfter"] = input.ByCreatedAfter.toISOString();
   }
   if (input.ByCreatedBefore !== undefined) {
-    query[
-      __extendedEncodeURIComponent("createdBefore")
-    ] = __extendedEncodeURIComponent(input.ByCreatedBefore.toISOString());
+    query["createdBefore"] = input.ByCreatedBefore.toISOString();
   }
   if (input.ByResourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.ByResourceArn);
+    query["resourceArn"] = input.ByResourceArn;
   }
   if (input.ByResourceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceType")
-    ] = __extendedEncodeURIComponent(input.ByResourceType);
+    query["resourceType"] = input.ByResourceType;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1456,14 +1382,10 @@ export async function serializeAws_restJson1_1ListRecoveryPointsByResourceComman
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1484,14 +1406,10 @@ export async function serializeAws_restJson1_1ListRestoreJobsCommand(
   let resolvedPath = "/restore-jobs";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1526,14 +1444,10 @@ export async function serializeAws_restJson1_1ListTagsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-chime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1_1.ts
@@ -2639,24 +2639,16 @@ export async function serializeAws_restJson1_1ListAccountsCommand(
   let resolvedPath = "/accounts";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.Name !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.Name
-    );
+    query["name"] = input.Name;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.UserEmail !== undefined) {
-    query[
-      __extendedEncodeURIComponent("user-email")
-    ] = __extendedEncodeURIComponent(input.UserEmail);
+    query["user-email"] = input.UserEmail;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2689,14 +2681,10 @@ export async function serializeAws_restJson1_1ListAttendeesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2729,14 +2717,10 @@ export async function serializeAws_restJson1_1ListBotsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2757,14 +2741,10 @@ export async function serializeAws_restJson1_1ListMeetingsCommand(
   let resolvedPath = "/meetings";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2785,14 +2765,10 @@ export async function serializeAws_restJson1_1ListPhoneNumberOrdersCommand(
   let resolvedPath = "/phone-number-orders";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2813,34 +2789,22 @@ export async function serializeAws_restJson1_1ListPhoneNumbersCommand(
   let resolvedPath = "/phone-numbers";
   const query: any = {};
   if (input.FilterName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("filter-name")
-    ] = __extendedEncodeURIComponent(input.FilterName);
+    query["filter-name"] = input.FilterName;
   }
   if (input.FilterValue !== undefined) {
-    query[
-      __extendedEncodeURIComponent("filter-value")
-    ] = __extendedEncodeURIComponent(input.FilterValue);
+    query["filter-value"] = input.FilterValue;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.ProductType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("product-type")
-    ] = __extendedEncodeURIComponent(input.ProductType);
+    query["product-type"] = input.ProductType;
   }
   if (input.Status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.Status);
+    query["status"] = input.Status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2885,14 +2849,10 @@ export async function serializeAws_restJson1_1ListRoomMembershipsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2925,19 +2885,13 @@ export async function serializeAws_restJson1_1ListRoomsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.MemberId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("member-id")
-    ] = __extendedEncodeURIComponent(input.MemberId);
+    query["member-id"] = input.MemberId;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2970,24 +2924,16 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.UserEmail !== undefined) {
-    query[
-      __extendedEncodeURIComponent("user-email")
-    ] = __extendedEncodeURIComponent(input.UserEmail);
+    query["user-email"] = input.UserEmail;
   }
   if (input.UserType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("user-type")
-    ] = __extendedEncodeURIComponent(input.UserType);
+    query["user-type"] = input.UserType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3008,14 +2954,10 @@ export async function serializeAws_restJson1_1ListVoiceConnectorGroupsCommand(
   let resolvedPath = "/voice-connector-groups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3069,14 +3011,10 @@ export async function serializeAws_restJson1_1ListVoiceConnectorsCommand(
   let resolvedPath = "/voice-connectors";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3537,39 +3475,25 @@ export async function serializeAws_restJson1_1SearchAvailablePhoneNumbersCommand
     type: "phone-numbers"
   };
   if (input.AreaCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("area-code")
-    ] = __extendedEncodeURIComponent(input.AreaCode);
+    query["area-code"] = input.AreaCode;
   }
   if (input.City !== undefined) {
-    query[__extendedEncodeURIComponent("city")] = __extendedEncodeURIComponent(
-      input.City
-    );
+    query["city"] = input.City;
   }
   if (input.Country !== undefined) {
-    query[
-      __extendedEncodeURIComponent("country")
-    ] = __extendedEncodeURIComponent(input.Country);
+    query["country"] = input.Country;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.State !== undefined) {
-    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
-      input.State
-    );
+    query["state"] = input.State;
   }
   if (input.TollFreePrefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("toll-free-prefix")
-    ] = __extendedEncodeURIComponent(input.TollFreePrefix);
+    query["toll-free-prefix"] = input.TollFreePrefix;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -1241,14 +1241,10 @@ export async function serializeAws_restXmlListCloudFrontOriginAccessIdentitiesCo
   let resolvedPath = "/2019-03-26/origin-access-identity/cloudfront";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1269,14 +1265,10 @@ export async function serializeAws_restXmlListDistributionsCommand(
   let resolvedPath = "/2019-03-26/distribution";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1309,14 +1301,10 @@ export async function serializeAws_restXmlListDistributionsByWebACLIdCommand(
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1337,14 +1325,10 @@ export async function serializeAws_restXmlListFieldLevelEncryptionConfigsCommand
   let resolvedPath = "/2019-03-26/field-level-encryption";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1365,14 +1349,10 @@ export async function serializeAws_restXmlListFieldLevelEncryptionProfilesComman
   let resolvedPath = "/2019-03-26/field-level-encryption-profile";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1407,14 +1387,10 @@ export async function serializeAws_restXmlListInvalidationsCommand(
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1435,14 +1411,10 @@ export async function serializeAws_restXmlListPublicKeysCommand(
   let resolvedPath = "/2019-03-26/public-key";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1463,14 +1435,10 @@ export async function serializeAws_restXmlListStreamingDistributionsCommand(
   let resolvedPath = "/2019-03-26/streaming-distribution";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["MaxItems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1491,9 +1459,7 @@ export async function serializeAws_restXmlListTagsForResourceCommand(
   let resolvedPath = "/2019-03-26/tagging";
   const query: any = {};
   if (input.Resource !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Resource")
-    ] = __extendedEncodeURIComponent(input.Resource);
+    query["Resource"] = input.Resource;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1516,9 +1482,7 @@ export async function serializeAws_restXmlTagResourceCommand(
     Operation: "Tag"
   };
   if (input.Resource !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Resource")
-    ] = __extendedEncodeURIComponent(input.Resource);
+    query["Resource"] = input.Resource;
   }
   let body: any;
   let contents: any;
@@ -1553,9 +1517,7 @@ export async function serializeAws_restXmlUntagResourceCommand(
     Operation: "Untag"
   };
   if (input.Resource !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Resource")
-    ] = __extendedEncodeURIComponent(input.Resource);
+    query["Resource"] = input.Resource;
   }
   let body: any;
   let contents: any;

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1_1.ts
@@ -51,74 +51,46 @@ export async function serializeAws_restJson1_1SearchCommand(
     pretty: "true"
   };
   if (input.cursor !== undefined) {
-    query[
-      __extendedEncodeURIComponent("cursor")
-    ] = __extendedEncodeURIComponent(input.cursor);
+    query["cursor"] = input.cursor;
   }
   if (input.expr !== undefined) {
-    query[__extendedEncodeURIComponent("expr")] = __extendedEncodeURIComponent(
-      input.expr
-    );
+    query["expr"] = input.expr;
   }
   if (input.facet !== undefined) {
-    query[__extendedEncodeURIComponent("facet")] = __extendedEncodeURIComponent(
-      input.facet
-    );
+    query["facet"] = input.facet;
   }
   if (input.filterQuery !== undefined) {
-    query[__extendedEncodeURIComponent("fq")] = __extendedEncodeURIComponent(
-      input.filterQuery
-    );
+    query["fq"] = input.filterQuery;
   }
   if (input.highlight !== undefined) {
-    query[
-      __extendedEncodeURIComponent("highlight")
-    ] = __extendedEncodeURIComponent(input.highlight);
+    query["highlight"] = input.highlight;
   }
   if (input.partial !== undefined) {
-    query[
-      __extendedEncodeURIComponent("partial")
-    ] = __extendedEncodeURIComponent(input.partial.toString());
+    query["partial"] = input.partial.toString();
   }
   if (input.query !== undefined) {
-    query[__extendedEncodeURIComponent("q")] = __extendedEncodeURIComponent(
-      input.query
-    );
+    query["q"] = input.query;
   }
   if (input.queryOptions !== undefined) {
-    query[
-      __extendedEncodeURIComponent("q.options")
-    ] = __extendedEncodeURIComponent(input.queryOptions);
+    query["q.options"] = input.queryOptions;
   }
   if (input.queryParser !== undefined) {
-    query[
-      __extendedEncodeURIComponent("q.parser")
-    ] = __extendedEncodeURIComponent(input.queryParser);
+    query["q.parser"] = input.queryParser;
   }
   if (input.return !== undefined) {
-    query[
-      __extendedEncodeURIComponent("return")
-    ] = __extendedEncodeURIComponent(input.return);
+    query["return"] = input.return;
   }
   if (input.size !== undefined) {
-    query[__extendedEncodeURIComponent("size")] = __extendedEncodeURIComponent(
-      input.size.toString()
-    );
+    query["size"] = input.size.toString();
   }
   if (input.sort !== undefined) {
-    query[__extendedEncodeURIComponent("sort")] = __extendedEncodeURIComponent(
-      input.sort
-    );
+    query["sort"] = input.sort;
   }
   if (input.start !== undefined) {
-    query[__extendedEncodeURIComponent("start")] = __extendedEncodeURIComponent(
-      input.start.toString()
-    );
+    query["start"] = input.start.toString();
   }
   if (input.stats !== undefined) {
-    query[__extendedEncodeURIComponent("stats")] = __extendedEncodeURIComponent(
-      input.stats
-    );
+    query["stats"] = input.stats;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -142,19 +114,13 @@ export async function serializeAws_restJson1_1SuggestCommand(
     pretty: "true"
   };
   if (input.query !== undefined) {
-    query[__extendedEncodeURIComponent("q")] = __extendedEncodeURIComponent(
-      input.query
-    );
+    query["q"] = input.query;
   }
   if (input.size !== undefined) {
-    query[__extendedEncodeURIComponent("size")] = __extendedEncodeURIComponent(
-      input.size.toString()
-    );
+    query["size"] = input.size.toString();
   }
   if (input.suggester !== undefined) {
-    query[
-      __extendedEncodeURIComponent("suggester")
-    ] = __extendedEncodeURIComponent(input.suggester);
+    query["suggester"] = input.suggester;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
@@ -143,34 +143,22 @@ export async function serializeAws_restJson1_1ListRepositoryAssociationsCommand(
   let resolvedPath = "/associations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.Names !== undefined) {
-    query[__extendedEncodeURIComponent("Name")] = input.Names.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["Name"] = input.Names;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.Owners !== undefined) {
-    query[__extendedEncodeURIComponent("Owner")] = input.Owners.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["Owner"] = input.Owners;
   }
   if (input.ProviderTypes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("ProviderType")
-    ] = input.ProviderTypes.map(entry => __extendedEncodeURIComponent(entry));
+    query["ProviderType"] = input.ProviderTypes;
   }
   if (input.States !== undefined) {
-    query[__extendedEncodeURIComponent("State")] = input.States.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["State"] = input.States;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1_1.ts
@@ -112,9 +112,7 @@ export async function serializeAws_restJson1_1CreateProfilingGroupCommand(
   let resolvedPath = "/profilingGroups";
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("clientToken")
-    ] = __extendedEncodeURIComponent(input.clientToken);
+    query["clientToken"] = input.clientToken;
   }
   let body: any;
   const bodyParams: any = {};
@@ -214,19 +212,13 @@ export async function serializeAws_restJson1_1ListProfilingGroupsCommand(
   let resolvedPath = "/profilingGroups";
   const query: any = {};
   if (input.includeDescription !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeDescription")
-    ] = __extendedEncodeURIComponent(input.includeDescription.toString());
+    query["includeDescription"] = input.includeDescription.toString();
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -310,24 +302,16 @@ export async function serializeAws_restJson1_1GetProfileCommand(
   }
   const query: any = {};
   if (input.endTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endTime")
-    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
+    query["endTime"] = input.endTime.toISOString();
   }
   if (input.maxDepth !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxDepth")
-    ] = __extendedEncodeURIComponent(input.maxDepth.toString());
+    query["maxDepth"] = input.maxDepth.toString();
   }
   if (input.period !== undefined) {
-    query[
-      __extendedEncodeURIComponent("period")
-    ] = __extendedEncodeURIComponent(input.period);
+    query["period"] = input.period;
   }
   if (input.startTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startTime")
-    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
+    query["startTime"] = input.startTime.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -364,34 +348,22 @@ export async function serializeAws_restJson1_1ListProfileTimesCommand(
   }
   const query: any = {};
   if (input.endTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endTime")
-    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
+    query["endTime"] = input.endTime.toISOString();
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.orderBy !== undefined) {
-    query[
-      __extendedEncodeURIComponent("orderBy")
-    ] = __extendedEncodeURIComponent(input.orderBy);
+    query["orderBy"] = input.orderBy;
   }
   if (input.period !== undefined) {
-    query[
-      __extendedEncodeURIComponent("period")
-    ] = __extendedEncodeURIComponent(input.period);
+    query["period"] = input.period;
   }
   if (input.startTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startTime")
-    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
+    query["startTime"] = input.startTime.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -431,9 +403,7 @@ export async function serializeAws_restJson1_1PostAgentProfileCommand(
   }
   const query: any = {};
   if (input.profileToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("profileToken")
-    ] = __extendedEncodeURIComponent(input.profileToken);
+    query["profileToken"] = input.profileToken;
   }
   let body: any;
   if (input.agentProfile !== undefined) {

--- a/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
@@ -446,14 +446,10 @@ export async function serializeAws_restJson1_1ListDatasetsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -474,14 +470,10 @@ export async function serializeAws_restJson1_1ListIdentityPoolUsageCommand(
   let resolvedPath = "/identitypools";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -543,24 +535,16 @@ export async function serializeAws_restJson1_1ListRecordsCommand(
   }
   const query: any = {};
   if (input.LastSyncCount !== undefined) {
-    query[
-      __extendedEncodeURIComponent("lastSyncCount")
-    ] = __extendedEncodeURIComponent(input.LastSyncCount.toString());
+    query["lastSyncCount"] = input.LastSyncCount.toString();
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.SyncSessionToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("syncSessionToken")
-    ] = __extendedEncodeURIComponent(input.SyncSessionToken);
+    query["syncSessionToken"] = input.SyncSessionToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-connect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1_1.ts
@@ -606,21 +606,13 @@ export async function serializeAws_restJson1_1ListContactFlowsCommand(
   }
   const query: any = {};
   if (input.ContactFlowTypes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("contactFlowTypes")
-    ] = input.ContactFlowTypes.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["contactFlowTypes"] = input.ContactFlowTypes;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -653,14 +645,10 @@ export async function serializeAws_restJson1_1ListHoursOfOperationsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -693,28 +681,16 @@ export async function serializeAws_restJson1_1ListPhoneNumbersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.PhoneNumberCountryCodes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("phoneNumberCountryCodes")
-    ] = input.PhoneNumberCountryCodes.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["phoneNumberCountryCodes"] = input.PhoneNumberCountryCodes;
   }
   if (input.PhoneNumberTypes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("phoneNumberTypes")
-    ] = input.PhoneNumberTypes.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["phoneNumberTypes"] = input.PhoneNumberTypes;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -747,19 +723,13 @@ export async function serializeAws_restJson1_1ListQueuesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.QueueTypes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("queueTypes")
-    ] = input.QueueTypes.map(entry => __extendedEncodeURIComponent(entry));
+    query["queueTypes"] = input.QueueTypes;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -792,14 +762,10 @@ export async function serializeAws_restJson1_1ListRoutingProfilesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -832,14 +798,10 @@ export async function serializeAws_restJson1_1ListSecurityProfilesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -902,14 +864,10 @@ export async function serializeAws_restJson1_1ListUserHierarchyGroupsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -942,14 +900,10 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1146,9 +1100,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
@@ -556,14 +556,10 @@ export async function serializeAws_restJson1_1ListDataSetRevisionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -584,19 +580,13 @@ export async function serializeAws_restJson1_1ListDataSetsCommand(
   let resolvedPath = "/v1/data-sets";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Origin !== undefined) {
-    query[
-      __extendedEncodeURIComponent("origin")
-    ] = __extendedEncodeURIComponent(input.Origin);
+    query["origin"] = input.Origin;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -617,24 +607,16 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   let resolvedPath = "/v1/jobs";
   const query: any = {};
   if (input.DataSetId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("dataSetId")
-    ] = __extendedEncodeURIComponent(input.DataSetId);
+    query["dataSetId"] = input.DataSetId;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.RevisionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("revisionId")
-    ] = __extendedEncodeURIComponent(input.RevisionId);
+    query["revisionId"] = input.RevisionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -679,14 +661,10 @@ export async function serializeAws_restJson1_1ListRevisionAssetsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -819,9 +797,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-dlm/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1_1.ts
@@ -138,29 +138,19 @@ export async function serializeAws_restJson1_1GetLifecyclePoliciesCommand(
   let resolvedPath = "/policies";
   const query: any = {};
   if (input.PolicyIds !== undefined) {
-    query[
-      __extendedEncodeURIComponent("policyIds")
-    ] = input.PolicyIds.map(entry => __extendedEncodeURIComponent(entry));
+    query["policyIds"] = input.PolicyIds;
   }
   if (input.ResourceTypes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceTypes")
-    ] = input.ResourceTypes.map(entry => __extendedEncodeURIComponent(entry));
+    query["resourceTypes"] = input.ResourceTypes;
   }
   if (input.State !== undefined) {
-    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
-      input.State
-    );
+    query["state"] = input.State;
   }
   if (input.TagsToAdd !== undefined) {
-    query[
-      __extendedEncodeURIComponent("tagsToAdd")
-    ] = input.TagsToAdd.map(entry => __extendedEncodeURIComponent(entry));
+    query["tagsToAdd"] = input.TagsToAdd;
   }
   if (input.TargetTags !== undefined) {
-    query[
-      __extendedEncodeURIComponent("targetTags")
-    ] = input.TargetTags.map(entry => __extendedEncodeURIComponent(entry));
+    query["targetTags"] = input.TargetTags;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -290,9 +280,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-ebs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1_1.ts
@@ -64,9 +64,7 @@ export async function serializeAws_restJson1_1GetSnapshotBlockCommand(
   }
   const query: any = {};
   if (input.BlockToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("blockToken")
-    ] = __extendedEncodeURIComponent(input.BlockToken);
+    query["blockToken"] = input.BlockToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -103,24 +101,16 @@ export async function serializeAws_restJson1_1ListChangedBlocksCommand(
   }
   const query: any = {};
   if (input.FirstSnapshotId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("firstSnapshotId")
-    ] = __extendedEncodeURIComponent(input.FirstSnapshotId);
+    query["firstSnapshotId"] = input.FirstSnapshotId;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["pageToken"] = input.NextToken;
   }
   if (input.StartingBlockIndex !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startingBlockIndex")
-    ] = __extendedEncodeURIComponent(input.StartingBlockIndex.toString());
+    query["startingBlockIndex"] = input.StartingBlockIndex.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -153,19 +143,13 @@ export async function serializeAws_restJson1_1ListSnapshotBlocksCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["pageToken"] = input.NextToken;
   }
   if (input.StartingBlockIndex !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startingBlockIndex")
-    ] = __extendedEncodeURIComponent(input.StartingBlockIndex.toString());
+    query["startingBlockIndex"] = input.StartingBlockIndex.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-efs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1_1.ts
@@ -473,24 +473,16 @@ export async function serializeAws_restJson1_1DescribeAccessPointsCommand(
   let resolvedPath = "/2015-02-01/access-points";
   const query: any = {};
   if (input.AccessPointId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("AccessPointId")
-    ] = __extendedEncodeURIComponent(input.AccessPointId);
+    query["AccessPointId"] = input.AccessPointId;
   }
   if (input.FileSystemId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("FileSystemId")
-    ] = __extendedEncodeURIComponent(input.FileSystemId);
+    query["FileSystemId"] = input.FileSystemId;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -541,24 +533,16 @@ export async function serializeAws_restJson1_1DescribeFileSystemsCommand(
   let resolvedPath = "/2015-02-01/file-systems";
   const query: any = {};
   if (input.CreationToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("CreationToken")
-    ] = __extendedEncodeURIComponent(input.CreationToken);
+    query["CreationToken"] = input.CreationToken;
   }
   if (input.FileSystemId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("FileSystemId")
-    ] = __extendedEncodeURIComponent(input.FileSystemId);
+    query["FileSystemId"] = input.FileSystemId;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -641,29 +625,19 @@ export async function serializeAws_restJson1_1DescribeMountTargetsCommand(
   let resolvedPath = "/2015-02-01/mount-targets";
   const query: any = {};
   if (input.AccessPointId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("AccessPointId")
-    ] = __extendedEncodeURIComponent(input.AccessPointId);
+    query["AccessPointId"] = input.AccessPointId;
   }
   if (input.FileSystemId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("FileSystemId")
-    ] = __extendedEncodeURIComponent(input.FileSystemId);
+    query["FileSystemId"] = input.FileSystemId;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   if (input.MountTargetId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MountTargetId")
-    ] = __extendedEncodeURIComponent(input.MountTargetId);
+    query["MountTargetId"] = input.MountTargetId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -698,14 +672,10 @@ export async function serializeAws_restJson1_1DescribeTagsCommand(
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -738,14 +708,10 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-eks/protocols/Aws_restJson1_1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1_1.ts
@@ -608,9 +608,7 @@ export async function serializeAws_restJson1_1DescribeUpdateCommand(
   }
   const query: any = {};
   if (input.nodegroupName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nodegroupName")
-    ] = __extendedEncodeURIComponent(input.nodegroupName);
+    query["nodegroupName"] = input.nodegroupName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -631,14 +629,10 @@ export async function serializeAws_restJson1_1ListClustersCommand(
   let resolvedPath = "/clusters";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -673,14 +667,10 @@ export async function serializeAws_restJson1_1ListFargateProfilesCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -715,14 +705,10 @@ export async function serializeAws_restJson1_1ListNodegroupsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -785,19 +771,13 @@ export async function serializeAws_restJson1_1ListUpdatesCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.nodegroupName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nodegroupName")
-    ] = __extendedEncodeURIComponent(input.nodegroupName);
+    query["nodegroupName"] = input.nodegroupName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -869,9 +849,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
@@ -120,9 +120,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
@@ -390,14 +390,10 @@ export async function serializeAws_restJson1_1ListJobsByPipelineCommand(
   }
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Ascending")
-    ] = __extendedEncodeURIComponent(input.Ascending);
+    query["Ascending"] = input.Ascending;
   }
   if (input.PageToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageToken")
-    ] = __extendedEncodeURIComponent(input.PageToken);
+    query["PageToken"] = input.PageToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -430,14 +426,10 @@ export async function serializeAws_restJson1_1ListJobsByStatusCommand(
   }
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Ascending")
-    ] = __extendedEncodeURIComponent(input.Ascending);
+    query["Ascending"] = input.Ascending;
   }
   if (input.PageToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageToken")
-    ] = __extendedEncodeURIComponent(input.PageToken);
+    query["PageToken"] = input.PageToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -458,14 +450,10 @@ export async function serializeAws_restJson1_1ListPipelinesCommand(
   let resolvedPath = "/2012-09-25/pipelines";
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Ascending")
-    ] = __extendedEncodeURIComponent(input.Ascending);
+    query["Ascending"] = input.Ascending;
   }
   if (input.PageToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageToken")
-    ] = __extendedEncodeURIComponent(input.PageToken);
+    query["PageToken"] = input.PageToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -486,14 +474,10 @@ export async function serializeAws_restJson1_1ListPresetsCommand(
   let resolvedPath = "/2012-09-25/presets";
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Ascending")
-    ] = __extendedEncodeURIComponent(input.Ascending);
+    query["Ascending"] = input.Ascending;
   }
   if (input.PageToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageToken")
-    ] = __extendedEncodeURIComponent(input.PageToken);
+    query["PageToken"] = input.PageToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
@@ -474,9 +474,7 @@ export async function serializeAws_restJson1_1DescribeElasticsearchInstanceTypeL
   }
   const query: any = {};
   if (input.DomainName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("domainName")
-    ] = __extendedEncodeURIComponent(input.DomainName);
+    query["domainName"] = input.DomainName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -497,21 +495,13 @@ export async function serializeAws_restJson1_1DescribeReservedElasticsearchInsta
   let resolvedPath = "/2015-01-01/es/reservedInstanceOfferings";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.ReservedElasticsearchInstanceOfferingId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("offeringId")
-    ] = __extendedEncodeURIComponent(
-      input.ReservedElasticsearchInstanceOfferingId
-    );
+    query["offeringId"] = input.ReservedElasticsearchInstanceOfferingId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -532,19 +522,13 @@ export async function serializeAws_restJson1_1DescribeReservedElasticsearchInsta
   let resolvedPath = "/2015-01-01/es/reservedInstances";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.ReservedElasticsearchInstanceId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("reservationId")
-    ] = __extendedEncodeURIComponent(input.ReservedElasticsearchInstanceId);
+    query["reservationId"] = input.ReservedElasticsearchInstanceId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -565,9 +549,7 @@ export async function serializeAws_restJson1_1GetCompatibleElasticsearchVersions
   let resolvedPath = "/2015-01-01/es/compatibleVersions";
   const query: any = {};
   if (input.DomainName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("domainName")
-    ] = __extendedEncodeURIComponent(input.DomainName);
+    query["domainName"] = input.DomainName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -600,14 +582,10 @@ export async function serializeAws_restJson1_1GetUpgradeHistoryCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -688,19 +666,13 @@ export async function serializeAws_restJson1_1ListElasticsearchInstanceTypesComm
   }
   const query: any = {};
   if (input.DomainName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("domainName")
-    ] = __extendedEncodeURIComponent(input.DomainName);
+    query["domainName"] = input.DomainName;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -721,14 +693,10 @@ export async function serializeAws_restJson1_1ListElasticsearchVersionsCommand(
   let resolvedPath = "/2015-01-01/es/versions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -749,9 +717,7 @@ export async function serializeAws_restJson1_1ListTagsCommand(
   let resolvedPath = "/2015-01-01/tags";
   const query: any = {};
   if (input.ARN !== undefined) {
-    query[__extendedEncodeURIComponent("arn")] = __extendedEncodeURIComponent(
-      input.ARN
-    );
+    query["arn"] = input.ARN;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-glacier/protocols/Aws_restJson1_1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1_1.ts
@@ -1119,24 +1119,16 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   }
   const query: any = {};
   if (input.completed !== undefined) {
-    query[
-      __extendedEncodeURIComponent("completed")
-    ] = __extendedEncodeURIComponent(input.completed);
+    query["completed"] = input.completed;
   }
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit
-    );
+    query["limit"] = input.limit;
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.statuscode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("statuscode")
-    ] = __extendedEncodeURIComponent(input.statuscode);
+    query["statuscode"] = input.statuscode;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1181,14 +1173,10 @@ export async function serializeAws_restJson1_1ListMultipartUploadsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit
-    );
+    query["limit"] = input.limit;
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1246,14 +1234,10 @@ export async function serializeAws_restJson1_1ListPartsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit
-    );
+    query["limit"] = input.limit;
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1354,14 +1338,10 @@ export async function serializeAws_restJson1_1ListVaultsCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.limit
-    );
+    query["limit"] = input.limit;
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-greengrass/protocols/Aws_restJson1_1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1_1.ts
@@ -1737,9 +1737,7 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionVersionComma
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1949,9 +1947,7 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionVersionCommand(
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2037,9 +2033,7 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionVersionComman
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2269,9 +2263,7 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionVersionCommand(
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2455,9 +2447,7 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionVersionCo
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2495,14 +2485,10 @@ export async function serializeAws_restJson1_1ListBulkDeploymentDetailedReportsC
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2523,14 +2509,10 @@ export async function serializeAws_restJson1_1ListBulkDeploymentsCommand(
   let resolvedPath = "/greengrass/bulk/deployments";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2568,14 +2550,10 @@ export async function serializeAws_restJson1_1ListConnectorDefinitionVersionsCom
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2596,14 +2574,10 @@ export async function serializeAws_restJson1_1ListConnectorDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/connectors";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2640,14 +2614,10 @@ export async function serializeAws_restJson1_1ListCoreDefinitionVersionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2668,14 +2638,10 @@ export async function serializeAws_restJson1_1ListCoreDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/cores";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2708,14 +2674,10 @@ export async function serializeAws_restJson1_1ListDeploymentsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2753,14 +2715,10 @@ export async function serializeAws_restJson1_1ListDeviceDefinitionVersionsComman
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2781,14 +2739,10 @@ export async function serializeAws_restJson1_1ListDeviceDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/devices";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2826,14 +2780,10 @@ export async function serializeAws_restJson1_1ListFunctionDefinitionVersionsComm
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2854,14 +2804,10 @@ export async function serializeAws_restJson1_1ListFunctionDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/functions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2922,14 +2868,10 @@ export async function serializeAws_restJson1_1ListGroupVersionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2950,14 +2892,10 @@ export async function serializeAws_restJson1_1ListGroupsCommand(
   let resolvedPath = "/greengrass/groups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2995,14 +2933,10 @@ export async function serializeAws_restJson1_1ListLoggerDefinitionVersionsComman
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3023,14 +2957,10 @@ export async function serializeAws_restJson1_1ListLoggerDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/loggers";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3068,14 +2998,10 @@ export async function serializeAws_restJson1_1ListResourceDefinitionVersionsComm
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3096,14 +3022,10 @@ export async function serializeAws_restJson1_1ListResourceDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/resources";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3141,14 +3063,10 @@ export async function serializeAws_restJson1_1ListSubscriptionDefinitionVersions
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3169,14 +3087,10 @@ export async function serializeAws_restJson1_1ListSubscriptionDefinitionsCommand
   let resolvedPath = "/greengrass/definition/subscriptions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["MaxResults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3380,9 +3294,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-groundstation/protocols/Aws_restJson1_1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1_1.ts
@@ -525,14 +525,10 @@ export async function serializeAws_restJson1_1ListConfigsCommand(
   let resolvedPath = "/config";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -600,14 +596,10 @@ export async function serializeAws_restJson1_1ListDataflowEndpointGroupsCommand(
   let resolvedPath = "/dataflowEndpointGroup";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -628,14 +620,10 @@ export async function serializeAws_restJson1_1ListMissionProfilesCommand(
   let resolvedPath = "/missionprofile";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -863,14 +851,10 @@ export async function serializeAws_restJson1_1ListGroundStationsCommand(
   let resolvedPath = "/groundstation";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -891,14 +875,10 @@ export async function serializeAws_restJson1_1ListSatellitesCommand(
   let resolvedPath = "/satellite";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1000,9 +980,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-guardduty/protocols/Aws_restJson1_1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1_1.ts
@@ -1429,14 +1429,10 @@ export async function serializeAws_restJson1_1ListDetectorsCommand(
   let resolvedPath = "/detector";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1469,14 +1465,10 @@ export async function serializeAws_restJson1_1ListFiltersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1559,14 +1551,10 @@ export async function serializeAws_restJson1_1ListIPSetsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1587,14 +1575,10 @@ export async function serializeAws_restJson1_1ListInvitationsCommand(
   let resolvedPath = "/invitation";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1627,19 +1611,13 @@ export async function serializeAws_restJson1_1ListMembersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.OnlyAssociated !== undefined) {
-    query[
-      __extendedEncodeURIComponent("onlyAssociated")
-    ] = __extendedEncodeURIComponent(input.OnlyAssociated);
+    query["onlyAssociated"] = input.OnlyAssociated;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1672,14 +1650,10 @@ export async function serializeAws_restJson1_1ListPublishingDestinationsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1742,14 +1716,10 @@ export async function serializeAws_restJson1_1ListThreatIntelSetsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1935,9 +1905,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
@@ -592,9 +592,7 @@ export async function serializeAws_restJson1_1DeleteComponentCommand(
   let resolvedPath = "/DeleteComponent";
   const query: any = {};
   if (input.componentBuildVersionArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("componentBuildVersionArn")
-    ] = __extendedEncodeURIComponent(input.componentBuildVersionArn);
+    query["componentBuildVersionArn"] = input.componentBuildVersionArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -615,9 +613,7 @@ export async function serializeAws_restJson1_1DeleteDistributionConfigurationCom
   let resolvedPath = "/DeleteDistributionConfiguration";
   const query: any = {};
   if (input.distributionConfigurationArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("distributionConfigurationArn")
-    ] = __extendedEncodeURIComponent(input.distributionConfigurationArn);
+    query["distributionConfigurationArn"] = input.distributionConfigurationArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -638,9 +634,7 @@ export async function serializeAws_restJson1_1DeleteImageCommand(
   let resolvedPath = "/DeleteImage";
   const query: any = {};
   if (input.imageBuildVersionArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imageBuildVersionArn")
-    ] = __extendedEncodeURIComponent(input.imageBuildVersionArn);
+    query["imageBuildVersionArn"] = input.imageBuildVersionArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -661,9 +655,7 @@ export async function serializeAws_restJson1_1DeleteImagePipelineCommand(
   let resolvedPath = "/DeleteImagePipeline";
   const query: any = {};
   if (input.imagePipelineArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imagePipelineArn")
-    ] = __extendedEncodeURIComponent(input.imagePipelineArn);
+    query["imagePipelineArn"] = input.imagePipelineArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -684,9 +676,7 @@ export async function serializeAws_restJson1_1DeleteImageRecipeCommand(
   let resolvedPath = "/DeleteImageRecipe";
   const query: any = {};
   if (input.imageRecipeArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imageRecipeArn")
-    ] = __extendedEncodeURIComponent(input.imageRecipeArn);
+    query["imageRecipeArn"] = input.imageRecipeArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -707,9 +697,8 @@ export async function serializeAws_restJson1_1DeleteInfrastructureConfigurationC
   let resolvedPath = "/DeleteInfrastructureConfiguration";
   const query: any = {};
   if (input.infrastructureConfigurationArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("infrastructureConfigurationArn")
-    ] = __extendedEncodeURIComponent(input.infrastructureConfigurationArn);
+    query["infrastructureConfigurationArn"] =
+      input.infrastructureConfigurationArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -730,9 +719,7 @@ export async function serializeAws_restJson1_1GetComponentCommand(
   let resolvedPath = "/GetComponent";
   const query: any = {};
   if (input.componentBuildVersionArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("componentBuildVersionArn")
-    ] = __extendedEncodeURIComponent(input.componentBuildVersionArn);
+    query["componentBuildVersionArn"] = input.componentBuildVersionArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -753,9 +740,7 @@ export async function serializeAws_restJson1_1GetComponentPolicyCommand(
   let resolvedPath = "/GetComponentPolicy";
   const query: any = {};
   if (input.componentArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("componentArn")
-    ] = __extendedEncodeURIComponent(input.componentArn);
+    query["componentArn"] = input.componentArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -776,9 +761,7 @@ export async function serializeAws_restJson1_1GetDistributionConfigurationComman
   let resolvedPath = "/GetDistributionConfiguration";
   const query: any = {};
   if (input.distributionConfigurationArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("distributionConfigurationArn")
-    ] = __extendedEncodeURIComponent(input.distributionConfigurationArn);
+    query["distributionConfigurationArn"] = input.distributionConfigurationArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -799,9 +782,7 @@ export async function serializeAws_restJson1_1GetImageCommand(
   let resolvedPath = "/GetImage";
   const query: any = {};
   if (input.imageBuildVersionArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imageBuildVersionArn")
-    ] = __extendedEncodeURIComponent(input.imageBuildVersionArn);
+    query["imageBuildVersionArn"] = input.imageBuildVersionArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -822,9 +803,7 @@ export async function serializeAws_restJson1_1GetImagePipelineCommand(
   let resolvedPath = "/GetImagePipeline";
   const query: any = {};
   if (input.imagePipelineArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imagePipelineArn")
-    ] = __extendedEncodeURIComponent(input.imagePipelineArn);
+    query["imagePipelineArn"] = input.imagePipelineArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -845,9 +824,7 @@ export async function serializeAws_restJson1_1GetImagePolicyCommand(
   let resolvedPath = "/GetImagePolicy";
   const query: any = {};
   if (input.imageArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imageArn")
-    ] = __extendedEncodeURIComponent(input.imageArn);
+    query["imageArn"] = input.imageArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -868,9 +845,7 @@ export async function serializeAws_restJson1_1GetImageRecipeCommand(
   let resolvedPath = "/GetImageRecipe";
   const query: any = {};
   if (input.imageRecipeArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imageRecipeArn")
-    ] = __extendedEncodeURIComponent(input.imageRecipeArn);
+    query["imageRecipeArn"] = input.imageRecipeArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -891,9 +866,7 @@ export async function serializeAws_restJson1_1GetImageRecipePolicyCommand(
   let resolvedPath = "/GetImageRecipePolicy";
   const query: any = {};
   if (input.imageRecipeArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("imageRecipeArn")
-    ] = __extendedEncodeURIComponent(input.imageRecipeArn);
+    query["imageRecipeArn"] = input.imageRecipeArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -914,9 +887,8 @@ export async function serializeAws_restJson1_1GetInfrastructureConfigurationComm
   let resolvedPath = "/GetInfrastructureConfiguration";
   const query: any = {};
   if (input.infrastructureConfigurationArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("infrastructureConfigurationArn")
-    ] = __extendedEncodeURIComponent(input.infrastructureConfigurationArn);
+    query["infrastructureConfigurationArn"] =
+      input.infrastructureConfigurationArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1484,9 +1456,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
@@ -291,24 +291,16 @@ export async function serializeAws_restJson1_1ListDeviceEventsCommand(
   }
   const query: any = {};
   if (input.FromTimeStamp !== undefined) {
-    query[
-      __extendedEncodeURIComponent("fromTimeStamp")
-    ] = __extendedEncodeURIComponent(input.FromTimeStamp.toISOString());
+    query["fromTimeStamp"] = input.FromTimeStamp.toISOString();
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.ToTimeStamp !== undefined) {
-    query[
-      __extendedEncodeURIComponent("toTimeStamp")
-    ] = __extendedEncodeURIComponent(input.ToTimeStamp.toISOString());
+    query["toTimeStamp"] = input.ToTimeStamp.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -329,19 +321,13 @@ export async function serializeAws_restJson1_1ListDevicesCommand(
   let resolvedPath = "/devices";
   const query: any = {};
   if (input.DeviceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deviceType")
-    ] = __extendedEncodeURIComponent(input.DeviceType);
+    query["deviceType"] = input.DeviceType;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -474,9 +460,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
@@ -513,14 +513,10 @@ export async function serializeAws_restJson1_1ListPlacementsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -541,14 +537,10 @@ export async function serializeAws_restJson1_1ListProjectsCommand(
   let resolvedPath = "/projects";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -650,9 +642,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iot-data-plane/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-data-plane/protocols/Aws_restJson1_1.ts
@@ -118,9 +118,7 @@ export async function serializeAws_restJson1_1PublishCommand(
   }
   const query: any = {};
   if (input.qos !== undefined) {
-    query[__extendedEncodeURIComponent("qos")] = __extendedEncodeURIComponent(
-      input.qos.toString()
-    );
+    query["qos"] = input.qos.toString();
   }
   let body: any;
   if (input.payload !== undefined) {

--- a/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
@@ -126,9 +126,7 @@ export async function serializeAws_restJson1_1DescribeDetectorCommand(
   }
   const query: any = {};
   if (input.keyValue !== undefined) {
-    query[
-      __extendedEncodeURIComponent("keyValue")
-    ] = __extendedEncodeURIComponent(input.keyValue);
+    query["keyValue"] = input.keyValue;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -165,19 +163,13 @@ export async function serializeAws_restJson1_1ListDetectorsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.stateName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("stateName")
-    ] = __extendedEncodeURIComponent(input.stateName);
+    query["stateName"] = input.stateName;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iot-events/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1_1.ts
@@ -284,9 +284,7 @@ export async function serializeAws_restJson1_1DescribeDetectorModelCommand(
   }
   const query: any = {};
   if (input.detectorModelVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.detectorModelVersion);
+    query["version"] = input.detectorModelVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -367,14 +365,10 @@ export async function serializeAws_restJson1_1ListDetectorModelVersionsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -395,14 +389,10 @@ export async function serializeAws_restJson1_1ListDetectorModelsCommand(
   let resolvedPath = "/detector-models";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -423,14 +413,10 @@ export async function serializeAws_restJson1_1ListInputsCommand(
   let resolvedPath = "/inputs";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -451,9 +437,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -500,9 +484,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   let body: any;
   const bodyParams: any = {};
@@ -530,14 +512,10 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
@@ -74,14 +74,10 @@ export async function serializeAws_restJson1_1DescribeJobExecutionCommand(
   }
   const query: any = {};
   if (input.executionNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("executionNumber")
-    ] = __extendedEncodeURIComponent(input.executionNumber.toString());
+    query["executionNumber"] = input.executionNumber.toString();
   }
   if (input.includeJobDocument !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeJobDocument")
-    ] = __extendedEncodeURIComponent(input.includeJobDocument.toString());
+    query["includeJobDocument"] = input.includeJobDocument.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iot/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1_1.ts
@@ -1182,14 +1182,10 @@ export async function serializeAws_restJson1_1DeleteV2LoggingLevelCommand(
   let resolvedPath = "/v2LoggingLevel";
   const query: any = {};
   if (input.targetName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("targetName")
-    ] = __extendedEncodeURIComponent(input.targetName);
+    query["targetName"] = input.targetName;
   }
   if (input.targetType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("targetType")
-    ] = __extendedEncodeURIComponent(input.targetType);
+    query["targetType"] = input.targetType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1357,14 +1353,10 @@ export async function serializeAws_restJson1_1ListTopicRuleDestinationsCommand(
   let resolvedPath = "/destinations";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1385,24 +1377,16 @@ export async function serializeAws_restJson1_1ListTopicRulesCommand(
   let resolvedPath = "/rules";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.ruleDisabled !== undefined) {
-    query[
-      __extendedEncodeURIComponent("ruleDisabled")
-    ] = __extendedEncodeURIComponent(input.ruleDisabled.toString());
+    query["ruleDisabled"] = input.ruleDisabled.toString();
   }
   if (input.topic !== undefined) {
-    query[__extendedEncodeURIComponent("topic")] = __extendedEncodeURIComponent(
-      input.topic
-    );
+    query["topic"] = input.topic;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1423,19 +1407,13 @@ export async function serializeAws_restJson1_1ListV2LoggingLevelsCommand(
   let resolvedPath = "/v2LoggingLevel";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.targetType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("targetType")
-    ] = __extendedEncodeURIComponent(input.targetType);
+    query["targetType"] = input.targetType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1622,9 +1600,7 @@ export async function serializeAws_restJson1_1AcceptCertificateTransferCommand(
   }
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("setAsActive")
-    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
+    query["setAsActive"] = input.setAsActive.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1809,9 +1785,7 @@ export async function serializeAws_restJson1_1CreateCertificateFromCsrCommand(
   let resolvedPath = "/certificates";
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("setAsActive")
-    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
+    query["setAsActive"] = input.setAsActive.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -1898,9 +1872,7 @@ export async function serializeAws_restJson1_1CreateKeysAndCertificateCommand(
   let resolvedPath = "/keys-and-certificate";
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("setAsActive")
-    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
+    query["setAsActive"] = input.setAsActive.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1968,9 +1940,7 @@ export async function serializeAws_restJson1_1CreatePolicyVersionCommand(
   }
   const query: any = {};
   if (input.setAsDefault !== undefined) {
-    query[
-      __extendedEncodeURIComponent("setAsDefault")
-    ] = __extendedEncodeURIComponent(input.setAsDefault.toString());
+    query["setAsDefault"] = input.setAsDefault.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -2081,9 +2051,7 @@ export async function serializeAws_restJson1_1CreateProvisioningTemplateVersionC
   }
   const query: any = {};
   if (input.setAsDefault !== undefined) {
-    query[
-      __extendedEncodeURIComponent("setAsDefault")
-    ] = __extendedEncodeURIComponent(input.setAsDefault.toString());
+    query["setAsDefault"] = input.setAsDefault.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -2223,9 +2191,7 @@ export async function serializeAws_restJson1_1DeleteCertificateCommand(
   }
   const query: any = {};
   if (input.forceDelete !== undefined) {
-    query[
-      __extendedEncodeURIComponent("forceDelete")
-    ] = __extendedEncodeURIComponent(input.forceDelete.toString());
+    query["forceDelete"] = input.forceDelete.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2603,9 +2569,7 @@ export async function serializeAws_restJson1_1DescribeEndpointCommand(
   let resolvedPath = "/endpoint";
   const query: any = {};
   if (input.endpointType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endpointType")
-    ] = __extendedEncodeURIComponent(input.endpointType);
+    query["endpointType"] = input.endpointType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2793,9 +2757,7 @@ export async function serializeAws_restJson1_1GetEffectivePoliciesCommand(
   let resolvedPath = "/effective-policies";
   const query: any = {};
   if (input.thingName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("thingName")
-    ] = __extendedEncodeURIComponent(input.thingName);
+    query["thingName"] = input.thingName;
   }
   let body: any;
   const bodyParams: any = {};
@@ -2924,19 +2886,13 @@ export async function serializeAws_restJson1_1ListAttachedPoliciesCommand(
   }
   const query: any = {};
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   if (input.recursive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("recursive")
-    ] = __extendedEncodeURIComponent(input.recursive.toString());
+    query["recursive"] = input.recursive.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2957,24 +2913,16 @@ export async function serializeAws_restJson1_1ListAuthorizersCommand(
   let resolvedPath = "/authorizers";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   if (input.status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.status);
+    query["status"] = input.status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2995,19 +2943,13 @@ export async function serializeAws_restJson1_1ListCACertificatesCommand(
   let resolvedPath = "/cacertificates";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3028,19 +2970,13 @@ export async function serializeAws_restJson1_1ListCertificatesCommand(
   let resolvedPath = "/certificates";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3075,19 +3011,13 @@ export async function serializeAws_restJson1_1ListCertificatesByCACommand(
   }
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3108,19 +3038,13 @@ export async function serializeAws_restJson1_1ListDomainConfigurationsCommand(
   let resolvedPath = "/domainConfigurations";
   const query: any = {};
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   if (input.serviceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("serviceType")
-    ] = __extendedEncodeURIComponent(input.serviceType);
+    query["serviceType"] = input.serviceType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3141,19 +3065,13 @@ export async function serializeAws_restJson1_1ListOutgoingCertificatesCommand(
   let resolvedPath = "/certificates-out-going";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3174,19 +3092,13 @@ export async function serializeAws_restJson1_1ListPoliciesCommand(
   let resolvedPath = "/policies";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3210,19 +3122,13 @@ export async function serializeAws_restJson1_1ListPolicyPrincipalsCommand(
   let resolvedPath = "/policy-principals";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3274,19 +3180,13 @@ export async function serializeAws_restJson1_1ListPrincipalPoliciesCommand(
   let resolvedPath = "/principal-policies";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3321,14 +3221,10 @@ export async function serializeAws_restJson1_1ListProvisioningTemplateVersionsCo
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3349,14 +3245,10 @@ export async function serializeAws_restJson1_1ListProvisioningTemplatesCommand(
   let resolvedPath = "/provisioning-templates";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3377,19 +3269,13 @@ export async function serializeAws_restJson1_1ListRoleAliasesCommand(
   let resolvedPath = "/role-aliases";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3422,14 +3308,10 @@ export async function serializeAws_restJson1_1ListTargetsForPolicyCommand(
   }
   const query: any = {};
   if (input.marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.marker);
+    query["marker"] = input.marker;
   }
   if (input.pageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("pageSize")
-    ] = __extendedEncodeURIComponent(input.pageSize.toString());
+    query["pageSize"] = input.pageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3450,14 +3332,10 @@ export async function serializeAws_restJson1_1RegisterCACertificateCommand(
   let resolvedPath = "/cacertificate";
   const query: any = {};
   if (input.allowAutoRegistration !== undefined) {
-    query[
-      __extendedEncodeURIComponent("allowAutoRegistration")
-    ] = __extendedEncodeURIComponent(input.allowAutoRegistration.toString());
+    query["allowAutoRegistration"] = input.allowAutoRegistration.toString();
   }
   if (input.setAsActive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("setAsActive")
-    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
+    query["setAsActive"] = input.setAsActive.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -3496,9 +3374,7 @@ export async function serializeAws_restJson1_1RegisterCertificateCommand(
   let resolvedPath = "/certificate/register";
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("setAsActive")
-    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
+    query["setAsActive"] = input.setAsActive.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -3663,9 +3539,7 @@ export async function serializeAws_restJson1_1TestAuthorizationCommand(
   let resolvedPath = "/test-authorization";
   const query: any = {};
   if (input.clientId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("clientId")
-    ] = __extendedEncodeURIComponent(input.clientId);
+    query["clientId"] = input.clientId;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3786,9 +3660,7 @@ export async function serializeAws_restJson1_1TransferCertificateCommand(
   }
   const query: any = {};
   if (input.targetAwsAccount !== undefined) {
-    query[
-      __extendedEncodeURIComponent("targetAwsAccount")
-    ] = __extendedEncodeURIComponent(input.targetAwsAccount);
+    query["targetAwsAccount"] = input.targetAwsAccount;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3879,14 +3751,10 @@ export async function serializeAws_restJson1_1UpdateCACertificateCommand(
   }
   const query: any = {};
   if (input.newAutoRegistrationStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("newAutoRegistrationStatus")
-    ] = __extendedEncodeURIComponent(input.newAutoRegistrationStatus);
+    query["newAutoRegistrationStatus"] = input.newAutoRegistrationStatus;
   }
   if (input.newStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("newStatus")
-    ] = __extendedEncodeURIComponent(input.newStatus);
+    query["newStatus"] = input.newStatus;
   }
   let body: any;
   const bodyParams: any = {};
@@ -3936,9 +3804,7 @@ export async function serializeAws_restJson1_1UpdateCertificateCommand(
   }
   const query: any = {};
   if (input.newStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("newStatus")
-    ] = __extendedEncodeURIComponent(input.newStatus);
+    query["newStatus"] = input.newStatus;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4237,14 +4103,10 @@ export async function serializeAws_restJson1_1ListIndicesCommand(
   let resolvedPath = "/indices";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4389,9 +4251,7 @@ export async function serializeAws_restJson1_1CancelJobCommand(
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
-      input.force.toString()
-    );
+    query["force"] = input.force.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -4446,9 +4306,7 @@ export async function serializeAws_restJson1_1CancelJobExecutionCommand(
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
-      input.force.toString()
-    );
+    query["force"] = input.force.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -4575,9 +4433,7 @@ export async function serializeAws_restJson1_1DeleteJobCommand(
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
-      input.force.toString()
-    );
+    query["force"] = input.force.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4637,9 +4493,7 @@ export async function serializeAws_restJson1_1DeleteJobExecutionCommand(
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
-      input.force.toString()
-    );
+    query["force"] = input.force.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4712,9 +4566,7 @@ export async function serializeAws_restJson1_1DescribeJobExecutionCommand(
   }
   const query: any = {};
   if (input.executionNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("executionNumber")
-    ] = __extendedEncodeURIComponent(input.executionNumber.toString());
+    query["executionNumber"] = input.executionNumber.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4775,19 +4627,13 @@ export async function serializeAws_restJson1_1ListJobExecutionsForJobCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.status);
+    query["status"] = input.status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4820,19 +4666,13 @@ export async function serializeAws_restJson1_1ListJobExecutionsForThingCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.status);
+    query["status"] = input.status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4853,34 +4693,22 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   let resolvedPath = "/jobs";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.status);
+    query["status"] = input.status;
   }
   if (input.targetSelection !== undefined) {
-    query[
-      __extendedEncodeURIComponent("targetSelection")
-    ] = __extendedEncodeURIComponent(input.targetSelection);
+    query["targetSelection"] = input.targetSelection;
   }
   if (input.thingGroupId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("thingGroupId")
-    ] = __extendedEncodeURIComponent(input.thingGroupId);
+    query["thingGroupId"] = input.thingGroupId;
   }
   if (input.thingGroupName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("thingGroupName")
-    ] = __extendedEncodeURIComponent(input.thingGroupName);
+    query["thingGroupName"] = input.thingGroupName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5066,14 +4894,10 @@ export async function serializeAws_restJson1_1DeleteOTAUpdateCommand(
   }
   const query: any = {};
   if (input.deleteStream !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deleteStream")
-    ] = __extendedEncodeURIComponent(input.deleteStream.toString());
+    query["deleteStream"] = input.deleteStream.toString();
   }
   if (input.forceDeleteAWSJob !== undefined) {
-    query[
-      __extendedEncodeURIComponent("forceDeleteAWSJob")
-    ] = __extendedEncodeURIComponent(input.forceDeleteAWSJob.toString());
+    query["forceDeleteAWSJob"] = input.forceDeleteAWSJob.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5124,19 +4948,13 @@ export async function serializeAws_restJson1_1ListOTAUpdatesCommand(
   let resolvedPath = "/otaUpdates";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.otaUpdateStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("otaUpdateStatus")
-    ] = __extendedEncodeURIComponent(input.otaUpdateStatus);
+    query["otaUpdateStatus"] = input.otaUpdateStatus;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5509,9 +5327,7 @@ export async function serializeAws_restJson1_1DeleteBillingGroupCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("expectedVersion")
-    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
+    query["expectedVersion"] = input.expectedVersion.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5546,9 +5362,7 @@ export async function serializeAws_restJson1_1DeleteDynamicThingGroupCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("expectedVersion")
-    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
+    query["expectedVersion"] = input.expectedVersion.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5581,9 +5395,7 @@ export async function serializeAws_restJson1_1DeleteThingCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("expectedVersion")
-    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
+    query["expectedVersion"] = input.expectedVersion.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5618,9 +5430,7 @@ export async function serializeAws_restJson1_1DeleteThingGroupCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("expectedVersion")
-    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
+    query["expectedVersion"] = input.expectedVersion.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5903,19 +5713,13 @@ export async function serializeAws_restJson1_1ListBillingGroupsCommand(
   let resolvedPath = "/billing-groups";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.namePrefixFilter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("namePrefixFilter")
-    ] = __extendedEncodeURIComponent(input.namePrefixFilter);
+    query["namePrefixFilter"] = input.namePrefixFilter;
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5939,14 +5743,10 @@ export async function serializeAws_restJson1_1ListPrincipalThingsCommand(
   let resolvedPath = "/principals/things";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5967,14 +5767,10 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5995,29 +5791,19 @@ export async function serializeAws_restJson1_1ListThingGroupsCommand(
   let resolvedPath = "/thing-groups";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.namePrefixFilter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("namePrefixFilter")
-    ] = __extendedEncodeURIComponent(input.namePrefixFilter);
+    query["namePrefixFilter"] = input.namePrefixFilter;
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.parentGroup !== undefined) {
-    query[
-      __extendedEncodeURIComponent("parentGroup")
-    ] = __extendedEncodeURIComponent(input.parentGroup);
+    query["parentGroup"] = input.parentGroup;
   }
   if (input.recursive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("recursive")
-    ] = __extendedEncodeURIComponent(input.recursive.toString());
+    query["recursive"] = input.recursive.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6050,14 +5836,10 @@ export async function serializeAws_restJson1_1ListThingGroupsForThingCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6118,19 +5900,13 @@ export async function serializeAws_restJson1_1ListThingRegistrationTaskReportsCo
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.reportType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("reportType")
-    ] = __extendedEncodeURIComponent(input.reportType);
+    query["reportType"] = input.reportType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6151,19 +5927,13 @@ export async function serializeAws_restJson1_1ListThingRegistrationTasksCommand(
   let resolvedPath = "/thing-registration-tasks";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.status);
+    query["status"] = input.status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6184,19 +5954,13 @@ export async function serializeAws_restJson1_1ListThingTypesCommand(
   let resolvedPath = "/thing-types";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.thingTypeName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("thingTypeName")
-    ] = __extendedEncodeURIComponent(input.thingTypeName);
+    query["thingTypeName"] = input.thingTypeName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6217,29 +5981,19 @@ export async function serializeAws_restJson1_1ListThingsCommand(
   let resolvedPath = "/things";
   const query: any = {};
   if (input.attributeName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("attributeName")
-    ] = __extendedEncodeURIComponent(input.attributeName);
+    query["attributeName"] = input.attributeName;
   }
   if (input.attributeValue !== undefined) {
-    query[
-      __extendedEncodeURIComponent("attributeValue")
-    ] = __extendedEncodeURIComponent(input.attributeValue);
+    query["attributeValue"] = input.attributeValue;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.thingTypeName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("thingTypeName")
-    ] = __extendedEncodeURIComponent(input.thingTypeName);
+    query["thingTypeName"] = input.thingTypeName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6276,14 +6030,10 @@ export async function serializeAws_restJson1_1ListThingsInBillingGroupCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6318,19 +6068,13 @@ export async function serializeAws_restJson1_1ListThingsInThingGroupCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.recursive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("recursive")
-    ] = __extendedEncodeURIComponent(input.recursive.toString());
+    query["recursive"] = input.recursive.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6805,9 +6549,7 @@ export async function serializeAws_restJson1_1AttachSecurityProfileCommand(
   }
   const query: any = {};
   if (input.securityProfileTargetArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("securityProfileTargetArn")
-    ] = __extendedEncodeURIComponent(input.securityProfileTargetArn);
+    query["securityProfileTargetArn"] = input.securityProfileTargetArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7046,9 +6788,7 @@ export async function serializeAws_restJson1_1DeleteAccountAuditConfigurationCom
   let resolvedPath = "/audit/configuration";
   const query: any = {};
   if (input.deleteScheduledAudits !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deleteScheduledAudits")
-    ] = __extendedEncodeURIComponent(input.deleteScheduledAudits.toString());
+    query["deleteScheduledAudits"] = input.deleteScheduledAudits.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7145,9 +6885,7 @@ export async function serializeAws_restJson1_1DeleteSecurityProfileCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("expectedVersion")
-    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
+    query["expectedVersion"] = input.expectedVersion.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7376,9 +7114,7 @@ export async function serializeAws_restJson1_1DetachSecurityProfileCommand(
   }
   const query: any = {};
   if (input.securityProfileTargetArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("securityProfileTargetArn")
-    ] = __extendedEncodeURIComponent(input.securityProfileTargetArn);
+    query["securityProfileTargetArn"] = input.securityProfileTargetArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7399,24 +7135,16 @@ export async function serializeAws_restJson1_1ListActiveViolationsCommand(
   let resolvedPath = "/active-violations";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.securityProfileName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("securityProfileName")
-    ] = __extendedEncodeURIComponent(input.securityProfileName);
+    query["securityProfileName"] = input.securityProfileName;
   }
   if (input.thingName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("thingName")
-    ] = __extendedEncodeURIComponent(input.thingName);
+    query["thingName"] = input.thingName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7483,29 +7211,19 @@ export async function serializeAws_restJson1_1ListAuditMitigationActionsExecutio
   let resolvedPath = "/audit/mitigationactions/executions";
   const query: any = {};
   if (input.actionStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("actionStatus")
-    ] = __extendedEncodeURIComponent(input.actionStatus);
+    query["actionStatus"] = input.actionStatus;
   }
   if (input.findingId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("findingId")
-    ] = __extendedEncodeURIComponent(input.findingId);
+    query["findingId"] = input.findingId;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.taskId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("taskId")
-    ] = __extendedEncodeURIComponent(input.taskId);
+    query["taskId"] = input.taskId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7526,39 +7244,25 @@ export async function serializeAws_restJson1_1ListAuditMitigationActionsTasksCom
   let resolvedPath = "/audit/mitigationactions/tasks";
   const query: any = {};
   if (input.auditTaskId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("auditTaskId")
-    ] = __extendedEncodeURIComponent(input.auditTaskId);
+    query["auditTaskId"] = input.auditTaskId;
   }
   if (input.endTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endTime")
-    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
+    query["endTime"] = input.endTime.toISOString();
   }
   if (input.findingId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("findingId")
-    ] = __extendedEncodeURIComponent(input.findingId);
+    query["findingId"] = input.findingId;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.startTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startTime")
-    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
+    query["startTime"] = input.startTime.toISOString();
   }
   if (input.taskStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("taskStatus")
-    ] = __extendedEncodeURIComponent(input.taskStatus);
+    query["taskStatus"] = input.taskStatus;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7579,34 +7283,22 @@ export async function serializeAws_restJson1_1ListAuditTasksCommand(
   let resolvedPath = "/audit/tasks";
   const query: any = {};
   if (input.endTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endTime")
-    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
+    query["endTime"] = input.endTime.toISOString();
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.startTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startTime")
-    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
+    query["startTime"] = input.startTime.toISOString();
   }
   if (input.taskStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("taskStatus")
-    ] = __extendedEncodeURIComponent(input.taskStatus);
+    query["taskStatus"] = input.taskStatus;
   }
   if (input.taskType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("taskType")
-    ] = __extendedEncodeURIComponent(input.taskType);
+    query["taskType"] = input.taskType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7627,19 +7319,13 @@ export async function serializeAws_restJson1_1ListMitigationActionsCommand(
   let resolvedPath = "/mitigationactions/actions";
   const query: any = {};
   if (input.actionType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("actionType")
-    ] = __extendedEncodeURIComponent(input.actionType);
+    query["actionType"] = input.actionType;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7660,14 +7346,10 @@ export async function serializeAws_restJson1_1ListScheduledAuditsCommand(
   let resolvedPath = "/audit/scheduledaudits";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7688,14 +7370,10 @@ export async function serializeAws_restJson1_1ListSecurityProfilesCommand(
   let resolvedPath = "/security-profiles";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7716,24 +7394,16 @@ export async function serializeAws_restJson1_1ListSecurityProfilesForTargetComma
   let resolvedPath = "/security-profiles-for-target";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.recursive !== undefined) {
-    query[
-      __extendedEncodeURIComponent("recursive")
-    ] = __extendedEncodeURIComponent(input.recursive.toString());
+    query["recursive"] = input.recursive.toString();
   }
   if (input.securityProfileTargetArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("securityProfileTargetArn")
-    ] = __extendedEncodeURIComponent(input.securityProfileTargetArn);
+    query["securityProfileTargetArn"] = input.securityProfileTargetArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7770,14 +7440,10 @@ export async function serializeAws_restJson1_1ListTargetsForSecurityProfileComma
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7798,34 +7464,22 @@ export async function serializeAws_restJson1_1ListViolationEventsCommand(
   let resolvedPath = "/violation-events";
   const query: any = {};
   if (input.endTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endTime")
-    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
+    query["endTime"] = input.endTime.toISOString();
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.securityProfileName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("securityProfileName")
-    ] = __extendedEncodeURIComponent(input.securityProfileName);
+    query["securityProfileName"] = input.securityProfileName;
   }
   if (input.startTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startTime")
-    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
+    query["startTime"] = input.startTime.toISOString();
   }
   if (input.thingName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("thingName")
-    ] = __extendedEncodeURIComponent(input.thingName);
+    query["thingName"] = input.thingName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -8077,9 +7731,7 @@ export async function serializeAws_restJson1_1UpdateSecurityProfileCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("expectedVersion")
-    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
+    query["expectedVersion"] = input.expectedVersion.toString();
   }
   let body: any;
   const bodyParams: any = {};
@@ -8266,19 +7918,13 @@ export async function serializeAws_restJson1_1ListStreamsCommand(
   let resolvedPath = "/streams";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isAscendingOrder")
-    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
+    query["isAscendingOrder"] = input.ascendingOrder.toString();
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
@@ -547,9 +547,7 @@ export async function serializeAws_restJson1_1DeleteDatasetContentCommand(
   }
   const query: any = {};
   if (input.versionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.versionId);
+    query["versionId"] = input.versionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -644,9 +642,7 @@ export async function serializeAws_restJson1_1DescribeChannelCommand(
   }
   const query: any = {};
   if (input.includeStatistics !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeStatistics")
-    ] = __extendedEncodeURIComponent(input.includeStatistics.toString());
+    query["includeStatistics"] = input.includeStatistics.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -711,9 +707,7 @@ export async function serializeAws_restJson1_1DescribeDatastoreCommand(
   }
   const query: any = {};
   if (input.includeStatistics !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeStatistics")
-    ] = __extendedEncodeURIComponent(input.includeStatistics.toString());
+    query["includeStatistics"] = input.includeStatistics.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -794,9 +788,7 @@ export async function serializeAws_restJson1_1GetDatasetContentCommand(
   }
   const query: any = {};
   if (input.versionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.versionId);
+    query["versionId"] = input.versionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -817,14 +809,10 @@ export async function serializeAws_restJson1_1ListChannelsCommand(
   let resolvedPath = "/channels";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -859,24 +847,16 @@ export async function serializeAws_restJson1_1ListDatasetContentsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.scheduledBefore !== undefined) {
-    query[
-      __extendedEncodeURIComponent("scheduledBefore")
-    ] = __extendedEncodeURIComponent(input.scheduledBefore.toISOString());
+    query["scheduledBefore"] = input.scheduledBefore.toISOString();
   }
   if (input.scheduledOnOrAfter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("scheduledOnOrAfter")
-    ] = __extendedEncodeURIComponent(input.scheduledOnOrAfter.toISOString());
+    query["scheduledOnOrAfter"] = input.scheduledOnOrAfter.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -897,14 +877,10 @@ export async function serializeAws_restJson1_1ListDatasetsCommand(
   let resolvedPath = "/datasets";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -925,14 +901,10 @@ export async function serializeAws_restJson1_1ListDatastoresCommand(
   let resolvedPath = "/datastores";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -953,14 +925,10 @@ export async function serializeAws_restJson1_1ListPipelinesCommand(
   let resolvedPath = "/pipelines";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -981,9 +949,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1076,19 +1042,13 @@ export async function serializeAws_restJson1_1SampleChannelDataCommand(
   }
   const query: any = {};
   if (input.endTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endTime")
-    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
+    query["endTime"] = input.endTime.toISOString();
   }
   if (input.maxMessages !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxMessages")
-    ] = __extendedEncodeURIComponent(input.maxMessages.toString());
+    query["maxMessages"] = input.maxMessages.toString();
   }
   if (input.startTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startTime")
-    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
+    query["startTime"] = input.startTime.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1149,9 +1109,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   let body: any;
   const bodyParams: any = {};
@@ -1179,14 +1137,10 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceArn")
-    ] = __extendedEncodeURIComponent(input.resourceArn);
+    query["resourceArn"] = input.resourceArn;
   }
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-kafka/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1_1.ts
@@ -261,9 +261,7 @@ export async function serializeAws_restJson1_1DeleteClusterCommand(
   }
   const query: any = {};
   if (input.CurrentVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("currentVersion")
-    ] = __extendedEncodeURIComponent(input.CurrentVersion);
+    query["currentVersion"] = input.CurrentVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -452,14 +450,10 @@ export async function serializeAws_restJson1_1ListClusterOperationsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -480,19 +474,13 @@ export async function serializeAws_restJson1_1ListClustersCommand(
   let resolvedPath = "/v1/clusters";
   const query: any = {};
   if (input.ClusterNameFilter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("clusterNameFilter")
-    ] = __extendedEncodeURIComponent(input.ClusterNameFilter);
+    query["clusterNameFilter"] = input.ClusterNameFilter;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -525,14 +513,10 @@ export async function serializeAws_restJson1_1ListConfigurationRevisionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -553,14 +537,10 @@ export async function serializeAws_restJson1_1ListConfigurationsCommand(
   let resolvedPath = "/v1/configurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -593,14 +573,10 @@ export async function serializeAws_restJson1_1ListNodesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -705,9 +681,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-lambda/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1_1.ts
@@ -302,9 +302,7 @@ export async function serializeAws_restJson1_1AddLayerVersionPermissionCommand(
   }
   const query: any = {};
   if (input.RevisionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("RevisionId")
-    ] = __extendedEncodeURIComponent(input.RevisionId);
+    query["RevisionId"] = input.RevisionId;
   }
   let body: any;
   const bodyParams: any = {};
@@ -355,9 +353,7 @@ export async function serializeAws_restJson1_1AddPermissionCommand(
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   let body: any;
   const bodyParams: any = {};
@@ -686,9 +682,7 @@ export async function serializeAws_restJson1_1DeleteFunctionCommand(
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -753,9 +747,7 @@ export async function serializeAws_restJson1_1DeleteFunctionEventInvokeConfigCom
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -833,9 +825,7 @@ export async function serializeAws_restJson1_1DeleteProvisionedConcurrencyConfig
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -956,9 +946,7 @@ export async function serializeAws_restJson1_1GetFunctionCommand(
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1023,9 +1011,7 @@ export async function serializeAws_restJson1_1GetFunctionConfigurationCommand(
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1060,9 +1046,7 @@ export async function serializeAws_restJson1_1GetFunctionEventInvokeConfigComman
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1127,9 +1111,7 @@ export async function serializeAws_restJson1_1GetLayerVersionByArnCommand(
     find: "LayerVersion"
   };
   if (input.Arn !== undefined) {
-    query[__extendedEncodeURIComponent("Arn")] = __extendedEncodeURIComponent(
-      input.Arn
-    );
+    query["Arn"] = input.Arn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1207,9 +1189,7 @@ export async function serializeAws_restJson1_1GetPolicyCommand(
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1245,9 +1225,7 @@ export async function serializeAws_restJson1_1GetProvisionedConcurrencyConfigCom
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1291,9 +1269,7 @@ export async function serializeAws_restJson1_1InvokeCommand(
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   let body: any;
   if (input.Payload !== undefined) {
@@ -1368,19 +1344,13 @@ export async function serializeAws_restJson1_1ListAliasesCommand(
   }
   const query: any = {};
   if (input.FunctionVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("FunctionVersion")
-    ] = __extendedEncodeURIComponent(input.FunctionVersion);
+    query["FunctionVersion"] = input.FunctionVersion;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1401,24 +1371,16 @@ export async function serializeAws_restJson1_1ListEventSourceMappingsCommand(
   let resolvedPath = "/2015-03-31/event-source-mappings";
   const query: any = {};
   if (input.EventSourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("EventSourceArn")
-    ] = __extendedEncodeURIComponent(input.EventSourceArn);
+    query["EventSourceArn"] = input.EventSourceArn;
   }
   if (input.FunctionName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("FunctionName")
-    ] = __extendedEncodeURIComponent(input.FunctionName);
+    query["FunctionName"] = input.FunctionName;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1454,14 +1416,10 @@ export async function serializeAws_restJson1_1ListFunctionEventInvokeConfigsComm
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1482,24 +1440,16 @@ export async function serializeAws_restJson1_1ListFunctionsCommand(
   let resolvedPath = "/2015-03-31/functions";
   const query: any = {};
   if (input.FunctionVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("FunctionVersion")
-    ] = __extendedEncodeURIComponent(input.FunctionVersion);
+    query["FunctionVersion"] = input.FunctionVersion;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MasterRegion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MasterRegion")
-    ] = __extendedEncodeURIComponent(input.MasterRegion);
+    query["MasterRegion"] = input.MasterRegion;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1532,19 +1482,13 @@ export async function serializeAws_restJson1_1ListLayerVersionsCommand(
   }
   const query: any = {};
   if (input.CompatibleRuntime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("CompatibleRuntime")
-    ] = __extendedEncodeURIComponent(input.CompatibleRuntime);
+    query["CompatibleRuntime"] = input.CompatibleRuntime;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1565,19 +1509,13 @@ export async function serializeAws_restJson1_1ListLayersCommand(
   let resolvedPath = "/2018-10-31/layers";
   const query: any = {};
   if (input.CompatibleRuntime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("CompatibleRuntime")
-    ] = __extendedEncodeURIComponent(input.CompatibleRuntime);
+    query["CompatibleRuntime"] = input.CompatibleRuntime;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1615,14 +1553,10 @@ export async function serializeAws_restJson1_1ListProvisionedConcurrencyConfigsC
     List: "ALL"
   };
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1685,14 +1619,10 @@ export async function serializeAws_restJson1_1ListVersionsByFunctionCommand(
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["Marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["MaxItems"] = input.MaxItems.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1860,9 +1790,7 @@ export async function serializeAws_restJson1_1PutFunctionEventInvokeConfigComman
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   let body: any;
   const bodyParams: any = {};
@@ -1914,9 +1842,7 @@ export async function serializeAws_restJson1_1PutProvisionedConcurrencyConfigCom
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   let body: any;
   const bodyParams: any = {};
@@ -1986,9 +1912,7 @@ export async function serializeAws_restJson1_1RemoveLayerVersionPermissionComman
   }
   const query: any = {};
   if (input.RevisionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("RevisionId")
-    ] = __extendedEncodeURIComponent(input.RevisionId);
+    query["RevisionId"] = input.RevisionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2038,14 +1962,10 @@ export async function serializeAws_restJson1_1RemovePermissionCommand(
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   if (input.RevisionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("RevisionId")
-    ] = __extendedEncodeURIComponent(input.RevisionId);
+    query["RevisionId"] = input.RevisionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2113,9 +2033,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2419,9 +2337,7 @@ export async function serializeAws_restJson1_1UpdateFunctionEventInvokeConfigCom
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Qualifier")
-    ] = __extendedEncodeURIComponent(input.Qualifier);
+    query["Qualifier"] = input.Qualifier;
   }
   let body: any;
   const bodyParams: any = {};

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
@@ -735,19 +735,13 @@ export async function serializeAws_restJson1_1GetBotAliasesCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nameContains !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nameContains")
-    ] = __extendedEncodeURIComponent(input.nameContains);
+    query["nameContains"] = input.nameContains;
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -844,19 +838,13 @@ export async function serializeAws_restJson1_1GetBotChannelAssociationsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nameContains !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nameContains")
-    ] = __extendedEncodeURIComponent(input.nameContains);
+    query["nameContains"] = input.nameContains;
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -889,14 +877,10 @@ export async function serializeAws_restJson1_1GetBotVersionsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -917,19 +901,13 @@ export async function serializeAws_restJson1_1GetBotsCommand(
   let resolvedPath = "/bots";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nameContains !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nameContains")
-    ] = __extendedEncodeURIComponent(input.nameContains);
+    query["nameContains"] = input.nameContains;
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -978,24 +956,16 @@ export async function serializeAws_restJson1_1GetBuiltinIntentsCommand(
   let resolvedPath = "/builtins/intents";
   const query: any = {};
   if (input.locale !== undefined) {
-    query[
-      __extendedEncodeURIComponent("locale")
-    ] = __extendedEncodeURIComponent(input.locale);
+    query["locale"] = input.locale;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.signatureContains !== undefined) {
-    query[
-      __extendedEncodeURIComponent("signatureContains")
-    ] = __extendedEncodeURIComponent(input.signatureContains);
+    query["signatureContains"] = input.signatureContains;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1016,24 +986,16 @@ export async function serializeAws_restJson1_1GetBuiltinSlotTypesCommand(
   let resolvedPath = "/builtins/slottypes";
   const query: any = {};
   if (input.locale !== undefined) {
-    query[
-      __extendedEncodeURIComponent("locale")
-    ] = __extendedEncodeURIComponent(input.locale);
+    query["locale"] = input.locale;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.signatureContains !== undefined) {
-    query[
-      __extendedEncodeURIComponent("signatureContains")
-    ] = __extendedEncodeURIComponent(input.signatureContains);
+    query["signatureContains"] = input.signatureContains;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1054,24 +1016,16 @@ export async function serializeAws_restJson1_1GetExportCommand(
   let resolvedPath = "/exports";
   const query: any = {};
   if (input.exportType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("exportType")
-    ] = __extendedEncodeURIComponent(input.exportType);
+    query["exportType"] = input.exportType;
   }
   if (input.name !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.name
-    );
+    query["name"] = input.name;
   }
   if (input.resourceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceType")
-    ] = __extendedEncodeURIComponent(input.resourceType);
+    query["resourceType"] = input.resourceType;
   }
   if (input.version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.version);
+    query["version"] = input.version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1172,14 +1126,10 @@ export async function serializeAws_restJson1_1GetIntentVersionsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1200,19 +1150,13 @@ export async function serializeAws_restJson1_1GetIntentsCommand(
   let resolvedPath = "/intents";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nameContains !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nameContains")
-    ] = __extendedEncodeURIComponent(input.nameContains);
+    query["nameContains"] = input.nameContains;
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1285,14 +1229,10 @@ export async function serializeAws_restJson1_1GetSlotTypeVersionsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1313,19 +1253,13 @@ export async function serializeAws_restJson1_1GetSlotTypesCommand(
   let resolvedPath = "/slottypes";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nameContains !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nameContains")
-    ] = __extendedEncodeURIComponent(input.nameContains);
+    query["nameContains"] = input.nameContains;
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1360,14 +1294,10 @@ export async function serializeAws_restJson1_1GetUtterancesViewCommand(
     view: "aggregation"
   };
   if (input.botVersions !== undefined) {
-    query[
-      __extendedEncodeURIComponent("bot_versions")
-    ] = input.botVersions.map(entry => __extendedEncodeURIComponent(entry));
+    query["bot_versions"] = input.botVersions;
   }
   if (input.statusType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status_type")
-    ] = __extendedEncodeURIComponent(input.statusType);
+    query["status_type"] = input.statusType;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
@@ -150,9 +150,7 @@ export async function serializeAws_restJson1_1GetSessionCommand(
   }
   const query: any = {};
   if (input.checkpointLabelFilter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("checkpointLabelFilter")
-    ] = __extendedEncodeURIComponent(input.checkpointLabelFilter);
+    query["checkpointLabelFilter"] = input.checkpointLabelFilter;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
@@ -600,14 +600,10 @@ export async function serializeAws_restJson1_1ListInvitationsCommand(
   let resolvedPath = "/invitations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -640,29 +636,19 @@ export async function serializeAws_restJson1_1ListMembersCommand(
   }
   const query: any = {};
   if (input.IsOwned !== undefined) {
-    query[
-      __extendedEncodeURIComponent("isOwned")
-    ] = __extendedEncodeURIComponent(input.IsOwned.toString());
+    query["isOwned"] = input.IsOwned.toString();
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.Name !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.Name
-    );
+    query["name"] = input.Name;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.Status);
+    query["status"] = input.Status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -683,29 +669,19 @@ export async function serializeAws_restJson1_1ListNetworksCommand(
   let resolvedPath = "/networks";
   const query: any = {};
   if (input.Framework !== undefined) {
-    query[
-      __extendedEncodeURIComponent("framework")
-    ] = __extendedEncodeURIComponent(input.Framework);
+    query["framework"] = input.Framework;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.Name !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.Name
-    );
+    query["name"] = input.Name;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.Status);
+    query["status"] = input.Status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -750,19 +726,13 @@ export async function serializeAws_restJson1_1ListNodesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.Status);
+    query["status"] = input.Status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -807,14 +777,10 @@ export async function serializeAws_restJson1_1ListProposalVotesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -847,14 +813,10 @@ export async function serializeAws_restJson1_1ListProposalsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
@@ -64,14 +64,10 @@ export async function serializeAws_restJson1_1CancelChangeSetCommand(
   let resolvedPath = "/CancelChangeSet";
   const query: any = {};
   if (input.Catalog !== undefined) {
-    query[
-      __extendedEncodeURIComponent("catalog")
-    ] = __extendedEncodeURIComponent(input.Catalog);
+    query["catalog"] = input.Catalog;
   }
   if (input.ChangeSetId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("changeSetId")
-    ] = __extendedEncodeURIComponent(input.ChangeSetId);
+    query["changeSetId"] = input.ChangeSetId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -92,14 +88,10 @@ export async function serializeAws_restJson1_1DescribeChangeSetCommand(
   let resolvedPath = "/DescribeChangeSet";
   const query: any = {};
   if (input.Catalog !== undefined) {
-    query[
-      __extendedEncodeURIComponent("catalog")
-    ] = __extendedEncodeURIComponent(input.Catalog);
+    query["catalog"] = input.Catalog;
   }
   if (input.ChangeSetId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("changeSetId")
-    ] = __extendedEncodeURIComponent(input.ChangeSetId);
+    query["changeSetId"] = input.ChangeSetId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -120,14 +112,10 @@ export async function serializeAws_restJson1_1DescribeEntityCommand(
   let resolvedPath = "/DescribeEntity";
   const query: any = {};
   if (input.Catalog !== undefined) {
-    query[
-      __extendedEncodeURIComponent("catalog")
-    ] = __extendedEncodeURIComponent(input.Catalog);
+    query["catalog"] = input.Catalog;
   }
   if (input.EntityId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("entityId")
-    ] = __extendedEncodeURIComponent(input.EntityId);
+    query["entityId"] = input.EntityId;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
@@ -294,14 +294,10 @@ export async function serializeAws_restJson1_1ListEntitlementsCommand(
   let resolvedPath = "/v1/entitlements";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -322,14 +318,10 @@ export async function serializeAws_restJson1_1ListFlowsCommand(
   let resolvedPath = "/v1/flows";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -572,9 +564,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
@@ -783,29 +783,19 @@ export async function serializeAws_restJson1_1ListJobTemplatesCommand(
   let resolvedPath = "/2017-08-29/jobTemplates";
   const query: any = {};
   if (input.Category !== undefined) {
-    query[
-      __extendedEncodeURIComponent("category")
-    ] = __extendedEncodeURIComponent(input.Category);
+    query["category"] = input.Category;
   }
   if (input.ListBy !== undefined) {
-    query[
-      __extendedEncodeURIComponent("listBy")
-    ] = __extendedEncodeURIComponent(input.ListBy);
+    query["listBy"] = input.ListBy;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Order !== undefined) {
-    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
-      input.Order
-    );
+    query["order"] = input.Order;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -826,29 +816,19 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   let resolvedPath = "/2017-08-29/jobs";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Order !== undefined) {
-    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
-      input.Order
-    );
+    query["order"] = input.Order;
   }
   if (input.Queue !== undefined) {
-    query[__extendedEncodeURIComponent("queue")] = __extendedEncodeURIComponent(
-      input.Queue
-    );
+    query["queue"] = input.Queue;
   }
   if (input.Status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.Status);
+    query["status"] = input.Status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -869,29 +849,19 @@ export async function serializeAws_restJson1_1ListPresetsCommand(
   let resolvedPath = "/2017-08-29/presets";
   const query: any = {};
   if (input.Category !== undefined) {
-    query[
-      __extendedEncodeURIComponent("category")
-    ] = __extendedEncodeURIComponent(input.Category);
+    query["category"] = input.Category;
   }
   if (input.ListBy !== undefined) {
-    query[
-      __extendedEncodeURIComponent("listBy")
-    ] = __extendedEncodeURIComponent(input.ListBy);
+    query["listBy"] = input.ListBy;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Order !== undefined) {
-    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
-      input.Order
-    );
+    query["order"] = input.Order;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -912,24 +882,16 @@ export async function serializeAws_restJson1_1ListQueuesCommand(
   let resolvedPath = "/2017-08-29/queues";
   const query: any = {};
   if (input.ListBy !== undefined) {
-    query[
-      __extendedEncodeURIComponent("listBy")
-    ] = __extendedEncodeURIComponent(input.ListBy);
+    query["listBy"] = input.ListBy;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Order !== undefined) {
-    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
-      input.Order
-    );
+    query["order"] = input.Order;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-medialive/protocols/Aws_restJson1_1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1_1.ts
@@ -974,9 +974,7 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1229,14 +1227,10 @@ export async function serializeAws_restJson1_1DescribeScheduleCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1257,14 +1251,10 @@ export async function serializeAws_restJson1_1ListChannelsCommand(
   let resolvedPath = "/prod/channels";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1285,14 +1275,10 @@ export async function serializeAws_restJson1_1ListInputSecurityGroupsCommand(
   let resolvedPath = "/prod/inputSecurityGroups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1313,14 +1299,10 @@ export async function serializeAws_restJson1_1ListInputsCommand(
   let resolvedPath = "/prod/inputs";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1355,14 +1337,10 @@ export async function serializeAws_restJson1_1ListMultiplexProgramsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1383,14 +1361,10 @@ export async function serializeAws_restJson1_1ListMultiplexesCommand(
   let resolvedPath = "/prod/multiplexes";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1411,64 +1385,40 @@ export async function serializeAws_restJson1_1ListOfferingsCommand(
   let resolvedPath = "/prod/offerings";
   const query: any = {};
   if (input.ChannelClass !== undefined) {
-    query[
-      __extendedEncodeURIComponent("channelClass")
-    ] = __extendedEncodeURIComponent(input.ChannelClass);
+    query["channelClass"] = input.ChannelClass;
   }
   if (input.ChannelConfiguration !== undefined) {
-    query[
-      __extendedEncodeURIComponent("channelConfiguration")
-    ] = __extendedEncodeURIComponent(input.ChannelConfiguration);
+    query["channelConfiguration"] = input.ChannelConfiguration;
   }
   if (input.Codec !== undefined) {
-    query[__extendedEncodeURIComponent("codec")] = __extendedEncodeURIComponent(
-      input.Codec
-    );
+    query["codec"] = input.Codec;
   }
   if (input.Duration !== undefined) {
-    query[
-      __extendedEncodeURIComponent("duration")
-    ] = __extendedEncodeURIComponent(input.Duration);
+    query["duration"] = input.Duration;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.MaximumBitrate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maximumBitrate")
-    ] = __extendedEncodeURIComponent(input.MaximumBitrate);
+    query["maximumBitrate"] = input.MaximumBitrate;
   }
   if (input.MaximumFramerate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maximumFramerate")
-    ] = __extendedEncodeURIComponent(input.MaximumFramerate);
+    query["maximumFramerate"] = input.MaximumFramerate;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Resolution !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resolution")
-    ] = __extendedEncodeURIComponent(input.Resolution);
+    query["resolution"] = input.Resolution;
   }
   if (input.ResourceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceType")
-    ] = __extendedEncodeURIComponent(input.ResourceType);
+    query["resourceType"] = input.ResourceType;
   }
   if (input.SpecialFeature !== undefined) {
-    query[
-      __extendedEncodeURIComponent("specialFeature")
-    ] = __extendedEncodeURIComponent(input.SpecialFeature);
+    query["specialFeature"] = input.SpecialFeature;
   }
   if (input.VideoQuality !== undefined) {
-    query[
-      __extendedEncodeURIComponent("videoQuality")
-    ] = __extendedEncodeURIComponent(input.VideoQuality);
+    query["videoQuality"] = input.VideoQuality;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1489,54 +1439,34 @@ export async function serializeAws_restJson1_1ListReservationsCommand(
   let resolvedPath = "/prod/reservations";
   const query: any = {};
   if (input.ChannelClass !== undefined) {
-    query[
-      __extendedEncodeURIComponent("channelClass")
-    ] = __extendedEncodeURIComponent(input.ChannelClass);
+    query["channelClass"] = input.ChannelClass;
   }
   if (input.Codec !== undefined) {
-    query[__extendedEncodeURIComponent("codec")] = __extendedEncodeURIComponent(
-      input.Codec
-    );
+    query["codec"] = input.Codec;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.MaximumBitrate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maximumBitrate")
-    ] = __extendedEncodeURIComponent(input.MaximumBitrate);
+    query["maximumBitrate"] = input.MaximumBitrate;
   }
   if (input.MaximumFramerate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maximumFramerate")
-    ] = __extendedEncodeURIComponent(input.MaximumFramerate);
+    query["maximumFramerate"] = input.MaximumFramerate;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Resolution !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resolution")
-    ] = __extendedEncodeURIComponent(input.Resolution);
+    query["resolution"] = input.Resolution;
   }
   if (input.ResourceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceType")
-    ] = __extendedEncodeURIComponent(input.ResourceType);
+    query["resourceType"] = input.ResourceType;
   }
   if (input.SpecialFeature !== undefined) {
-    query[
-      __extendedEncodeURIComponent("specialFeature")
-    ] = __extendedEncodeURIComponent(input.SpecialFeature);
+    query["specialFeature"] = input.SpecialFeature;
   }
   if (input.VideoQuality !== undefined) {
-    query[
-      __extendedEncodeURIComponent("videoQuality")
-    ] = __extendedEncodeURIComponent(input.VideoQuality);
+    query["videoQuality"] = input.VideoQuality;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
@@ -371,19 +371,13 @@ export async function serializeAws_restJson1_1ListAssetsCommand(
   let resolvedPath = "/assets";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.PackagingGroupId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("packagingGroupId")
-    ] = __extendedEncodeURIComponent(input.PackagingGroupId);
+    query["packagingGroupId"] = input.PackagingGroupId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -404,19 +398,13 @@ export async function serializeAws_restJson1_1ListPackagingConfigurationsCommand
   let resolvedPath = "/packaging_configurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.PackagingGroupId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("packagingGroupId")
-    ] = __extendedEncodeURIComponent(input.PackagingGroupId);
+    query["packagingGroupId"] = input.PackagingGroupId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -437,14 +425,10 @@ export async function serializeAws_restJson1_1ListPackagingGroupsCommand(
   let resolvedPath = "/packaging_groups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
@@ -413,14 +413,10 @@ export async function serializeAws_restJson1_1ListChannelsCommand(
   let resolvedPath = "/channels";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -441,24 +437,16 @@ export async function serializeAws_restJson1_1ListHarvestJobsCommand(
   let resolvedPath = "/harvest_jobs";
   const query: any = {};
   if (input.IncludeChannelId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeChannelId")
-    ] = __extendedEncodeURIComponent(input.IncludeChannelId);
+    query["includeChannelId"] = input.IncludeChannelId;
   }
   if (input.IncludeStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeStatus")
-    ] = __extendedEncodeURIComponent(input.IncludeStatus);
+    query["includeStatus"] = input.IncludeStatus;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -479,19 +467,13 @@ export async function serializeAws_restJson1_1ListOriginEndpointsCommand(
   let resolvedPath = "/origin_endpoints";
   const query: any = {};
   if (input.ChannelId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("channelId")
-    ] = __extendedEncodeURIComponent(input.ChannelId);
+    query["channelId"] = input.ChannelId;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -669,9 +651,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-mediastore-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1_1.ts
@@ -145,19 +145,13 @@ export async function serializeAws_restJson1_1ListItemsCommand(
   let resolvedPath = "/";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.Path !== undefined) {
-    query[__extendedEncodeURIComponent("Path")] = __extendedEncodeURIComponent(
-      input.Path
-    );
+    query["Path"] = input.Path;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
@@ -115,14 +115,10 @@ export async function serializeAws_restJson1_1ListPlaybackConfigurationsCommand(
   let resolvedPath = "/playbackConfigurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -290,9 +286,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-mobile/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1_1.ts
@@ -73,19 +73,13 @@ export async function serializeAws_restJson1_1CreateProjectCommand(
   let resolvedPath = "/projects";
   const query: any = {};
   if (input.name !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.name
-    );
+    query["name"] = input.name;
   }
   if (input.region !== undefined) {
-    query[
-      __extendedEncodeURIComponent("region")
-    ] = __extendedEncodeURIComponent(input.region);
+    query["region"] = input.region;
   }
   if (input.snapshotId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("snapshotId")
-    ] = __extendedEncodeURIComponent(input.snapshotId);
+    query["snapshotId"] = input.snapshotId;
   }
   let body: any;
   if (input.contents !== undefined) {
@@ -167,14 +161,10 @@ export async function serializeAws_restJson1_1DescribeProjectCommand(
   let resolvedPath = "/project";
   const query: any = {};
   if (input.projectId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("projectId")
-    ] = __extendedEncodeURIComponent(input.projectId);
+    query["projectId"] = input.projectId;
   }
   if (input.syncFromResources !== undefined) {
-    query[
-      __extendedEncodeURIComponent("syncFromResources")
-    ] = __extendedEncodeURIComponent(input.syncFromResources.toString());
+    query["syncFromResources"] = input.syncFromResources.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -207,14 +197,10 @@ export async function serializeAws_restJson1_1ExportBundleCommand(
   }
   const query: any = {};
   if (input.platform !== undefined) {
-    query[
-      __extendedEncodeURIComponent("platform")
-    ] = __extendedEncodeURIComponent(input.platform);
+    query["platform"] = input.platform;
   }
   if (input.projectId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("projectId")
-    ] = __extendedEncodeURIComponent(input.projectId);
+    query["projectId"] = input.projectId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -263,14 +249,10 @@ export async function serializeAws_restJson1_1ListBundlesCommand(
   let resolvedPath = "/bundles";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -291,14 +273,10 @@ export async function serializeAws_restJson1_1ListProjectsCommand(
   let resolvedPath = "/projects";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -319,9 +297,7 @@ export async function serializeAws_restJson1_1UpdateProjectCommand(
   let resolvedPath = "/update";
   const query: any = {};
   if (input.projectId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("projectId")
-    ] = __extendedEncodeURIComponent(input.projectId);
+    query["projectId"] = input.projectId;
   }
   let body: any;
   if (input.contents !== undefined) {

--- a/clients/client-mq/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1_1.ts
@@ -409,9 +409,7 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -500,19 +498,13 @@ export async function serializeAws_restJson1_1DescribeBrokerEngineTypesCommand(
   let resolvedPath = "/v1/broker-engine-types";
   const query: any = {};
   if (input.EngineType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("engineType")
-    ] = __extendedEncodeURIComponent(input.EngineType);
+    query["engineType"] = input.EngineType;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -533,29 +525,19 @@ export async function serializeAws_restJson1_1DescribeBrokerInstanceOptionsComma
   let resolvedPath = "/v1/broker-instance-options";
   const query: any = {};
   if (input.EngineType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("engineType")
-    ] = __extendedEncodeURIComponent(input.EngineType);
+    query["engineType"] = input.EngineType;
   }
   if (input.HostInstanceType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("hostInstanceType")
-    ] = __extendedEncodeURIComponent(input.HostInstanceType);
+    query["hostInstanceType"] = input.HostInstanceType;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.StorageType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("storageType")
-    ] = __extendedEncodeURIComponent(input.StorageType);
+    query["storageType"] = input.StorageType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -693,14 +675,10 @@ export async function serializeAws_restJson1_1ListBrokersCommand(
   let resolvedPath = "/v1/brokers";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -735,14 +713,10 @@ export async function serializeAws_restJson1_1ListConfigurationRevisionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -763,14 +737,10 @@ export async function serializeAws_restJson1_1ListConfigurationsCommand(
   let resolvedPath = "/v1/configurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -833,14 +803,10 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
@@ -630,21 +630,13 @@ export async function serializeAws_restJson1_1DescribeGlobalNetworksCommand(
   let resolvedPath = "/global-networks";
   const query: any = {};
   if (input.GlobalNetworkIds !== undefined) {
-    query[
-      __extendedEncodeURIComponent("globalNetworkIds")
-    ] = input.GlobalNetworkIds.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["globalNetworkIds"] = input.GlobalNetworkIds;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -726,14 +718,10 @@ export async function serializeAws_restJson1_1DisassociateLinkCommand(
   }
   const query: any = {};
   if (input.DeviceId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deviceId")
-    ] = __extendedEncodeURIComponent(input.DeviceId);
+    query["deviceId"] = input.DeviceId;
   }
   if (input.LinkId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("linkId")
-    ] = __extendedEncodeURIComponent(input.LinkId);
+    query["linkId"] = input.LinkId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -769,21 +757,13 @@ export async function serializeAws_restJson1_1GetCustomerGatewayAssociationsComm
   }
   const query: any = {};
   if (input.CustomerGatewayArns !== undefined) {
-    query[
-      __extendedEncodeURIComponent("customerGatewayArns")
-    ] = input.CustomerGatewayArns.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["customerGatewayArns"] = input.CustomerGatewayArns;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -818,24 +798,16 @@ export async function serializeAws_restJson1_1GetDevicesCommand(
   }
   const query: any = {};
   if (input.DeviceIds !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deviceIds")
-    ] = input.DeviceIds.map(entry => __extendedEncodeURIComponent(entry));
+    query["deviceIds"] = input.DeviceIds;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.SiteId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("siteId")
-    ] = __extendedEncodeURIComponent(input.SiteId);
+    query["siteId"] = input.SiteId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -870,24 +842,16 @@ export async function serializeAws_restJson1_1GetLinkAssociationsCommand(
   }
   const query: any = {};
   if (input.DeviceId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deviceId")
-    ] = __extendedEncodeURIComponent(input.DeviceId);
+    query["deviceId"] = input.DeviceId;
   }
   if (input.LinkId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("linkId")
-    ] = __extendedEncodeURIComponent(input.LinkId);
+    query["linkId"] = input.LinkId;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -922,34 +886,22 @@ export async function serializeAws_restJson1_1GetLinksCommand(
   }
   const query: any = {};
   if (input.LinkIds !== undefined) {
-    query[__extendedEncodeURIComponent("linkIds")] = input.LinkIds.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["linkIds"] = input.LinkIds;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.Provider !== undefined) {
-    query[
-      __extendedEncodeURIComponent("provider")
-    ] = __extendedEncodeURIComponent(input.Provider);
+    query["provider"] = input.Provider;
   }
   if (input.SiteId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("siteId")
-    ] = __extendedEncodeURIComponent(input.SiteId);
+    query["siteId"] = input.SiteId;
   }
   if (input.Type !== undefined) {
-    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
-      input.Type
-    );
+    query["type"] = input.Type;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -984,19 +936,13 @@ export async function serializeAws_restJson1_1GetSitesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.SiteIds !== undefined) {
-    query[__extendedEncodeURIComponent("siteIds")] = input.SiteIds.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["siteIds"] = input.SiteIds;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1032,21 +978,13 @@ export async function serializeAws_restJson1_1GetTransitGatewayRegistrationsComm
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.TransitGatewayArns !== undefined) {
-    query[
-      __extendedEncodeURIComponent("transitGatewayArns")
-    ] = input.TransitGatewayArns.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["transitGatewayArns"] = input.TransitGatewayArns;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1186,9 +1124,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-outposts/protocols/Aws_restJson1_1.ts
+++ b/clients/client-outposts/protocols/Aws_restJson1_1.ts
@@ -127,14 +127,10 @@ export async function serializeAws_restJson1_1GetOutpostInstanceTypesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -155,14 +151,10 @@ export async function serializeAws_restJson1_1ListOutpostsCommand(
   let resolvedPath = "/outposts";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -183,14 +175,10 @@ export async function serializeAws_restJson1_1ListSitesCommand(
   let resolvedPath = "/sites";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
@@ -579,11 +579,7 @@ export async function serializeAws_restJson1_1GetBlacklistReportsCommand(
   let resolvedPath = "/v1/email/deliverability-dashboard/blacklist-report";
   const query: any = {};
   if (input.BlacklistItemNames !== undefined) {
-    query[
-      __extendedEncodeURIComponent("BlacklistItemNames")
-    ] = input.BlacklistItemNames.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["BlacklistItemNames"] = input.BlacklistItemNames;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -697,19 +693,13 @@ export async function serializeAws_restJson1_1GetDedicatedIpsCommand(
   let resolvedPath = "/v1/email/dedicated-ips";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   if (input.PoolName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PoolName")
-    ] = __extendedEncodeURIComponent(input.PoolName);
+    query["PoolName"] = input.PoolName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -817,14 +807,10 @@ export async function serializeAws_restJson1_1GetDomainStatisticsReportCommand(
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("EndDate")
-    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
+    query["EndDate"] = input.EndDate.toISOString();
   }
   if (input.StartDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("StartDate")
-    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
+    query["StartDate"] = input.StartDate.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -875,14 +861,10 @@ export async function serializeAws_restJson1_1ListConfigurationSetsCommand(
   let resolvedPath = "/v1/email/configuration-sets";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -903,14 +885,10 @@ export async function serializeAws_restJson1_1ListDedicatedIpPoolsCommand(
   let resolvedPath = "/v1/email/dedicated-ip-pools";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -931,14 +909,10 @@ export async function serializeAws_restJson1_1ListDeliverabilityTestReportsComma
   let resolvedPath = "/v1/email/deliverability-dashboard/test-reports";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -976,24 +950,16 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("EndDate")
-    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
+    query["EndDate"] = input.EndDate.toISOString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   if (input.StartDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("StartDate")
-    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
+    query["StartDate"] = input.StartDate.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1014,14 +980,10 @@ export async function serializeAws_restJson1_1ListEmailIdentitiesCommand(
   let resolvedPath = "/v1/email/identities";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1042,9 +1004,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/v1/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("ResourceArn")
-    ] = __extendedEncodeURIComponent(input.ResourceArn);
+    query["ResourceArn"] = input.ResourceArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1569,14 +1529,10 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/v1/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("ResourceArn")
-    ] = __extendedEncodeURIComponent(input.ResourceArn);
+    query["ResourceArn"] = input.ResourceArn;
   }
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("TagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["TagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
@@ -257,14 +257,10 @@ export async function serializeAws_restJson1_1ListConfigurationSetsCommand(
   let resolvedPath = "/v1/sms-voice/configuration-sets";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["PageSize"] = input.PageSize;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
@@ -1325,9 +1325,7 @@ export async function serializeAws_restJson1_1DeleteEmailTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1506,9 +1504,7 @@ export async function serializeAws_restJson1_1DeletePushTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1615,9 +1611,7 @@ export async function serializeAws_restJson1_1DeleteSmsTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1724,9 +1718,7 @@ export async function serializeAws_restJson1_1DeleteVoiceTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1953,24 +1945,16 @@ export async function serializeAws_restJson1_1GetApplicationDateRangeKpiCommand(
   }
   const query: any = {};
   if (input.EndTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("end-time")
-    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
+    query["end-time"] = input.EndTime.toISOString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.StartTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("start-time")
-    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
+    query["start-time"] = input.StartTime.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2021,14 +2005,10 @@ export async function serializeAws_restJson1_1GetAppsCommand(
   let resolvedPath = "/v1/apps";
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2148,14 +2128,10 @@ export async function serializeAws_restJson1_1GetCampaignActivitiesCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2215,24 +2191,16 @@ export async function serializeAws_restJson1_1GetCampaignDateRangeKpiCommand(
   }
   const query: any = {};
   if (input.EndTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("end-time")
-    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
+    query["end-time"] = input.EndTime.toISOString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.StartTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("start-time")
-    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
+    query["start-time"] = input.StartTime.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2334,14 +2302,10 @@ export async function serializeAws_restJson1_1GetCampaignVersionsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2376,14 +2340,10 @@ export async function serializeAws_restJson1_1GetCampaignsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2478,9 +2438,7 @@ export async function serializeAws_restJson1_1GetEmailTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2629,14 +2587,10 @@ export async function serializeAws_restJson1_1GetExportJobsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2743,14 +2697,10 @@ export async function serializeAws_restJson1_1GetImportJobsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2852,24 +2802,16 @@ export async function serializeAws_restJson1_1GetJourneyDateRangeKpiCommand(
   }
   const query: any = {};
   if (input.EndTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("end-time")
-    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
+    query["end-time"] = input.EndTime.toISOString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.StartTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("start-time")
-    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
+    query["start-time"] = input.StartTime.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2933,14 +2875,10 @@ export async function serializeAws_restJson1_1GetJourneyExecutionActivityMetrics
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2988,14 +2926,10 @@ export async function serializeAws_restJson1_1GetJourneyExecutionMetricsCommand(
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3030,9 +2964,7 @@ export async function serializeAws_restJson1_1GetPushTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3122,14 +3054,10 @@ export async function serializeAws_restJson1_1GetSegmentExportJobsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3177,14 +3105,10 @@ export async function serializeAws_restJson1_1GetSegmentImportJobsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3286,14 +3210,10 @@ export async function serializeAws_restJson1_1GetSegmentVersionsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3328,14 +3248,10 @@ export async function serializeAws_restJson1_1GetSegmentsCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3400,9 +3316,7 @@ export async function serializeAws_restJson1_1GetSmsTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3509,9 +3423,7 @@ export async function serializeAws_restJson1_1GetVoiceTemplateCommand(
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3546,14 +3458,10 @@ export async function serializeAws_restJson1_1ListJourneysCommand(
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Token !== undefined) {
-    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
-      input.Token
-    );
+    query["token"] = input.Token;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3632,14 +3540,10 @@ export async function serializeAws_restJson1_1ListTemplateVersionsCommand(
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3660,24 +3564,16 @@ export async function serializeAws_restJson1_1ListTemplatesCommand(
   let resolvedPath = "/v1/templates";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("page-size")
-    ] = __extendedEncodeURIComponent(input.PageSize);
+    query["page-size"] = input.PageSize;
   }
   if (input.Prefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("prefix")
-    ] = __extendedEncodeURIComponent(input.Prefix);
+    query["prefix"] = input.Prefix;
   }
   if (input.TemplateType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("template-type")
-    ] = __extendedEncodeURIComponent(input.TemplateType);
+    query["template-type"] = input.TemplateType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4000,9 +3896,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4427,14 +4321,10 @@ export async function serializeAws_restJson1_1UpdateEmailTemplateCommand(
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("create-new-version")
-    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
+    query["create-new-version"] = input.CreateNewVersion.toString();
   }
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   let body: any;
   if (input.EmailTemplateRequest !== undefined) {
@@ -4727,14 +4617,10 @@ export async function serializeAws_restJson1_1UpdatePushTemplateCommand(
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("create-new-version")
-    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
+    query["create-new-version"] = input.CreateNewVersion.toString();
   }
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   let body: any;
   if (input.PushNotificationTemplateRequest !== undefined) {
@@ -4877,14 +4763,10 @@ export async function serializeAws_restJson1_1UpdateSmsTemplateCommand(
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("create-new-version")
-    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
+    query["create-new-version"] = input.CreateNewVersion.toString();
   }
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   let body: any;
   if (input.SMSTemplateRequest !== undefined) {
@@ -5030,14 +4912,10 @@ export async function serializeAws_restJson1_1UpdateVoiceTemplateCommand(
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("create-new-version")
-    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
+    query["create-new-version"] = input.CreateNewVersion.toString();
   }
   if (input.Version !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.Version);
+    query["version"] = input.Version;
   }
   let body: any;
   if (input.VoiceTemplateRequest !== undefined) {

--- a/clients/client-polly/protocols/Aws_restJson1_1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1_1.ts
@@ -117,26 +117,18 @@ export async function serializeAws_restJson1_1DescribeVoicesCommand(
   let resolvedPath = "/v1/voices";
   const query: any = {};
   if (input.Engine !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Engine")
-    ] = __extendedEncodeURIComponent(input.Engine);
+    query["Engine"] = input.Engine;
   }
   if (input.IncludeAdditionalLanguageCodes !== undefined) {
     query[
-      __extendedEncodeURIComponent("IncludeAdditionalLanguageCodes")
-    ] = __extendedEncodeURIComponent(
-      input.IncludeAdditionalLanguageCodes.toString()
-    );
+      "IncludeAdditionalLanguageCodes"
+    ] = input.IncludeAdditionalLanguageCodes.toString();
   }
   if (input.LanguageCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("LanguageCode")
-    ] = __extendedEncodeURIComponent(input.LanguageCode);
+    query["LanguageCode"] = input.LanguageCode;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -213,9 +205,7 @@ export async function serializeAws_restJson1_1ListLexiconsCommand(
   let resolvedPath = "/v1/lexicons";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -236,19 +226,13 @@ export async function serializeAws_restJson1_1ListSpeechSynthesisTasksCommand(
   let resolvedPath = "/v1/synthesisTasks";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.Status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("Status")
-    ] = __extendedEncodeURIComponent(input.Status);
+    query["Status"] = input.Status;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-qldb/protocols/Aws_restJson1_1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1_1.ts
@@ -395,14 +395,10 @@ export async function serializeAws_restJson1_1ListJournalS3ExportsCommand(
   let resolvedPath = "/journal-s3-exports";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -435,14 +431,10 @@ export async function serializeAws_restJson1_1ListJournalS3ExportsForLedgerComma
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -463,14 +455,10 @@ export async function serializeAws_restJson1_1ListLedgersCommand(
   let resolvedPath = "/ledgers";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max_results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next_token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -572,9 +560,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-quicksight/protocols/Aws_restJson1_1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1_1.ts
@@ -1088,9 +1088,7 @@ export async function serializeAws_restJson1_1DeleteDashboardCommand(
   }
   const query: any = {};
   if (input.VersionNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version-number")
-    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
+    query["version-number"] = input.VersionNumber.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1402,9 +1400,7 @@ export async function serializeAws_restJson1_1DeleteTemplateCommand(
   }
   const query: any = {};
   if (input.VersionNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version-number")
-    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
+    query["version-number"] = input.VersionNumber.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1620,14 +1616,10 @@ export async function serializeAws_restJson1_1DescribeDashboardCommand(
   }
   const query: any = {};
   if (input.AliasName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("alias-name")
-    ] = __extendedEncodeURIComponent(input.AliasName);
+    query["alias-name"] = input.AliasName;
   }
   if (input.VersionNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version-number")
-    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
+    query["version-number"] = input.VersionNumber.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2062,14 +2054,10 @@ export async function serializeAws_restJson1_1DescribeTemplateCommand(
   }
   const query: any = {};
   if (input.AliasName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("alias-name")
-    ] = __extendedEncodeURIComponent(input.AliasName);
+    query["alias-name"] = input.AliasName;
   }
   if (input.VersionNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version-number")
-    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
+    query["version-number"] = input.VersionNumber.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2272,29 +2260,19 @@ export async function serializeAws_restJson1_1GetDashboardEmbedUrlCommand(
   }
   const query: any = {};
   if (input.IdentityType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("creds-type")
-    ] = __extendedEncodeURIComponent(input.IdentityType);
+    query["creds-type"] = input.IdentityType;
   }
   if (input.ResetDisabled !== undefined) {
-    query[
-      __extendedEncodeURIComponent("reset-disabled")
-    ] = __extendedEncodeURIComponent(input.ResetDisabled.toString());
+    query["reset-disabled"] = input.ResetDisabled.toString();
   }
   if (input.SessionLifetimeInMinutes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("session-lifetime")
-    ] = __extendedEncodeURIComponent(input.SessionLifetimeInMinutes.toString());
+    query["session-lifetime"] = input.SessionLifetimeInMinutes.toString();
   }
   if (input.UndoRedoDisabled !== undefined) {
-    query[
-      __extendedEncodeURIComponent("undo-redo-disabled")
-    ] = __extendedEncodeURIComponent(input.UndoRedoDisabled.toString());
+    query["undo-redo-disabled"] = input.UndoRedoDisabled.toString();
   }
   if (input.UserArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("user-arn")
-    ] = __extendedEncodeURIComponent(input.UserArn);
+    query["user-arn"] = input.UserArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2344,14 +2322,10 @@ export async function serializeAws_restJson1_1ListDashboardVersionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2386,14 +2360,10 @@ export async function serializeAws_restJson1_1ListDashboardsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2428,14 +2398,10 @@ export async function serializeAws_restJson1_1ListDataSetsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2470,14 +2436,10 @@ export async function serializeAws_restJson1_1ListDataSourcesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2537,14 +2499,10 @@ export async function serializeAws_restJson1_1ListGroupMembershipsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2591,14 +2549,10 @@ export async function serializeAws_restJson1_1ListGroupsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2646,14 +2600,10 @@ export async function serializeAws_restJson1_1ListIAMPolicyAssignmentsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   let body: any;
   const bodyParams: any = {};
@@ -2720,14 +2670,10 @@ export async function serializeAws_restJson1_1ListIAMPolicyAssignmentsForUserCom
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2775,14 +2721,10 @@ export async function serializeAws_restJson1_1ListIngestionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2859,14 +2801,10 @@ export async function serializeAws_restJson1_1ListTemplateAliasesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-result")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-result"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2913,14 +2851,10 @@ export async function serializeAws_restJson1_1ListTemplateVersionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2955,14 +2889,10 @@ export async function serializeAws_restJson1_1ListTemplatesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-result")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-result"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3022,14 +2952,10 @@ export async function serializeAws_restJson1_1ListUserGroupsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3076,14 +3002,10 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-results")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["max-results"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next-token")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["next-token"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3219,9 +3141,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("keys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["keys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-ram/protocols/Aws_restJson1_1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1_1.ts
@@ -292,14 +292,10 @@ export async function serializeAws_restJson1_1DeleteResourceShareCommand(
   let resolvedPath = "/deleteresourceshare";
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("clientToken")
-    ] = __extendedEncodeURIComponent(input.clientToken);
+    query["clientToken"] = input.clientToken;
   }
   if (input.resourceShareArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceShareArn")
-    ] = __extendedEncodeURIComponent(input.resourceShareArn);
+    query["resourceShareArn"] = input.resourceShareArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -786,9 +782,7 @@ export async function serializeAws_restJson1_1PromoteResourceShareCreatedFromPol
   let resolvedPath = "/promoteresourcesharecreatedfrompolicy";
   const query: any = {};
   if (input.resourceShareArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceShareArn")
-    ] = __extendedEncodeURIComponent(input.resourceShareArn);
+    query["resourceShareArn"] = input.resourceShareArn;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
@@ -243,14 +243,10 @@ export async function serializeAws_restJson1_1ListGroupResourcesCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   let body: any;
   const bodyParams: any = {};
@@ -281,14 +277,10 @@ export async function serializeAws_restJson1_1ListGroupsCommand(
   let resolvedPath = "/groups-list";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   let body: any;
   const bodyParams: any = {};

--- a/clients/client-robomaker/protocols/Aws_restJson1_1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1_1.ts
@@ -1232,9 +1232,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -1201,19 +1201,13 @@ export async function serializeAws_restXmlGetGeoLocationCommand(
   let resolvedPath = "/2013-04-01/geolocation";
   const query: any = {};
   if (input.ContinentCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("continentcode")
-    ] = __extendedEncodeURIComponent(input.ContinentCode);
+    query["continentcode"] = input.ContinentCode;
   }
   if (input.CountryCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("countrycode")
-    ] = __extendedEncodeURIComponent(input.CountryCode);
+    query["countrycode"] = input.CountryCode;
   }
   if (input.SubdivisionCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("subdivisioncode")
-    ] = __extendedEncodeURIComponent(input.SubdivisionCode);
+    query["subdivisioncode"] = input.SubdivisionCode;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1610,24 +1604,16 @@ export async function serializeAws_restXmlListGeoLocationsCommand(
   let resolvedPath = "/2013-04-01/geolocations";
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   if (input.StartContinentCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startcontinentcode")
-    ] = __extendedEncodeURIComponent(input.StartContinentCode);
+    query["startcontinentcode"] = input.StartContinentCode;
   }
   if (input.StartCountryCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startcountrycode")
-    ] = __extendedEncodeURIComponent(input.StartCountryCode);
+    query["startcountrycode"] = input.StartCountryCode;
   }
   if (input.StartSubdivisionCode !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startsubdivisioncode")
-    ] = __extendedEncodeURIComponent(input.StartSubdivisionCode);
+    query["startsubdivisioncode"] = input.StartSubdivisionCode;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1648,14 +1634,10 @@ export async function serializeAws_restXmlListHealthChecksCommand(
   let resolvedPath = "/2013-04-01/healthcheck";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1676,19 +1658,13 @@ export async function serializeAws_restXmlListHostedZonesCommand(
   let resolvedPath = "/2013-04-01/hostedzone";
   const query: any = {};
   if (input.DelegationSetId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("delegationsetid")
-    ] = __extendedEncodeURIComponent(input.DelegationSetId);
+    query["delegationsetid"] = input.DelegationSetId;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1709,19 +1685,13 @@ export async function serializeAws_restXmlListHostedZonesByNameCommand(
   let resolvedPath = "/2013-04-01/hostedzonesbyname";
   const query: any = {};
   if (input.DNSName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("dnsname")
-    ] = __extendedEncodeURIComponent(input.DNSName);
+    query["dnsname"] = input.DNSName;
   }
   if (input.HostedZoneId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("hostedzoneid")
-    ] = __extendedEncodeURIComponent(input.HostedZoneId);
+    query["hostedzoneid"] = input.HostedZoneId;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1742,19 +1712,13 @@ export async function serializeAws_restXmlListQueryLoggingConfigsCommand(
   let resolvedPath = "/2013-04-01/queryloggingconfig";
   const query: any = {};
   if (input.HostedZoneId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("hostedzoneid")
-    ] = __extendedEncodeURIComponent(input.HostedZoneId);
+    query["hostedzoneid"] = input.HostedZoneId;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxresults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxresults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nexttoken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nexttoken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1789,24 +1753,16 @@ export async function serializeAws_restXmlListResourceRecordSetsCommand(
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   if (input.StartRecordIdentifier !== undefined) {
-    query[
-      __extendedEncodeURIComponent("identifier")
-    ] = __extendedEncodeURIComponent(input.StartRecordIdentifier);
+    query["identifier"] = input.StartRecordIdentifier;
   }
   if (input.StartRecordName !== undefined) {
-    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
-      input.StartRecordName
-    );
+    query["name"] = input.StartRecordName;
   }
   if (input.StartRecordType !== undefined) {
-    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
-      input.StartRecordType
-    );
+    query["type"] = input.StartRecordType;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1827,14 +1783,10 @@ export async function serializeAws_restXmlListReusableDelegationSetsCommand(
   let resolvedPath = "/2013-04-01/delegationset";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1947,14 +1899,10 @@ export async function serializeAws_restXmlListTrafficPoliciesCommand(
   let resolvedPath = "/2013-04-01/trafficpolicies";
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   if (input.TrafficPolicyIdMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyid")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyIdMarker);
+    query["trafficpolicyid"] = input.TrafficPolicyIdMarker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1975,24 +1923,16 @@ export async function serializeAws_restXmlListTrafficPolicyInstancesCommand(
   let resolvedPath = "/2013-04-01/trafficpolicyinstances";
   const query: any = {};
   if (input.HostedZoneIdMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("hostedzoneid")
-    ] = __extendedEncodeURIComponent(input.HostedZoneIdMarker);
+    query["hostedzoneid"] = input.HostedZoneIdMarker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   if (input.TrafficPolicyInstanceNameMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyinstancename")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceNameMarker);
+    query["trafficpolicyinstancename"] = input.TrafficPolicyInstanceNameMarker;
   }
   if (input.TrafficPolicyInstanceTypeMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyinstancetype")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceTypeMarker);
+    query["trafficpolicyinstancetype"] = input.TrafficPolicyInstanceTypeMarker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2013,24 +1953,16 @@ export async function serializeAws_restXmlListTrafficPolicyInstancesByHostedZone
   let resolvedPath = "/2013-04-01/trafficpolicyinstances/hostedzone";
   const query: any = {};
   if (input.HostedZoneId !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.HostedZoneId
-    );
+    query["id"] = input.HostedZoneId;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   if (input.TrafficPolicyInstanceNameMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyinstancename")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceNameMarker);
+    query["trafficpolicyinstancename"] = input.TrafficPolicyInstanceNameMarker;
   }
   if (input.TrafficPolicyInstanceTypeMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyinstancetype")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceTypeMarker);
+    query["trafficpolicyinstancetype"] = input.TrafficPolicyInstanceTypeMarker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2051,34 +1983,22 @@ export async function serializeAws_restXmlListTrafficPolicyInstancesByPolicyComm
   let resolvedPath = "/2013-04-01/trafficpolicyinstances/trafficpolicy";
   const query: any = {};
   if (input.HostedZoneIdMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("hostedzoneid")
-    ] = __extendedEncodeURIComponent(input.HostedZoneIdMarker);
+    query["hostedzoneid"] = input.HostedZoneIdMarker;
   }
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   if (input.TrafficPolicyId !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.TrafficPolicyId
-    );
+    query["id"] = input.TrafficPolicyId;
   }
   if (input.TrafficPolicyInstanceNameMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyinstancename")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceNameMarker);
+    query["trafficpolicyinstancename"] = input.TrafficPolicyInstanceNameMarker;
   }
   if (input.TrafficPolicyInstanceTypeMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyinstancetype")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceTypeMarker);
+    query["trafficpolicyinstancetype"] = input.TrafficPolicyInstanceTypeMarker;
   }
   if (input.TrafficPolicyVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyVersion.toString());
+    query["version"] = input.TrafficPolicyVersion.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2111,14 +2031,10 @@ export async function serializeAws_restXmlListTrafficPolicyVersionsCommand(
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxitems")
-    ] = __extendedEncodeURIComponent(input.MaxItems);
+    query["maxitems"] = input.MaxItems;
   }
   if (input.TrafficPolicyVersionMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("trafficpolicyversion")
-    ] = __extendedEncodeURIComponent(input.TrafficPolicyVersionMarker);
+    query["trafficpolicyversion"] = input.TrafficPolicyVersionMarker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2154,14 +2070,10 @@ export async function serializeAws_restXmlListVPCAssociationAuthorizationsComman
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxresults")
-    ] = __extendedEncodeURIComponent(input.MaxResults);
+    query["maxresults"] = input.MaxResults;
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nexttoken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nexttoken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2182,34 +2094,22 @@ export async function serializeAws_restXmlTestDNSAnswerCommand(
   let resolvedPath = "/2013-04-01/testdnsanswer";
   const query: any = {};
   if (input.EDNS0ClientSubnetIP !== undefined) {
-    query[
-      __extendedEncodeURIComponent("edns0clientsubnetip")
-    ] = __extendedEncodeURIComponent(input.EDNS0ClientSubnetIP);
+    query["edns0clientsubnetip"] = input.EDNS0ClientSubnetIP;
   }
   if (input.EDNS0ClientSubnetMask !== undefined) {
-    query[
-      __extendedEncodeURIComponent("edns0clientsubnetmask")
-    ] = __extendedEncodeURIComponent(input.EDNS0ClientSubnetMask);
+    query["edns0clientsubnetmask"] = input.EDNS0ClientSubnetMask;
   }
   if (input.HostedZoneId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("hostedzoneid")
-    ] = __extendedEncodeURIComponent(input.HostedZoneId);
+    query["hostedzoneid"] = input.HostedZoneId;
   }
   if (input.RecordName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("recordname")
-    ] = __extendedEncodeURIComponent(input.RecordName);
+    query["recordname"] = input.RecordName;
   }
   if (input.RecordType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("recordtype")
-    ] = __extendedEncodeURIComponent(input.RecordType);
+    query["recordtype"] = input.RecordType;
   }
   if (input.ResolverIP !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resolverip")
-    ] = __extendedEncodeURIComponent(input.ResolverIP);
+    query["resolverip"] = input.ResolverIP;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -494,19 +494,13 @@ export async function serializeAws_restXmlListAccessPointsCommand(
   let resolvedPath = "/v20180820/accesspoint";
   const query: any = {};
   if (input.Bucket !== undefined) {
-    query[
-      __extendedEncodeURIComponent("bucket")
-    ] = __extendedEncodeURIComponent(input.Bucket);
+    query["bucket"] = input.Bucket;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -530,19 +524,13 @@ export async function serializeAws_restXmlListJobsCommand(
   let resolvedPath = "/v20180820/jobs";
   const query: any = {};
   if (input.JobStatuses !== undefined) {
-    query[
-      __extendedEncodeURIComponent("jobStatuses")
-    ] = input.JobStatuses.map(entry => __extendedEncodeURIComponent(entry));
+    query["jobStatuses"] = input.JobStatuses;
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["maxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -658,9 +646,7 @@ export async function serializeAws_restXmlUpdateJobPriorityCommand(
   }
   const query: any = {};
   if (input.Priority !== undefined) {
-    query[
-      __extendedEncodeURIComponent("priority")
-    ] = __extendedEncodeURIComponent(input.Priority.toString());
+    query["priority"] = input.Priority.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -696,14 +682,10 @@ export async function serializeAws_restXmlUpdateJobStatusCommand(
   }
   const query: any = {};
   if (input.RequestedJobStatus !== undefined) {
-    query[
-      __extendedEncodeURIComponent("requestedJobStatus")
-    ] = __extendedEncodeURIComponent(input.RequestedJobStatus);
+    query["requestedJobStatus"] = input.RequestedJobStatus;
   }
   if (input.StatusUpdateReason !== undefined) {
-    query[
-      __extendedEncodeURIComponent("statusUpdateReason")
-    ] = __extendedEncodeURIComponent(input.StatusUpdateReason);
+    query["statusUpdateReason"] = input.StatusUpdateReason;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -525,9 +525,7 @@ export async function serializeAws_restXmlAbortMultipartUploadCommand(
     "x-id": "AbortMultipartUpload"
   };
   if (input.UploadId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("uploadId")
-    ] = __extendedEncodeURIComponent(input.UploadId);
+    query["uploadId"] = input.UploadId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -578,9 +576,7 @@ export async function serializeAws_restXmlCompleteMultipartUploadCommand(
   }
   const query: any = {};
   if (input.UploadId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("uploadId")
-    ] = __extendedEncodeURIComponent(input.UploadId);
+    query["uploadId"] = input.UploadId;
   }
   let body: any;
   let contents: any;
@@ -1013,9 +1009,7 @@ export async function serializeAws_restXmlDeleteBucketAnalyticsConfigurationComm
     analytics: ""
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1114,9 +1108,7 @@ export async function serializeAws_restXmlDeleteBucketInventoryConfigurationComm
     inventory: ""
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1183,9 +1175,7 @@ export async function serializeAws_restXmlDeleteBucketMetricsConfigurationComman
     metrics: ""
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1374,9 +1364,7 @@ export async function serializeAws_restXmlDeleteObjectCommand(
     "x-id": "DeleteObject"
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1426,9 +1414,7 @@ export async function serializeAws_restXmlDeleteObjectTaggingCommand(
     tagging: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1612,9 +1598,7 @@ export async function serializeAws_restXmlGetBucketAnalyticsConfigurationCommand
     "x-id": "GetBucketAnalyticsConfiguration"
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1714,9 +1698,7 @@ export async function serializeAws_restXmlGetBucketInventoryConfigurationCommand
     "x-id": "GetBucketInventoryConfiguration"
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1848,9 +1830,7 @@ export async function serializeAws_restXmlGetBucketMetricsConfigurationCommand(
     "x-id": "GetBucketMetricsConfiguration"
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2185,44 +2165,28 @@ export async function serializeAws_restXmlGetObjectCommand(
     "x-id": "GetObject"
   };
   if (input.PartNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("partNumber")
-    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
+    query["partNumber"] = input.PartNumber.toString();
   }
   if (input.ResponseCacheControl !== undefined) {
-    query[
-      __extendedEncodeURIComponent("response-cache-control")
-    ] = __extendedEncodeURIComponent(input.ResponseCacheControl);
+    query["response-cache-control"] = input.ResponseCacheControl;
   }
   if (input.ResponseContentDisposition !== undefined) {
-    query[
-      __extendedEncodeURIComponent("response-content-disposition")
-    ] = __extendedEncodeURIComponent(input.ResponseContentDisposition);
+    query["response-content-disposition"] = input.ResponseContentDisposition;
   }
   if (input.ResponseContentEncoding !== undefined) {
-    query[
-      __extendedEncodeURIComponent("response-content-encoding")
-    ] = __extendedEncodeURIComponent(input.ResponseContentEncoding);
+    query["response-content-encoding"] = input.ResponseContentEncoding;
   }
   if (input.ResponseContentLanguage !== undefined) {
-    query[
-      __extendedEncodeURIComponent("response-content-language")
-    ] = __extendedEncodeURIComponent(input.ResponseContentLanguage);
+    query["response-content-language"] = input.ResponseContentLanguage;
   }
   if (input.ResponseContentType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("response-content-type")
-    ] = __extendedEncodeURIComponent(input.ResponseContentType);
+    query["response-content-type"] = input.ResponseContentType;
   }
   if (input.ResponseExpires !== undefined) {
-    query[
-      __extendedEncodeURIComponent("response-expires")
-    ] = __extendedEncodeURIComponent(input.ResponseExpires.toISOString());
+    query["response-expires"] = input.ResponseExpires.toISOString();
   }
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2275,9 +2239,7 @@ export async function serializeAws_restXmlGetObjectAclCommand(
     acl: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2330,9 +2292,7 @@ export async function serializeAws_restXmlGetObjectLegalHoldCommand(
     "legal-hold": ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2417,9 +2377,7 @@ export async function serializeAws_restXmlGetObjectRetentionCommand(
     retention: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2469,9 +2427,7 @@ export async function serializeAws_restXmlGetObjectTaggingCommand(
     tagging: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2658,14 +2614,10 @@ export async function serializeAws_restXmlHeadObjectCommand(
   }
   const query: any = {};
   if (input.PartNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("partNumber")
-    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
+    query["partNumber"] = input.PartNumber.toString();
   }
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2701,9 +2653,7 @@ export async function serializeAws_restXmlListBucketAnalyticsConfigurationsComma
     "x-id": "ListBucketAnalyticsConfigurations"
   };
   if (input.ContinuationToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("continuation-token")
-    ] = __extendedEncodeURIComponent(input.ContinuationToken);
+    query["continuation-token"] = input.ContinuationToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2739,9 +2689,7 @@ export async function serializeAws_restXmlListBucketInventoryConfigurationsComma
     "x-id": "ListBucketInventoryConfigurations"
   };
   if (input.ContinuationToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("continuation-token")
-    ] = __extendedEncodeURIComponent(input.ContinuationToken);
+    query["continuation-token"] = input.ContinuationToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2777,9 +2725,7 @@ export async function serializeAws_restXmlListBucketMetricsConfigurationsCommand
     "x-id": "ListBucketMetricsConfigurations"
   };
   if (input.ContinuationToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("continuation-token")
-    ] = __extendedEncodeURIComponent(input.ContinuationToken);
+    query["continuation-token"] = input.ContinuationToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2830,34 +2776,22 @@ export async function serializeAws_restXmlListMultipartUploadsCommand(
     uploads: ""
   };
   if (input.Delimiter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("delimiter")
-    ] = __extendedEncodeURIComponent(input.Delimiter);
+    query["delimiter"] = input.Delimiter;
   }
   if (input.EncodingType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("encoding-type")
-    ] = __extendedEncodeURIComponent(input.EncodingType);
+    query["encoding-type"] = input.EncodingType;
   }
   if (input.KeyMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("key-marker")
-    ] = __extendedEncodeURIComponent(input.KeyMarker);
+    query["key-marker"] = input.KeyMarker;
   }
   if (input.MaxUploads !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-uploads")
-    ] = __extendedEncodeURIComponent(input.MaxUploads.toString());
+    query["max-uploads"] = input.MaxUploads.toString();
   }
   if (input.Prefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("prefix")
-    ] = __extendedEncodeURIComponent(input.Prefix);
+    query["prefix"] = input.Prefix;
   }
   if (input.UploadIdMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("upload-id-marker")
-    ] = __extendedEncodeURIComponent(input.UploadIdMarker);
+    query["upload-id-marker"] = input.UploadIdMarker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2892,34 +2826,22 @@ export async function serializeAws_restXmlListObjectVersionsCommand(
     versions: ""
   };
   if (input.Delimiter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("delimiter")
-    ] = __extendedEncodeURIComponent(input.Delimiter);
+    query["delimiter"] = input.Delimiter;
   }
   if (input.EncodingType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("encoding-type")
-    ] = __extendedEncodeURIComponent(input.EncodingType);
+    query["encoding-type"] = input.EncodingType;
   }
   if (input.KeyMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("key-marker")
-    ] = __extendedEncodeURIComponent(input.KeyMarker);
+    query["key-marker"] = input.KeyMarker;
   }
   if (input.MaxKeys !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-keys")
-    ] = __extendedEncodeURIComponent(input.MaxKeys.toString());
+    query["max-keys"] = input.MaxKeys.toString();
   }
   if (input.Prefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("prefix")
-    ] = __extendedEncodeURIComponent(input.Prefix);
+    query["prefix"] = input.Prefix;
   }
   if (input.VersionIdMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("version-id-marker")
-    ] = __extendedEncodeURIComponent(input.VersionIdMarker);
+    query["version-id-marker"] = input.VersionIdMarker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2955,29 +2877,19 @@ export async function serializeAws_restXmlListObjectsCommand(
   }
   const query: any = {};
   if (input.Delimiter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("delimiter")
-    ] = __extendedEncodeURIComponent(input.Delimiter);
+    query["delimiter"] = input.Delimiter;
   }
   if (input.EncodingType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("encoding-type")
-    ] = __extendedEncodeURIComponent(input.EncodingType);
+    query["encoding-type"] = input.EncodingType;
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.MaxKeys !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-keys")
-    ] = __extendedEncodeURIComponent(input.MaxKeys.toString());
+    query["max-keys"] = input.MaxKeys.toString();
   }
   if (input.Prefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("prefix")
-    ] = __extendedEncodeURIComponent(input.Prefix);
+    query["prefix"] = input.Prefix;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3015,39 +2927,25 @@ export async function serializeAws_restXmlListObjectsV2Command(
     "list-type": "2"
   };
   if (input.ContinuationToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("continuation-token")
-    ] = __extendedEncodeURIComponent(input.ContinuationToken);
+    query["continuation-token"] = input.ContinuationToken;
   }
   if (input.Delimiter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("delimiter")
-    ] = __extendedEncodeURIComponent(input.Delimiter);
+    query["delimiter"] = input.Delimiter;
   }
   if (input.EncodingType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("encoding-type")
-    ] = __extendedEncodeURIComponent(input.EncodingType);
+    query["encoding-type"] = input.EncodingType;
   }
   if (input.FetchOwner !== undefined) {
-    query[
-      __extendedEncodeURIComponent("fetch-owner")
-    ] = __extendedEncodeURIComponent(input.FetchOwner.toString());
+    query["fetch-owner"] = input.FetchOwner.toString();
   }
   if (input.MaxKeys !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-keys")
-    ] = __extendedEncodeURIComponent(input.MaxKeys.toString());
+    query["max-keys"] = input.MaxKeys.toString();
   }
   if (input.Prefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("prefix")
-    ] = __extendedEncodeURIComponent(input.Prefix);
+    query["prefix"] = input.Prefix;
   }
   if (input.StartAfter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("start-after")
-    ] = __extendedEncodeURIComponent(input.StartAfter);
+    query["start-after"] = input.StartAfter;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3100,19 +2998,13 @@ export async function serializeAws_restXmlListPartsCommand(
     "x-id": "ListParts"
   };
   if (input.MaxParts !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max-parts")
-    ] = __extendedEncodeURIComponent(input.MaxParts.toString());
+    query["max-parts"] = input.MaxParts.toString();
   }
   if (input.PartNumberMarker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("part-number-marker")
-    ] = __extendedEncodeURIComponent(input.PartNumberMarker.toString());
+    query["part-number-marker"] = input.PartNumberMarker.toString();
   }
   if (input.UploadId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("uploadId")
-    ] = __extendedEncodeURIComponent(input.UploadId);
+    query["uploadId"] = input.UploadId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3256,9 +3148,7 @@ export async function serializeAws_restXmlPutBucketAnalyticsConfigurationCommand
     analytics: ""
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   let body: any;
   let contents: any;
@@ -3399,9 +3289,7 @@ export async function serializeAws_restXmlPutBucketInventoryConfigurationCommand
     inventory: ""
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   let body: any;
   let contents: any;
@@ -3539,9 +3427,7 @@ export async function serializeAws_restXmlPutBucketMetricsConfigurationCommand(
     metrics: ""
   };
   if (input.Id !== undefined) {
-    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
-      input.Id
-    );
+    query["id"] = input.Id;
   }
   let body: any;
   let contents: any;
@@ -4103,9 +3989,7 @@ export async function serializeAws_restXmlPutObjectAclCommand(
     acl: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   let body: any;
   let contents: any;
@@ -4173,9 +4057,7 @@ export async function serializeAws_restXmlPutObjectLegalHoldCommand(
     "legal-hold": ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   let body: any;
   let contents: any;
@@ -4301,9 +4183,7 @@ export async function serializeAws_restXmlPutObjectRetentionCommand(
     retention: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   let body: any;
   let contents: any;
@@ -4368,9 +4248,7 @@ export async function serializeAws_restXmlPutObjectTaggingCommand(
     tagging: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   let body: any;
   let contents: any;
@@ -4479,9 +4357,7 @@ export async function serializeAws_restXmlRestoreObjectCommand(
     restore: ""
   };
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   let body: any;
   let contents: any;
@@ -4665,14 +4541,10 @@ export async function serializeAws_restXmlUploadPartCommand(
     "x-id": "UploadPart"
   };
   if (input.PartNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("partNumber")
-    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
+    query["partNumber"] = input.PartNumber.toString();
   }
   if (input.UploadId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("uploadId")
-    ] = __extendedEncodeURIComponent(input.UploadId);
+    query["uploadId"] = input.UploadId;
   }
   let body: any;
   let contents: any;
@@ -4777,14 +4649,10 @@ export async function serializeAws_restXmlUploadPartCopyCommand(
     "x-id": "UploadPartCopy"
   };
   if (input.PartNumber !== undefined) {
-    query[
-      __extendedEncodeURIComponent("partNumber")
-    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
+    query["partNumber"] = input.PartNumber.toString();
   }
   if (input.UploadId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("uploadId")
-    ] = __extendedEncodeURIComponent(input.UploadId);
+    query["uploadId"] = input.UploadId;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
@@ -116,29 +116,19 @@ export async function serializeAws_restJson1_1ListHumanLoopsCommand(
   let resolvedPath = "/human-loops";
   const query: any = {};
   if (input.CreationTimeAfter !== undefined) {
-    query[
-      __extendedEncodeURIComponent("CreationTimeAfter")
-    ] = __extendedEncodeURIComponent(input.CreationTimeAfter.toISOString());
+    query["CreationTimeAfter"] = input.CreationTimeAfter.toISOString();
   }
   if (input.CreationTimeBefore !== undefined) {
-    query[
-      __extendedEncodeURIComponent("CreationTimeBefore")
-    ] = __extendedEncodeURIComponent(input.CreationTimeBefore.toISOString());
+    query["CreationTimeBefore"] = input.CreationTimeBefore.toISOString();
   }
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.SortOrder !== undefined) {
-    query[
-      __extendedEncodeURIComponent("SortOrder")
-    ] = __extendedEncodeURIComponent(input.SortOrder);
+    query["SortOrder"] = input.SortOrder;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-schemas/protocols/Aws_restJson1_1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1_1.ts
@@ -483,9 +483,7 @@ export async function serializeAws_restJson1_1DescribeCodeBindingCommand(
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("schemaVersion")
-    ] = __extendedEncodeURIComponent(input.SchemaVersion);
+    query["schemaVersion"] = input.SchemaVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -593,9 +591,7 @@ export async function serializeAws_restJson1_1DescribeSchemaCommand(
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("schemaVersion")
-    ] = __extendedEncodeURIComponent(input.SchemaVersion);
+    query["schemaVersion"] = input.SchemaVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -655,9 +651,7 @@ export async function serializeAws_restJson1_1GetCodeBindingSourceCommand(
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("schemaVersion")
-    ] = __extendedEncodeURIComponent(input.SchemaVersion);
+    query["schemaVersion"] = input.SchemaVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -709,24 +703,16 @@ export async function serializeAws_restJson1_1ListDiscoverersCommand(
   let resolvedPath = "/v1/discoverers";
   const query: any = {};
   if (input.DiscovererIdPrefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("discovererIdPrefix")
-    ] = __extendedEncodeURIComponent(input.DiscovererIdPrefix);
+    query["discovererIdPrefix"] = input.DiscovererIdPrefix;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.SourceArnPrefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("sourceArnPrefix")
-    ] = __extendedEncodeURIComponent(input.SourceArnPrefix);
+    query["sourceArnPrefix"] = input.SourceArnPrefix;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -747,24 +733,16 @@ export async function serializeAws_restJson1_1ListRegistriesCommand(
   let resolvedPath = "/v1/registries";
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.RegistryNamePrefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("registryNamePrefix")
-    ] = __extendedEncodeURIComponent(input.RegistryNamePrefix);
+    query["registryNamePrefix"] = input.RegistryNamePrefix;
   }
   if (input.Scope !== undefined) {
-    query[__extendedEncodeURIComponent("scope")] = __extendedEncodeURIComponent(
-      input.Scope
-    );
+    query["scope"] = input.Scope;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -812,14 +790,10 @@ export async function serializeAws_restJson1_1ListSchemaVersionsCommand(
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -854,19 +828,13 @@ export async function serializeAws_restJson1_1ListSchemasCommand(
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.SchemaNamePrefix !== undefined) {
-    query[
-      __extendedEncodeURIComponent("schemaNamePrefix")
-    ] = __extendedEncodeURIComponent(input.SchemaNamePrefix);
+    query["schemaNamePrefix"] = input.SchemaNamePrefix;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -982,9 +950,7 @@ export async function serializeAws_restJson1_1PutCodeBindingCommand(
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("schemaVersion")
-    ] = __extendedEncodeURIComponent(input.SchemaVersion);
+    query["schemaVersion"] = input.SchemaVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1019,19 +985,13 @@ export async function serializeAws_restJson1_1SearchSchemasCommand(
   }
   const query: any = {};
   if (input.Keywords !== undefined) {
-    query[
-      __extendedEncodeURIComponent("keywords")
-    ] = __extendedEncodeURIComponent(input.Keywords);
+    query["keywords"] = input.Keywords;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1186,9 +1146,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-securityhub/protocols/Aws_restJson1_1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1_1.ts
@@ -620,9 +620,7 @@ export async function serializeAws_restJson1_1DescribeHubCommand(
   let resolvedPath = "/accounts";
   const query: any = {};
   if (input.HubArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("HubArn")
-    ] = __extendedEncodeURIComponent(input.HubArn);
+    query["HubArn"] = input.HubArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -643,14 +641,10 @@ export async function serializeAws_restJson1_1DescribeProductsCommand(
   let resolvedPath = "/products";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -690,14 +684,10 @@ export async function serializeAws_restJson1_1DescribeStandardsControlsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1076,14 +1066,10 @@ export async function serializeAws_restJson1_1ListEnabledProductsForImportComman
   let resolvedPath = "/productSubscriptions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1104,14 +1090,10 @@ export async function serializeAws_restJson1_1ListInvitationsCommand(
   let resolvedPath = "/invitations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1132,19 +1114,13 @@ export async function serializeAws_restJson1_1ListMembersCommand(
   let resolvedPath = "/members";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("MaxResults")
-    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
+    query["MaxResults"] = input.MaxResults.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.OnlyAssociated !== undefined) {
-    query[
-      __extendedEncodeURIComponent("OnlyAssociated")
-    ] = __extendedEncodeURIComponent(input.OnlyAssociated.toString());
+    query["OnlyAssociated"] = input.OnlyAssociated.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1246,9 +1222,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
@@ -394,9 +394,7 @@ export async function serializeAws_restJson1_1GetApplicationCommand(
   }
   const query: any = {};
   if (input.SemanticVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("semanticVersion")
-    ] = __extendedEncodeURIComponent(input.SemanticVersion);
+    query["semanticVersion"] = input.SemanticVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -503,19 +501,13 @@ export async function serializeAws_restJson1_1ListApplicationDependenciesCommand
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["maxItems"] = input.MaxItems.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   if (input.SemanticVersion !== undefined) {
-    query[
-      __extendedEncodeURIComponent("semanticVersion")
-    ] = __extendedEncodeURIComponent(input.SemanticVersion);
+    query["semanticVersion"] = input.SemanticVersion;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -550,14 +542,10 @@ export async function serializeAws_restJson1_1ListApplicationVersionsCommand(
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["maxItems"] = input.MaxItems.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -578,14 +566,10 @@ export async function serializeAws_restJson1_1ListApplicationsCommand(
   let resolvedPath = "/applications";
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxItems")
-    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
+    query["maxItems"] = input.MaxItems.toString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["nextToken"] = input.NextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-sesv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1_1.ts
@@ -661,11 +661,7 @@ export async function serializeAws_restJson1_1GetBlacklistReportsCommand(
   let resolvedPath = "/v2/email/deliverability-dashboard/blacklist-report";
   const query: any = {};
   if (input.BlacklistItemNames !== undefined) {
-    query[
-      __extendedEncodeURIComponent("BlacklistItemNames")
-    ] = input.BlacklistItemNames.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["BlacklistItemNames"] = input.BlacklistItemNames;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -779,19 +775,13 @@ export async function serializeAws_restJson1_1GetDedicatedIpsCommand(
   let resolvedPath = "/v2/email/dedicated-ips";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   if (input.PoolName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PoolName")
-    ] = __extendedEncodeURIComponent(input.PoolName);
+    query["PoolName"] = input.PoolName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -899,14 +889,10 @@ export async function serializeAws_restJson1_1GetDomainStatisticsReportCommand(
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("EndDate")
-    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
+    query["EndDate"] = input.EndDate.toISOString();
   }
   if (input.StartDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("StartDate")
-    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
+    query["StartDate"] = input.StartDate.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -987,14 +973,10 @@ export async function serializeAws_restJson1_1ListConfigurationSetsCommand(
   let resolvedPath = "/v2/email/configuration-sets";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1015,14 +997,10 @@ export async function serializeAws_restJson1_1ListDedicatedIpPoolsCommand(
   let resolvedPath = "/v2/email/dedicated-ip-pools";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1043,14 +1021,10 @@ export async function serializeAws_restJson1_1ListDeliverabilityTestReportsComma
   let resolvedPath = "/v2/email/deliverability-dashboard/test-reports";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1088,24 +1062,16 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("EndDate")
-    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
+    query["EndDate"] = input.EndDate.toISOString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   if (input.StartDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("StartDate")
-    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
+    query["StartDate"] = input.StartDate.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1126,14 +1092,10 @@ export async function serializeAws_restJson1_1ListEmailIdentitiesCommand(
   let resolvedPath = "/v2/email/identities";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1154,29 +1116,19 @@ export async function serializeAws_restJson1_1ListSuppressedDestinationsCommand(
   let resolvedPath = "/v2/email/suppression/addresses";
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("EndDate")
-    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
+    query["EndDate"] = input.EndDate.toISOString();
   }
   if (input.NextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("NextToken")
-    ] = __extendedEncodeURIComponent(input.NextToken);
+    query["NextToken"] = input.NextToken;
   }
   if (input.PageSize !== undefined) {
-    query[
-      __extendedEncodeURIComponent("PageSize")
-    ] = __extendedEncodeURIComponent(input.PageSize.toString());
+    query["PageSize"] = input.PageSize.toString();
   }
   if (input.Reasons !== undefined) {
-    query[__extendedEncodeURIComponent("Reason")] = input.Reasons.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["Reason"] = input.Reasons;
   }
   if (input.StartDate !== undefined) {
-    query[
-      __extendedEncodeURIComponent("StartDate")
-    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
+    query["StartDate"] = input.StartDate.toISOString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1197,9 +1149,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/v2/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("ResourceArn")
-    ] = __extendedEncodeURIComponent(input.ResourceArn);
+    query["ResourceArn"] = input.ResourceArn;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1868,14 +1818,10 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/v2/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query[
-      __extendedEncodeURIComponent("ResourceArn")
-    ] = __extendedEncodeURIComponent(input.ResourceArn);
+    query["ResourceArn"] = input.ResourceArn;
   }
   if (input.TagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("TagKeys")] = input.TagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["TagKeys"] = input.TagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-signer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1_1.ts
@@ -215,29 +215,19 @@ export async function serializeAws_restJson1_1ListSigningJobsCommand(
   let resolvedPath = "/signing-jobs";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.platformId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("platformId")
-    ] = __extendedEncodeURIComponent(input.platformId);
+    query["platformId"] = input.platformId;
   }
   if (input.requestedBy !== undefined) {
-    query[
-      __extendedEncodeURIComponent("requestedBy")
-    ] = __extendedEncodeURIComponent(input.requestedBy);
+    query["requestedBy"] = input.requestedBy;
   }
   if (input.status !== undefined) {
-    query[
-      __extendedEncodeURIComponent("status")
-    ] = __extendedEncodeURIComponent(input.status);
+    query["status"] = input.status;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -258,29 +248,19 @@ export async function serializeAws_restJson1_1ListSigningPlatformsCommand(
   let resolvedPath = "/signing-platforms";
   const query: any = {};
   if (input.category !== undefined) {
-    query[
-      __extendedEncodeURIComponent("category")
-    ] = __extendedEncodeURIComponent(input.category);
+    query["category"] = input.category;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   if (input.partner !== undefined) {
-    query[
-      __extendedEncodeURIComponent("partner")
-    ] = __extendedEncodeURIComponent(input.partner);
+    query["partner"] = input.partner;
   }
   if (input.target !== undefined) {
-    query[
-      __extendedEncodeURIComponent("target")
-    ] = __extendedEncodeURIComponent(input.target);
+    query["target"] = input.target;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -301,19 +281,13 @@ export async function serializeAws_restJson1_1ListSigningProfilesCommand(
   let resolvedPath = "/signing-profiles";
   const query: any = {};
   if (input.includeCanceled !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeCanceled")
-    ] = __extendedEncodeURIComponent(input.includeCanceled.toString());
+    query["includeCanceled"] = input.includeCanceled.toString();
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("maxResults")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["maxResults"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("nextToken")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["nextToken"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -514,9 +488,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["tagKeys"] = input.tagKeys;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-sso/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1_1.ts
@@ -50,14 +50,10 @@ export async function serializeAws_restJson1_1GetRoleCredentialsCommand(
   let resolvedPath = "/federation/credentials";
   const query: any = {};
   if (input.accountId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("account_id")
-    ] = __extendedEncodeURIComponent(input.accountId);
+    query["account_id"] = input.accountId;
   }
   if (input.roleName !== undefined) {
-    query[
-      __extendedEncodeURIComponent("role_name")
-    ] = __extendedEncodeURIComponent(input.roleName);
+    query["role_name"] = input.roleName;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -81,19 +77,13 @@ export async function serializeAws_restJson1_1ListAccountRolesCommand(
   let resolvedPath = "/assignment/roles";
   const query: any = {};
   if (input.accountId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("account_id")
-    ] = __extendedEncodeURIComponent(input.accountId);
+    query["account_id"] = input.accountId;
   }
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_result")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["max_result"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["next_token"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -117,14 +107,10 @@ export async function serializeAws_restJson1_1ListAccountsCommand(
   let resolvedPath = "/assignment/accounts";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query[
-      __extendedEncodeURIComponent("max_result")
-    ] = __extendedEncodeURIComponent(input.maxResults.toString());
+    query["max_result"] = input.maxResults.toString();
   }
   if (input.nextToken !== undefined) {
-    query[
-      __extendedEncodeURIComponent("next_token")
-    ] = __extendedEncodeURIComponent(input.nextToken);
+    query["next_token"] = input.nextToken;
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-workdocs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1_1.ts
@@ -436,9 +436,7 @@ export async function serializeAws_restJson1_1CreateCustomMetadataCommand(
   }
   const query: any = {};
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionid")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionid"] = input.VersionId;
   }
   let body: any;
   const bodyParams: any = {};
@@ -734,19 +732,13 @@ export async function serializeAws_restJson1_1DeleteCustomMetadataCommand(
   }
   const query: any = {};
   if (input.DeleteAll !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deleteAll")
-    ] = __extendedEncodeURIComponent(input.DeleteAll.toString());
+    query["deleteAll"] = input.DeleteAll.toString();
   }
   if (input.Keys !== undefined) {
-    query[__extendedEncodeURIComponent("keys")] = input.Keys.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["keys"] = input.Keys;
   }
   if (input.VersionId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("versionId")
-    ] = __extendedEncodeURIComponent(input.VersionId);
+    query["versionId"] = input.VersionId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -875,14 +867,10 @@ export async function serializeAws_restJson1_1DeleteLabelsCommand(
   }
   const query: any = {};
   if (input.DeleteAll !== undefined) {
-    query[
-      __extendedEncodeURIComponent("deleteAll")
-    ] = __extendedEncodeURIComponent(input.DeleteAll.toString());
+    query["deleteAll"] = input.DeleteAll.toString();
   }
   if (input.Labels !== undefined) {
-    query[__extendedEncodeURIComponent("labels")] = input.Labels.map(entry =>
-      __extendedEncodeURIComponent(entry)
-    );
+    query["labels"] = input.Labels;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -982,51 +970,33 @@ export async function serializeAws_restJson1_1DescribeActivitiesCommand(
   let resolvedPath = "/api/v1/activities";
   const query: any = {};
   if (input.ActivityTypes !== undefined) {
-    query[
-      __extendedEncodeURIComponent("activityTypes")
-    ] = __extendedEncodeURIComponent(input.ActivityTypes);
+    query["activityTypes"] = input.ActivityTypes;
   }
   if (input.EndTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("endTime")
-    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
+    query["endTime"] = input.EndTime.toISOString();
   }
   if (input.IncludeIndirectActivities !== undefined) {
     query[
-      __extendedEncodeURIComponent("includeIndirectActivities")
-    ] = __extendedEncodeURIComponent(
-      input.IncludeIndirectActivities.toString()
-    );
+      "includeIndirectActivities"
+    ] = input.IncludeIndirectActivities.toString();
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.OrganizationId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("organizationId")
-    ] = __extendedEncodeURIComponent(input.OrganizationId);
+    query["organizationId"] = input.OrganizationId;
   }
   if (input.ResourceId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("resourceId")
-    ] = __extendedEncodeURIComponent(input.ResourceId);
+    query["resourceId"] = input.ResourceId;
   }
   if (input.StartTime !== undefined) {
-    query[
-      __extendedEncodeURIComponent("startTime")
-    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
+    query["startTime"] = input.StartTime.toISOString();
   }
   if (input.UserId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("userId")
-    ] = __extendedEncodeURIComponent(input.UserId);
+    query["userId"] = input.UserId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1075,14 +1045,10 @@ export async function serializeAws_restJson1_1DescribeCommentsCommand(
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1118,24 +1084,16 @@ export async function serializeAws_restJson1_1DescribeDocumentVersionsCommand(
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query[
-      __extendedEncodeURIComponent("fields")
-    ] = __extendedEncodeURIComponent(input.Fields);
+    query["fields"] = input.Fields;
   }
   if (input.Include !== undefined) {
-    query[
-      __extendedEncodeURIComponent("include")
-    ] = __extendedEncodeURIComponent(input.Include);
+    query["include"] = input.Include;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1171,34 +1129,22 @@ export async function serializeAws_restJson1_1DescribeFolderContentsCommand(
   }
   const query: any = {};
   if (input.Include !== undefined) {
-    query[
-      __extendedEncodeURIComponent("include")
-    ] = __extendedEncodeURIComponent(input.Include);
+    query["include"] = input.Include;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.Order !== undefined) {
-    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
-      input.Order
-    );
+    query["order"] = input.Order;
   }
   if (input.Sort !== undefined) {
-    query[__extendedEncodeURIComponent("sort")] = __extendedEncodeURIComponent(
-      input.Sort
-    );
+    query["sort"] = input.Sort;
   }
   if (input.Type !== undefined) {
-    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
-      input.Type
-    );
+    query["type"] = input.Type;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1222,24 +1168,16 @@ export async function serializeAws_restJson1_1DescribeGroupsCommand(
   let resolvedPath = "/api/v1/groups";
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.OrganizationId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("organizationId")
-    ] = __extendedEncodeURIComponent(input.OrganizationId);
+    query["organizationId"] = input.OrganizationId;
   }
   if (input.SearchQuery !== undefined) {
-    query[
-      __extendedEncodeURIComponent("searchQuery")
-    ] = __extendedEncodeURIComponent(input.SearchQuery);
+    query["searchQuery"] = input.SearchQuery;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1274,14 +1212,10 @@ export async function serializeAws_restJson1_1DescribeNotificationSubscriptionsC
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1317,19 +1251,13 @@ export async function serializeAws_restJson1_1DescribeResourcePermissionsCommand
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.PrincipalId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("principalId")
-    ] = __extendedEncodeURIComponent(input.PrincipalId);
+    query["principalId"] = input.PrincipalId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1353,14 +1281,10 @@ export async function serializeAws_restJson1_1DescribeRootFoldersCommand(
   let resolvedPath = "/api/v1/me/root";
   const query: any = {};
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1384,49 +1308,31 @@ export async function serializeAws_restJson1_1DescribeUsersCommand(
   let resolvedPath = "/api/v1/users";
   const query: any = {};
   if (input.Fields !== undefined) {
-    query[
-      __extendedEncodeURIComponent("fields")
-    ] = __extendedEncodeURIComponent(input.Fields);
+    query["fields"] = input.Fields;
   }
   if (input.Include !== undefined) {
-    query[
-      __extendedEncodeURIComponent("include")
-    ] = __extendedEncodeURIComponent(input.Include);
+    query["include"] = input.Include;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.Order !== undefined) {
-    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
-      input.Order
-    );
+    query["order"] = input.Order;
   }
   if (input.OrganizationId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("organizationId")
-    ] = __extendedEncodeURIComponent(input.OrganizationId);
+    query["organizationId"] = input.OrganizationId;
   }
   if (input.Query !== undefined) {
-    query[__extendedEncodeURIComponent("query")] = __extendedEncodeURIComponent(
-      input.Query
-    );
+    query["query"] = input.Query;
   }
   if (input.Sort !== undefined) {
-    query[__extendedEncodeURIComponent("sort")] = __extendedEncodeURIComponent(
-      input.Sort
-    );
+    query["sort"] = input.Sort;
   }
   if (input.UserIds !== undefined) {
-    query[
-      __extendedEncodeURIComponent("userIds")
-    ] = __extendedEncodeURIComponent(input.UserIds);
+    query["userIds"] = input.UserIds;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1481,9 +1387,7 @@ export async function serializeAws_restJson1_1GetDocumentCommand(
   }
   const query: any = {};
   if (input.IncludeCustomMetadata !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeCustomMetadata")
-    ] = __extendedEncodeURIComponent(input.IncludeCustomMetadata.toString());
+    query["includeCustomMetadata"] = input.IncludeCustomMetadata.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1519,19 +1423,13 @@ export async function serializeAws_restJson1_1GetDocumentPathCommand(
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query[
-      __extendedEncodeURIComponent("fields")
-    ] = __extendedEncodeURIComponent(input.Fields);
+    query["fields"] = input.Fields;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1579,14 +1477,10 @@ export async function serializeAws_restJson1_1GetDocumentVersionCommand(
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query[
-      __extendedEncodeURIComponent("fields")
-    ] = __extendedEncodeURIComponent(input.Fields);
+    query["fields"] = input.Fields;
   }
   if (input.IncludeCustomMetadata !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeCustomMetadata")
-    ] = __extendedEncodeURIComponent(input.IncludeCustomMetadata.toString());
+    query["includeCustomMetadata"] = input.IncludeCustomMetadata.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1622,9 +1516,7 @@ export async function serializeAws_restJson1_1GetFolderCommand(
   }
   const query: any = {};
   if (input.IncludeCustomMetadata !== undefined) {
-    query[
-      __extendedEncodeURIComponent("includeCustomMetadata")
-    ] = __extendedEncodeURIComponent(input.IncludeCustomMetadata.toString());
+    query["includeCustomMetadata"] = input.IncludeCustomMetadata.toString();
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1660,19 +1552,13 @@ export async function serializeAws_restJson1_1GetFolderPathCommand(
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query[
-      __extendedEncodeURIComponent("fields")
-    ] = __extendedEncodeURIComponent(input.Fields);
+    query["fields"] = input.Fields;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1696,24 +1582,16 @@ export async function serializeAws_restJson1_1GetResourcesCommand(
   let resolvedPath = "/api/v1/resources";
   const query: any = {};
   if (input.CollectionType !== undefined) {
-    query[
-      __extendedEncodeURIComponent("collectionType")
-    ] = __extendedEncodeURIComponent(input.CollectionType);
+    query["collectionType"] = input.CollectionType;
   }
   if (input.Limit !== undefined) {
-    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
-      input.Limit.toString()
-    );
+    query["limit"] = input.Limit.toString();
   }
   if (input.Marker !== undefined) {
-    query[
-      __extendedEncodeURIComponent("marker")
-    ] = __extendedEncodeURIComponent(input.Marker);
+    query["marker"] = input.Marker;
   }
   if (input.UserId !== undefined) {
-    query[
-      __extendedEncodeURIComponent("userId")
-    ] = __extendedEncodeURIComponent(input.UserId);
+    query["userId"] = input.UserId;
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1842,9 +1720,7 @@ export async function serializeAws_restJson1_1RemoveResourcePermissionCommand(
   }
   const query: any = {};
   if (input.PrincipalType !== undefined) {
-    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
-      input.PrincipalType
-    );
+    query["type"] = input.PrincipalType;
   }
   return new __HttpRequest({
     ...context.endpoint,


### PR DESCRIPTION
remove the query encoding in the codegenerator. It will be handled
inside request handler.

Corresponding V3 PR: [#935](https://github.com/aws/aws-sdk-js-v3/pull/935)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
