### PR TITLE
Set `sha256` configuration before setting `signer`

### DIFF
--- a/clients/node/client-cognito-identity-provider-node/CognitoIdentityProviderConfiguration.ts
+++ b/clients/node/client-cognito-identity-provider-node/CognitoIdentityProviderConfiguration.ts
@@ -387,6 +387,9 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
   signingName: {
     defaultValue: "cognito-idp"
   },
+  sha256: {
+    defaultValue: __aws_sdk_hash_node.Hash.bind(null, "sha256")
+  },
   signer: {
     defaultProvider: (configuration: {
       credentials: __aws_sdk_types.Provider<__aws_sdk_types.Credentials>;
@@ -401,8 +404,5 @@ export const configurationProperties: __aws_sdk_types.ConfigurationDefinition<
         sha256: configuration.sha256,
         uriEscapePath: true
       })
-  },
-  sha256: {
-    defaultValue: __aws_sdk_hash_node.Hash.bind(null, "sha256")
   }
 };


### PR DESCRIPTION
This is required because the default signer uses the default sha256 option.

*Issue #460 *

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
