### PR TITLE
fix: Only flatten lists, sets, and maps for aws.ec2

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/Ec2ShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/Ec2ShapeSerVisitor.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.aws.traits.Ec2QueryNameTrait;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.shapes.DocumentShape;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.model.traits.XmlNameTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
@@ -73,8 +74,9 @@ final class Ec2ShapeSerVisitor extends QueryShapeSerVisitor {
     }
 
     @Override
-    protected boolean isFlattenedMember(MemberShape memberShape) {
+    protected boolean isFlattenedMember(GenerationContext context, MemberShape memberShape) {
         // All lists, sets, and maps are flattened in aws.ec2.
-        return true;
+        ShapeType targetType = context.getModel().expectShape(memberShape.getTarget()).getType();
+        return targetType == ShapeType.LIST || targetType == ShapeType.SET || targetType == ShapeType.MAP;
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -196,7 +196,7 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
         TypeScriptWriter writer = context.getWriter();
 
         // Handle flattening for collections and maps.
-        boolean isFlattened = isFlattenedMember(memberShape);
+        boolean isFlattened = isFlattenedMember(context, memberShape);
 
         // Set up a location to store all of the entry pairs.
         writer.write("const memberEntries = $L;", target.accept(inputVisitor));
@@ -218,10 +218,11 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
      * Tells whether the contents of the member should be flattened
      * when serialized.
      *
+     * @param context The generation context.
      * @param memberShape The member being serialized.
      * @return If the member's contents should be flattened when serialized.
      */
-    protected boolean isFlattenedMember(MemberShape memberShape) {
+    protected boolean isFlattenedMember(GenerationContext context, MemberShape memberShape) {
         // The @xmlFlattened trait determines the flattening of members in aws.query.
         return memberShape.hasTrait(XmlFlattenedTrait.class);
     }


### PR DESCRIPTION
Fixes an issue where nested structure members were being flattened for `aws.ec2`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
