### PR TITLE
chore: codegen for ec2 flattening, empty xml return, error location

### DIFF
--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -6788,7 +6788,6 @@ const deserializeAws_queryActivitiesType = (
   };
   if (output.Activities === "") {
     contents.Activities = [];
-    return contents;
   }
   if (
     output["Activities"] !== undefined &&
@@ -6998,7 +6997,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -7024,7 +7022,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.EnabledMetrics === "") {
     contents.EnabledMetrics = [];
-    return contents;
   }
   if (
     output["EnabledMetrics"] !== undefined &&
@@ -7049,7 +7046,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.Instances === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["Instances"] !== undefined &&
@@ -7072,7 +7068,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.LoadBalancerNames === "") {
     contents.LoadBalancerNames = [];
-    return contents;
   }
   if (
     output["LoadBalancerNames"] !== undefined &&
@@ -7117,7 +7112,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.SuspendedProcesses === "") {
     contents.SuspendedProcesses = [];
-    return contents;
   }
   if (
     output["SuspendedProcesses"] !== undefined &&
@@ -7134,7 +7128,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -7148,7 +7141,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.TargetGroupARNs === "") {
     contents.TargetGroupARNs = [];
-    return contents;
   }
   if (
     output["TargetGroupARNs"] !== undefined &&
@@ -7165,7 +7157,6 @@ const deserializeAws_queryAutoScalingGroup = (
   }
   if (output.TerminationPolicies === "") {
     contents.TerminationPolicies = [];
-    return contents;
   }
   if (
     output["TerminationPolicies"] !== undefined &&
@@ -7206,7 +7197,6 @@ const deserializeAws_queryAutoScalingGroupsType = (
   };
   if (output.AutoScalingGroups === "") {
     contents.AutoScalingGroups = [];
-    return contents;
   }
   if (
     output["AutoScalingGroups"] !== undefined &&
@@ -7300,7 +7290,6 @@ const deserializeAws_queryAutoScalingInstancesType = (
   };
   if (output.AutoScalingInstances === "") {
     contents.AutoScalingInstances = [];
-    return contents;
   }
   if (
     output["AutoScalingInstances"] !== undefined &&
@@ -7345,7 +7334,6 @@ const deserializeAws_queryBatchDeleteScheduledActionAnswer = (
   };
   if (output.FailedScheduledActions === "") {
     contents.FailedScheduledActions = [];
-    return contents;
   }
   if (
     output["FailedScheduledActions"] !== undefined &&
@@ -7373,7 +7361,6 @@ const deserializeAws_queryBatchPutScheduledUpdateGroupActionAnswer = (
   };
   if (output.FailedScheduledUpdateGroupActions === "") {
     contents.FailedScheduledUpdateGroupActions = [];
-    return contents;
   }
   if (
     output["FailedScheduledUpdateGroupActions"] !== undefined &&
@@ -7457,7 +7444,6 @@ const deserializeAws_queryCustomizedMetricSpecification = (
   };
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-    return contents;
   }
   if (
     output["Dimensions"] !== undefined &&
@@ -7541,7 +7527,6 @@ const deserializeAws_queryDescribeAdjustmentTypesAnswer = (
   };
   if (output.AdjustmentTypes === "") {
     contents.AdjustmentTypes = [];
-    return contents;
   }
   if (
     output["AdjustmentTypes"] !== undefined &&
@@ -7569,7 +7554,6 @@ const deserializeAws_queryDescribeAutoScalingNotificationTypesAnswer = (
   };
   if (output.AutoScalingNotificationTypes === "") {
     contents.AutoScalingNotificationTypes = [];
-    return contents;
   }
   if (
     output["AutoScalingNotificationTypes"] !== undefined &&
@@ -7597,7 +7581,6 @@ const deserializeAws_queryDescribeLifecycleHookTypesAnswer = (
   };
   if (output.LifecycleHookTypes === "") {
     contents.LifecycleHookTypes = [];
-    return contents;
   }
   if (
     output["LifecycleHookTypes"] !== undefined &&
@@ -7625,7 +7608,6 @@ const deserializeAws_queryDescribeLifecycleHooksAnswer = (
   };
   if (output.LifecycleHooks === "") {
     contents.LifecycleHooks = [];
-    return contents;
   }
   if (
     output["LifecycleHooks"] !== undefined &&
@@ -7654,7 +7636,6 @@ const deserializeAws_queryDescribeLoadBalancerTargetGroupsResponse = (
   };
   if (output.LoadBalancerTargetGroups === "") {
     contents.LoadBalancerTargetGroups = [];
-    return contents;
   }
   if (
     output["LoadBalancerTargetGroups"] !== undefined &&
@@ -7686,7 +7667,6 @@ const deserializeAws_queryDescribeLoadBalancersResponse = (
   };
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-    return contents;
   }
   if (
     output["LoadBalancers"] !== undefined &&
@@ -7718,7 +7698,6 @@ const deserializeAws_queryDescribeMetricCollectionTypesAnswer = (
   };
   if (output.Granularities === "") {
     contents.Granularities = [];
-    return contents;
   }
   if (
     output["Granularities"] !== undefined &&
@@ -7735,7 +7714,6 @@ const deserializeAws_queryDescribeMetricCollectionTypesAnswer = (
   }
   if (output.Metrics === "") {
     contents.Metrics = [];
-    return contents;
   }
   if (
     output["Metrics"] !== undefined &&
@@ -7767,7 +7745,6 @@ const deserializeAws_queryDescribeNotificationConfigurationsAnswer = (
   }
   if (output.NotificationConfigurations === "") {
     contents.NotificationConfigurations = [];
-    return contents;
   }
   if (
     output["NotificationConfigurations"] !== undefined &&
@@ -7795,7 +7772,6 @@ const deserializeAws_queryDescribeTerminationPolicyTypesAnswer = (
   };
   if (output.TerminationPolicyTypes === "") {
     contents.TerminationPolicyTypes = [];
-    return contents;
   }
   if (
     output["TerminationPolicyTypes"] !== undefined &&
@@ -7823,7 +7799,6 @@ const deserializeAws_queryDetachInstancesAnswer = (
   };
   if (output.Activities === "") {
     contents.Activities = [];
-    return contents;
   }
   if (
     output["Activities"] !== undefined &&
@@ -7926,7 +7901,6 @@ const deserializeAws_queryEnterStandbyAnswer = (
   };
   if (output.Activities === "") {
     contents.Activities = [];
-    return contents;
   }
   if (
     output["Activities"] !== undefined &&
@@ -7951,7 +7925,6 @@ const deserializeAws_queryExitStandbyAnswer = (
   };
   if (output.Activities === "") {
     contents.Activities = [];
-    return contents;
   }
   if (
     output["Activities"] !== undefined &&
@@ -8151,7 +8124,6 @@ const deserializeAws_queryLaunchConfiguration = (
   }
   if (output.BlockDeviceMappings === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["BlockDeviceMappings"] !== undefined &&
@@ -8171,7 +8143,6 @@ const deserializeAws_queryLaunchConfiguration = (
   }
   if (output.ClassicLinkVPCSecurityGroups === "") {
     contents.ClassicLinkVPCSecurityGroups = [];
-    return contents;
   }
   if (
     output["ClassicLinkVPCSecurityGroups"] !== undefined &&
@@ -8227,7 +8198,6 @@ const deserializeAws_queryLaunchConfiguration = (
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["SecurityGroups"] !== undefined &&
@@ -8271,7 +8241,6 @@ const deserializeAws_queryLaunchConfigurationsType = (
   };
   if (output.LaunchConfigurations === "") {
     contents.LaunchConfigurations = [];
-    return contents;
   }
   if (
     output["LaunchConfigurations"] !== undefined &&
@@ -8309,7 +8278,6 @@ const deserializeAws_queryLaunchTemplate = (
   }
   if (output.Overrides === "") {
     contents.Overrides = [];
-    return contents;
   }
   if (
     output["Overrides"] !== undefined &&
@@ -8645,7 +8613,6 @@ const deserializeAws_queryPoliciesType = (
   }
   if (output.ScalingPolicies === "") {
     contents.ScalingPolicies = [];
-    return contents;
   }
   if (
     output["ScalingPolicies"] !== undefined &&
@@ -8674,7 +8641,6 @@ const deserializeAws_queryPolicyARNType = (
   };
   if (output.Alarms === "") {
     contents.Alarms = [];
-    return contents;
   }
   if (
     output["Alarms"] !== undefined &&
@@ -8743,7 +8709,6 @@ const deserializeAws_queryProcessesType = (
   };
   if (output.Processes === "") {
     contents.Processes = [];
-    return contents;
   }
   if (
     output["Processes"] !== undefined &&
@@ -8855,7 +8820,6 @@ const deserializeAws_queryScalingPolicy = (
   }
   if (output.Alarms === "") {
     contents.Alarms = [];
-    return contents;
   }
   if (
     output["Alarms"] !== undefined &&
@@ -8903,7 +8867,6 @@ const deserializeAws_queryScalingPolicy = (
   }
   if (output.StepAdjustments === "") {
     contents.StepAdjustments = [];
-    return contents;
   }
   if (
     output["StepAdjustments"] !== undefined &&
@@ -8941,7 +8904,6 @@ const deserializeAws_queryScheduledActionsType = (
   }
   if (output.ScheduledUpdateGroupActions === "") {
     contents.ScheduledUpdateGroupActions = [];
-    return contents;
   }
   if (
     output["ScheduledUpdateGroupActions"] !== undefined &&
@@ -9164,7 +9126,6 @@ const deserializeAws_queryTagsType = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -7072,7 +7072,6 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   };
   if (output.AccountLimits === "") {
     contents.AccountLimits = [];
-    return contents;
   }
   if (
     output["AccountLimits"] !== undefined &&
@@ -7118,7 +7117,6 @@ const deserializeAws_queryDescribeChangeSetOutput = (
   };
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-    return contents;
   }
   if (
     output["Capabilities"] !== undefined &&
@@ -7141,7 +7139,6 @@ const deserializeAws_queryDescribeChangeSetOutput = (
   }
   if (output.Changes === "") {
     contents.Changes = [];
-    return contents;
   }
   if (
     output["Changes"] !== undefined &&
@@ -7167,7 +7164,6 @@ const deserializeAws_queryDescribeChangeSetOutput = (
   }
   if (output.NotificationARNs === "") {
     contents.NotificationARNs = [];
-    return contents;
   }
   if (
     output["NotificationARNs"] !== undefined &&
@@ -7184,7 +7180,6 @@ const deserializeAws_queryDescribeChangeSetOutput = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -7216,7 +7211,6 @@ const deserializeAws_queryDescribeChangeSetOutput = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -7282,7 +7276,6 @@ const deserializeAws_queryDescribeStackEventsOutput = (
   }
   if (output.StackEvents === "") {
     contents.StackEvents = [];
-    return contents;
   }
   if (
     output["StackEvents"] !== undefined &&
@@ -7314,7 +7307,6 @@ const deserializeAws_queryDescribeStackResourceDriftsOutput = (
   }
   if (output.StackResourceDrifts === "") {
     contents.StackResourceDrifts = [];
-    return contents;
   }
   if (
     output["StackResourceDrifts"] !== undefined &&
@@ -7359,7 +7351,6 @@ const deserializeAws_queryDescribeStackResourcesOutput = (
   };
   if (output.StackResources === "") {
     contents.StackResources = [];
-    return contents;
   }
   if (
     output["StackResources"] !== undefined &&
@@ -7391,7 +7382,6 @@ const deserializeAws_queryDescribeStacksOutput = (
   }
   if (output.Stacks === "") {
     contents.Stacks = [];
-    return contents;
   }
   if (
     output["Stacks"] !== undefined &&
@@ -7616,7 +7606,6 @@ const deserializeAws_queryGetTemplateOutput = (
   };
   if (output.StagesAvailable === "") {
     contents.StagesAvailable = [];
-    return contents;
   }
   if (
     output["StagesAvailable"] !== undefined &&
@@ -7655,7 +7644,6 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   };
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-    return contents;
   }
   if (
     output["Capabilities"] !== undefined &&
@@ -7675,7 +7663,6 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.DeclaredTransforms === "") {
     contents.DeclaredTransforms = [];
-    return contents;
   }
   if (
     output["DeclaredTransforms"] !== undefined &&
@@ -7698,7 +7685,6 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -7715,7 +7701,6 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.ResourceIdentifierSummaries === "") {
     contents.ResourceIdentifierSummaries = [];
-    return contents;
   }
   if (
     output["ResourceIdentifierSummaries"] !== undefined &&
@@ -7732,7 +7717,6 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.ResourceTypes === "") {
     contents.ResourceTypes = [];
-    return contents;
   }
   if (
     output["ResourceTypes"] !== undefined &&
@@ -7830,7 +7814,6 @@ const deserializeAws_queryListChangeSetsOutput = (
   }
   if (output.Summaries === "") {
     contents.Summaries = [];
-    return contents;
   }
   if (
     output["Summaries"] !== undefined &&
@@ -7859,7 +7842,6 @@ const deserializeAws_queryListExportsOutput = (
   };
   if (output.Exports === "") {
     contents.Exports = [];
-    return contents;
   }
   if (
     output["Exports"] !== undefined &&
@@ -7888,7 +7870,6 @@ const deserializeAws_queryListImportsOutput = (
   };
   if (output.Imports === "") {
     contents.Imports = [];
-    return contents;
   }
   if (
     output["Imports"] !== undefined &&
@@ -7920,7 +7901,6 @@ const deserializeAws_queryListStackResourcesOutput = (
   }
   if (output.StackResourceSummaries === "") {
     contents.StackResourceSummaries = [];
-    return contents;
   }
   if (
     output["StackResourceSummaries"] !== undefined &&
@@ -7952,7 +7932,6 @@ const deserializeAws_queryListStacksOutput = (
   }
   if (output.StackSummaries === "") {
     contents.StackSummaries = [];
-    return contents;
   }
   if (
     output["StackSummaries"] !== undefined &&
@@ -7984,7 +7963,6 @@ const deserializeAws_queryListTypeRegistrationsOutput = (
   }
   if (output.RegistrationTokenList === "") {
     contents.RegistrationTokenList = [];
-    return contents;
   }
   if (
     output["RegistrationTokenList"] !== undefined &&
@@ -8016,7 +7994,6 @@ const deserializeAws_queryListTypeVersionsOutput = (
   }
   if (output.TypeVersionSummaries === "") {
     contents.TypeVersionSummaries = [];
-    return contents;
   }
   if (
     output["TypeVersionSummaries"] !== undefined &&
@@ -8048,7 +8025,6 @@ const deserializeAws_queryListTypesOutput = (
   }
   if (output.TypeSummaries === "") {
     contents.TypeSummaries = [];
-    return contents;
   }
   if (
     output["TypeSummaries"] !== undefined &&
@@ -8183,7 +8159,6 @@ const deserializeAws_queryParameterConstraints = (
   };
   if (output.AllowedValues === "") {
     contents.AllowedValues = [];
-    return contents;
   }
   if (
     output["AllowedValues"] !== undefined &&
@@ -8368,7 +8343,6 @@ const deserializeAws_queryResourceChange = (
   }
   if (output.Details === "") {
     contents.Details = [];
-    return contents;
   }
   if (
     output["Details"] !== undefined &&
@@ -8397,7 +8371,6 @@ const deserializeAws_queryResourceChange = (
   }
   if (output.Scope === "") {
     contents.Scope = [];
-    return contents;
   }
   if (
     output["Scope"] !== undefined &&
@@ -8471,7 +8444,6 @@ const deserializeAws_queryResourceIdentifierSummary = (
   };
   if (output.LogicalResourceIds === "") {
     contents.LogicalResourceIds = [];
-    return contents;
   }
   if (
     output["LogicalResourceIds"] !== undefined &&
@@ -8488,7 +8460,6 @@ const deserializeAws_queryResourceIdentifierSummary = (
   }
   if (output.ResourceIdentifiers === "") {
     contents.ResourceIdentifiers = [];
-    return contents;
   }
   if (
     output["ResourceIdentifiers"] !== undefined &&
@@ -8561,7 +8532,6 @@ const deserializeAws_queryRollbackConfiguration = (
   }
   if (output.RollbackTriggers === "") {
     contents.RollbackTriggers = [];
-    return contents;
   }
   if (
     output["RollbackTriggers"] !== undefined &&
@@ -8654,7 +8624,6 @@ const deserializeAws_queryStack = (
   };
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-    return contents;
   }
   if (
     output["Capabilities"] !== undefined &&
@@ -8699,7 +8668,6 @@ const deserializeAws_queryStack = (
   }
   if (output.NotificationARNs === "") {
     contents.NotificationARNs = [];
-    return contents;
   }
   if (
     output["NotificationARNs"] !== undefined &&
@@ -8716,7 +8684,6 @@ const deserializeAws_queryStack = (
   }
   if (output.Outputs === "") {
     contents.Outputs = [];
-    return contents;
   }
   if (
     output["Outputs"] !== undefined &&
@@ -8730,7 +8697,6 @@ const deserializeAws_queryStack = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -8771,7 +8737,6 @@ const deserializeAws_queryStack = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -9026,7 +8991,6 @@ const deserializeAws_queryStackResourceDrift = (
   }
   if (output.PhysicalResourceIdContext === "") {
     contents.PhysicalResourceIdContext = [];
-    return contents;
   }
   if (
     output["PhysicalResourceIdContext"] !== undefined &&
@@ -9043,7 +9007,6 @@ const deserializeAws_queryStackResourceDrift = (
   }
   if (output.PropertyDifferences === "") {
     contents.PropertyDifferences = [];
-    return contents;
   }
   if (
     output["PropertyDifferences"] !== undefined &&
@@ -9495,7 +9458,6 @@ const deserializeAws_queryValidateTemplateOutput = (
   };
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-    return contents;
   }
   if (
     output["Capabilities"] !== undefined &&
@@ -9515,7 +9477,6 @@ const deserializeAws_queryValidateTemplateOutput = (
   }
   if (output.DeclaredTransforms === "") {
     contents.DeclaredTransforms = [];
-    return contents;
   }
   if (
     output["DeclaredTransforms"] !== undefined &&
@@ -9535,7 +9496,6 @@ const deserializeAws_queryValidateTemplateOutput = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -9730,7 +9690,6 @@ const deserializeAws_queryListStackInstancesOutput = (
   }
   if (output.Summaries === "") {
     contents.Summaries = [];
-    return contents;
   }
   if (
     output["Summaries"] !== undefined &&
@@ -9762,7 +9721,6 @@ const deserializeAws_queryListStackSetOperationResultsOutput = (
   }
   if (output.Summaries === "") {
     contents.Summaries = [];
-    return contents;
   }
   if (
     output["Summaries"] !== undefined &&
@@ -9794,7 +9752,6 @@ const deserializeAws_queryListStackSetOperationsOutput = (
   }
   if (output.Summaries === "") {
     contents.Summaries = [];
-    return contents;
   }
   if (
     output["Summaries"] !== undefined &&
@@ -9826,7 +9783,6 @@ const deserializeAws_queryListStackSetsOutput = (
   }
   if (output.Summaries === "") {
     contents.Summaries = [];
-    return contents;
   }
   if (
     output["Summaries"] !== undefined &&
@@ -9936,7 +9892,6 @@ const deserializeAws_queryStackInstance = (
   }
   if (output.ParameterOverrides === "") {
     contents.ParameterOverrides = [];
-    return contents;
   }
   if (
     output["ParameterOverrides"] !== undefined &&
@@ -10060,7 +10015,6 @@ const deserializeAws_queryStackSet = (
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-    return contents;
   }
   if (
     output["Capabilities"] !== undefined &&
@@ -10083,7 +10037,6 @@ const deserializeAws_queryStackSet = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -10115,7 +10068,6 @@ const deserializeAws_queryStackSet = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -10288,7 +10240,6 @@ const deserializeAws_queryStackSetOperationPreferences = (
   }
   if (output.RegionOrder === "") {
     contents.RegionOrder = [];
-    return contents;
   }
   if (
     output["RegionOrder"] !== undefined &&

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -9546,7 +9546,6 @@ const deserializeAws_restXmlActiveTrustedSigners = (
   }
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -9609,7 +9608,6 @@ const deserializeAws_restXmlAliases = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (output["Items"] !== undefined && output["Items"]["CNAME"] !== undefined) {
     const wrappedItem =
@@ -9642,7 +9640,6 @@ const deserializeAws_restXmlAllowedMethods = (
   }
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -9761,7 +9758,6 @@ const deserializeAws_restXmlCacheBehaviors = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -9793,7 +9789,6 @@ const deserializeAws_restXmlCachedMethods = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -9872,7 +9867,6 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -9997,7 +9991,6 @@ const deserializeAws_restXmlContentTypeProfiles = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -10036,7 +10029,6 @@ const deserializeAws_restXmlCookieNames = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
     const wrappedItem =
@@ -10118,7 +10110,6 @@ const deserializeAws_restXmlCustomErrorResponses = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -10150,7 +10141,6 @@ const deserializeAws_restXmlCustomHeaders = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -10307,7 +10297,6 @@ const deserializeAws_restXmlDistribution = (
   }
   if (output.AliasICPRecordals === "") {
     contents.AliasICPRecordals = [];
-    return contents;
   }
   if (
     output["AliasICPRecordals"] !== undefined &&
@@ -10471,7 +10460,6 @@ const deserializeAws_restXmlDistributionList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -10533,7 +10521,6 @@ const deserializeAws_restXmlDistributionSummary = (
   }
   if (output.AliasICPRecordals === "") {
     contents.AliasICPRecordals = [];
-    return contents;
   }
   if (
     output["AliasICPRecordals"] !== undefined &&
@@ -10649,7 +10636,6 @@ const deserializeAws_restXmlEncryptionEntities = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -10774,7 +10760,6 @@ const deserializeAws_restXmlFieldLevelEncryptionList = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -10868,7 +10853,6 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileList = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11000,7 +10984,6 @@ const deserializeAws_restXmlFieldPatterns = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11068,7 +11051,6 @@ const deserializeAws_restXmlGeoRestriction = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11107,7 +11089,6 @@ const deserializeAws_restXmlHeaders = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
     const wrappedItem =
@@ -11187,7 +11168,6 @@ const deserializeAws_restXmlInvalidationList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11266,7 +11246,6 @@ const deserializeAws_restXmlKeyPairIds = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11326,7 +11305,6 @@ const deserializeAws_restXmlLambdaFunctionAssociations = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11545,7 +11523,6 @@ const deserializeAws_restXmlOriginGroupMembers = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11577,7 +11554,6 @@ const deserializeAws_restXmlOriginGroups = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11618,7 +11594,6 @@ const deserializeAws_restXmlOriginSslProtocols = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11650,7 +11625,6 @@ const deserializeAws_restXmlOrigins = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11686,7 +11660,6 @@ const deserializeAws_restXmlPaths = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (output["Items"] !== undefined && output["Items"]["Path"] !== undefined) {
     const wrappedItem =
@@ -11765,7 +11738,6 @@ const deserializeAws_restXmlPublicKeyList = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11891,7 +11863,6 @@ const deserializeAws_restXmlQueryArgProfiles = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -11923,7 +11894,6 @@ const deserializeAws_restXmlQueryStringCacheKeys = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
     const wrappedItem =
@@ -12052,7 +12022,6 @@ const deserializeAws_restXmlStatusCodes = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -12186,7 +12155,6 @@ const deserializeAws_restXmlStreamingDistributionList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&
@@ -12347,7 +12315,6 @@ const deserializeAws_restXmlTags = (
   };
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (output["Items"] !== undefined && output["Items"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -12374,7 +12341,6 @@ const deserializeAws_restXmlTrustedSigners = (
   }
   if (output.Items === "") {
     contents.Items = [];
-    return contents;
   }
   if (
     output["Items"] !== undefined &&

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -3998,7 +3998,6 @@ const deserializeAws_queryBuildSuggestersResponse = (
   };
   if (output.FieldNames === "") {
     contents.FieldNames = [];
-    return contents;
   }
   if (
     output["FieldNames"] !== undefined &&
@@ -4260,7 +4259,6 @@ const deserializeAws_queryDescribeAnalysisSchemesResponse = (
   };
   if (output.AnalysisSchemes === "") {
     contents.AnalysisSchemes = [];
-    return contents;
   }
   if (
     output["AnalysisSchemes"] !== undefined &&
@@ -4322,7 +4320,6 @@ const deserializeAws_queryDescribeDomainsResponse = (
   };
   if (output.DomainStatusList === "") {
     contents.DomainStatusList = [];
-    return contents;
   }
   if (
     output["DomainStatusList"] !== undefined &&
@@ -4350,7 +4347,6 @@ const deserializeAws_queryDescribeExpressionsResponse = (
   };
   if (output.Expressions === "") {
     contents.Expressions = [];
-    return contents;
   }
   if (
     output["Expressions"] !== undefined &&
@@ -4378,7 +4374,6 @@ const deserializeAws_queryDescribeIndexFieldsResponse = (
   };
   if (output.IndexFields === "") {
     contents.IndexFields = [];
-    return contents;
   }
   if (
     output["IndexFields"] !== undefined &&
@@ -4440,7 +4435,6 @@ const deserializeAws_queryDescribeSuggestersResponse = (
   };
   if (output.Suggesters === "") {
     contents.Suggesters = [];
-    return contents;
   }
   if (
     output["Suggesters"] !== undefined &&
@@ -4761,7 +4755,6 @@ const deserializeAws_queryIndexDocumentsResponse = (
   };
   if (output.FieldNames === "") {
     contents.FieldNames = [];
-    return contents;
   }
   if (
     output["FieldNames"] !== undefined &&
@@ -5089,7 +5082,6 @@ const deserializeAws_queryListDomainNamesResponse = (
   };
   if (output.DomainNames === "") {
     contents.DomainNames = {};
-    return contents;
   }
   if (
     output["DomainNames"] !== undefined &&

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -4138,7 +4138,6 @@ const deserializeAws_queryAnomalyDetector = (
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-    return contents;
   }
   if (
     output["Dimensions"] !== undefined &&
@@ -4176,7 +4175,6 @@ const deserializeAws_queryAnomalyDetectorConfiguration = (
   };
   if (output.ExcludedTimeRanges === "") {
     contents.ExcludedTimeRanges = [];
-    return contents;
   }
   if (
     output["ExcludedTimeRanges"] !== undefined &&
@@ -4284,7 +4282,6 @@ const deserializeAws_queryDashboardInvalidInputError = (
   };
   if (output.dashboardValidationMessages === "") {
     contents.dashboardValidationMessages = [];
-    return contents;
   }
   if (
     output["dashboardValidationMessages"] !== undefined &&
@@ -4366,7 +4363,6 @@ const deserializeAws_queryDatapoint = (
   }
   if (output.ExtendedStatistics === "") {
     contents.ExtendedStatistics = {};
-    return contents;
   }
   if (
     output["ExtendedStatistics"] !== undefined &&
@@ -4459,7 +4455,6 @@ const deserializeAws_queryDeleteInsightRulesOutput = (
   };
   if (output.Failures === "") {
     contents.Failures = [];
-    return contents;
   }
   if (
     output["Failures"] !== undefined &&
@@ -4485,7 +4480,6 @@ const deserializeAws_queryDescribeAlarmHistoryOutput = (
   };
   if (output.AlarmHistoryItems === "") {
     contents.AlarmHistoryItems = [];
-    return contents;
   }
   if (
     output["AlarmHistoryItems"] !== undefined &&
@@ -4516,7 +4510,6 @@ const deserializeAws_queryDescribeAlarmsForMetricOutput = (
   };
   if (output.MetricAlarms === "") {
     contents.MetricAlarms = [];
-    return contents;
   }
   if (
     output["MetricAlarms"] !== undefined &&
@@ -4545,7 +4538,6 @@ const deserializeAws_queryDescribeAlarmsOutput = (
   };
   if (output.MetricAlarms === "") {
     contents.MetricAlarms = [];
-    return contents;
   }
   if (
     output["MetricAlarms"] !== undefined &&
@@ -4577,7 +4569,6 @@ const deserializeAws_queryDescribeAnomalyDetectorsOutput = (
   };
   if (output.AnomalyDetectors === "") {
     contents.AnomalyDetectors = [];
-    return contents;
   }
   if (
     output["AnomalyDetectors"] !== undefined &&
@@ -4609,7 +4600,6 @@ const deserializeAws_queryDescribeInsightRulesOutput = (
   };
   if (output.InsightRules === "") {
     contents.InsightRules = [];
-    return contents;
   }
   if (
     output["InsightRules"] !== undefined &&
@@ -4667,7 +4657,6 @@ const deserializeAws_queryDisableInsightRulesOutput = (
   };
   if (output.Failures === "") {
     contents.Failures = [];
-    return contents;
   }
   if (
     output["Failures"] !== undefined &&
@@ -4692,7 +4681,6 @@ const deserializeAws_queryEnableInsightRulesOutput = (
   };
   if (output.Failures === "") {
     contents.Failures = [];
-    return contents;
   }
   if (
     output["Failures"] !== undefined &&
@@ -4755,7 +4743,6 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
   }
   if (output.Contributors === "") {
     contents.Contributors = [];
-    return contents;
   }
   if (
     output["Contributors"] !== undefined &&
@@ -4772,7 +4759,6 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
   }
   if (output.KeyLabels === "") {
     contents.KeyLabels = [];
-    return contents;
   }
   if (
     output["KeyLabels"] !== undefined &&
@@ -4789,7 +4775,6 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
   }
   if (output.MetricDatapoints === "") {
     contents.MetricDatapoints = [];
-    return contents;
   }
   if (
     output["MetricDatapoints"] !== undefined &&
@@ -4819,7 +4804,6 @@ const deserializeAws_queryGetMetricDataOutput = (
   };
   if (output.Messages === "") {
     contents.Messages = [];
-    return contents;
   }
   if (
     output["Messages"] !== undefined &&
@@ -4836,7 +4820,6 @@ const deserializeAws_queryGetMetricDataOutput = (
   }
   if (output.MetricDataResults === "") {
     contents.MetricDataResults = [];
-    return contents;
   }
   if (
     output["MetricDataResults"] !== undefined &&
@@ -4868,7 +4851,6 @@ const deserializeAws_queryGetMetricStatisticsOutput = (
   };
   if (output.Datapoints === "") {
     contents.Datapoints = [];
-    return contents;
   }
   if (
     output["Datapoints"] !== undefined &&
@@ -4945,7 +4927,6 @@ const deserializeAws_queryInsightRuleContributor = (
   }
   if (output.Datapoints === "") {
     contents.Datapoints = [];
-    return contents;
   }
   if (
     output["Datapoints"] !== undefined &&
@@ -4962,7 +4943,6 @@ const deserializeAws_queryInsightRuleContributor = (
   }
   if (output.Keys === "") {
     contents.Keys = [];
-    return contents;
   }
   if (output["Keys"] !== undefined && output["Keys"]["member"] !== undefined) {
     const wrappedItem =
@@ -5168,7 +5148,6 @@ const deserializeAws_queryListDashboardsOutput = (
   };
   if (output.DashboardEntries === "") {
     contents.DashboardEntries = [];
-    return contents;
   }
   if (
     output["DashboardEntries"] !== undefined &&
@@ -5200,7 +5179,6 @@ const deserializeAws_queryListMetricsOutput = (
   };
   if (output.Metrics === "") {
     contents.Metrics = [];
-    return contents;
   }
   if (
     output["Metrics"] !== undefined &&
@@ -5228,7 +5206,6 @@ const deserializeAws_queryListTagsForResourceOutput = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -5270,7 +5247,6 @@ const deserializeAws_queryMetric = (
   };
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-    return contents;
   }
   if (
     output["Dimensions"] !== undefined &&
@@ -5330,7 +5306,6 @@ const deserializeAws_queryMetricAlarm = (
   }
   if (output.AlarmActions === "") {
     contents.AlarmActions = [];
-    return contents;
   }
   if (
     output["AlarmActions"] !== undefined &&
@@ -5367,7 +5342,6 @@ const deserializeAws_queryMetricAlarm = (
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-    return contents;
   }
   if (
     output["Dimensions"] !== undefined &&
@@ -5391,7 +5365,6 @@ const deserializeAws_queryMetricAlarm = (
   }
   if (output.InsufficientDataActions === "") {
     contents.InsufficientDataActions = [];
-    return contents;
   }
   if (
     output["InsufficientDataActions"] !== undefined &&
@@ -5411,7 +5384,6 @@ const deserializeAws_queryMetricAlarm = (
   }
   if (output.Metrics === "") {
     contents.Metrics = [];
-    return contents;
   }
   if (
     output["Metrics"] !== undefined &&
@@ -5431,7 +5403,6 @@ const deserializeAws_queryMetricAlarm = (
   }
   if (output.OKActions === "") {
     contents.OKActions = [];
-    return contents;
   }
   if (
     output["OKActions"] !== undefined &&
@@ -5552,7 +5523,6 @@ const deserializeAws_queryMetricDataResult = (
   }
   if (output.Messages === "") {
     contents.Messages = [];
-    return contents;
   }
   if (
     output["Messages"] !== undefined &&
@@ -5572,7 +5542,6 @@ const deserializeAws_queryMetricDataResult = (
   }
   if (output.Timestamps === "") {
     contents.Timestamps = [];
-    return contents;
   }
   if (
     output["Timestamps"] !== undefined &&
@@ -5586,7 +5555,6 @@ const deserializeAws_queryMetricDataResult = (
   }
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -5700,7 +5668,6 @@ const deserializeAws_queryPutDashboardOutput = (
   };
   if (output.DashboardValidationMessages === "") {
     contents.DashboardValidationMessages = [];
-    return contents;
   }
   if (
     output["DashboardValidationMessages"] !== undefined &&

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -7333,7 +7333,6 @@ const deserializeAws_queryCertificateMessage = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-    return contents;
   }
   if (
     output["Certificates"] !== undefined &&
@@ -7511,7 +7510,6 @@ const deserializeAws_queryDBCluster = (
   };
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-    return contents;
   }
   if (
     output["AssociatedRoles"] !== undefined &&
@@ -7528,7 +7526,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -7557,7 +7554,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.DBClusterMembers === "") {
     contents.DBClusterMembers = [];
-    return contents;
   }
   if (
     output["DBClusterMembers"] !== undefined &&
@@ -7591,7 +7587,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-    return contents;
   }
   if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
@@ -7653,7 +7648,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroups"] !== undefined &&
@@ -7727,7 +7721,6 @@ const deserializeAws_queryDBClusterMessage = (
   };
   if (output.DBClusters === "") {
     contents.DBClusters = [];
-    return contents;
   }
   if (
     output["DBClusters"] !== undefined &&
@@ -7789,7 +7782,6 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -7842,7 +7834,6 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   };
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
-    return contents;
   }
   if (
     output["DBClusterParameterGroups"] !== undefined &&
@@ -7917,7 +7908,6 @@ const deserializeAws_queryDBClusterSnapshot = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -7998,7 +7988,6 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-    return contents;
   }
   if (
     output["AttributeValues"] !== undefined &&
@@ -8036,7 +8025,6 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   };
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
-    return contents;
   }
   if (
     output["DBClusterSnapshotAttributes"] !== undefined &&
@@ -8081,7 +8069,6 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   };
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
-    return contents;
   }
   if (
     output["DBClusterSnapshots"] !== undefined &&
@@ -8134,7 +8121,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.ExportableLogTypes === "") {
     contents.ExportableLogTypes = [];
-    return contents;
   }
   if (
     output["ExportableLogTypes"] !== undefined &&
@@ -8155,7 +8141,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.ValidUpgradeTarget === "") {
     contents.ValidUpgradeTarget = [];
-    return contents;
   }
   if (
     output["ValidUpgradeTarget"] !== undefined &&
@@ -8193,7 +8178,6 @@ const deserializeAws_queryDBEngineVersionMessage = (
   };
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
-    return contents;
   }
   if (
     output["DBEngineVersions"] !== undefined &&
@@ -8286,7 +8270,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-    return contents;
   }
   if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
@@ -8342,7 +8325,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.StatusInfos === "") {
     contents.StatusInfos = [];
-    return contents;
   }
   if (
     output["StatusInfos"] !== undefined &&
@@ -8362,7 +8344,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroups"] !== undefined &&
@@ -8400,7 +8381,6 @@ const deserializeAws_queryDBInstanceMessage = (
   };
   if (output.DBInstances === "") {
     contents.DBInstances = [];
-    return contents;
   }
   if (
     output["DBInstances"] !== undefined &&
@@ -8483,7 +8463,6 @@ const deserializeAws_queryDBSubnetGroup = (
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -8512,7 +8491,6 @@ const deserializeAws_queryDBSubnetGroupMessage = (
   };
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
-    return contents;
   }
   if (
     output["DBSubnetGroups"] !== undefined &&
@@ -8667,7 +8645,6 @@ const deserializeAws_queryEngineDefaults = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -8703,7 +8680,6 @@ const deserializeAws_queryEvent = (
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -8751,7 +8727,6 @@ const deserializeAws_queryEventCategoriesMap = (
   };
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -8791,7 +8766,6 @@ const deserializeAws_queryEventCategoriesMessage = (
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-    return contents;
   }
   if (
     output["EventCategoriesMapList"] !== undefined &&
@@ -8829,7 +8803,6 @@ const deserializeAws_queryEventsMessage = (
   };
   if (output.Events === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["Events"] !== undefined &&
@@ -8954,7 +8927,6 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -9010,7 +8982,6 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   }
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
-    return contents;
   }
   if (
     output["OrderableDBInstanceOptions"] !== undefined &&
@@ -9101,7 +9072,6 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   };
   if (output.LogTypesToDisable === "") {
     contents.LogTypesToDisable = [];
-    return contents;
   }
   if (
     output["LogTypesToDisable"] !== undefined &&
@@ -9118,7 +9088,6 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   }
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
-    return contents;
   }
   if (
     output["LogTypesToEnable"] !== undefined &&
@@ -9202,7 +9171,6 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   }
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
-    return contents;
   }
   if (
     output["PendingMaintenanceActions"] !== undefined &&
@@ -9326,7 +9294,6 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   };
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
-    return contents;
   }
   if (
     output["PendingMaintenanceActionDetails"] !== undefined &&
@@ -9490,7 +9457,6 @@ const deserializeAws_queryTagListMessage = (
   };
   if (output.TagList === "") {
     contents.TagList = [];
-    return contents;
   }
   if (
     output["TagList"] !== undefined &&

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -32220,7 +32220,7 @@ const serializeAws_ec2AssociateIamInstanceProfileRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `IamInstanceProfile.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `IamInstanceProfile.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -32639,7 +32639,7 @@ const serializeAws_ec2BlockDeviceMapping = (
   if (input.Ebs !== undefined) {
     const memberEntries = serializeAws_ec2EbsBlockDevice(input.Ebs, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Ebs.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Ebs.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -32711,7 +32711,7 @@ const serializeAws_ec2BundleInstanceRequest = (
   if (input.Storage !== undefined) {
     const memberEntries = serializeAws_ec2Storage(input.Storage, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Storage.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Storage.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -32888,9 +32888,7 @@ const serializeAws_ec2CapacityReservationSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CapacityReservationTarget.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CapacityReservationTarget.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33010,7 +33008,7 @@ const serializeAws_ec2ClientVpnAuthenticationRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `ActiveDirectory.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `ActiveDirectory.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33020,7 +33018,7 @@ const serializeAws_ec2ClientVpnAuthenticationRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `MutualAuthentication.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `MutualAuthentication.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33323,7 +33321,7 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `ConnectionLogOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `ConnectionLogOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33519,7 +33517,7 @@ const serializeAws_ec2CreateFleetRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `OnDemandOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `OnDemandOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33532,7 +33530,7 @@ const serializeAws_ec2CreateFleetRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SpotOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SpotOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33552,9 +33550,7 @@ const serializeAws_ec2CreateFleetRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `TargetCapacitySpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `TargetCapacitySpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33639,7 +33635,7 @@ const serializeAws_ec2CreateFpgaImageRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `InputStorageLocation.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `InputStorageLocation.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33649,7 +33645,7 @@ const serializeAws_ec2CreateFpgaImageRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LogsStorageLocation.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LogsStorageLocation.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33716,7 +33712,7 @@ const serializeAws_ec2CreateInstanceExportTaskRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `ExportToS3.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `ExportToS3.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33771,7 +33767,7 @@ const serializeAws_ec2CreateLaunchTemplateRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchTemplateData.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LaunchTemplateData.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33811,7 +33807,7 @@ const serializeAws_ec2CreateLaunchTemplateVersionRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchTemplateData.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LaunchTemplateData.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33905,7 +33901,7 @@ const serializeAws_ec2CreateNetworkAclEntryRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Icmp.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Icmp.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -33918,7 +33914,7 @@ const serializeAws_ec2CreateNetworkAclEntryRequest = (
   if (input.PortRange !== undefined) {
     const memberEntries = serializeAws_ec2PortRange(input.PortRange, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `PortRange.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `PortRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -34203,9 +34199,7 @@ const serializeAws_ec2CreateSnapshotsRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `InstanceSpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `InstanceSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -34349,7 +34343,7 @@ const serializeAws_ec2CreateTrafficMirrorFilterRuleRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `DestinationPortRange.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `DestinationPortRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -34374,7 +34368,7 @@ const serializeAws_ec2CreateTrafficMirrorFilterRuleRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SourcePortRange.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SourcePortRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -34545,7 +34539,7 @@ const serializeAws_ec2CreateTransitGatewayRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Options.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Options.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -34623,7 +34617,7 @@ const serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Options.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Options.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -34970,7 +34964,7 @@ const serializeAws_ec2CreateVpnConnectionRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Options.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Options.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -38148,9 +38142,7 @@ const serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `FirstSlotStartTimeRange.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `FirstSlotStartTimeRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -38172,7 +38164,7 @@ const serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Recurrence.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Recurrence.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -38216,7 +38208,7 @@ const serializeAws_ec2DescribeScheduledInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SlotStartTimeRange.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SlotStartTimeRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -39773,14 +39765,14 @@ const serializeAws_ec2DiskImage = (
   if (input.Image !== undefined) {
     const memberEntries = serializeAws_ec2DiskImageDetail(input.Image, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Image.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Image.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
   if (input.Volume !== undefined) {
     const memberEntries = serializeAws_ec2VolumeDetail(input.Volume, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Volume.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Volume.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -40177,7 +40169,7 @@ const serializeAws_ec2ExportImageRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `S3ExportLocation.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `S3ExportLocation.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -40348,9 +40340,7 @@ const serializeAws_ec2FleetLaunchTemplateConfigRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchTemplateSpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `LaunchTemplateSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -40403,7 +40393,7 @@ const serializeAws_ec2FleetLaunchTemplateOverridesRequest = (
   if (input.Placement !== undefined) {
     const memberEntries = serializeAws_ec2Placement(input.Placement, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Placement.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Placement.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -40966,7 +40956,7 @@ const serializeAws_ec2ImageDiskContainer = (
   if (input.UserBucket !== undefined) {
     const memberEntries = serializeAws_ec2UserBucket(input.UserBucket, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `UserBucket.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `UserBucket.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41060,7 +41050,7 @@ const serializeAws_ec2ImportImageRequest = (
   if (input.ClientData !== undefined) {
     const memberEntries = serializeAws_ec2ClientData(input.ClientData, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `ClientData.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `ClientData.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41160,7 +41150,7 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
   if (input.Placement !== undefined) {
     const memberEntries = serializeAws_ec2Placement(input.Placement, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Placement.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Placement.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41173,7 +41163,7 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
   if (input.UserData !== undefined) {
     const memberEntries = serializeAws_ec2UserData(input.UserData, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `UserData.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `UserData.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41207,7 +41197,7 @@ const serializeAws_ec2ImportInstanceRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchSpecification.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LaunchSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41244,7 +41234,7 @@ const serializeAws_ec2ImportSnapshotRequest = (
   if (input.ClientData !== undefined) {
     const memberEntries = serializeAws_ec2ClientData(input.ClientData, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `ClientData.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `ClientData.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41260,7 +41250,7 @@ const serializeAws_ec2ImportSnapshotRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `DiskContainer.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `DiskContainer.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41309,14 +41299,14 @@ const serializeAws_ec2ImportVolumeRequest = (
   if (input.Image !== undefined) {
     const memberEntries = serializeAws_ec2DiskImageDetail(input.Image, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Image.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Image.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
   if (input.Volume !== undefined) {
     const memberEntries = serializeAws_ec2VolumeDetail(input.Volume, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Volume.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Volume.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41337,7 +41327,7 @@ const serializeAws_ec2InstanceBlockDeviceMappingSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Ebs.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Ebs.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41486,7 +41476,7 @@ const serializeAws_ec2InstanceMarketOptionsRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SpotOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SpotOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41885,7 +41875,7 @@ const serializeAws_ec2LaunchTemplateBlockDeviceMappingRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Ebs.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Ebs.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41932,9 +41922,7 @@ const serializeAws_ec2LaunchTemplateCapacityReservationSpecificationRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CapacityReservationTarget.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CapacityReservationTarget.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -41952,9 +41940,7 @@ const serializeAws_ec2LaunchTemplateConfig = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchTemplateSpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `LaunchTemplateSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42102,7 +42088,7 @@ const serializeAws_ec2LaunchTemplateInstanceMarketOptionsRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SpotOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SpotOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42466,9 +42452,7 @@ const serializeAws_ec2LoadBalancersConfig = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `ClassicLoadBalancersConfig.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `ClassicLoadBalancersConfig.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42478,7 +42462,7 @@ const serializeAws_ec2LoadBalancersConfig = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `TargetGroupsConfig.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `TargetGroupsConfig.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42658,7 +42642,7 @@ const serializeAws_ec2ModifyClientVpnEndpointRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `ConnectionLogOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `ConnectionLogOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42671,7 +42655,7 @@ const serializeAws_ec2ModifyClientVpnEndpointRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `DnsServers.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `DnsServers.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42742,9 +42726,7 @@ const serializeAws_ec2ModifyFleetRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `TargetCapacitySpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `TargetCapacitySpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42774,7 +42756,7 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LoadPermission.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LoadPermission.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42892,7 +42874,7 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Description.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Description.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42908,7 +42890,7 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchPermission.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LaunchPermission.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42975,9 +42957,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `DisableApiTermination.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `DisableApiTermination.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -42990,7 +42970,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `EbsOptimized.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `EbsOptimized.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43000,7 +42980,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `EnaSupport.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `EnaSupport.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43023,9 +43003,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `InstanceInitiatedShutdownBehavior.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `InstanceInitiatedShutdownBehavior.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43035,14 +43013,14 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `InstanceType.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `InstanceType.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
   if (input.Kernel !== undefined) {
     const memberEntries = serializeAws_ec2AttributeValue(input.Kernel, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Kernel.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Kernel.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43052,7 +43030,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Ramdisk.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Ramdisk.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43062,7 +43040,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SourceDestCheck.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SourceDestCheck.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43072,7 +43050,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SriovNetSupport.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SriovNetSupport.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43082,7 +43060,7 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `UserData.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `UserData.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43103,9 +43081,7 @@ const serializeAws_ec2ModifyInstanceCapacityReservationAttributesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CapacityReservationSpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CapacityReservationSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43250,7 +43226,7 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Attachment.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Attachment.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43260,7 +43236,7 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Description.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Description.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43286,7 +43262,7 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SourceDestCheck.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SourceDestCheck.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43340,9 +43316,7 @@ const serializeAws_ec2ModifySnapshotAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CreateVolumePermission.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CreateVolumePermission.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43410,9 +43384,7 @@ const serializeAws_ec2ModifySubnetAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `AssignIpv6AddressOnCreation.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `AssignIpv6AddressOnCreation.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43422,7 +43394,7 @@ const serializeAws_ec2ModifySubnetAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `MapPublicIpOnLaunch.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `MapPublicIpOnLaunch.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43483,7 +43455,7 @@ const serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `DestinationPortRange.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `DestinationPortRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43518,7 +43490,7 @@ const serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SourcePortRange.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `SourcePortRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43597,7 +43569,7 @@ const serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Options.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Options.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43642,7 +43614,7 @@ const serializeAws_ec2ModifyVolumeAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `AutoEnableIO.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `AutoEnableIO.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43689,7 +43661,7 @@ const serializeAws_ec2ModifyVpcAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `EnableDnsHostnames.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `EnableDnsHostnames.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43699,7 +43671,7 @@ const serializeAws_ec2ModifyVpcAttributeRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `EnableDnsSupport.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `EnableDnsSupport.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43915,9 +43887,7 @@ const serializeAws_ec2ModifyVpcPeeringConnectionOptionsRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `AccepterPeeringConnectionOptions.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `AccepterPeeringConnectionOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -43930,9 +43900,7 @@ const serializeAws_ec2ModifyVpcPeeringConnectionOptionsRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `RequesterPeeringConnectionOptions.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `RequesterPeeringConnectionOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -44013,7 +43981,7 @@ const serializeAws_ec2ModifyVpnTunnelOptionsRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `TunnelOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `TunnelOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -44275,9 +44243,7 @@ const serializeAws_ec2OnDemandOptionsRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CapacityReservationOptions.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CapacityReservationOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -44753,9 +44719,7 @@ const serializeAws_ec2ProvisionByoipCidrRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CidrAuthorizationContext.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CidrAuthorizationContext.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -44861,7 +44825,7 @@ const serializeAws_ec2PurchaseReservedInstancesOfferingRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LimitPrice.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LimitPrice.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45183,7 +45147,7 @@ const serializeAws_ec2ReplaceIamInstanceProfileAssociationRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `IamInstanceProfile.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `IamInstanceProfile.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45227,7 +45191,7 @@ const serializeAws_ec2ReplaceNetworkAclEntryRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Icmp.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Icmp.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45240,7 +45204,7 @@ const serializeAws_ec2ReplaceNetworkAclEntryRequest = (
   if (input.PortRange !== undefined) {
     const memberEntries = serializeAws_ec2PortRange(input.PortRange, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `PortRange.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `PortRange.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45446,9 +45410,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CapacityReservationSpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CapacityReservationSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45458,7 +45420,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CpuOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `CpuOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45468,7 +45430,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CreditSpecification.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `CreditSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45508,7 +45470,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `HibernationOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `HibernationOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45518,7 +45480,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `IamInstanceProfile.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `IamInstanceProfile.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45535,9 +45497,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `InstanceMarketOptions.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `InstanceMarketOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45566,7 +45526,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `MetadataOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `MetadataOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45576,7 +45536,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Monitoring.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Monitoring.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45596,7 +45556,7 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Placement.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Placement.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45653,9 +45613,7 @@ const serializeAws_ec2RequestSpotFleetRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `SpotFleetRequestConfig.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `SpotFleetRequestConfig.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45695,7 +45653,7 @@ const serializeAws_ec2RequestSpotInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchSpecification.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LaunchSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45741,7 +45699,7 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `IamInstanceProfile.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `IamInstanceProfile.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45763,7 +45721,7 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Monitoring.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Monitoring.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -45783,7 +45741,7 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Placement.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Placement.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46221,9 +46179,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CapacityReservationSpecification.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `CapacityReservationSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46236,7 +46192,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CpuOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `CpuOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46246,7 +46202,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `CreditSpecification.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `CreditSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46289,7 +46245,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `HibernationOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `HibernationOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46299,7 +46255,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `IamInstanceProfile.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `IamInstanceProfile.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46316,9 +46272,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `InstanceMarketOptions.${key.substring(
-        key.indexOf(".") + 1
-      )}`;
+      const loc = `InstanceMarketOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46350,7 +46304,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchTemplate.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LaunchTemplate.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46373,7 +46327,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `MetadataOptions.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `MetadataOptions.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46386,7 +46340,7 @@ const serializeAws_ec2RunInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Monitoring.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Monitoring.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46403,7 +46357,7 @@ const serializeAws_ec2RunInstancesRequest = (
   if (input.Placement !== undefined) {
     const memberEntries = serializeAws_ec2Placement(input.Placement, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Placement.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Placement.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46475,7 +46429,7 @@ const serializeAws_ec2RunScheduledInstancesRequest = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LaunchSpecification.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LaunchSpecification.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46565,7 +46519,7 @@ const serializeAws_ec2ScheduledInstancesBlockDeviceMapping = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Ebs.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Ebs.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46691,7 +46645,7 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `IamInstanceProfile.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `IamInstanceProfile.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46713,7 +46667,7 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Monitoring.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Monitoring.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -46733,7 +46687,7 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Placement.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Placement.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -47062,7 +47016,7 @@ const serializeAws_ec2SnapshotDiskContainer = (
   if (input.UserBucket !== undefined) {
     const memberEntries = serializeAws_ec2UserBucket(input.UserBucket, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `UserBucket.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `UserBucket.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -47109,7 +47063,7 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `IamInstanceProfile.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `IamInstanceProfile.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -47131,7 +47085,7 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Monitoring.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Monitoring.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -47151,7 +47105,7 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `Placement.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `Placement.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -47260,7 +47214,7 @@ const serializeAws_ec2SpotFleetRequestConfigData = (
       context
     );
     Object.keys(memberEntries).forEach(key => {
-      const loc = `LoadBalancersConfig.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `LoadBalancersConfig.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -47498,7 +47452,7 @@ const serializeAws_ec2Storage = (
   if (input.S3 !== undefined) {
     const memberEntries = serializeAws_ec2S3Storage(input.S3, context);
     Object.keys(memberEntries).forEach(key => {
-      const loc = `S3.${key.substring(key.indexOf(".") + 1)}`;
+      const loc = `S3.${key}`;
       entries[loc] = memberEntries[key];
     });
   }
@@ -48435,7 +48389,6 @@ const deserializeAws_ec2AcceptVpcEndpointConnectionsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -48484,7 +48437,6 @@ const deserializeAws_ec2AccountAttribute = (
   }
   if (output.attributeValueSet === "") {
     contents.AttributeValues = [];
-    return contents;
   }
   if (
     output["attributeValueSet"] !== undefined &&
@@ -48627,7 +48579,6 @@ const deserializeAws_ec2Address = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -48716,7 +48667,6 @@ const deserializeAws_ec2AllocateHostsResult = (
   };
   if (output.hostIdSet === "") {
     contents.HostIds = [];
-    return contents;
   }
   if (
     output["hostIdSet"] !== undefined &&
@@ -48771,7 +48721,6 @@ const deserializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkResult = (
   };
   if (output.securityGroupIds === "") {
     contents.SecurityGroupIds = [];
-    return contents;
   }
   if (
     output["securityGroupIds"] !== undefined &&
@@ -48807,7 +48756,6 @@ const deserializeAws_ec2AssignIpv6AddressesResult = (
   };
   if (output.assignedIpv6Addresses === "") {
     contents.AssignedIpv6Addresses = [];
-    return contents;
   }
   if (
     output["assignedIpv6Addresses"] !== undefined &&
@@ -48839,7 +48787,6 @@ const deserializeAws_ec2AssignPrivateIpAddressesResult = (
   };
   if (output.assignedPrivateIpAddressesSet === "") {
     contents.AssignedPrivateIpAddresses = [];
-    return contents;
   }
   if (
     output["assignedPrivateIpAddressesSet"] !== undefined &&
@@ -49240,7 +49187,6 @@ const deserializeAws_ec2AvailabilityZone = (
   }
   if (output.messageSet === "") {
     contents.Messages = [];
-    return contents;
   }
   if (
     output["messageSet"] !== undefined &&
@@ -49319,7 +49265,6 @@ const deserializeAws_ec2AvailableCapacity = (
   };
   if (output.availableInstanceCapacity === "") {
     contents.AvailableInstanceCapacity = [];
-    return contents;
   }
   if (
     output["availableInstanceCapacity"] !== undefined &&
@@ -49571,7 +49516,6 @@ const deserializeAws_ec2CancelReservedInstancesListingResult = (
   };
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
-    return contents;
   }
   if (
     output["reservedInstancesListingsSet"] !== undefined &&
@@ -49648,7 +49592,6 @@ const deserializeAws_ec2CancelSpotFleetRequestsResponse = (
   };
   if (output.successfulFleetRequestSet === "") {
     contents.SuccessfulFleetRequests = [];
-    return contents;
   }
   if (
     output["successfulFleetRequestSet"] !== undefined &&
@@ -49665,7 +49608,6 @@ const deserializeAws_ec2CancelSpotFleetRequestsResponse = (
   }
   if (output.unsuccessfulFleetRequestSet === "") {
     contents.UnsuccessfulFleetRequests = [];
-    return contents;
   }
   if (
     output["unsuccessfulFleetRequestSet"] !== undefined &&
@@ -49726,7 +49668,6 @@ const deserializeAws_ec2CancelSpotInstanceRequestsResult = (
   };
   if (output.spotInstanceRequestSet === "") {
     contents.CancelledSpotInstanceRequests = [];
-    return contents;
   }
   if (
     output["spotInstanceRequestSet"] !== undefined &&
@@ -49845,7 +49786,6 @@ const deserializeAws_ec2CapacityReservation = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -50003,7 +49943,6 @@ const deserializeAws_ec2ClassicLinkInstance = (
   };
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -50023,7 +49962,6 @@ const deserializeAws_ec2ClassicLinkInstance = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -50083,7 +50021,6 @@ const deserializeAws_ec2ClassicLoadBalancersConfig = (
   };
   if (output.classicLoadBalancers === "") {
     contents.ClassicLoadBalancers = [];
-    return contents;
   }
   if (
     output["classicLoadBalancers"] !== undefined &&
@@ -50292,7 +50229,6 @@ const deserializeAws_ec2ClientVpnEndpoint = (
   };
   if (output.associatedTargetNetwork === "") {
     contents.AssociatedTargetNetworks = [];
-    return contents;
   }
   if (
     output["associatedTargetNetwork"] !== undefined &&
@@ -50309,7 +50245,6 @@ const deserializeAws_ec2ClientVpnEndpoint = (
   }
   if (output.authenticationOptions === "") {
     contents.AuthenticationOptions = [];
-    return contents;
   }
   if (
     output["authenticationOptions"] !== undefined &&
@@ -50350,7 +50285,6 @@ const deserializeAws_ec2ClientVpnEndpoint = (
   }
   if (output.dnsServer === "") {
     contents.DnsServers = [];
-    return contents;
   }
   if (
     output["dnsServer"] !== undefined &&
@@ -50379,7 +50313,6 @@ const deserializeAws_ec2ClientVpnEndpoint = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -50547,7 +50480,6 @@ const deserializeAws_ec2CoipPool = (
   }
   if (output.poolCidrSet === "") {
     contents.PoolCidrs = [];
-    return contents;
   }
   if (
     output["poolCidrSet"] !== undefined &&
@@ -50567,7 +50499,6 @@ const deserializeAws_ec2CoipPool = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -50647,7 +50578,6 @@ const deserializeAws_ec2ConnectionNotification = (
   };
   if (output.connectionEvents === "") {
     contents.ConnectionEvents = [];
-    return contents;
   }
   if (
     output["connectionEvents"] !== undefined &&
@@ -50733,7 +50663,6 @@ const deserializeAws_ec2ConversionTask = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -50790,7 +50719,6 @@ const deserializeAws_ec2CopySnapshotResult = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -51024,7 +50952,6 @@ const deserializeAws_ec2CreateFleetInstance = (
   };
   if (output.instanceIds === "") {
     contents.InstanceIds = [];
-    return contents;
   }
   if (
     output["instanceIds"] !== undefined &&
@@ -51078,7 +51005,6 @@ const deserializeAws_ec2CreateFleetResult = (
   };
   if (output.errorSet === "") {
     contents.Errors = [];
-    return contents;
   }
   if (
     output["errorSet"] !== undefined &&
@@ -51098,7 +51024,6 @@ const deserializeAws_ec2CreateFleetResult = (
   }
   if (output.fleetInstanceSet === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["fleetInstanceSet"] !== undefined &&
@@ -51131,7 +51056,6 @@ const deserializeAws_ec2CreateFlowLogsResult = (
   }
   if (output.flowLogIdSet === "") {
     contents.FlowLogIds = [];
-    return contents;
   }
   if (
     output["flowLogIdSet"] !== undefined &&
@@ -51148,7 +51072,6 @@ const deserializeAws_ec2CreateFlowLogsResult = (
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -51382,7 +51305,6 @@ const deserializeAws_ec2CreateReservedInstancesListingResult = (
   };
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
-    return contents;
   }
   if (
     output["reservedInstancesListingsSet"] !== undefined &&
@@ -51455,7 +51377,6 @@ const deserializeAws_ec2CreateSnapshotsResult = (
   };
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
-    return contents;
   }
   if (
     output["snapshotSet"] !== undefined &&
@@ -51891,7 +51812,6 @@ const deserializeAws_ec2CustomerGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -52056,7 +51976,6 @@ const deserializeAws_ec2DeleteFleetsResult = (
   };
   if (output.successfulFleetDeletionSet === "") {
     contents.SuccessfulFleetDeletions = [];
-    return contents;
   }
   if (
     output["successfulFleetDeletionSet"] !== undefined &&
@@ -52073,7 +51992,6 @@ const deserializeAws_ec2DeleteFleetsResult = (
   }
   if (output.unsuccessfulFleetDeletionSet === "") {
     contents.UnsuccessfulFleetDeletions = [];
-    return contents;
   }
   if (
     output["unsuccessfulFleetDeletionSet"] !== undefined &&
@@ -52101,7 +52019,6 @@ const deserializeAws_ec2DeleteFlowLogsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -52236,7 +52153,6 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResult = (
   };
   if (output.successfullyDeletedLaunchTemplateVersionSet === "") {
     contents.SuccessfullyDeletedLaunchTemplateVersions = [];
-    return contents;
   }
   if (
     output["successfullyDeletedLaunchTemplateVersionSet"] !== undefined &&
@@ -52254,7 +52170,6 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResult = (
   }
   if (output.unsuccessfullyDeletedLaunchTemplateVersionSet === "") {
     contents.UnsuccessfullyDeletedLaunchTemplateVersions = [];
-    return contents;
   }
   if (
     output["unsuccessfullyDeletedLaunchTemplateVersionSet"] !== undefined &&
@@ -52365,7 +52280,6 @@ const deserializeAws_ec2DeleteQueuedReservedInstancesResult = (
   };
   if (output.failedQueuedPurchaseDeletionSet === "") {
     contents.FailedQueuedPurchaseDeletions = [];
-    return contents;
   }
   if (
     output["failedQueuedPurchaseDeletionSet"] !== undefined &&
@@ -52382,7 +52296,6 @@ const deserializeAws_ec2DeleteQueuedReservedInstancesResult = (
   }
   if (output.successfulQueuedPurchaseDeletionSet === "") {
     contents.SuccessfulQueuedPurchaseDeletions = [];
-    return contents;
   }
   if (
     output["successfulQueuedPurchaseDeletionSet"] !== undefined &&
@@ -52568,7 +52481,6 @@ const deserializeAws_ec2DeleteVpcEndpointConnectionNotificationsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -52596,7 +52508,6 @@ const deserializeAws_ec2DeleteVpcEndpointServiceConfigurationsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -52624,7 +52535,6 @@ const deserializeAws_ec2DeleteVpcEndpointsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -52717,7 +52627,6 @@ const deserializeAws_ec2DescribeAccountAttributesResult = (
   };
   if (output.accountAttributeSet === "") {
     contents.AccountAttributes = [];
-    return contents;
   }
   if (
     output["accountAttributeSet"] !== undefined &&
@@ -52745,7 +52654,6 @@ const deserializeAws_ec2DescribeAddressesResult = (
   };
   if (output.addressesSet === "") {
     contents.Addresses = [];
-    return contents;
   }
   if (
     output["addressesSet"] !== undefined &&
@@ -52771,7 +52679,6 @@ const deserializeAws_ec2DescribeAggregateIdFormatResult = (
   };
   if (output.statusSet === "") {
     contents.Statuses = [];
-    return contents;
   }
   if (
     output["statusSet"] !== undefined &&
@@ -52799,7 +52706,6 @@ const deserializeAws_ec2DescribeAvailabilityZonesResult = (
   };
   if (output.availabilityZoneInfo === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["availabilityZoneInfo"] !== undefined &&
@@ -52827,7 +52733,6 @@ const deserializeAws_ec2DescribeBundleTasksResult = (
   };
   if (output.bundleInstanceTasksSet === "") {
     contents.BundleTasks = [];
-    return contents;
   }
   if (
     output["bundleInstanceTasksSet"] !== undefined &&
@@ -52856,7 +52761,6 @@ const deserializeAws_ec2DescribeByoipCidrsResult = (
   };
   if (output.byoipCidrSet === "") {
     contents.ByoipCidrs = [];
-    return contents;
   }
   if (
     output["byoipCidrSet"] !== undefined &&
@@ -52885,7 +52789,6 @@ const deserializeAws_ec2DescribeCapacityReservationsResult = (
   };
   if (output.capacityReservationSet === "") {
     contents.CapacityReservations = [];
-    return contents;
   }
   if (
     output["capacityReservationSet"] !== undefined &&
@@ -52917,7 +52820,6 @@ const deserializeAws_ec2DescribeClassicLinkInstancesResult = (
   };
   if (output.instancesSet === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["instancesSet"] !== undefined &&
@@ -52949,7 +52851,6 @@ const deserializeAws_ec2DescribeClientVpnAuthorizationRulesResult = (
   };
   if (output.authorizationRule === "") {
     contents.AuthorizationRules = [];
-    return contents;
   }
   if (
     output["authorizationRule"] !== undefined &&
@@ -52981,7 +52882,6 @@ const deserializeAws_ec2DescribeClientVpnConnectionsResult = (
   };
   if (output.connections === "") {
     contents.Connections = [];
-    return contents;
   }
   if (
     output["connections"] !== undefined &&
@@ -53013,7 +52913,6 @@ const deserializeAws_ec2DescribeClientVpnEndpointsResult = (
   };
   if (output.clientVpnEndpoint === "") {
     contents.ClientVpnEndpoints = [];
-    return contents;
   }
   if (
     output["clientVpnEndpoint"] !== undefined &&
@@ -53048,7 +52947,6 @@ const deserializeAws_ec2DescribeClientVpnRoutesResult = (
   }
   if (output.routes === "") {
     contents.Routes = [];
-    return contents;
   }
   if (
     output["routes"] !== undefined &&
@@ -53074,7 +52972,6 @@ const deserializeAws_ec2DescribeClientVpnTargetNetworksResult = (
   };
   if (output.clientVpnTargetNetworks === "") {
     contents.ClientVpnTargetNetworks = [];
-    return contents;
   }
   if (
     output["clientVpnTargetNetworks"] !== undefined &&
@@ -53106,7 +53003,6 @@ const deserializeAws_ec2DescribeCoipPoolsResult = (
   };
   if (output.coipPoolSet === "") {
     contents.CoipPools = [];
-    return contents;
   }
   if (
     output["coipPoolSet"] !== undefined &&
@@ -53143,7 +53039,6 @@ const deserializeAws_ec2DescribeConversionTasksResult = (
   };
   if (output.conversionTasks === "") {
     contents.ConversionTasks = [];
-    return contents;
   }
   if (
     output["conversionTasks"] !== undefined &&
@@ -53171,7 +53066,6 @@ const deserializeAws_ec2DescribeCustomerGatewaysResult = (
   };
   if (output.customerGatewaySet === "") {
     contents.CustomerGateways = [];
-    return contents;
   }
   if (
     output["customerGatewaySet"] !== undefined &&
@@ -53200,7 +53094,6 @@ const deserializeAws_ec2DescribeDhcpOptionsResult = (
   };
   if (output.dhcpOptionsSet === "") {
     contents.DhcpOptions = [];
-    return contents;
   }
   if (
     output["dhcpOptionsSet"] !== undefined &&
@@ -53232,7 +53125,6 @@ const deserializeAws_ec2DescribeEgressOnlyInternetGatewaysResult = (
   };
   if (output.egressOnlyInternetGatewaySet === "") {
     contents.EgressOnlyInternetGateways = [];
-    return contents;
   }
   if (
     output["egressOnlyInternetGatewaySet"] !== undefined &&
@@ -53265,7 +53157,6 @@ const deserializeAws_ec2DescribeElasticGpusResult = (
   };
   if (output.elasticGpuSet === "") {
     contents.ElasticGpuSet = [];
-    return contents;
   }
   if (
     output["elasticGpuSet"] !== undefined &&
@@ -53300,7 +53191,6 @@ const deserializeAws_ec2DescribeExportImageTasksResult = (
   };
   if (output.exportImageTaskSet === "") {
     contents.ExportImageTasks = [];
-    return contents;
   }
   if (
     output["exportImageTaskSet"] !== undefined &&
@@ -53331,7 +53221,6 @@ const deserializeAws_ec2DescribeExportTasksResult = (
   };
   if (output.exportTaskSet === "") {
     contents.ExportTasks = [];
-    return contents;
   }
   if (
     output["exportTaskSet"] !== undefined &&
@@ -53423,7 +53312,6 @@ const deserializeAws_ec2DescribeFastSnapshotRestoresResult = (
   };
   if (output.fastSnapshotRestoreSet === "") {
     contents.FastSnapshotRestores = [];
-    return contents;
   }
   if (
     output["fastSnapshotRestoreSet"] !== undefined &&
@@ -53490,7 +53378,6 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
   }
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
-    return contents;
   }
   if (
     output["historyRecordSet"] !== undefined &&
@@ -53529,7 +53416,6 @@ const deserializeAws_ec2DescribeFleetInstancesResult = (
   };
   if (output.activeInstanceSet === "") {
     contents.ActiveInstances = [];
-    return contents;
   }
   if (
     output["activeInstanceSet"] !== undefined &&
@@ -53576,7 +53462,6 @@ const deserializeAws_ec2DescribeFleetsInstances = (
   };
   if (output.instanceIds === "") {
     contents.InstanceIds = [];
-    return contents;
   }
   if (
     output["instanceIds"] !== undefined &&
@@ -53629,7 +53514,6 @@ const deserializeAws_ec2DescribeFleetsResult = (
   };
   if (output.fleetSet === "") {
     contents.Fleets = [];
-    return contents;
   }
   if (
     output["fleetSet"] !== undefined &&
@@ -53658,7 +53542,6 @@ const deserializeAws_ec2DescribeFlowLogsResult = (
   };
   if (output.flowLogSet === "") {
     contents.FlowLogs = [];
-    return contents;
   }
   if (
     output["flowLogSet"] !== undefined &&
@@ -53704,7 +53587,6 @@ const deserializeAws_ec2DescribeFpgaImagesResult = (
   };
   if (output.fpgaImageSet === "") {
     contents.FpgaImages = [];
-    return contents;
   }
   if (
     output["fpgaImageSet"] !== undefined &&
@@ -53736,7 +53618,6 @@ const deserializeAws_ec2DescribeHostReservationOfferingsResult = (
   }
   if (output.offeringSet === "") {
     contents.OfferingSet = [];
-    return contents;
   }
   if (
     output["offeringSet"] !== undefined &&
@@ -53765,7 +53646,6 @@ const deserializeAws_ec2DescribeHostReservationsResult = (
   };
   if (output.hostReservationSet === "") {
     contents.HostReservationSet = [];
-    return contents;
   }
   if (
     output["hostReservationSet"] !== undefined &&
@@ -53797,7 +53677,6 @@ const deserializeAws_ec2DescribeHostsResult = (
   };
   if (output.hostSet === "") {
     contents.Hosts = [];
-    return contents;
   }
   if (
     output["hostSet"] !== undefined &&
@@ -53826,7 +53705,6 @@ const deserializeAws_ec2DescribeIamInstanceProfileAssociationsResult = (
   };
   if (output.iamInstanceProfileAssociationSet === "") {
     contents.IamInstanceProfileAssociations = [];
-    return contents;
   }
   if (
     output["iamInstanceProfileAssociationSet"] !== undefined &&
@@ -53857,7 +53735,6 @@ const deserializeAws_ec2DescribeIdFormatResult = (
   };
   if (output.statusSet === "") {
     contents.Statuses = [];
-    return contents;
   }
   if (
     output["statusSet"] !== undefined &&
@@ -53882,7 +53759,6 @@ const deserializeAws_ec2DescribeIdentityIdFormatResult = (
   };
   if (output.statusSet === "") {
     contents.Statuses = [];
-    return contents;
   }
   if (
     output["statusSet"] !== undefined &&
@@ -53907,7 +53783,6 @@ const deserializeAws_ec2DescribeImagesResult = (
   };
   if (output.imagesSet === "") {
     contents.Images = [];
-    return contents;
   }
   if (
     output["imagesSet"] !== undefined &&
@@ -53933,7 +53808,6 @@ const deserializeAws_ec2DescribeImportImageTasksResult = (
   };
   if (output.importImageTaskSet === "") {
     contents.ImportImageTasks = [];
-    return contents;
   }
   if (
     output["importImageTaskSet"] !== undefined &&
@@ -53965,7 +53839,6 @@ const deserializeAws_ec2DescribeImportSnapshotTasksResult = (
   };
   if (output.importSnapshotTaskSet === "") {
     contents.ImportSnapshotTasks = [];
-    return contents;
   }
   if (
     output["importSnapshotTaskSet"] !== undefined &&
@@ -53997,7 +53870,6 @@ const deserializeAws_ec2DescribeInstanceCreditSpecificationsResult = (
   };
   if (output.instanceCreditSpecificationSet === "") {
     contents.InstanceCreditSpecifications = [];
-    return contents;
   }
   if (
     output["instanceCreditSpecificationSet"] !== undefined &&
@@ -54029,7 +53901,6 @@ const deserializeAws_ec2DescribeInstanceStatusResult = (
   };
   if (output.instanceStatusSet === "") {
     contents.InstanceStatuses = [];
-    return contents;
   }
   if (
     output["instanceStatusSet"] !== undefined &&
@@ -54061,7 +53932,6 @@ const deserializeAws_ec2DescribeInstanceTypeOfferingsResult = (
   };
   if (output.instanceTypeOfferingSet === "") {
     contents.InstanceTypeOfferings = [];
-    return contents;
   }
   if (
     output["instanceTypeOfferingSet"] !== undefined &&
@@ -54093,7 +53963,6 @@ const deserializeAws_ec2DescribeInstanceTypesResult = (
   };
   if (output.instanceTypeSet === "") {
     contents.InstanceTypes = [];
-    return contents;
   }
   if (
     output["instanceTypeSet"] !== undefined &&
@@ -54128,7 +53997,6 @@ const deserializeAws_ec2DescribeInstancesResult = (
   }
   if (output.reservationSet === "") {
     contents.Reservations = [];
-    return contents;
   }
   if (
     output["reservationSet"] !== undefined &&
@@ -54157,7 +54025,6 @@ const deserializeAws_ec2DescribeInternetGatewaysResult = (
   };
   if (output.internetGatewaySet === "") {
     contents.InternetGateways = [];
-    return contents;
   }
   if (
     output["internetGatewaySet"] !== undefined &&
@@ -54189,7 +54056,6 @@ const deserializeAws_ec2DescribeIpv6PoolsResult = (
   };
   if (output.ipv6PoolSet === "") {
     contents.Ipv6Pools = [];
-    return contents;
   }
   if (
     output["ipv6PoolSet"] !== undefined &&
@@ -54217,7 +54083,6 @@ const deserializeAws_ec2DescribeKeyPairsResult = (
   };
   if (output.keySet === "") {
     contents.KeyPairs = [];
-    return contents;
   }
   if (
     output["keySet"] !== undefined &&
@@ -54243,7 +54108,6 @@ const deserializeAws_ec2DescribeLaunchTemplateVersionsResult = (
   };
   if (output.launchTemplateVersionSet === "") {
     contents.LaunchTemplateVersions = [];
-    return contents;
   }
   if (
     output["launchTemplateVersionSet"] !== undefined &&
@@ -54275,7 +54139,6 @@ const deserializeAws_ec2DescribeLaunchTemplatesResult = (
   };
   if (output.launchTemplates === "") {
     contents.LaunchTemplates = [];
-    return contents;
   }
   if (
     output["launchTemplates"] !== undefined &&
@@ -54308,7 +54171,6 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssoc
   };
   if (output.localGatewayRouteTableVirtualInterfaceGroupAssociationSet === "") {
     contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociations = [];
-    return contents;
   }
   if (
     output["localGatewayRouteTableVirtualInterfaceGroupAssociationSet"] !==
@@ -54351,7 +54213,6 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsResult = (
   };
   if (output.localGatewayRouteTableVpcAssociationSet === "") {
     contents.LocalGatewayRouteTableVpcAssociations = [];
-    return contents;
   }
   if (
     output["localGatewayRouteTableVpcAssociationSet"] !== undefined &&
@@ -54383,7 +54244,6 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTablesResult = (
   };
   if (output.localGatewayRouteTableSet === "") {
     contents.LocalGatewayRouteTables = [];
-    return contents;
   }
   if (
     output["localGatewayRouteTableSet"] !== undefined &&
@@ -54415,7 +54275,6 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsResult = (
   };
   if (output.localGatewayVirtualInterfaceGroupSet === "") {
     contents.LocalGatewayVirtualInterfaceGroups = [];
-    return contents;
   }
   if (
     output["localGatewayVirtualInterfaceGroupSet"] !== undefined &&
@@ -54447,7 +54306,6 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfacesResult = (
   };
   if (output.localGatewayVirtualInterfaceSet === "") {
     contents.LocalGatewayVirtualInterfaces = [];
-    return contents;
   }
   if (
     output["localGatewayVirtualInterfaceSet"] !== undefined &&
@@ -54479,7 +54337,6 @@ const deserializeAws_ec2DescribeLocalGatewaysResult = (
   };
   if (output.localGatewaySet === "") {
     contents.LocalGateways = [];
-    return contents;
   }
   if (
     output["localGatewaySet"] !== undefined &&
@@ -54511,7 +54368,6 @@ const deserializeAws_ec2DescribeMovingAddressesResult = (
   };
   if (output.movingAddressStatusSet === "") {
     contents.MovingAddressStatuses = [];
-    return contents;
   }
   if (
     output["movingAddressStatusSet"] !== undefined &&
@@ -54543,7 +54399,6 @@ const deserializeAws_ec2DescribeNatGatewaysResult = (
   };
   if (output.natGatewaySet === "") {
     contents.NatGateways = [];
-    return contents;
   }
   if (
     output["natGatewaySet"] !== undefined &&
@@ -54575,7 +54430,6 @@ const deserializeAws_ec2DescribeNetworkAclsResult = (
   };
   if (output.networkAclSet === "") {
     contents.NetworkAcls = [];
-    return contents;
   }
   if (
     output["networkAclSet"] !== undefined &&
@@ -54622,7 +54476,6 @@ const deserializeAws_ec2DescribeNetworkInterfaceAttributeResult = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -54660,7 +54513,6 @@ const deserializeAws_ec2DescribeNetworkInterfacePermissionsResult = (
   };
   if (output.networkInterfacePermissions === "") {
     contents.NetworkInterfacePermissions = [];
-    return contents;
   }
   if (
     output["networkInterfacePermissions"] !== undefined &&
@@ -54692,7 +54544,6 @@ const deserializeAws_ec2DescribeNetworkInterfacesResult = (
   };
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-    return contents;
   }
   if (
     output["networkInterfaceSet"] !== undefined &&
@@ -54723,7 +54574,6 @@ const deserializeAws_ec2DescribePlacementGroupsResult = (
   };
   if (output.placementGroupSet === "") {
     contents.PlacementGroups = [];
-    return contents;
   }
   if (
     output["placementGroupSet"] !== undefined &&
@@ -54755,7 +54605,6 @@ const deserializeAws_ec2DescribePrefixListsResult = (
   }
   if (output.prefixListSet === "") {
     contents.PrefixLists = [];
-    return contents;
   }
   if (
     output["prefixListSet"] !== undefined &&
@@ -54787,7 +54636,6 @@ const deserializeAws_ec2DescribePrincipalIdFormatResult = (
   }
   if (output.principalSet === "") {
     contents.Principals = [];
-    return contents;
   }
   if (
     output["principalSet"] !== undefined &&
@@ -54819,7 +54667,6 @@ const deserializeAws_ec2DescribePublicIpv4PoolsResult = (
   }
   if (output.publicIpv4PoolSet === "") {
     contents.PublicIpv4Pools = [];
-    return contents;
   }
   if (
     output["publicIpv4PoolSet"] !== undefined &&
@@ -54847,7 +54694,6 @@ const deserializeAws_ec2DescribeRegionsResult = (
   };
   if (output.regionInfo === "") {
     contents.Regions = [];
-    return contents;
   }
   if (
     output["regionInfo"] !== undefined &&
@@ -54872,7 +54718,6 @@ const deserializeAws_ec2DescribeReservedInstancesListingsResult = (
   };
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
-    return contents;
   }
   if (
     output["reservedInstancesListingsSet"] !== undefined &&
@@ -54904,7 +54749,6 @@ const deserializeAws_ec2DescribeReservedInstancesModificationsResult = (
   }
   if (output.reservedInstancesModificationsSet === "") {
     contents.ReservedInstancesModifications = [];
-    return contents;
   }
   if (
     output["reservedInstancesModificationsSet"] !== undefined &&
@@ -54936,7 +54780,6 @@ const deserializeAws_ec2DescribeReservedInstancesOfferingsResult = (
   }
   if (output.reservedInstancesOfferingsSet === "") {
     contents.ReservedInstancesOfferings = [];
-    return contents;
   }
   if (
     output["reservedInstancesOfferingsSet"] !== undefined &&
@@ -54964,7 +54807,6 @@ const deserializeAws_ec2DescribeReservedInstancesResult = (
   };
   if (output.reservedInstancesSet === "") {
     contents.ReservedInstances = [];
-    return contents;
   }
   if (
     output["reservedInstancesSet"] !== undefined &&
@@ -54996,7 +54838,6 @@ const deserializeAws_ec2DescribeRouteTablesResult = (
   }
   if (output.routeTableSet === "") {
     contents.RouteTables = [];
-    return contents;
   }
   if (
     output["routeTableSet"] !== undefined &&
@@ -55028,7 +54869,6 @@ const deserializeAws_ec2DescribeScheduledInstanceAvailabilityResult = (
   }
   if (output.scheduledInstanceAvailabilitySet === "") {
     contents.ScheduledInstanceAvailabilitySet = [];
-    return contents;
   }
   if (
     output["scheduledInstanceAvailabilitySet"] !== undefined &&
@@ -55060,7 +54900,6 @@ const deserializeAws_ec2DescribeScheduledInstancesResult = (
   }
   if (output.scheduledInstanceSet === "") {
     contents.ScheduledInstanceSet = [];
-    return contents;
   }
   if (
     output["scheduledInstanceSet"] !== undefined &&
@@ -55088,7 +54927,6 @@ const deserializeAws_ec2DescribeSecurityGroupReferencesResult = (
   };
   if (output.securityGroupReferenceSet === "") {
     contents.SecurityGroupReferenceSet = [];
-    return contents;
   }
   if (
     output["securityGroupReferenceSet"] !== undefined &&
@@ -55120,7 +54958,6 @@ const deserializeAws_ec2DescribeSecurityGroupsResult = (
   }
   if (output.securityGroupInfo === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["securityGroupInfo"] !== undefined &&
@@ -55150,7 +54987,6 @@ const deserializeAws_ec2DescribeSnapshotAttributeResult = (
   };
   if (output.createVolumePermission === "") {
     contents.CreateVolumePermissions = [];
-    return contents;
   }
   if (
     output["createVolumePermission"] !== undefined &&
@@ -55167,7 +55003,6 @@ const deserializeAws_ec2DescribeSnapshotAttributeResult = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -55202,7 +55037,6 @@ const deserializeAws_ec2DescribeSnapshotsResult = (
   }
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
-    return contents;
   }
   if (
     output["snapshotSet"] !== undefined &&
@@ -55246,7 +55080,6 @@ const deserializeAws_ec2DescribeSpotFleetInstancesResponse = (
   };
   if (output.activeInstanceSet === "") {
     contents.ActiveInstances = [];
-    return contents;
   }
   if (
     output["activeInstanceSet"] !== undefined &&
@@ -55284,7 +55117,6 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
   };
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
-    return contents;
   }
   if (
     output["historyRecordSet"] !== undefined &&
@@ -55328,7 +55160,6 @@ const deserializeAws_ec2DescribeSpotFleetRequestsResponse = (
   }
   if (output.spotFleetRequestConfigSet === "") {
     contents.SpotFleetRequestConfigs = [];
-    return contents;
   }
   if (
     output["spotFleetRequestConfigSet"] !== undefined &&
@@ -55360,7 +55191,6 @@ const deserializeAws_ec2DescribeSpotInstanceRequestsResult = (
   }
   if (output.spotInstanceRequestSet === "") {
     contents.SpotInstanceRequests = [];
-    return contents;
   }
   if (
     output["spotInstanceRequestSet"] !== undefined &&
@@ -55392,7 +55222,6 @@ const deserializeAws_ec2DescribeSpotPriceHistoryResult = (
   }
   if (output.spotPriceHistorySet === "") {
     contents.SpotPriceHistory = [];
-    return contents;
   }
   if (
     output["spotPriceHistorySet"] !== undefined &&
@@ -55424,7 +55253,6 @@ const deserializeAws_ec2DescribeStaleSecurityGroupsResult = (
   }
   if (output.staleSecurityGroupSet === "") {
     contents.StaleSecurityGroupSet = [];
-    return contents;
   }
   if (
     output["staleSecurityGroupSet"] !== undefined &&
@@ -55456,7 +55284,6 @@ const deserializeAws_ec2DescribeSubnetsResult = (
   }
   if (output.subnetSet === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["subnetSet"] !== undefined &&
@@ -55485,7 +55312,6 @@ const deserializeAws_ec2DescribeTagsResult = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -55514,7 +55340,6 @@ const deserializeAws_ec2DescribeTrafficMirrorFiltersResult = (
   }
   if (output.trafficMirrorFilterSet === "") {
     contents.TrafficMirrorFilters = [];
-    return contents;
   }
   if (
     output["trafficMirrorFilterSet"] !== undefined &&
@@ -55546,7 +55371,6 @@ const deserializeAws_ec2DescribeTrafficMirrorSessionsResult = (
   }
   if (output.trafficMirrorSessionSet === "") {
     contents.TrafficMirrorSessions = [];
-    return contents;
   }
   if (
     output["trafficMirrorSessionSet"] !== undefined &&
@@ -55578,7 +55402,6 @@ const deserializeAws_ec2DescribeTrafficMirrorTargetsResult = (
   }
   if (output.trafficMirrorTargetSet === "") {
     contents.TrafficMirrorTargets = [];
-    return contents;
   }
   if (
     output["trafficMirrorTargetSet"] !== undefined &&
@@ -55610,7 +55433,6 @@ const deserializeAws_ec2DescribeTransitGatewayAttachmentsResult = (
   }
   if (output.transitGatewayAttachments === "") {
     contents.TransitGatewayAttachments = [];
-    return contents;
   }
   if (
     output["transitGatewayAttachments"] !== undefined &&
@@ -55642,7 +55464,6 @@ const deserializeAws_ec2DescribeTransitGatewayMulticastDomainsResult = (
   }
   if (output.transitGatewayMulticastDomains === "") {
     contents.TransitGatewayMulticastDomains = [];
-    return contents;
   }
   if (
     output["transitGatewayMulticastDomains"] !== undefined &&
@@ -55674,7 +55495,6 @@ const deserializeAws_ec2DescribeTransitGatewayPeeringAttachmentsResult = (
   }
   if (output.transitGatewayPeeringAttachments === "") {
     contents.TransitGatewayPeeringAttachments = [];
-    return contents;
   }
   if (
     output["transitGatewayPeeringAttachments"] !== undefined &&
@@ -55706,7 +55526,6 @@ const deserializeAws_ec2DescribeTransitGatewayRouteTablesResult = (
   }
   if (output.transitGatewayRouteTables === "") {
     contents.TransitGatewayRouteTables = [];
-    return contents;
   }
   if (
     output["transitGatewayRouteTables"] !== undefined &&
@@ -55738,7 +55557,6 @@ const deserializeAws_ec2DescribeTransitGatewayVpcAttachmentsResult = (
   }
   if (output.transitGatewayVpcAttachments === "") {
     contents.TransitGatewayVpcAttachments = [];
-    return contents;
   }
   if (
     output["transitGatewayVpcAttachments"] !== undefined &&
@@ -55770,7 +55588,6 @@ const deserializeAws_ec2DescribeTransitGatewaysResult = (
   }
   if (output.transitGatewaySet === "") {
     contents.TransitGateways = [];
-    return contents;
   }
   if (
     output["transitGatewaySet"] !== undefined &&
@@ -55806,7 +55623,6 @@ const deserializeAws_ec2DescribeVolumeAttributeResult = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -55841,7 +55657,6 @@ const deserializeAws_ec2DescribeVolumeStatusResult = (
   }
   if (output.volumeStatusSet === "") {
     contents.VolumeStatuses = [];
-    return contents;
   }
   if (
     output["volumeStatusSet"] !== undefined &&
@@ -55873,7 +55688,6 @@ const deserializeAws_ec2DescribeVolumesModificationsResult = (
   }
   if (output.volumeModificationSet === "") {
     contents.VolumesModifications = [];
-    return contents;
   }
   if (
     output["volumeModificationSet"] !== undefined &&
@@ -55905,7 +55719,6 @@ const deserializeAws_ec2DescribeVolumesResult = (
   }
   if (output.volumeSet === "") {
     contents.Volumes = [];
-    return contents;
   }
   if (
     output["volumeSet"] !== undefined &&
@@ -55962,7 +55775,6 @@ const deserializeAws_ec2DescribeVpcClassicLinkDnsSupportResult = (
   }
   if (output.vpcs === "") {
     contents.Vpcs = [];
-    return contents;
   }
   if (output["vpcs"] !== undefined && output["vpcs"]["item"] !== undefined) {
     const wrappedItem =
@@ -55987,7 +55799,6 @@ const deserializeAws_ec2DescribeVpcClassicLinkResult = (
   };
   if (output.vpcSet === "") {
     contents.Vpcs = [];
-    return contents;
   }
   if (
     output["vpcSet"] !== undefined &&
@@ -56013,7 +55824,6 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionNotificationsResult = (
   };
   if (output.connectionNotificationSet === "") {
     contents.ConnectionNotificationSet = [];
-    return contents;
   }
   if (
     output["connectionNotificationSet"] !== undefined &&
@@ -56048,7 +55858,6 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionsResult = (
   }
   if (output.vpcEndpointConnectionSet === "") {
     contents.VpcEndpointConnections = [];
-    return contents;
   }
   if (
     output["vpcEndpointConnectionSet"] !== undefined &&
@@ -56080,7 +55889,6 @@ const deserializeAws_ec2DescribeVpcEndpointServiceConfigurationsResult = (
   }
   if (output.serviceConfigurationSet === "") {
     contents.ServiceConfigurations = [];
-    return contents;
   }
   if (
     output["serviceConfigurationSet"] !== undefined &&
@@ -56109,7 +55917,6 @@ const deserializeAws_ec2DescribeVpcEndpointServicePermissionsResult = (
   };
   if (output.allowedPrincipals === "") {
     contents.AllowedPrincipals = [];
-    return contents;
   }
   if (
     output["allowedPrincipals"] !== undefined &&
@@ -56145,7 +55952,6 @@ const deserializeAws_ec2DescribeVpcEndpointServicesResult = (
   }
   if (output.serviceDetailSet === "") {
     contents.ServiceDetails = [];
-    return contents;
   }
   if (
     output["serviceDetailSet"] !== undefined &&
@@ -56162,7 +55968,6 @@ const deserializeAws_ec2DescribeVpcEndpointServicesResult = (
   }
   if (output.serviceNameSet === "") {
     contents.ServiceNames = [];
-    return contents;
   }
   if (
     output["serviceNameSet"] !== undefined &&
@@ -56194,7 +55999,6 @@ const deserializeAws_ec2DescribeVpcEndpointsResult = (
   }
   if (output.vpcEndpointSet === "") {
     contents.VpcEndpoints = [];
-    return contents;
   }
   if (
     output["vpcEndpointSet"] !== undefined &&
@@ -56226,7 +56030,6 @@ const deserializeAws_ec2DescribeVpcPeeringConnectionsResult = (
   }
   if (output.vpcPeeringConnectionSet === "") {
     contents.VpcPeeringConnections = [];
-    return contents;
   }
   if (
     output["vpcPeeringConnectionSet"] !== undefined &&
@@ -56258,7 +56061,6 @@ const deserializeAws_ec2DescribeVpcsResult = (
   }
   if (output.vpcSet === "") {
     contents.Vpcs = [];
-    return contents;
   }
   if (
     output["vpcSet"] !== undefined &&
@@ -56283,7 +56085,6 @@ const deserializeAws_ec2DescribeVpnConnectionsResult = (
   };
   if (output.vpnConnectionSet === "") {
     contents.VpnConnections = [];
-    return contents;
   }
   if (
     output["vpnConnectionSet"] !== undefined &&
@@ -56311,7 +56112,6 @@ const deserializeAws_ec2DescribeVpnGatewaysResult = (
   };
   if (output.vpnGatewaySet === "") {
     contents.VpnGateways = [];
-    return contents;
   }
   if (
     output["vpnGatewaySet"] !== undefined &&
@@ -56357,7 +56157,6 @@ const deserializeAws_ec2DhcpConfiguration = (
   }
   if (output.valueSet === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["valueSet"] !== undefined &&
@@ -56406,7 +56205,6 @@ const deserializeAws_ec2DhcpOptions = (
   };
   if (output.dhcpConfigurationSet === "") {
     contents.DhcpConfigurations = [];
-    return contents;
   }
   if (
     output["dhcpConfigurationSet"] !== undefined &&
@@ -56429,7 +56227,6 @@ const deserializeAws_ec2DhcpOptions = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -56493,7 +56290,6 @@ const deserializeAws_ec2DisableFastSnapshotRestoreErrorItem = (
   };
   if (output.fastSnapshotRestoreStateErrorSet === "") {
     contents.FastSnapshotRestoreStateErrors = [];
-    return contents;
   }
   if (
     output["fastSnapshotRestoreStateErrorSet"] !== undefined &&
@@ -56645,7 +56441,6 @@ const deserializeAws_ec2DisableFastSnapshotRestoresResult = (
   };
   if (output.successful === "") {
     contents.Successful = [];
-    return contents;
   }
   if (
     output["successful"] !== undefined &&
@@ -56662,7 +56457,6 @@ const deserializeAws_ec2DisableFastSnapshotRestoresResult = (
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -57042,7 +56836,6 @@ const deserializeAws_ec2EgressOnlyInternetGateway = (
   };
   if (output.attachmentSet === "") {
     contents.Attachments = [];
-    return contents;
   }
   if (
     output["attachmentSet"] !== undefined &&
@@ -57063,7 +56856,6 @@ const deserializeAws_ec2EgressOnlyInternetGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -57205,7 +56997,6 @@ const deserializeAws_ec2ElasticGpus = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -57286,7 +57077,6 @@ const deserializeAws_ec2EnableFastSnapshotRestoreErrorItem = (
   };
   if (output.fastSnapshotRestoreStateErrorSet === "") {
     contents.FastSnapshotRestoreStateErrors = [];
-    return contents;
   }
   if (
     output["fastSnapshotRestoreStateErrorSet"] !== undefined &&
@@ -57438,7 +57228,6 @@ const deserializeAws_ec2EnableFastSnapshotRestoresResult = (
   };
   if (output.successful === "") {
     contents.Successful = [];
-    return contents;
   }
   if (
     output["successful"] !== undefined &&
@@ -57455,7 +57244,6 @@ const deserializeAws_ec2EnableFastSnapshotRestoresResult = (
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -57723,7 +57511,6 @@ const deserializeAws_ec2ExportTask = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -57873,7 +57660,6 @@ const deserializeAws_ec2FleetData = (
   }
   if (output.errorSet === "") {
     contents.Errors = [];
-    return contents;
   }
   if (
     output["errorSet"] !== undefined &&
@@ -57908,7 +57694,6 @@ const deserializeAws_ec2FleetData = (
   }
   if (output.fleetInstanceSet === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["fleetInstanceSet"] !== undefined &&
@@ -57925,7 +57710,6 @@ const deserializeAws_ec2FleetData = (
   }
   if (output.launchTemplateConfigs === "") {
     contents.LaunchTemplateConfigs = [];
-    return contents;
   }
   if (
     output["launchTemplateConfigs"] !== undefined &&
@@ -57958,7 +57742,6 @@ const deserializeAws_ec2FleetData = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -58009,7 +57792,6 @@ const deserializeAws_ec2FleetLaunchTemplateConfig = (
   }
   if (output.overrides === "") {
     contents.Overrides = [];
-    return contents;
   }
   if (
     output["overrides"] !== undefined &&
@@ -58287,7 +58069,6 @@ const deserializeAws_ec2FpgaImage = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -58313,7 +58094,6 @@ const deserializeAws_ec2FpgaImage = (
   }
   if (output.tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["tags"] !== undefined && output["tags"]["item"] !== undefined) {
     const wrappedItem =
@@ -58348,7 +58128,6 @@ const deserializeAws_ec2FpgaImageAttribute = (
   }
   if (output.loadPermissions === "") {
     contents.LoadPermissions = [];
-    return contents;
   }
   if (
     output["loadPermissions"] !== undefined &&
@@ -58368,7 +58147,6 @@ const deserializeAws_ec2FpgaImageAttribute = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -58424,7 +58202,6 @@ const deserializeAws_ec2FpgaInfo = (
   };
   if (output.fpgas === "") {
     contents.Fpgas = [];
-    return contents;
   }
   if (output["fpgas"] !== undefined && output["fpgas"]["item"] !== undefined) {
     const wrappedItem =
@@ -58450,7 +58227,6 @@ const deserializeAws_ec2GetAssociatedIpv6PoolCidrsResult = (
   };
   if (output.ipv6CidrAssociationSet === "") {
     contents.Ipv6CidrAssociations = [];
-    return contents;
   }
   if (
     output["ipv6CidrAssociationSet"] !== undefined &&
@@ -58498,7 +58274,6 @@ const deserializeAws_ec2GetCapacityReservationUsageResult = (
   }
   if (output.instanceUsageSet === "") {
     contents.InstanceUsages = [];
-    return contents;
   }
   if (
     output["instanceUsageSet"] !== undefined &&
@@ -58537,7 +58312,6 @@ const deserializeAws_ec2GetCoipPoolUsageResult = (
   };
   if (output.coipAddressUsageSet === "") {
     contents.CoipAddressUsages = [];
-    return contents;
   }
   if (
     output["coipAddressUsageSet"] !== undefined &&
@@ -58663,7 +58437,6 @@ const deserializeAws_ec2GetHostReservationPurchasePreviewResult = (
   }
   if (output.purchase === "") {
     contents.Purchase = [];
-    return contents;
   }
   if (
     output["purchase"] !== undefined &&
@@ -58761,7 +58534,6 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
   }
   if (output.reservedInstanceValueSet === "") {
     contents.ReservedInstanceValueSet = [];
-    return contents;
   }
   if (
     output["reservedInstanceValueSet"] !== undefined &&
@@ -58784,7 +58556,6 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
   }
   if (output.targetConfigurationValueSet === "") {
     contents.TargetConfigurationValueSet = [];
-    return contents;
   }
   if (
     output["targetConfigurationValueSet"] !== undefined &&
@@ -58819,7 +58590,6 @@ const deserializeAws_ec2GetTransitGatewayAttachmentPropagationsResult = (
   }
   if (output.transitGatewayAttachmentPropagations === "") {
     contents.TransitGatewayAttachmentPropagations = [];
-    return contents;
   }
   if (
     output["transitGatewayAttachmentPropagations"] !== undefined &&
@@ -58848,7 +58618,6 @@ const deserializeAws_ec2GetTransitGatewayMulticastDomainAssociationsResult = (
   };
   if (output.multicastDomainAssociations === "") {
     contents.MulticastDomainAssociations = [];
-    return contents;
   }
   if (
     output["multicastDomainAssociations"] !== undefined &&
@@ -58880,7 +58649,6 @@ const deserializeAws_ec2GetTransitGatewayRouteTableAssociationsResult = (
   };
   if (output.associations === "") {
     contents.Associations = [];
-    return contents;
   }
   if (
     output["associations"] !== undefined &&
@@ -58915,7 +58683,6 @@ const deserializeAws_ec2GetTransitGatewayRouteTablePropagationsResult = (
   }
   if (output.transitGatewayRouteTablePropagations === "") {
     contents.TransitGatewayRouteTablePropagations = [];
-    return contents;
   }
   if (
     output["transitGatewayRouteTablePropagations"] !== undefined &&
@@ -58996,7 +58763,6 @@ const deserializeAws_ec2GpuInfo = (
   };
   if (output.gpus === "") {
     contents.Gpus = [];
-    return contents;
   }
   if (output["gpus"] !== undefined && output["gpus"]["item"] !== undefined) {
     const wrappedItem =
@@ -59199,7 +58965,6 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
   }
   if (output.instances === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["instances"] !== undefined &&
@@ -59229,7 +58994,6 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -59396,7 +59160,6 @@ const deserializeAws_ec2HostReservation = (
   }
   if (output.hostIdSet === "") {
     contents.HostIdSet = [];
-    return contents;
   }
   if (
     output["hostIdSet"] !== undefined &&
@@ -59434,7 +59197,6 @@ const deserializeAws_ec2HostReservation = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -59647,7 +59409,6 @@ const deserializeAws_ec2Image = (
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["blockDeviceMapping"] !== undefined &&
@@ -59700,7 +59461,6 @@ const deserializeAws_ec2Image = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -59741,7 +59501,6 @@ const deserializeAws_ec2Image = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -59776,7 +59535,6 @@ const deserializeAws_ec2ImageAttribute = (
   };
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["blockDeviceMapping"] !== undefined &&
@@ -59808,7 +59566,6 @@ const deserializeAws_ec2ImageAttribute = (
   }
   if (output.launchPermission === "") {
     contents.LaunchPermissions = [];
-    return contents;
   }
   if (
     output["launchPermission"] !== undefined &&
@@ -59825,7 +59582,6 @@ const deserializeAws_ec2ImageAttribute = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -59945,7 +59701,6 @@ const deserializeAws_ec2ImportImageResult = (
   }
   if (output.licenseSpecifications === "") {
     contents.LicenseSpecifications = [];
-    return contents;
   }
   if (
     output["licenseSpecifications"] !== undefined &&
@@ -59971,7 +59726,6 @@ const deserializeAws_ec2ImportImageResult = (
   }
   if (output.snapshotDetailSet === "") {
     contents.SnapshotDetails = [];
-    return contents;
   }
   if (
     output["snapshotDetailSet"] !== undefined &&
@@ -60040,7 +59794,6 @@ const deserializeAws_ec2ImportImageTask = (
   }
   if (output.licenseSpecifications === "") {
     contents.LicenseSpecifications = [];
-    return contents;
   }
   if (
     output["licenseSpecifications"] !== undefined &&
@@ -60066,7 +59819,6 @@ const deserializeAws_ec2ImportImageTask = (
   }
   if (output.snapshotDetailSet === "") {
     contents.SnapshotDetails = [];
-    return contents;
   }
   if (
     output["snapshotDetailSet"] !== undefined &&
@@ -60089,7 +59841,6 @@ const deserializeAws_ec2ImportImageTask = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -60152,7 +59903,6 @@ const deserializeAws_ec2ImportInstanceTaskDetails = (
   }
   if (output.volumes === "") {
     contents.Volumes = [];
-    return contents;
   }
   if (
     output["volumes"] !== undefined &&
@@ -60291,7 +60041,6 @@ const deserializeAws_ec2ImportSnapshotTask = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -60378,7 +60127,6 @@ const deserializeAws_ec2InferenceAcceleratorInfo = (
   };
   if (output.accelerators === "") {
     contents.Accelerators = [];
-    return contents;
   }
   if (
     output["accelerators"] !== undefined &&
@@ -60489,7 +60237,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["blockDeviceMapping"] !== undefined &&
@@ -60527,7 +60274,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.elasticGpuAssociationSet === "") {
     contents.ElasticGpuAssociations = [];
-    return contents;
   }
   if (
     output["elasticGpuAssociationSet"] !== undefined &&
@@ -60544,7 +60290,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.elasticInferenceAcceleratorAssociationSet === "") {
     contents.ElasticInferenceAcceleratorAssociations = [];
-    return contents;
   }
   if (
     output["elasticInferenceAcceleratorAssociationSet"] !== undefined &&
@@ -60601,7 +60346,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.licenseSet === "") {
     contents.Licenses = [];
-    return contents;
   }
   if (
     output["licenseSet"] !== undefined &&
@@ -60627,7 +60371,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-    return contents;
   }
   if (
     output["networkInterfaceSet"] !== undefined &&
@@ -60662,7 +60405,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -60694,7 +60436,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -60738,7 +60479,6 @@ const deserializeAws_ec2Instance = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -60783,7 +60523,6 @@ const deserializeAws_ec2InstanceAttribute = (
   };
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["blockDeviceMapping"] !== undefined &&
@@ -60818,7 +60557,6 @@ const deserializeAws_ec2InstanceAttribute = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -60856,7 +60594,6 @@ const deserializeAws_ec2InstanceAttribute = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-    return contents;
   }
   if (
     output["productCodes"] !== undefined &&
@@ -61190,7 +60927,6 @@ const deserializeAws_ec2InstanceNetworkInterface = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -61210,7 +60946,6 @@ const deserializeAws_ec2InstanceNetworkInterface = (
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-    return contents;
   }
   if (
     output["ipv6AddressesSet"] !== undefined &&
@@ -61242,7 +60977,6 @@ const deserializeAws_ec2InstanceNetworkInterface = (
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-    return contents;
   }
   if (
     output["privateIpAddressesSet"] !== undefined &&
@@ -61368,7 +61102,6 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.SecurityGroupId === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["SecurityGroupId"] !== undefined &&
@@ -61391,7 +61124,6 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-    return contents;
   }
   if (
     output["ipv6AddressesSet"] !== undefined &&
@@ -61414,7 +61146,6 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-    return contents;
   }
   if (
     output["privateIpAddressesSet"] !== undefined &&
@@ -61561,7 +61292,6 @@ const deserializeAws_ec2InstanceStatus = (
   }
   if (output.eventsSet === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["eventsSet"] !== undefined &&
@@ -61697,7 +61427,6 @@ const deserializeAws_ec2InstanceStatusSummary = (
   };
   if (output.details === "") {
     contents.Details = [];
-    return contents;
   }
   if (
     output["details"] !== undefined &&
@@ -61729,7 +61458,6 @@ const deserializeAws_ec2InstanceStorageInfo = (
   };
   if (output.disks === "") {
     contents.Disks = [];
-    return contents;
   }
   if (output["disks"] !== undefined && output["disks"]["item"] !== undefined) {
     const wrappedItem =
@@ -61853,7 +61581,6 @@ const deserializeAws_ec2InstanceTypeInfo = (
   }
   if (output.supportedRootDeviceTypes === "") {
     contents.SupportedRootDeviceTypes = [];
-    return contents;
   }
   if (
     output["supportedRootDeviceTypes"] !== undefined &&
@@ -61870,7 +61597,6 @@ const deserializeAws_ec2InstanceTypeInfo = (
   }
   if (output.supportedUsageClasses === "") {
     contents.SupportedUsageClasses = [];
-    return contents;
   }
   if (
     output["supportedUsageClasses"] !== undefined &&
@@ -61971,7 +61697,6 @@ const deserializeAws_ec2InternetGateway = (
   };
   if (output.attachmentSet === "") {
     contents.Attachments = [];
-    return contents;
   }
   if (
     output["attachmentSet"] !== undefined &&
@@ -61994,7 +61719,6 @@ const deserializeAws_ec2InternetGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -62067,7 +61791,6 @@ const deserializeAws_ec2IpPermission = (
   }
   if (output.ipRanges === "") {
     contents.IpRanges = [];
-    return contents;
   }
   if (
     output["ipRanges"] !== undefined &&
@@ -62081,7 +61804,6 @@ const deserializeAws_ec2IpPermission = (
   }
   if (output.ipv6Ranges === "") {
     contents.Ipv6Ranges = [];
-    return contents;
   }
   if (
     output["ipv6Ranges"] !== undefined &&
@@ -62095,7 +61817,6 @@ const deserializeAws_ec2IpPermission = (
   }
   if (output.prefixListIds === "") {
     contents.PrefixListIds = [];
-    return contents;
   }
   if (
     output["prefixListIds"] !== undefined &&
@@ -62115,7 +61836,6 @@ const deserializeAws_ec2IpPermission = (
   }
   if (output.groups === "") {
     contents.UserIdGroupPairs = [];
-    return contents;
   }
   if (
     output["groups"] !== undefined &&
@@ -62249,7 +61969,6 @@ const deserializeAws_ec2Ipv6Pool = (
   }
   if (output.poolCidrBlockSet === "") {
     contents.PoolCidrBlocks = [];
-    return contents;
   }
   if (
     output["poolCidrBlockSet"] !== undefined &&
@@ -62269,7 +61988,6 @@ const deserializeAws_ec2Ipv6Pool = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -62368,7 +62086,6 @@ const deserializeAws_ec2KeyPairInfo = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -62464,7 +62181,6 @@ const deserializeAws_ec2LaunchSpecification = (
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["blockDeviceMapping"] !== undefined &&
@@ -62508,7 +62224,6 @@ const deserializeAws_ec2LaunchSpecification = (
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-    return contents;
   }
   if (
     output["networkInterfaceSet"] !== undefined &&
@@ -62534,7 +62249,6 @@ const deserializeAws_ec2LaunchSpecification = (
   }
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -62601,7 +62315,6 @@ const deserializeAws_ec2LaunchTemplate = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -62717,7 +62430,6 @@ const deserializeAws_ec2LaunchTemplateConfig = (
   }
   if (output.overrides === "") {
     contents.Overrides = [];
-    return contents;
   }
   if (
     output["overrides"] !== undefined &&
@@ -62946,7 +62658,6 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -62966,7 +62677,6 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-    return contents;
   }
   if (
     output["ipv6AddressesSet"] !== undefined &&
@@ -62989,7 +62699,6 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-    return contents;
   }
   if (
     output["privateIpAddressesSet"] !== undefined &&
@@ -63189,7 +62898,6 @@ const deserializeAws_ec2LaunchTemplateTagSpecification = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -63381,7 +63089,6 @@ const deserializeAws_ec2LocalGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -63462,7 +63169,6 @@ const deserializeAws_ec2LocalGatewayRouteTable = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -63521,7 +63227,6 @@ const deserializeAws_ec2LocalGatewayRouteTableVirtualInterfaceGroupAssociation =
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -63576,7 +63281,6 @@ const deserializeAws_ec2LocalGatewayRouteTableVpcAssociation = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -63648,7 +63352,6 @@ const deserializeAws_ec2LocalGatewayVirtualInterface = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -63686,7 +63389,6 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceGroup = (
   }
   if (output.localGatewayVirtualInterfaceIdSet === "") {
     contents.LocalGatewayVirtualInterfaceIds = [];
-    return contents;
   }
   if (
     output["localGatewayVirtualInterfaceIdSet"] !== undefined &&
@@ -63703,7 +63405,6 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceGroup = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -63858,7 +63559,6 @@ const deserializeAws_ec2ModifyHostsResult = (
   };
   if (output.successful === "") {
     contents.Successful = [];
-    return contents;
   }
   if (
     output["successful"] !== undefined &&
@@ -63875,7 +63575,6 @@ const deserializeAws_ec2ModifyHostsResult = (
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -63918,7 +63617,6 @@ const deserializeAws_ec2ModifyInstanceCreditSpecificationResult = (
   };
   if (output.successfulInstanceCreditSpecificationSet === "") {
     contents.SuccessfulInstanceCreditSpecifications = [];
-    return contents;
   }
   if (
     output["successfulInstanceCreditSpecificationSet"] !== undefined &&
@@ -63936,7 +63634,6 @@ const deserializeAws_ec2ModifyInstanceCreditSpecificationResult = (
   }
   if (output.unsuccessfulInstanceCreditSpecificationSet === "") {
     contents.UnsuccessfulInstanceCreditSpecifications = [];
-    return contents;
   }
   if (
     output["unsuccessfulInstanceCreditSpecificationSet"] !== undefined &&
@@ -64293,7 +63990,6 @@ const deserializeAws_ec2MonitorInstancesResult = (
   };
   if (output.instancesSet === "") {
     contents.InstanceMonitorings = [];
-    return contents;
   }
   if (
     output["instancesSet"] !== undefined &&
@@ -64402,7 +64098,6 @@ const deserializeAws_ec2NatGateway = (
   }
   if (output.natGatewayAddressSet === "") {
     contents.NatGatewayAddresses = [];
-    return contents;
   }
   if (
     output["natGatewayAddressSet"] !== undefined &&
@@ -64434,7 +64129,6 @@ const deserializeAws_ec2NatGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -64512,7 +64206,6 @@ const deserializeAws_ec2NetworkAcl = (
   };
   if (output.associationSet === "") {
     contents.Associations = [];
-    return contents;
   }
   if (
     output["associationSet"] !== undefined &&
@@ -64529,7 +64222,6 @@ const deserializeAws_ec2NetworkAcl = (
   }
   if (output.entrySet === "") {
     contents.Entries = [];
-    return contents;
   }
   if (
     output["entrySet"] !== undefined &&
@@ -64555,7 +64247,6 @@ const deserializeAws_ec2NetworkAcl = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -64758,7 +64449,6 @@ const deserializeAws_ec2NetworkInterface = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -64778,7 +64468,6 @@ const deserializeAws_ec2NetworkInterface = (
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-    return contents;
   }
   if (
     output["ipv6AddressesSet"] !== undefined &&
@@ -64813,7 +64502,6 @@ const deserializeAws_ec2NetworkInterface = (
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-    return contents;
   }
   if (
     output["privateIpAddressesSet"] !== undefined &&
@@ -64845,7 +64533,6 @@ const deserializeAws_ec2NetworkInterface = (
   }
   if (output.tagSet === "") {
     contents.TagSet = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -65412,7 +65099,6 @@ const deserializeAws_ec2PlacementGroup = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -65437,7 +65123,6 @@ const deserializeAws_ec2PlacementGroupInfo = (
   };
   if (output.supportedStrategies === "") {
     contents.SupportedStrategies = [];
-    return contents;
   }
   if (
     output["supportedStrategies"] !== undefined &&
@@ -65538,7 +65223,6 @@ const deserializeAws_ec2PrefixList = (
   };
   if (output.cidrSet === "") {
     contents.Cidrs = [];
-    return contents;
   }
   if (
     output["cidrSet"] !== undefined &&
@@ -65678,7 +65362,6 @@ const deserializeAws_ec2PrincipalIdFormat = (
   }
   if (output.statusSet === "") {
     contents.Statuses = [];
-    return contents;
   }
   if (
     output["statusSet"] !== undefined &&
@@ -65766,7 +65449,6 @@ const deserializeAws_ec2ProcessorInfo = (
   };
   if (output.supportedArchitectures === "") {
     contents.SupportedArchitectures = [];
-    return contents;
   }
   if (
     output["supportedArchitectures"] !== undefined &&
@@ -65903,7 +65585,6 @@ const deserializeAws_ec2PublicIpv4Pool = (
   }
   if (output.poolAddressRangeSet === "") {
     contents.PoolAddressRanges = [];
-    return contents;
   }
   if (
     output["poolAddressRangeSet"] !== undefined &&
@@ -65999,7 +65680,6 @@ const deserializeAws_ec2Purchase = (
   }
   if (output.hostIdSet === "") {
     contents.HostIdSet = [];
-    return contents;
   }
   if (
     output["hostIdSet"] !== undefined &&
@@ -66052,7 +65732,6 @@ const deserializeAws_ec2PurchaseHostReservationResult = (
   }
   if (output.purchase === "") {
     contents.Purchase = [];
-    return contents;
   }
   if (
     output["purchase"] !== undefined &&
@@ -66097,7 +65776,6 @@ const deserializeAws_ec2PurchaseScheduledInstancesResult = (
   };
   if (output.scheduledInstanceSet === "") {
     contents.ScheduledInstanceSet = [];
-    return contents;
   }
   if (
     output["scheduledInstanceSet"] !== undefined &&
@@ -66283,7 +65961,6 @@ const deserializeAws_ec2RejectVpcEndpointConnectionsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -66326,7 +66003,6 @@ const deserializeAws_ec2ReleaseHostsResult = (
   };
   if (output.successful === "") {
     contents.Successful = [];
-    return contents;
   }
   if (
     output["successful"] !== undefined &&
@@ -66343,7 +66019,6 @@ const deserializeAws_ec2ReleaseHostsResult = (
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-    return contents;
   }
   if (
     output["unsuccessful"] !== undefined &&
@@ -66454,7 +66129,6 @@ const deserializeAws_ec2RequestSpotInstancesResult = (
   };
   if (output.spotInstanceRequestSet === "") {
     contents.SpotInstanceRequests = [];
-    return contents;
   }
   if (
     output["spotInstanceRequestSet"] !== undefined &&
@@ -66486,7 +66160,6 @@ const deserializeAws_ec2Reservation = (
   };
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -66503,7 +66176,6 @@ const deserializeAws_ec2Reservation = (
   }
   if (output.instancesSet === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["instancesSet"] !== undefined &&
@@ -66648,7 +66320,6 @@ const deserializeAws_ec2ReservedInstances = (
   }
   if (output.recurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["recurringCharges"] !== undefined &&
@@ -66677,7 +66348,6 @@ const deserializeAws_ec2ReservedInstances = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -66773,7 +66443,6 @@ const deserializeAws_ec2ReservedInstancesListing = (
   }
   if (output.instanceCounts === "") {
     contents.InstanceCounts = [];
-    return contents;
   }
   if (
     output["instanceCounts"] !== undefined &&
@@ -66790,7 +66459,6 @@ const deserializeAws_ec2ReservedInstancesListing = (
   }
   if (output.priceSchedules === "") {
     contents.PriceSchedules = [];
-    return contents;
   }
   if (
     output["priceSchedules"] !== undefined &&
@@ -66819,7 +66487,6 @@ const deserializeAws_ec2ReservedInstancesListing = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -66873,7 +66540,6 @@ const deserializeAws_ec2ReservedInstancesModification = (
   }
   if (output.modificationResultSet === "") {
     contents.ModificationResults = [];
-    return contents;
   }
   if (
     output["modificationResultSet"] !== undefined &&
@@ -66890,7 +66556,6 @@ const deserializeAws_ec2ReservedInstancesModification = (
   }
   if (output.reservedInstancesSet === "") {
     contents.ReservedInstancesIds = [];
-    return contents;
   }
   if (
     output["reservedInstancesSet"] !== undefined &&
@@ -67011,7 +66676,6 @@ const deserializeAws_ec2ReservedInstancesOffering = (
   }
   if (output.pricingDetailsSet === "") {
     contents.PricingDetails = [];
-    return contents;
   }
   if (
     output["pricingDetailsSet"] !== undefined &&
@@ -67031,7 +66695,6 @@ const deserializeAws_ec2ReservedInstancesOffering = (
   }
   if (output.recurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["recurringCharges"] !== undefined &&
@@ -67172,7 +66835,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   };
   if (output.blockDeviceMappingSet === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["blockDeviceMappingSet"] !== undefined &&
@@ -67213,7 +66875,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.elasticGpuSpecificationSet === "") {
     contents.ElasticGpuSpecifications = [];
-    return contents;
   }
   if (
     output["elasticGpuSpecificationSet"] !== undefined &&
@@ -67230,7 +66891,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.elasticInferenceAcceleratorSet === "") {
     contents.ElasticInferenceAccelerators = [];
-    return contents;
   }
   if (
     output["elasticInferenceAcceleratorSet"] !== undefined &&
@@ -67281,7 +66941,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.licenseSet === "") {
     contents.LicenseSpecifications = [];
-    return contents;
   }
   if (
     output["licenseSet"] !== undefined &&
@@ -67310,7 +66969,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-    return contents;
   }
   if (
     output["networkInterfaceSet"] !== undefined &&
@@ -67336,7 +66994,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.securityGroupIdSet === "") {
     contents.SecurityGroupIds = [];
-    return contents;
   }
   if (
     output["securityGroupIdSet"] !== undefined &&
@@ -67353,7 +67010,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.securityGroupSet === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["securityGroupSet"] !== undefined &&
@@ -67370,7 +67026,6 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.tagSpecificationSet === "") {
     contents.TagSpecifications = [];
-    return contents;
   }
   if (
     output["tagSpecificationSet"] !== undefined &&
@@ -67525,7 +67180,6 @@ const deserializeAws_ec2RouteTable = (
   };
   if (output.associationSet === "") {
     contents.Associations = [];
-    return contents;
   }
   if (
     output["associationSet"] !== undefined &&
@@ -67545,7 +67199,6 @@ const deserializeAws_ec2RouteTable = (
   }
   if (output.propagatingVgwSet === "") {
     contents.PropagatingVgws = [];
-    return contents;
   }
   if (
     output["propagatingVgwSet"] !== undefined &&
@@ -67565,7 +67218,6 @@ const deserializeAws_ec2RouteTable = (
   }
   if (output.routeSet === "") {
     contents.Routes = [];
-    return contents;
   }
   if (
     output["routeSet"] !== undefined &&
@@ -67579,7 +67231,6 @@ const deserializeAws_ec2RouteTable = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -67694,7 +67345,6 @@ const deserializeAws_ec2RunScheduledInstancesResult = (
   };
   if (output.instanceIdSet === "") {
     contents.InstanceIdSet = [];
-    return contents;
   }
   if (
     output["instanceIdSet"] !== undefined &&
@@ -67915,7 +67565,6 @@ const deserializeAws_ec2ScheduledInstanceRecurrence = (
   }
   if (output.occurrenceDaySet === "") {
     contents.OccurrenceDaySet = [];
-    return contents;
   }
   if (
     output["occurrenceDaySet"] !== undefined &&
@@ -67963,7 +67612,6 @@ const deserializeAws_ec2SearchLocalGatewayRoutesResult = (
   }
   if (output.routeSet === "") {
     contents.Routes = [];
-    return contents;
   }
   if (
     output["routeSet"] !== undefined &&
@@ -67992,7 +67640,6 @@ const deserializeAws_ec2SearchTransitGatewayMulticastGroupsResult = (
   };
   if (output.multicastGroups === "") {
     contents.MulticastGroups = [];
-    return contents;
   }
   if (
     output["multicastGroups"] !== undefined &&
@@ -68028,7 +67675,6 @@ const deserializeAws_ec2SearchTransitGatewayRoutesResult = (
   }
   if (output.routeSet === "") {
     contents.Routes = [];
-    return contents;
   }
   if (
     output["routeSet"] !== undefined &&
@@ -68072,7 +67718,6 @@ const deserializeAws_ec2SecurityGroup = (
   }
   if (output.ipPermissions === "") {
     contents.IpPermissions = [];
-    return contents;
   }
   if (
     output["ipPermissions"] !== undefined &&
@@ -68089,7 +67734,6 @@ const deserializeAws_ec2SecurityGroup = (
   }
   if (output.ipPermissionsEgress === "") {
     contents.IpPermissionsEgress = [];
-    return contents;
   }
   if (
     output["ipPermissionsEgress"] !== undefined &&
@@ -68109,7 +67753,6 @@ const deserializeAws_ec2SecurityGroup = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -68216,7 +67859,6 @@ const deserializeAws_ec2ServiceConfiguration = (
   }
   if (output.availabilityZoneSet === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["availabilityZoneSet"] !== undefined &&
@@ -68233,7 +67875,6 @@ const deserializeAws_ec2ServiceConfiguration = (
   }
   if (output.baseEndpointDnsNameSet === "") {
     contents.BaseEndpointDnsNames = [];
-    return contents;
   }
   if (
     output["baseEndpointDnsNameSet"] !== undefined &&
@@ -68253,7 +67894,6 @@ const deserializeAws_ec2ServiceConfiguration = (
   }
   if (output.networkLoadBalancerArnSet === "") {
     contents.NetworkLoadBalancerArns = [];
-    return contents;
   }
   if (
     output["networkLoadBalancerArnSet"] !== undefined &&
@@ -68288,7 +67928,6 @@ const deserializeAws_ec2ServiceConfiguration = (
   }
   if (output.serviceType === "") {
     contents.ServiceType = [];
-    return contents;
   }
   if (
     output["serviceType"] !== undefined &&
@@ -68305,7 +67944,6 @@ const deserializeAws_ec2ServiceConfiguration = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -68353,7 +67991,6 @@ const deserializeAws_ec2ServiceDetail = (
   }
   if (output.availabilityZoneSet === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["availabilityZoneSet"] !== undefined &&
@@ -68370,7 +68007,6 @@ const deserializeAws_ec2ServiceDetail = (
   }
   if (output.baseEndpointDnsNameSet === "") {
     contents.BaseEndpointDnsNames = [];
-    return contents;
   }
   if (
     output["baseEndpointDnsNameSet"] !== undefined &&
@@ -68406,7 +68042,6 @@ const deserializeAws_ec2ServiceDetail = (
   }
   if (output.serviceType === "") {
     contents.ServiceType = [];
-    return contents;
   }
   if (
     output["serviceType"] !== undefined &&
@@ -68423,7 +68058,6 @@ const deserializeAws_ec2ServiceDetail = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -68530,7 +68164,6 @@ const deserializeAws_ec2Snapshot = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -68653,7 +68286,6 @@ const deserializeAws_ec2SnapshotInfo = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -68812,7 +68444,6 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-    return contents;
   }
   if (
     output["blockDeviceMapping"] !== undefined &&
@@ -68856,7 +68487,6 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-    return contents;
   }
   if (
     output["networkInterfaceSet"] !== undefined &&
@@ -68882,7 +68512,6 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -68905,7 +68534,6 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (output.tagSpecificationSet === "") {
     contents.TagSpecifications = [];
-    return contents;
   }
   if (
     output["tagSpecificationSet"] !== undefined &&
@@ -69032,7 +68660,6 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (output.launchSpecifications === "") {
     contents.LaunchSpecifications = [];
-    return contents;
   }
   if (
     output["launchSpecifications"] !== undefined &&
@@ -69049,7 +68676,6 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (output.launchTemplateConfigs === "") {
     contents.LaunchTemplateConfigs = [];
-    return contents;
   }
   if (
     output["launchTemplateConfigs"] !== undefined &&
@@ -69138,7 +68764,6 @@ const deserializeAws_ec2SpotFleetTagSpecification = (
   }
   if (output.tag === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["tag"] !== undefined && output["tag"]["item"] !== undefined) {
     const wrappedItem =
@@ -69242,7 +68867,6 @@ const deserializeAws_ec2SpotInstanceRequest = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -69439,7 +69063,6 @@ const deserializeAws_ec2StaleIpPermission = (
   }
   if (output.ipRanges === "") {
     contents.IpRanges = [];
-    return contents;
   }
   if (
     output["ipRanges"] !== undefined &&
@@ -69453,7 +69076,6 @@ const deserializeAws_ec2StaleIpPermission = (
   }
   if (output.prefixListIds === "") {
     contents.PrefixListIds = [];
-    return contents;
   }
   if (
     output["prefixListIds"] !== undefined &&
@@ -69473,7 +69095,6 @@ const deserializeAws_ec2StaleIpPermission = (
   }
   if (output.groups === "") {
     contents.UserIdGroupPairs = [];
-    return contents;
   }
   if (
     output["groups"] !== undefined &&
@@ -69524,7 +69145,6 @@ const deserializeAws_ec2StaleSecurityGroup = (
   }
   if (output.staleIpPermissions === "") {
     contents.StaleIpPermissions = [];
-    return contents;
   }
   if (
     output["staleIpPermissions"] !== undefined &&
@@ -69541,7 +69161,6 @@ const deserializeAws_ec2StaleSecurityGroup = (
   }
   if (output.staleIpPermissionsEgress === "") {
     contents.StaleIpPermissionsEgress = [];
-    return contents;
   }
   if (
     output["staleIpPermissionsEgress"] !== undefined &&
@@ -69581,7 +69200,6 @@ const deserializeAws_ec2StartInstancesResult = (
   };
   if (output.instancesSet === "") {
     contents.StartingInstances = [];
-    return contents;
   }
   if (
     output["instancesSet"] !== undefined &&
@@ -69641,7 +69259,6 @@ const deserializeAws_ec2StopInstancesResult = (
   };
   if (output.instancesSet === "") {
     contents.StoppingInstances = [];
-    return contents;
   }
   if (
     output["instancesSet"] !== undefined &&
@@ -69718,7 +69335,6 @@ const deserializeAws_ec2Subnet = (
   }
   if (output.ipv6CidrBlockAssociationSet === "") {
     contents.Ipv6CidrBlockAssociationSet = [];
-    return contents;
   }
   if (
     output["ipv6CidrBlockAssociationSet"] !== undefined &&
@@ -69753,7 +69369,6 @@ const deserializeAws_ec2Subnet = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -70043,7 +69658,6 @@ const deserializeAws_ec2TargetGroupsConfig = (
   };
   if (output.targetGroups === "") {
     contents.TargetGroups = [];
-    return contents;
   }
   if (
     output["targetGroups"] !== undefined &&
@@ -70082,7 +69696,6 @@ const deserializeAws_ec2TargetNetwork = (
   }
   if (output.securityGroups === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["securityGroups"] !== undefined &&
@@ -70169,7 +69782,6 @@ const deserializeAws_ec2TerminateClientVpnConnectionsResult = (
   }
   if (output.connectionStatuses === "") {
     contents.ConnectionStatuses = [];
-    return contents;
   }
   if (
     output["connectionStatuses"] !== undefined &&
@@ -70237,7 +69849,6 @@ const deserializeAws_ec2TerminateInstancesResult = (
   };
   if (output.instancesSet === "") {
     contents.TerminatingInstances = [];
-    return contents;
   }
   if (
     output["instancesSet"] !== undefined &&
@@ -70280,7 +69891,6 @@ const deserializeAws_ec2TrafficMirrorFilter = (
   }
   if (output.egressFilterRuleSet === "") {
     contents.EgressFilterRules = [];
-    return contents;
   }
   if (
     output["egressFilterRuleSet"] !== undefined &&
@@ -70297,7 +69907,6 @@ const deserializeAws_ec2TrafficMirrorFilter = (
   }
   if (output.ingressFilterRuleSet === "") {
     contents.IngressFilterRules = [];
-    return contents;
   }
   if (
     output["ingressFilterRuleSet"] !== undefined &&
@@ -70314,7 +69923,6 @@ const deserializeAws_ec2TrafficMirrorFilter = (
   }
   if (output.networkServiceSet === "") {
     contents.NetworkServices = [];
-    return contents;
   }
   if (
     output["networkServiceSet"] !== undefined &&
@@ -70331,7 +69939,6 @@ const deserializeAws_ec2TrafficMirrorFilter = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -70486,7 +70093,6 @@ const deserializeAws_ec2TrafficMirrorSession = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -70550,7 +70156,6 @@ const deserializeAws_ec2TrafficMirrorTarget = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -70615,7 +70220,6 @@ const deserializeAws_ec2TransitGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -70706,7 +70310,6 @@ const deserializeAws_ec2TransitGatewayAttachment = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -70805,7 +70408,6 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupMembers = (
   };
   if (output.deregisteredNetworkInterfaceIds === "") {
     contents.DeregisteredNetworkInterfaceIds = [];
-    return contents;
   }
   if (
     output["deregisteredNetworkInterfaceIds"] !== undefined &&
@@ -70842,7 +70444,6 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupSources = (
   };
   if (output.deregisteredNetworkInterfaceIds === "") {
     contents.DeregisteredNetworkInterfaceIds = [];
-    return contents;
   }
   if (
     output["deregisteredNetworkInterfaceIds"] !== undefined &&
@@ -70887,7 +70488,6 @@ const deserializeAws_ec2TransitGatewayMulticastDomain = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -70967,7 +70567,6 @@ const deserializeAws_ec2TransitGatewayMulticastDomainAssociations = (
   }
   if (output.subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["subnets"] !== undefined &&
@@ -71075,7 +70674,6 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupMembers = (
   }
   if (output.registeredNetworkInterfaceIds === "") {
     contents.RegisteredNetworkInterfaceIds = [];
-    return contents;
   }
   if (
     output["registeredNetworkInterfaceIds"] !== undefined &&
@@ -71112,7 +70710,6 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupSources = (
   }
   if (output.registeredNetworkInterfaceIds === "") {
     contents.RegisteredNetworkInterfaceIds = [];
-    return contents;
   }
   if (
     output["registeredNetworkInterfaceIds"] !== undefined &&
@@ -71225,7 +70822,6 @@ const deserializeAws_ec2TransitGatewayPeeringAttachment = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -71301,7 +70897,6 @@ const deserializeAws_ec2TransitGatewayRoute = (
   }
   if (output.transitGatewayAttachments === "") {
     contents.TransitGatewayAttachments = [];
-    return contents;
   }
   if (
     output["transitGatewayAttachments"] !== undefined &&
@@ -71392,7 +70987,6 @@ const deserializeAws_ec2TransitGatewayRouteTable = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -71522,7 +71116,6 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
   }
   if (output.subnetIds === "") {
     contents.SubnetIds = [];
-    return contents;
   }
   if (
     output["subnetIds"] !== undefined &&
@@ -71539,7 +71132,6 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -71621,7 +71213,6 @@ const deserializeAws_ec2TunnelOption = (
   }
   if (output.ikeVersionSet === "") {
     contents.IkeVersions = [];
-    return contents;
   }
   if (
     output["ikeVersionSet"] !== undefined &&
@@ -71641,7 +71232,6 @@ const deserializeAws_ec2TunnelOption = (
   }
   if (output.phase1DHGroupNumberSet === "") {
     contents.Phase1DHGroupNumbers = [];
-    return contents;
   }
   if (
     output["phase1DHGroupNumberSet"] !== undefined &&
@@ -71658,7 +71248,6 @@ const deserializeAws_ec2TunnelOption = (
   }
   if (output.phase1EncryptionAlgorithmSet === "") {
     contents.Phase1EncryptionAlgorithms = [];
-    return contents;
   }
   if (
     output["phase1EncryptionAlgorithmSet"] !== undefined &&
@@ -71675,7 +71264,6 @@ const deserializeAws_ec2TunnelOption = (
   }
   if (output.phase1IntegrityAlgorithmSet === "") {
     contents.Phase1IntegrityAlgorithms = [];
-    return contents;
   }
   if (
     output["phase1IntegrityAlgorithmSet"] !== undefined &&
@@ -71695,7 +71283,6 @@ const deserializeAws_ec2TunnelOption = (
   }
   if (output.phase2DHGroupNumberSet === "") {
     contents.Phase2DHGroupNumbers = [];
-    return contents;
   }
   if (
     output["phase2DHGroupNumberSet"] !== undefined &&
@@ -71712,7 +71299,6 @@ const deserializeAws_ec2TunnelOption = (
   }
   if (output.phase2EncryptionAlgorithmSet === "") {
     contents.Phase2EncryptionAlgorithms = [];
-    return contents;
   }
   if (
     output["phase2EncryptionAlgorithmSet"] !== undefined &&
@@ -71729,7 +71315,6 @@ const deserializeAws_ec2TunnelOption = (
   }
   if (output.phase2IntegrityAlgorithmSet === "") {
     contents.Phase2IntegrityAlgorithms = [];
-    return contents;
   }
   if (
     output["phase2IntegrityAlgorithmSet"] !== undefined &&
@@ -71790,7 +71375,6 @@ const deserializeAws_ec2UnassignIpv6AddressesResult = (
   }
   if (output.unassignedIpv6Addresses === "") {
     contents.UnassignedIpv6Addresses = [];
-    return contents;
   }
   if (
     output["unassignedIpv6Addresses"] !== undefined &&
@@ -71818,7 +71402,6 @@ const deserializeAws_ec2UnmonitorInstancesResult = (
   };
   if (output.instancesSet === "") {
     contents.InstanceMonitorings = [];
-    return contents;
   }
   if (
     output["instancesSet"] !== undefined &&
@@ -72076,7 +71659,6 @@ const deserializeAws_ec2VCpuInfo = (
   }
   if (output.validCores === "") {
     contents.ValidCores = [];
-    return contents;
   }
   if (
     output["validCores"] !== undefined &&
@@ -72090,7 +71672,6 @@ const deserializeAws_ec2VCpuInfo = (
   }
   if (output.validThreadsPerCore === "") {
     contents.ValidThreadsPerCore = [];
-    return contents;
   }
   if (
     output["validThreadsPerCore"] !== undefined &&
@@ -72181,7 +71762,6 @@ const deserializeAws_ec2Volume = (
   };
   if (output.attachmentSet === "") {
     contents.Attachments = [];
-    return contents;
   }
   if (
     output["attachmentSet"] !== undefined &&
@@ -72228,7 +71808,6 @@ const deserializeAws_ec2Volume = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -72480,7 +72059,6 @@ const deserializeAws_ec2VolumeStatusInfo = (
   };
   if (output.details === "") {
     contents.Details = [];
-    return contents;
   }
   if (
     output["details"] !== undefined &&
@@ -72516,7 +72094,6 @@ const deserializeAws_ec2VolumeStatusItem = (
   };
   if (output.actionsSet === "") {
     contents.Actions = [];
-    return contents;
   }
   if (
     output["actionsSet"] !== undefined &&
@@ -72536,7 +72113,6 @@ const deserializeAws_ec2VolumeStatusItem = (
   }
   if (output.eventsSet === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["eventsSet"] !== undefined &&
@@ -72594,7 +72170,6 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
   }
   if (output.cidrBlockAssociationSet === "") {
     contents.CidrBlockAssociationSet = [];
-    return contents;
   }
   if (
     output["cidrBlockAssociationSet"] !== undefined &&
@@ -72617,7 +72192,6 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
   }
   if (output.ipv6CidrBlockAssociationSet === "") {
     contents.Ipv6CidrBlockAssociationSet = [];
-    return contents;
   }
   if (
     output["ipv6CidrBlockAssociationSet"] !== undefined &&
@@ -72643,7 +72217,6 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -72755,7 +72328,6 @@ const deserializeAws_ec2VpcClassicLink = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -72811,7 +72383,6 @@ const deserializeAws_ec2VpcEndpoint = (
   }
   if (output.dnsEntrySet === "") {
     contents.DnsEntries = [];
-    return contents;
   }
   if (
     output["dnsEntrySet"] !== undefined &&
@@ -72825,7 +72396,6 @@ const deserializeAws_ec2VpcEndpoint = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["groupSet"] !== undefined &&
@@ -72848,7 +72418,6 @@ const deserializeAws_ec2VpcEndpoint = (
   }
   if (output.networkInterfaceIdSet === "") {
     contents.NetworkInterfaceIds = [];
-    return contents;
   }
   if (
     output["networkInterfaceIdSet"] !== undefined &&
@@ -72877,7 +72446,6 @@ const deserializeAws_ec2VpcEndpoint = (
   }
   if (output.routeTableIdSet === "") {
     contents.RouteTableIds = [];
-    return contents;
   }
   if (
     output["routeTableIdSet"] !== undefined &&
@@ -72900,7 +72468,6 @@ const deserializeAws_ec2VpcEndpoint = (
   }
   if (output.subnetIdSet === "") {
     contents.SubnetIds = [];
-    return contents;
   }
   if (
     output["subnetIdSet"] !== undefined &&
@@ -72917,7 +72484,6 @@ const deserializeAws_ec2VpcEndpoint = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -72960,7 +72526,6 @@ const deserializeAws_ec2VpcEndpointConnection = (
   }
   if (output.dnsEntrySet === "") {
     contents.DnsEntries = [];
-    return contents;
   }
   if (
     output["dnsEntrySet"] !== undefined &&
@@ -72974,7 +72539,6 @@ const deserializeAws_ec2VpcEndpointConnection = (
   }
   if (output.networkLoadBalancerArnSet === "") {
     contents.NetworkLoadBalancerArns = [];
-    return contents;
   }
   if (
     output["networkLoadBalancerArnSet"] !== undefined &&
@@ -73109,7 +72673,6 @@ const deserializeAws_ec2VpcPeeringConnection = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -73198,7 +72761,6 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
   }
   if (output.cidrBlockSet === "") {
     contents.CidrBlockSet = [];
-    return contents;
   }
   if (
     output["cidrBlockSet"] !== undefined &&
@@ -73215,7 +72777,6 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
   }
   if (output.ipv6CidrBlockSet === "") {
     contents.Ipv6CidrBlockSet = [];
-    return contents;
   }
   if (
     output["ipv6CidrBlockSet"] !== undefined &&
@@ -73285,7 +72846,6 @@ const deserializeAws_ec2VpnConnection = (
   }
   if (output.routes === "") {
     contents.Routes = [];
-    return contents;
   }
   if (
     output["routes"] !== undefined &&
@@ -73305,7 +72865,6 @@ const deserializeAws_ec2VpnConnection = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -73325,7 +72884,6 @@ const deserializeAws_ec2VpnConnection = (
   }
   if (output.vgwTelemetry === "") {
     contents.VgwTelemetry = [];
-    return contents;
   }
   if (
     output["vgwTelemetry"] !== undefined &&
@@ -73376,7 +72934,6 @@ const deserializeAws_ec2VpnConnectionOptions = (
   }
   if (output.tunnelOptionSet === "") {
     contents.TunnelOptions = [];
-    return contents;
   }
   if (
     output["tunnelOptionSet"] !== undefined &&
@@ -73419,7 +72976,6 @@ const deserializeAws_ec2VpnGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-    return contents;
   }
   if (
     output["tagSet"] !== undefined &&
@@ -73436,7 +72992,6 @@ const deserializeAws_ec2VpnGateway = (
   }
   if (output.attachments === "") {
     contents.VpcAttachments = [];
-    return contents;
   }
   if (
     output["attachments"] !== undefined &&

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -5671,7 +5671,6 @@ const deserializeAws_queryApplicationDescription = (
   }
   if (output.ConfigurationTemplates === "") {
     contents.ConfigurationTemplates = [];
-    return contents;
   }
   if (
     output["ConfigurationTemplates"] !== undefined &&
@@ -5703,7 +5702,6 @@ const deserializeAws_queryApplicationDescription = (
   }
   if (output.Versions === "") {
     contents.Versions = [];
-    return contents;
   }
   if (
     output["Versions"] !== undefined &&
@@ -5757,7 +5755,6 @@ const deserializeAws_queryApplicationDescriptionsMessage = (
   };
   if (output.Applications === "") {
     contents.Applications = [];
-    return contents;
   }
   if (
     output["Applications"] !== undefined &&
@@ -5939,7 +5936,6 @@ const deserializeAws_queryApplicationVersionDescriptionsMessage = (
   };
   if (output.ApplicationVersions === "") {
     contents.ApplicationVersions = [];
-    return contents;
   }
   if (
     output["ApplicationVersions"] !== undefined &&
@@ -6194,7 +6190,6 @@ const deserializeAws_queryConfigurationOptionDescription = (
   }
   if (output.ValueOptions === "") {
     contents.ValueOptions = [];
-    return contents;
   }
   if (
     output["ValueOptions"] !== undefined &&
@@ -6278,7 +6273,6 @@ const deserializeAws_queryConfigurationOptionsDescription = (
   };
   if (output.Options === "") {
     contents.Options = [];
-    return contents;
   }
   if (
     output["Options"] !== undefined &&
@@ -6339,7 +6333,6 @@ const deserializeAws_queryConfigurationSettingsDescription = (
   }
   if (output.OptionSettings === "") {
     contents.OptionSettings = [];
-    return contents;
   }
   if (
     output["OptionSettings"] !== undefined &&
@@ -6385,7 +6378,6 @@ const deserializeAws_queryConfigurationSettingsDescriptions = (
   };
   if (output.ConfigurationSettings === "") {
     contents.ConfigurationSettings = [];
-    return contents;
   }
   if (
     output["ConfigurationSettings"] !== undefined &&
@@ -6413,7 +6405,6 @@ const deserializeAws_queryConfigurationSettingsValidationMessages = (
   };
   if (output.Messages === "") {
     contents.Messages = [];
-    return contents;
   }
   if (
     output["Messages"] !== undefined &&
@@ -6583,7 +6574,6 @@ const deserializeAws_queryDescribeEnvironmentHealthResult = (
   }
   if (output.Causes === "") {
     contents.Causes = [];
-    return contents;
   }
   if (
     output["Causes"] !== undefined &&
@@ -6630,7 +6620,6 @@ const deserializeAws_queryDescribeEnvironmentManagedActionHistoryResult = (
   };
   if (output.ManagedActionHistoryItems === "") {
     contents.ManagedActionHistoryItems = [];
-    return contents;
   }
   if (
     output["ManagedActionHistoryItems"] !== undefined &&
@@ -6661,7 +6650,6 @@ const deserializeAws_queryDescribeEnvironmentManagedActionsResult = (
   };
   if (output.ManagedActions === "") {
     contents.ManagedActions = [];
-    return contents;
   }
   if (
     output["ManagedActions"] !== undefined &&
@@ -6691,7 +6679,6 @@ const deserializeAws_queryDescribeInstancesHealthResult = (
   };
   if (output.InstanceHealthList === "") {
     contents.InstanceHealthList = [];
-    return contents;
   }
   if (
     output["InstanceHealthList"] !== undefined &&
@@ -6803,7 +6790,6 @@ const deserializeAws_queryEnvironmentDescription = (
   }
   if (output.EnvironmentLinks === "") {
     contents.EnvironmentLinks = [];
-    return contents;
   }
   if (
     output["EnvironmentLinks"] !== undefined &&
@@ -6877,7 +6863,6 @@ const deserializeAws_queryEnvironmentDescriptionsMessage = (
   };
   if (output.Environments === "") {
     contents.Environments = [];
-    return contents;
   }
   if (
     output["Environments"] !== undefined &&
@@ -6977,7 +6962,6 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   };
   if (output.AutoScalingGroups === "") {
     contents.AutoScalingGroups = [];
-    return contents;
   }
   if (
     output["AutoScalingGroups"] !== undefined &&
@@ -6997,7 +6981,6 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.Instances === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["Instances"] !== undefined &&
@@ -7011,7 +6994,6 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.LaunchConfigurations === "") {
     contents.LaunchConfigurations = [];
-    return contents;
   }
   if (
     output["LaunchConfigurations"] !== undefined &&
@@ -7028,7 +7010,6 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.LaunchTemplates === "") {
     contents.LaunchTemplates = [];
-    return contents;
   }
   if (
     output["LaunchTemplates"] !== undefined &&
@@ -7045,7 +7026,6 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-    return contents;
   }
   if (
     output["LoadBalancers"] !== undefined &&
@@ -7062,7 +7042,6 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.Queues === "") {
     contents.Queues = [];
-    return contents;
   }
   if (
     output["Queues"] !== undefined &&
@@ -7076,7 +7055,6 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.Triggers === "") {
     contents.Triggers = [];
-    return contents;
   }
   if (
     output["Triggers"] !== undefined &&
@@ -7213,7 +7191,6 @@ const deserializeAws_queryEventDescriptionsMessage = (
   };
   if (output.Events === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["Events"] !== undefined &&
@@ -7435,7 +7412,6 @@ const deserializeAws_queryListAvailableSolutionStacksResultMessage = (
   };
   if (output.SolutionStackDetails === "") {
     contents.SolutionStackDetails = [];
-    return contents;
   }
   if (
     output["SolutionStackDetails"] !== undefined &&
@@ -7452,7 +7428,6 @@ const deserializeAws_queryListAvailableSolutionStacksResultMessage = (
   }
   if (output.SolutionStacks === "") {
     contents.SolutionStacks = [];
-    return contents;
   }
   if (
     output["SolutionStacks"] !== undefined &&
@@ -7484,7 +7459,6 @@ const deserializeAws_queryListPlatformVersionsResult = (
   }
   if (output.PlatformSummaryList === "") {
     contents.PlatformSummaryList = [];
-    return contents;
   }
   if (
     output["PlatformSummaryList"] !== undefined &&
@@ -7556,7 +7530,6 @@ const deserializeAws_queryLoadBalancerDescription = (
   }
   if (output.Listeners === "") {
     contents.Listeners = [];
-    return contents;
   }
   if (
     output["Listeners"] !== undefined &&
@@ -7802,7 +7775,6 @@ const deserializeAws_queryPlatformDescription = (
   };
   if (output.CustomAmiList === "") {
     contents.CustomAmiList = [];
-    return contents;
   }
   if (
     output["CustomAmiList"] !== undefined &&
@@ -7828,7 +7800,6 @@ const deserializeAws_queryPlatformDescription = (
   }
   if (output.Frameworks === "") {
     contents.Frameworks = [];
-    return contents;
   }
   if (
     output["Frameworks"] !== undefined &&
@@ -7872,7 +7843,6 @@ const deserializeAws_queryPlatformDescription = (
   }
   if (output.ProgrammingLanguages === "") {
     contents.ProgrammingLanguages = [];
-    return contents;
   }
   if (
     output["ProgrammingLanguages"] !== undefined &&
@@ -7892,7 +7862,6 @@ const deserializeAws_queryPlatformDescription = (
   }
   if (output.SupportedAddonList === "") {
     contents.SupportedAddonList = [];
-    return contents;
   }
   if (
     output["SupportedAddonList"] !== undefined &&
@@ -7909,7 +7878,6 @@ const deserializeAws_queryPlatformDescription = (
   }
   if (output.SupportedTierList === "") {
     contents.SupportedTierList = [];
-    return contents;
   }
   if (
     output["SupportedTierList"] !== undefined &&
@@ -8016,7 +7984,6 @@ const deserializeAws_queryPlatformSummary = (
   }
   if (output.SupportedAddonList === "") {
     contents.SupportedAddonList = [];
-    return contents;
   }
   if (
     output["SupportedAddonList"] !== undefined &&
@@ -8033,7 +8000,6 @@ const deserializeAws_queryPlatformSummary = (
   }
   if (output.SupportedTierList === "") {
     contents.SupportedTierList = [];
-    return contents;
   }
   if (
     output["SupportedTierList"] !== undefined &&
@@ -8188,7 +8154,6 @@ const deserializeAws_queryResourceTagsDescriptionMessage = (
   }
   if (output.ResourceTags === "") {
     contents.ResourceTags = [];
-    return contents;
   }
   if (
     output["ResourceTags"] !== undefined &&
@@ -8227,7 +8192,6 @@ const deserializeAws_queryRetrieveEnvironmentInfoResultMessage = (
   };
   if (output.EnvironmentInfo === "") {
     contents.EnvironmentInfo = [];
-    return contents;
   }
   if (
     output["EnvironmentInfo"] !== undefined &&
@@ -8319,7 +8283,6 @@ const deserializeAws_querySingleInstanceHealth = (
   }
   if (output.Causes === "") {
     contents.Causes = [];
-    return contents;
   }
   if (
     output["Causes"] !== undefined &&
@@ -8372,7 +8335,6 @@ const deserializeAws_querySolutionStackDescription = (
   };
   if (output.PermittedFileTypes === "") {
     contents.PermittedFileTypes = [];
-    return contents;
   }
   if (
     output["PermittedFileTypes"] !== undefined &&
@@ -8493,7 +8455,6 @@ const deserializeAws_querySystemStatus = (
   }
   if (output.LoadAverage === "") {
     contents.LoadAverage = [];
-    return contents;
   }
   if (
     output["LoadAverage"] !== undefined &&

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -6087,7 +6087,6 @@ const deserializeAws_queryAddListenerCertificatesOutput = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-    return contents;
   }
   if (
     output["Certificates"] !== undefined &&
@@ -6157,7 +6156,6 @@ const deserializeAws_queryAuthenticateCognitoActionConfig = (
   };
   if (output.AuthenticationRequestExtraParams === "") {
     contents.AuthenticationRequestExtraParams = {};
-    return contents;
   }
   if (
     output["AuthenticationRequestExtraParams"] !== undefined &&
@@ -6228,7 +6226,6 @@ const deserializeAws_queryAuthenticateOidcActionConfig = (
   };
   if (output.AuthenticationRequestExtraParams === "") {
     contents.AuthenticationRequestExtraParams = {};
-    return contents;
   }
   if (
     output["AuthenticationRequestExtraParams"] !== undefined &&
@@ -6292,7 +6289,6 @@ const deserializeAws_queryAvailabilityZone = (
   };
   if (output.LoadBalancerAddresses === "") {
     contents.LoadBalancerAddresses = [];
-    return contents;
   }
   if (
     output["LoadBalancerAddresses"] !== undefined &&
@@ -6417,7 +6413,6 @@ const deserializeAws_queryCreateListenerOutput = (
   };
   if (output.Listeners === "") {
     contents.Listeners = [];
-    return contents;
   }
   if (
     output["Listeners"] !== undefined &&
@@ -6442,7 +6437,6 @@ const deserializeAws_queryCreateLoadBalancerOutput = (
   };
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-    return contents;
   }
   if (
     output["LoadBalancers"] !== undefined &&
@@ -6470,7 +6464,6 @@ const deserializeAws_queryCreateRuleOutput = (
   };
   if (output.Rules === "") {
     contents.Rules = [];
-    return contents;
   }
   if (
     output["Rules"] !== undefined &&
@@ -6495,7 +6488,6 @@ const deserializeAws_queryCreateTargetGroupOutput = (
   };
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-    return contents;
   }
   if (
     output["TargetGroups"] !== undefined &&
@@ -6574,7 +6566,6 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   };
   if (output.Limits === "") {
     contents.Limits = [];
-    return contents;
   }
   if (
     output["Limits"] !== undefined &&
@@ -6603,7 +6594,6 @@ const deserializeAws_queryDescribeListenerCertificatesOutput = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-    return contents;
   }
   if (
     output["Certificates"] !== undefined &&
@@ -6635,7 +6625,6 @@ const deserializeAws_queryDescribeListenersOutput = (
   };
   if (output.Listeners === "") {
     contents.Listeners = [];
-    return contents;
   }
   if (
     output["Listeners"] !== undefined &&
@@ -6663,7 +6652,6 @@ const deserializeAws_queryDescribeLoadBalancerAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -6692,7 +6680,6 @@ const deserializeAws_queryDescribeLoadBalancersOutput = (
   };
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-    return contents;
   }
   if (
     output["LoadBalancers"] !== undefined &&
@@ -6727,7 +6714,6 @@ const deserializeAws_queryDescribeRulesOutput = (
   }
   if (output.Rules === "") {
     contents.Rules = [];
-    return contents;
   }
   if (
     output["Rules"] !== undefined &&
@@ -6756,7 +6742,6 @@ const deserializeAws_queryDescribeSSLPoliciesOutput = (
   }
   if (output.SslPolicies === "") {
     contents.SslPolicies = [];
-    return contents;
   }
   if (
     output["SslPolicies"] !== undefined &&
@@ -6784,7 +6769,6 @@ const deserializeAws_queryDescribeTagsOutput = (
   };
   if (output.TagDescriptions === "") {
     contents.TagDescriptions = [];
-    return contents;
   }
   if (
     output["TagDescriptions"] !== undefined &&
@@ -6812,7 +6796,6 @@ const deserializeAws_queryDescribeTargetGroupAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -6844,7 +6827,6 @@ const deserializeAws_queryDescribeTargetGroupsOutput = (
   }
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-    return contents;
   }
   if (
     output["TargetGroups"] !== undefined &&
@@ -6872,7 +6854,6 @@ const deserializeAws_queryDescribeTargetHealthOutput = (
   };
   if (output.TargetHealthDescriptions === "") {
     contents.TargetHealthDescriptions = [];
-    return contents;
   }
   if (
     output["TargetHealthDescriptions"] !== undefined &&
@@ -6985,7 +6966,6 @@ const deserializeAws_queryForwardActionConfig = (
   }
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-    return contents;
   }
   if (
     output["TargetGroups"] !== undefined &&
@@ -7027,7 +7007,6 @@ const deserializeAws_queryHostHeaderConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -7056,7 +7035,6 @@ const deserializeAws_queryHttpHeaderConditionConfig = (
   }
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -7081,7 +7059,6 @@ const deserializeAws_queryHttpRequestMethodConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -7244,7 +7221,6 @@ const deserializeAws_queryListener = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-    return contents;
   }
   if (
     output["Certificates"] !== undefined &&
@@ -7261,7 +7237,6 @@ const deserializeAws_queryListener = (
   }
   if (output.DefaultActions === "") {
     contents.DefaultActions = [];
-    return contents;
   }
   if (
     output["DefaultActions"] !== undefined &&
@@ -7335,7 +7310,6 @@ const deserializeAws_queryLoadBalancer = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -7373,7 +7347,6 @@ const deserializeAws_queryLoadBalancer = (
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["SecurityGroups"] !== undefined &&
@@ -7533,7 +7506,6 @@ const deserializeAws_queryModifyListenerOutput = (
   };
   if (output.Listeners === "") {
     contents.Listeners = [];
-    return contents;
   }
   if (
     output["Listeners"] !== undefined &&
@@ -7558,7 +7530,6 @@ const deserializeAws_queryModifyLoadBalancerAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -7586,7 +7557,6 @@ const deserializeAws_queryModifyRuleOutput = (
   };
   if (output.Rules === "") {
     contents.Rules = [];
-    return contents;
   }
   if (
     output["Rules"] !== undefined &&
@@ -7611,7 +7581,6 @@ const deserializeAws_queryModifyTargetGroupAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -7639,7 +7608,6 @@ const deserializeAws_queryModifyTargetGroupOutput = (
   };
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-    return contents;
   }
   if (
     output["TargetGroups"] !== undefined &&
@@ -7681,7 +7649,6 @@ const deserializeAws_queryPathPatternConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -7720,7 +7687,6 @@ const deserializeAws_queryQueryStringConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -7857,7 +7823,6 @@ const deserializeAws_queryRule = (
   };
   if (output.Actions === "") {
     contents.Actions = [];
-    return contents;
   }
   if (
     output["Actions"] !== undefined &&
@@ -7871,7 +7836,6 @@ const deserializeAws_queryRule = (
   }
   if (output.Conditions === "") {
     contents.Conditions = [];
-    return contents;
   }
   if (
     output["Conditions"] !== undefined &&
@@ -7954,7 +7918,6 @@ const deserializeAws_queryRuleCondition = (
   }
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -8046,7 +8009,6 @@ const deserializeAws_querySetRulePrioritiesOutput = (
   };
   if (output.Rules === "") {
     contents.Rules = [];
-    return contents;
   }
   if (
     output["Rules"] !== undefined &&
@@ -8071,7 +8033,6 @@ const deserializeAws_querySetSecurityGroupsOutput = (
   };
   if (output.SecurityGroupIds === "") {
     contents.SecurityGroupIds = [];
-    return contents;
   }
   if (
     output["SecurityGroupIds"] !== undefined &&
@@ -8099,7 +8060,6 @@ const deserializeAws_querySetSubnetsOutput = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -8127,7 +8087,6 @@ const deserializeAws_querySourceIpConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-    return contents;
   }
   if (
     output["Values"] !== undefined &&
@@ -8163,7 +8122,6 @@ const deserializeAws_querySslPolicy = (
   };
   if (output.Ciphers === "") {
     contents.Ciphers = [];
-    return contents;
   }
   if (
     output["Ciphers"] !== undefined &&
@@ -8180,7 +8138,6 @@ const deserializeAws_querySslPolicy = (
   }
   if (output.SslProtocols === "") {
     contents.SslProtocols = [];
-    return contents;
   }
   if (
     output["SslProtocols"] !== undefined &&
@@ -8248,7 +8205,6 @@ const deserializeAws_queryTagDescription = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -8350,7 +8306,6 @@ const deserializeAws_queryTargetGroup = (
   }
   if (output.LoadBalancerArns === "") {
     contents.LoadBalancerArns = [];
-    return contents;
   }
   if (
     output["LoadBalancerArns"] !== undefined &&

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -4315,7 +4315,6 @@ const deserializeAws_queryAddAvailabilityZonesOutput = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -4407,7 +4406,6 @@ const deserializeAws_queryApplySecurityGroupsToLoadBalancerOutput = (
   };
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["SecurityGroups"] !== undefined &&
@@ -4435,7 +4433,6 @@ const deserializeAws_queryAttachLoadBalancerToSubnetsOutput = (
   };
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -4471,7 +4468,6 @@ const deserializeAws_queryBackendServerDescription = (
   }
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-    return contents;
   }
   if (
     output["PolicyNames"] !== undefined &&
@@ -4683,7 +4679,6 @@ const deserializeAws_queryDeregisterEndPointsOutput = (
   };
   if (output.Instances === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["Instances"] !== undefined &&
@@ -4709,7 +4704,6 @@ const deserializeAws_queryDescribeAccessPointsOutput = (
   };
   if (output.LoadBalancerDescriptions === "") {
     contents.LoadBalancerDescriptions = [];
-    return contents;
   }
   if (
     output["LoadBalancerDescriptions"] !== undefined &&
@@ -4741,7 +4735,6 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   };
   if (output.Limits === "") {
     contents.Limits = [];
-    return contents;
   }
   if (
     output["Limits"] !== undefined &&
@@ -4769,7 +4762,6 @@ const deserializeAws_queryDescribeEndPointStateOutput = (
   };
   if (output.InstanceStates === "") {
     contents.InstanceStates = [];
-    return contents;
   }
   if (
     output["InstanceStates"] !== undefined &&
@@ -4814,7 +4806,6 @@ const deserializeAws_queryDescribeLoadBalancerPoliciesOutput = (
   };
   if (output.PolicyDescriptions === "") {
     contents.PolicyDescriptions = [];
-    return contents;
   }
   if (
     output["PolicyDescriptions"] !== undefined &&
@@ -4842,7 +4833,6 @@ const deserializeAws_queryDescribeLoadBalancerPolicyTypesOutput = (
   };
   if (output.PolicyTypeDescriptions === "") {
     contents.PolicyTypeDescriptions = [];
-    return contents;
   }
   if (
     output["PolicyTypeDescriptions"] !== undefined &&
@@ -4870,7 +4860,6 @@ const deserializeAws_queryDescribeTagsOutput = (
   };
   if (output.TagDescriptions === "") {
     contents.TagDescriptions = [];
-    return contents;
   }
   if (
     output["TagDescriptions"] !== undefined &&
@@ -4898,7 +4887,6 @@ const deserializeAws_queryDetachLoadBalancerFromSubnetsOutput = (
   };
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -5230,7 +5218,6 @@ const deserializeAws_queryListenerDescription = (
   }
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-    return contents;
   }
   if (
     output["PolicyNames"] !== undefined &&
@@ -5305,7 +5292,6 @@ const deserializeAws_queryLoadBalancerAttributes = (
   }
   if (output.AdditionalAttributes === "") {
     contents.AdditionalAttributes = [];
-    return contents;
   }
   if (
     output["AdditionalAttributes"] !== undefined &&
@@ -5366,7 +5352,6 @@ const deserializeAws_queryLoadBalancerDescription = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -5383,7 +5368,6 @@ const deserializeAws_queryLoadBalancerDescription = (
   }
   if (output.BackendServerDescriptions === "") {
     contents.BackendServerDescriptions = [];
-    return contents;
   }
   if (
     output["BackendServerDescriptions"] !== undefined &&
@@ -5418,7 +5402,6 @@ const deserializeAws_queryLoadBalancerDescription = (
   }
   if (output.Instances === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["Instances"] !== undefined &&
@@ -5432,7 +5415,6 @@ const deserializeAws_queryLoadBalancerDescription = (
   }
   if (output.ListenerDescriptions === "") {
     contents.ListenerDescriptions = [];
-    return contents;
   }
   if (
     output["ListenerDescriptions"] !== undefined &&
@@ -5461,7 +5443,6 @@ const deserializeAws_queryLoadBalancerDescription = (
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["SecurityGroups"] !== undefined &&
@@ -5484,7 +5465,6 @@ const deserializeAws_queryLoadBalancerDescription = (
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -5558,7 +5538,6 @@ const deserializeAws_queryPolicies = (
   };
   if (output.AppCookieStickinessPolicies === "") {
     contents.AppCookieStickinessPolicies = [];
-    return contents;
   }
   if (
     output["AppCookieStickinessPolicies"] !== undefined &&
@@ -5575,7 +5554,6 @@ const deserializeAws_queryPolicies = (
   }
   if (output.LBCookieStickinessPolicies === "") {
     contents.LBCookieStickinessPolicies = [];
-    return contents;
   }
   if (
     output["LBCookieStickinessPolicies"] !== undefined &&
@@ -5592,7 +5570,6 @@ const deserializeAws_queryPolicies = (
   }
   if (output.OtherPolicies === "") {
     contents.OtherPolicies = [];
-    return contents;
   }
   if (
     output["OtherPolicies"] !== undefined &&
@@ -5688,7 +5665,6 @@ const deserializeAws_queryPolicyDescription = (
   };
   if (output.PolicyAttributeDescriptions === "") {
     contents.PolicyAttributeDescriptions = [];
-    return contents;
   }
   if (
     output["PolicyAttributeDescriptions"] !== undefined &&
@@ -5757,7 +5733,6 @@ const deserializeAws_queryPolicyTypeDescription = (
   }
   if (output.PolicyAttributeTypeDescriptions === "") {
     contents.PolicyAttributeTypeDescriptions = [];
-    return contents;
   }
   if (
     output["PolicyAttributeTypeDescriptions"] !== undefined &&
@@ -5811,7 +5786,6 @@ const deserializeAws_queryRegisterEndPointsOutput = (
   };
   if (output.Instances === "") {
     contents.Instances = [];
-    return contents;
   }
   if (
     output["Instances"] !== undefined &&
@@ -5836,7 +5810,6 @@ const deserializeAws_queryRemoveAvailabilityZonesOutput = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -5969,7 +5942,6 @@ const deserializeAws_queryTagDescription = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -8983,7 +8983,6 @@ const deserializeAws_queryAllowedNodeTypeModificationsMessage = (
   };
   if (output.ScaleDownModifications === "") {
     contents.ScaleDownModifications = [];
-    return contents;
   }
   if (
     output["ScaleDownModifications"] !== undefined &&
@@ -9000,7 +8999,6 @@ const deserializeAws_queryAllowedNodeTypeModificationsMessage = (
   }
   if (output.ScaleUpModifications === "") {
     contents.ScaleUpModifications = [];
-    return contents;
   }
   if (
     output["ScaleUpModifications"] !== undefined &&
@@ -9121,7 +9119,6 @@ const deserializeAws_queryCacheCluster = (
   }
   if (output.CacheNodes === "") {
     contents.CacheNodes = [];
-    return contents;
   }
   if (
     output["CacheNodes"] !== undefined &&
@@ -9144,7 +9141,6 @@ const deserializeAws_queryCacheCluster = (
   }
   if (output.CacheSecurityGroups === "") {
     contents.CacheSecurityGroups = [];
-    return contents;
   }
   if (
     output["CacheSecurityGroups"] !== undefined &&
@@ -9203,7 +9199,6 @@ const deserializeAws_queryCacheCluster = (
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-    return contents;
   }
   if (
     output["SecurityGroups"] !== undefined &&
@@ -9253,7 +9248,6 @@ const deserializeAws_queryCacheClusterMessage = (
   };
   if (output.CacheClusters === "") {
     contents.CacheClusters = [];
-    return contents;
   }
   if (
     output["CacheClusters"] !== undefined &&
@@ -9325,7 +9319,6 @@ const deserializeAws_queryCacheEngineVersionMessage = (
   };
   if (output.CacheEngineVersions === "") {
     contents.CacheEngineVersions = [];
-    return contents;
   }
   if (
     output["CacheEngineVersions"] !== undefined &&
@@ -9424,7 +9417,6 @@ const deserializeAws_queryCacheNodeTypeSpecificParameter = (
   }
   if (output.CacheNodeTypeSpecificValues === "") {
     contents.CacheNodeTypeSpecificValues = [];
-    return contents;
   }
   if (
     output["CacheNodeTypeSpecificValues"] !== undefined &&
@@ -9591,7 +9583,6 @@ const deserializeAws_queryCacheParameterGroupDetails = (
   };
   if (output.CacheNodeTypeSpecificParameters === "") {
     contents.CacheNodeTypeSpecificParameters = [];
-    return contents;
   }
   if (
     output["CacheNodeTypeSpecificParameters"] !== undefined &&
@@ -9621,7 +9612,6 @@ const deserializeAws_queryCacheParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -9674,7 +9664,6 @@ const deserializeAws_queryCacheParameterGroupStatus = (
   };
   if (output.CacheNodeIdsToReboot === "") {
     contents.CacheNodeIdsToReboot = [];
-    return contents;
   }
   if (
     output["CacheNodeIdsToReboot"] !== undefined &&
@@ -9709,7 +9698,6 @@ const deserializeAws_queryCacheParameterGroupsMessage = (
   };
   if (output.CacheParameterGroups === "") {
     contents.CacheParameterGroups = [];
-    return contents;
   }
   if (
     output["CacheParameterGroups"] !== undefined &&
@@ -9749,7 +9737,6 @@ const deserializeAws_queryCacheSecurityGroup = (
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
-    return contents;
   }
   if (
     output["EC2SecurityGroups"] !== undefined &&
@@ -9808,7 +9795,6 @@ const deserializeAws_queryCacheSecurityGroupMessage = (
   };
   if (output.CacheSecurityGroups === "") {
     contents.CacheSecurityGroups = [];
-    return contents;
   }
   if (
     output["CacheSecurityGroups"] !== undefined &&
@@ -9858,7 +9844,6 @@ const deserializeAws_queryCacheSubnetGroup = (
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -9887,7 +9872,6 @@ const deserializeAws_queryCacheSubnetGroupMessage = (
   };
   if (output.CacheSubnetGroups === "") {
     contents.CacheSubnetGroups = [];
-    return contents;
   }
   if (
     output["CacheSubnetGroups"] !== undefined &&
@@ -10159,7 +10143,6 @@ const deserializeAws_queryDescribeSnapshotsListMessage = (
   }
   if (output.Snapshots === "") {
     contents.Snapshots = [];
-    return contents;
   }
   if (
     output["Snapshots"] !== undefined &&
@@ -10236,7 +10219,6 @@ const deserializeAws_queryEngineDefaults = (
   };
   if (output.CacheNodeTypeSpecificParameters === "") {
     contents.CacheNodeTypeSpecificParameters = [];
-    return contents;
   }
   if (
     output["CacheNodeTypeSpecificParameters"] !== undefined &&
@@ -10269,7 +10251,6 @@ const deserializeAws_queryEngineDefaults = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -10333,7 +10314,6 @@ const deserializeAws_queryEventsMessage = (
   };
   if (output.Events === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["Events"] !== undefined &&
@@ -10454,7 +10434,6 @@ const deserializeAws_queryNodeGroup = (
   }
   if (output.NodeGroupMembers === "") {
     contents.NodeGroupMembers = [];
-    return contents;
   }
   if (
     output["NodeGroupMembers"] !== undefined &&
@@ -10510,7 +10489,6 @@ const deserializeAws_queryNodeGroupConfiguration = (
   }
   if (output.ReplicaAvailabilityZones === "") {
     contents.ReplicaAvailabilityZones = [];
-    return contents;
   }
   if (
     output["ReplicaAvailabilityZones"] !== undefined &&
@@ -10658,7 +10636,6 @@ const deserializeAws_queryNodeGroupUpdateStatus = (
   }
   if (output.NodeGroupMemberUpdateStatus === "") {
     contents.NodeGroupMemberUpdateStatus = [];
-    return contents;
   }
   if (
     output["NodeGroupMemberUpdateStatus"] !== undefined &&
@@ -10837,7 +10814,6 @@ const deserializeAws_queryPendingModifiedValues = (
   }
   if (output.CacheNodeIdsToRemove === "") {
     contents.CacheNodeIdsToRemove = [];
-    return contents;
   }
   if (
     output["CacheNodeIdsToRemove"] !== undefined &&
@@ -11022,7 +10998,6 @@ const deserializeAws_queryReplicationGroup = (
   }
   if (output.MemberClusters === "") {
     contents.MemberClusters = [];
-    return contents;
   }
   if (
     output["MemberClusters"] !== undefined &&
@@ -11039,7 +11014,6 @@ const deserializeAws_queryReplicationGroup = (
   }
   if (output.NodeGroups === "") {
     contents.NodeGroups = [];
-    return contents;
   }
   if (
     output["NodeGroups"] !== undefined &&
@@ -11107,7 +11081,6 @@ const deserializeAws_queryReplicationGroupMessage = (
   }
   if (output.ReplicationGroups === "") {
     contents.ReplicationGroups = [];
-    return contents;
   }
   if (
     output["ReplicationGroups"] !== undefined &&
@@ -11194,7 +11167,6 @@ const deserializeAws_queryReservedCacheNode = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["RecurringCharges"] !== undefined &&
@@ -11254,7 +11226,6 @@ const deserializeAws_queryReservedCacheNodeMessage = (
   }
   if (output.ReservedCacheNodes === "") {
     contents.ReservedCacheNodes = [];
-    return contents;
   }
   if (
     output["ReservedCacheNodes"] !== undefined &&
@@ -11304,7 +11275,6 @@ const deserializeAws_queryReservedCacheNodesOffering = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["RecurringCharges"] !== undefined &&
@@ -11352,7 +11322,6 @@ const deserializeAws_queryReservedCacheNodesOfferingMessage = (
   }
   if (output.ReservedCacheNodesOfferings === "") {
     contents.ReservedCacheNodesOfferings = [];
-    return contents;
   }
   if (
     output["ReservedCacheNodesOfferings"] !== undefined &&
@@ -11520,7 +11489,6 @@ const deserializeAws_queryServiceUpdatesMessage = (
   }
   if (output.ServiceUpdates === "") {
     contents.ServiceUpdates = [];
-    return contents;
   }
   if (
     output["ServiceUpdates"] !== undefined &&
@@ -11619,7 +11587,6 @@ const deserializeAws_querySnapshot = (
   }
   if (output.NodeSnapshots === "") {
     contents.NodeSnapshots = [];
-    return contents;
   }
   if (
     output["NodeSnapshots"] !== undefined &&
@@ -11772,7 +11739,6 @@ const deserializeAws_queryTagListMessage = (
   };
   if (output.TagList === "") {
     contents.TagList = [];
-    return contents;
   }
   if (
     output["TagList"] !== undefined &&
@@ -11872,7 +11838,6 @@ const deserializeAws_queryUpdateAction = (
   }
   if (output.CacheNodeUpdateStatus === "") {
     contents.CacheNodeUpdateStatus = [];
-    return contents;
   }
   if (
     output["CacheNodeUpdateStatus"] !== undefined &&
@@ -11895,7 +11860,6 @@ const deserializeAws_queryUpdateAction = (
   }
   if (output.NodeGroupUpdateStatus === "") {
     contents.NodeGroupUpdateStatus = [];
-    return contents;
   }
   if (
     output["NodeGroupUpdateStatus"] !== undefined &&
@@ -11977,7 +11941,6 @@ const deserializeAws_queryUpdateActionResultsMessage = (
   };
   if (output.ProcessedUpdateActions === "") {
     contents.ProcessedUpdateActions = [];
-    return contents;
   }
   if (
     output["ProcessedUpdateActions"] !== undefined &&
@@ -11994,7 +11957,6 @@ const deserializeAws_queryUpdateActionResultsMessage = (
   }
   if (output.UnprocessedUpdateActions === "") {
     contents.UnprocessedUpdateActions = [];
-    return contents;
   }
   if (
     output["UnprocessedUpdateActions"] !== undefined &&
@@ -12027,7 +11989,6 @@ const deserializeAws_queryUpdateActionsMessage = (
   }
   if (output.UpdateActions === "") {
     contents.UpdateActions = [];
-    return contents;
   }
   if (
     output["UpdateActions"] !== undefined &&

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -16502,7 +16502,6 @@ const deserializeAws_queryDeletionTaskFailureReasonType = (
   }
   if (output.RoleUsageList === "") {
     contents.RoleUsageList = [];
-    return contents;
   }
   if (
     output["RoleUsageList"] !== undefined &&
@@ -16679,7 +16678,6 @@ const deserializeAws_queryEvaluationResult = (
   }
   if (output.EvalDecisionDetails === "") {
     contents.EvalDecisionDetails = {};
-    return contents;
   }
   if (
     output["EvalDecisionDetails"] !== undefined &&
@@ -16699,7 +16697,6 @@ const deserializeAws_queryEvaluationResult = (
   }
   if (output.MatchedStatements === "") {
     contents.MatchedStatements = [];
-    return contents;
   }
   if (
     output["MatchedStatements"] !== undefined &&
@@ -16716,7 +16713,6 @@ const deserializeAws_queryEvaluationResult = (
   }
   if (output.MissingContextValues === "") {
     contents.MissingContextValues = [];
-    return contents;
   }
   if (
     output["MissingContextValues"] !== undefined &&
@@ -16739,7 +16735,6 @@ const deserializeAws_queryEvaluationResult = (
   }
   if (output.ResourceSpecificResults === "") {
     contents.ResourceSpecificResults = [];
-    return contents;
   }
   if (
     output["ResourceSpecificResults"] !== undefined &&
@@ -16848,7 +16843,6 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   };
   if (output.GroupDetailList === "") {
     contents.GroupDetailList = [];
-    return contents;
   }
   if (
     output["GroupDetailList"] !== undefined &&
@@ -16871,7 +16865,6 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   }
   if (output.Policies === "") {
     contents.Policies = [];
-    return contents;
   }
   if (
     output["Policies"] !== undefined &&
@@ -16888,7 +16881,6 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   }
   if (output.RoleDetailList === "") {
     contents.RoleDetailList = [];
-    return contents;
   }
   if (
     output["RoleDetailList"] !== undefined &&
@@ -16905,7 +16897,6 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   }
   if (output.UserDetailList === "") {
     contents.UserDetailList = [];
-    return contents;
   }
   if (
     output["UserDetailList"] !== undefined &&
@@ -16950,7 +16941,6 @@ const deserializeAws_queryGetAccountSummaryResponse = (
   };
   if (output.SummaryMap === "") {
     contents.SummaryMap = {};
-    return contents;
   }
   if (
     output["SummaryMap"] !== undefined &&
@@ -16978,7 +16968,6 @@ const deserializeAws_queryGetContextKeysForPolicyResponse = (
   };
   if (output.ContextKeyNames === "") {
     contents.ContextKeyNames = [];
-    return contents;
   }
   if (
     output["ContextKeyNames"] !== undefined &&
@@ -17062,7 +17051,6 @@ const deserializeAws_queryGetGroupResponse = (
   }
   if (output.Users === "") {
     contents.Users = [];
-    return contents;
   }
   if (
     output["Users"] !== undefined &&
@@ -17124,7 +17112,6 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
   };
   if (output.ClientIDList === "") {
     contents.ClientIDList = [];
-    return contents;
   }
   if (
     output["ClientIDList"] !== undefined &&
@@ -17144,7 +17131,6 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
   }
   if (output.ThumbprintList === "") {
     contents.ThumbprintList = [];
-    return contents;
   }
   if (
     output["ThumbprintList"] !== undefined &&
@@ -17183,7 +17169,6 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
   };
   if (output.AccessDetails === "") {
     contents.AccessDetails = [];
-    return contents;
   }
   if (
     output["AccessDetails"] !== undefined &&
@@ -17389,7 +17374,6 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
   }
   if (output.ServicesLastAccessed === "") {
     contents.ServicesLastAccessed = [];
-    return contents;
   }
   if (
     output["ServicesLastAccessed"] !== undefined &&
@@ -17423,7 +17407,6 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesResponse = (
   };
   if (output.EntityDetailsList === "") {
     contents.EntityDetailsList = [];
-    return contents;
   }
   if (
     output["EntityDetailsList"] !== undefined &&
@@ -17565,7 +17548,6 @@ const deserializeAws_queryGroupDetail = (
   }
   if (output.AttachedManagedPolicies === "") {
     contents.AttachedManagedPolicies = [];
-    return contents;
   }
   if (
     output["AttachedManagedPolicies"] !== undefined &&
@@ -17591,7 +17573,6 @@ const deserializeAws_queryGroupDetail = (
   }
   if (output.GroupPolicyList === "") {
     contents.GroupPolicyList = [];
-    return contents;
   }
   if (
     output["GroupPolicyList"] !== undefined &&
@@ -17642,7 +17623,6 @@ const deserializeAws_queryInstanceProfile = (
   }
   if (output.Roles === "") {
     contents.Roles = [];
-    return contents;
   }
   if (
     output["Roles"] !== undefined &&
@@ -17767,7 +17747,6 @@ const deserializeAws_queryListAccessKeysResponse = (
   };
   if (output.AccessKeyMetadata === "") {
     contents.AccessKeyMetadata = [];
-    return contents;
   }
   if (
     output["AccessKeyMetadata"] !== undefined &&
@@ -17803,7 +17782,6 @@ const deserializeAws_queryListAccountAliasesResponse = (
   };
   if (output.AccountAliases === "") {
     contents.AccountAliases = [];
-    return contents;
   }
   if (
     output["AccountAliases"] !== undefined &&
@@ -17839,7 +17817,6 @@ const deserializeAws_queryListAttachedGroupPoliciesResponse = (
   };
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
-    return contents;
   }
   if (
     output["AttachedPolicies"] !== undefined &&
@@ -17875,7 +17852,6 @@ const deserializeAws_queryListAttachedRolePoliciesResponse = (
   };
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
-    return contents;
   }
   if (
     output["AttachedPolicies"] !== undefined &&
@@ -17911,7 +17887,6 @@ const deserializeAws_queryListAttachedUserPoliciesResponse = (
   };
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
-    return contents;
   }
   if (
     output["AttachedPolicies"] !== undefined &&
@@ -17955,7 +17930,6 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
   }
   if (output.PolicyGroups === "") {
     contents.PolicyGroups = [];
-    return contents;
   }
   if (
     output["PolicyGroups"] !== undefined &&
@@ -17972,7 +17946,6 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
   }
   if (output.PolicyRoles === "") {
     contents.PolicyRoles = [];
-    return contents;
   }
   if (
     output["PolicyRoles"] !== undefined &&
@@ -17989,7 +17962,6 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
   }
   if (output.PolicyUsers === "") {
     contents.PolicyUsers = [];
-    return contents;
   }
   if (
     output["PolicyUsers"] !== undefined &&
@@ -18025,7 +17997,6 @@ const deserializeAws_queryListGroupPoliciesResponse = (
   }
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-    return contents;
   }
   if (
     output["PolicyNames"] !== undefined &&
@@ -18055,7 +18026,6 @@ const deserializeAws_queryListGroupsForUserResponse = (
   };
   if (output.Groups === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["Groups"] !== undefined &&
@@ -18088,7 +18058,6 @@ const deserializeAws_queryListGroupsResponse = (
   };
   if (output.Groups === "") {
     contents.Groups = [];
-    return contents;
   }
   if (
     output["Groups"] !== undefined &&
@@ -18121,7 +18090,6 @@ const deserializeAws_queryListInstanceProfilesForRoleResponse = (
   };
   if (output.InstanceProfiles === "") {
     contents.InstanceProfiles = [];
-    return contents;
   }
   if (
     output["InstanceProfiles"] !== undefined &&
@@ -18157,7 +18125,6 @@ const deserializeAws_queryListInstanceProfilesResponse = (
   };
   if (output.InstanceProfiles === "") {
     contents.InstanceProfiles = [];
-    return contents;
   }
   if (
     output["InstanceProfiles"] !== undefined &&
@@ -18196,7 +18163,6 @@ const deserializeAws_queryListMFADevicesResponse = (
   }
   if (output.MFADevices === "") {
     contents.MFADevices = [];
-    return contents;
   }
   if (
     output["MFADevices"] !== undefined &&
@@ -18227,7 +18193,6 @@ const deserializeAws_queryListOpenIDConnectProvidersResponse = (
   };
   if (output.OpenIDConnectProviderList === "") {
     contents.OpenIDConnectProviderList = [];
-    return contents;
   }
   if (
     output["OpenIDConnectProviderList"] !== undefined &&
@@ -18256,7 +18221,6 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessEntry = (
   };
   if (output.Policies === "") {
     contents.Policies = [];
-    return contents;
   }
   if (
     output["Policies"] !== undefined &&
@@ -18295,7 +18259,6 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessResponse = (
   }
   if (output.PoliciesGrantingServiceAccess === "") {
     contents.PoliciesGrantingServiceAccess = [];
-    return contents;
   }
   if (
     output["PoliciesGrantingServiceAccess"] !== undefined &&
@@ -18331,7 +18294,6 @@ const deserializeAws_queryListPoliciesResponse = (
   }
   if (output.Policies === "") {
     contents.Policies = [];
-    return contents;
   }
   if (
     output["Policies"] !== undefined &&
@@ -18367,7 +18329,6 @@ const deserializeAws_queryListPolicyVersionsResponse = (
   }
   if (output.Versions === "") {
     contents.Versions = [];
-    return contents;
   }
   if (
     output["Versions"] !== undefined &&
@@ -18403,7 +18364,6 @@ const deserializeAws_queryListRolePoliciesResponse = (
   }
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-    return contents;
   }
   if (
     output["PolicyNames"] !== undefined &&
@@ -18439,7 +18399,6 @@ const deserializeAws_queryListRoleTagsResponse = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -18469,7 +18428,6 @@ const deserializeAws_queryListRolesResponse = (
   }
   if (output.Roles === "") {
     contents.Roles = [];
-    return contents;
   }
   if (
     output["Roles"] !== undefined &&
@@ -18494,7 +18452,6 @@ const deserializeAws_queryListSAMLProvidersResponse = (
   };
   if (output.SAMLProviderList === "") {
     contents.SAMLProviderList = [];
-    return contents;
   }
   if (
     output["SAMLProviderList"] !== undefined &&
@@ -18530,7 +18487,6 @@ const deserializeAws_queryListSSHPublicKeysResponse = (
   }
   if (output.SSHPublicKeys === "") {
     contents.SSHPublicKeys = [];
-    return contents;
   }
   if (
     output["SSHPublicKeys"] !== undefined &&
@@ -18566,7 +18522,6 @@ const deserializeAws_queryListServerCertificatesResponse = (
   }
   if (output.ServerCertificateMetadataList === "") {
     contents.ServerCertificateMetadataList = [];
-    return contents;
   }
   if (
     output["ServerCertificateMetadataList"] !== undefined &&
@@ -18594,7 +18549,6 @@ const deserializeAws_queryListServiceSpecificCredentialsResponse = (
   };
   if (output.ServiceSpecificCredentials === "") {
     contents.ServiceSpecificCredentials = [];
-    return contents;
   }
   if (
     output["ServiceSpecificCredentials"] !== undefined &&
@@ -18624,7 +18578,6 @@ const deserializeAws_queryListSigningCertificatesResponse = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-    return contents;
   }
   if (
     output["Certificates"] !== undefined &&
@@ -18666,7 +18619,6 @@ const deserializeAws_queryListUserPoliciesResponse = (
   }
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-    return contents;
   }
   if (
     output["PolicyNames"] !== undefined &&
@@ -18702,7 +18654,6 @@ const deserializeAws_queryListUserTagsResponse = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -18732,7 +18683,6 @@ const deserializeAws_queryListUsersResponse = (
   }
   if (output.Users === "") {
     contents.Users = [];
-    return contents;
   }
   if (
     output["Users"] !== undefined &&
@@ -18765,7 +18715,6 @@ const deserializeAws_queryListVirtualMFADevicesResponse = (
   }
   if (output.VirtualMFADevices === "") {
     contents.VirtualMFADevices = [];
-    return contents;
   }
   if (
     output["VirtualMFADevices"] !== undefined &&
@@ -18908,7 +18857,6 @@ const deserializeAws_queryManagedPolicyDetail = (
   }
   if (output.PolicyVersionList === "") {
     contents.PolicyVersionList = [];
-    return contents;
   }
   if (
     output["PolicyVersionList"] !== undefined &&
@@ -19361,7 +19309,6 @@ const deserializeAws_queryResourceSpecificResult = (
   };
   if (output.EvalDecisionDetails === "") {
     contents.EvalDecisionDetails = {};
-    return contents;
   }
   if (
     output["EvalDecisionDetails"] !== undefined &&
@@ -19384,7 +19331,6 @@ const deserializeAws_queryResourceSpecificResult = (
   }
   if (output.MatchedStatements === "") {
     contents.MatchedStatements = [];
-    return contents;
   }
   if (
     output["MatchedStatements"] !== undefined &&
@@ -19401,7 +19347,6 @@ const deserializeAws_queryResourceSpecificResult = (
   }
   if (output.MissingContextValues === "") {
     contents.MissingContextValues = [];
-    return contents;
   }
   if (
     output["MissingContextValues"] !== undefined &&
@@ -19484,7 +19429,6 @@ const deserializeAws_queryRole = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -19523,7 +19467,6 @@ const deserializeAws_queryRoleDetail = (
   }
   if (output.AttachedManagedPolicies === "") {
     contents.AttachedManagedPolicies = [];
-    return contents;
   }
   if (
     output["AttachedManagedPolicies"] !== undefined &&
@@ -19543,7 +19486,6 @@ const deserializeAws_queryRoleDetail = (
   }
   if (output.InstanceProfileList === "") {
     contents.InstanceProfileList = [];
-    return contents;
   }
   if (
     output["InstanceProfileList"] !== undefined &&
@@ -19581,7 +19523,6 @@ const deserializeAws_queryRoleDetail = (
   }
   if (output.RolePolicyList === "") {
     contents.RolePolicyList = [];
-    return contents;
   }
   if (
     output["RolePolicyList"] !== undefined &&
@@ -19598,7 +19539,6 @@ const deserializeAws_queryRoleDetail = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -19651,7 +19591,6 @@ const deserializeAws_queryRoleUsageType = (
   }
   if (output.Resources === "") {
     contents.Resources = [];
-    return contents;
   }
   if (
     output["Resources"] !== undefined &&
@@ -20019,7 +19958,6 @@ const deserializeAws_querySimulatePolicyResponse = (
   };
   if (output.EvaluationResults === "") {
     contents.EvaluationResults = [];
-    return contents;
   }
   if (
     output["EvaluationResults"] !== undefined &&
@@ -20251,7 +20189,6 @@ const deserializeAws_queryUser = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -20291,7 +20228,6 @@ const deserializeAws_queryUserDetail = (
   }
   if (output.AttachedManagedPolicies === "") {
     contents.AttachedManagedPolicies = [];
-    return contents;
   }
   if (
     output["AttachedManagedPolicies"] !== undefined &&
@@ -20311,7 +20247,6 @@ const deserializeAws_queryUserDetail = (
   }
   if (output.GroupList === "") {
     contents.GroupList = [];
-    return contents;
   }
   if (
     output["GroupList"] !== undefined &&
@@ -20337,7 +20272,6 @@ const deserializeAws_queryUserDetail = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -20354,7 +20288,6 @@ const deserializeAws_queryUserDetail = (
   }
   if (output.UserPolicyList === "") {
     contents.UserPolicyList = [];
-    return contents;
   }
   if (
     output["UserPolicyList"] !== undefined &&

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -10161,7 +10161,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-    return contents;
   }
   if (
     output["AssociatedRoles"] !== undefined &&
@@ -10178,7 +10177,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -10213,7 +10211,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.DBClusterMembers === "") {
     contents.DBClusterMembers = [];
-    return contents;
   }
   if (
     output["DBClusterMembers"] !== undefined &&
@@ -10230,7 +10227,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.DBClusterOptionGroupMemberships === "") {
     contents.DBClusterOptionGroupMemberships = [];
-    return contents;
   }
   if (
     output["DBClusterOptionGroupMemberships"] !== undefined &&
@@ -10270,7 +10266,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-    return contents;
   }
   if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
@@ -10327,7 +10322,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.ReadReplicaIdentifiers === "") {
     contents.ReadReplicaIdentifiers = [];
-    return contents;
   }
   if (
     output["ReadReplicaIdentifiers"] !== undefined &&
@@ -10357,7 +10351,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroups"] !== undefined &&
@@ -10431,7 +10424,6 @@ const deserializeAws_queryDBClusterMessage = (
   };
   if (output.DBClusters === "") {
     contents.DBClusters = [];
-    return contents;
   }
   if (
     output["DBClusters"] !== undefined &&
@@ -10520,7 +10512,6 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -10573,7 +10564,6 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   };
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
-    return contents;
   }
   if (
     output["DBClusterParameterGroups"] !== undefined &&
@@ -10654,7 +10644,6 @@ const deserializeAws_queryDBClusterSnapshot = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -10742,7 +10731,6 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-    return contents;
   }
   if (
     output["AttributeValues"] !== undefined &&
@@ -10780,7 +10768,6 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   };
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
-    return contents;
   }
   if (
     output["DBClusterSnapshotAttributes"] !== undefined &&
@@ -10825,7 +10812,6 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   };
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
-    return contents;
   }
   if (
     output["DBClusterSnapshots"] !== undefined &&
@@ -10888,7 +10874,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.ExportableLogTypes === "") {
     contents.ExportableLogTypes = [];
-    return contents;
   }
   if (
     output["ExportableLogTypes"] !== undefined &&
@@ -10905,7 +10890,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.SupportedCharacterSets === "") {
     contents.SupportedCharacterSets = [];
-    return contents;
   }
   if (
     output["SupportedCharacterSets"] !== undefined &&
@@ -10922,7 +10906,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.SupportedTimezones === "") {
     contents.SupportedTimezones = [];
-    return contents;
   }
   if (
     output["SupportedTimezones"] !== undefined &&
@@ -10946,7 +10929,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.ValidUpgradeTarget === "") {
     contents.ValidUpgradeTarget = [];
-    return contents;
   }
   if (
     output["ValidUpgradeTarget"] !== undefined &&
@@ -10984,7 +10966,6 @@ const deserializeAws_queryDBEngineVersionMessage = (
   };
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
-    return contents;
   }
   if (
     output["DBEngineVersions"] !== undefined &&
@@ -11107,7 +11088,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-    return contents;
   }
   if (
     output["DBParameterGroups"] !== undefined &&
@@ -11124,7 +11104,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.DBSecurityGroups === "") {
     contents.DBSecurityGroups = [];
-    return contents;
   }
   if (
     output["DBSecurityGroups"] !== undefined &&
@@ -11156,7 +11135,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.DomainMemberships === "") {
     contents.DomainMemberships = [];
-    return contents;
   }
   if (
     output["DomainMemberships"] !== undefined &&
@@ -11173,7 +11151,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-    return contents;
   }
   if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
@@ -11237,7 +11214,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.OptionGroupMemberships === "") {
     contents.OptionGroupMemberships = [];
-    return contents;
   }
   if (
     output["OptionGroupMemberships"] !== undefined &&
@@ -11280,7 +11256,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.ReadReplicaDBClusterIdentifiers === "") {
     contents.ReadReplicaDBClusterIdentifiers = [];
-    return contents;
   }
   if (
     output["ReadReplicaDBClusterIdentifiers"] !== undefined &&
@@ -11307,7 +11282,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.ReadReplicaDBInstanceIdentifiers === "") {
     contents.ReadReplicaDBInstanceIdentifiers = [];
-    return contents;
   }
   if (
     output["ReadReplicaDBInstanceIdentifiers"] !== undefined &&
@@ -11341,7 +11315,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.StatusInfos === "") {
     contents.StatusInfos = [];
-    return contents;
   }
   if (
     output["StatusInfos"] !== undefined &&
@@ -11370,7 +11343,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroups"] !== undefined &&
@@ -11408,7 +11380,6 @@ const deserializeAws_queryDBInstanceMessage = (
   };
   if (output.DBInstances === "") {
     contents.DBInstances = [];
-    return contents;
   }
   if (
     output["DBInstances"] !== undefined &&
@@ -11504,7 +11475,6 @@ const deserializeAws_queryDBParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -11583,7 +11553,6 @@ const deserializeAws_queryDBParameterGroupsMessage = (
   };
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-    return contents;
   }
   if (
     output["DBParameterGroups"] !== undefined &&
@@ -11658,7 +11627,6 @@ const deserializeAws_queryDBSubnetGroup = (
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -11687,7 +11655,6 @@ const deserializeAws_queryDBSubnetGroupMessage = (
   };
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
-    return contents;
   }
   if (
     output["DBSubnetGroups"] !== undefined &&
@@ -11955,7 +11922,6 @@ const deserializeAws_queryEngineDefaults = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -11991,7 +11957,6 @@ const deserializeAws_queryEvent = (
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -12039,7 +12004,6 @@ const deserializeAws_queryEventCategoriesMap = (
   };
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -12079,7 +12043,6 @@ const deserializeAws_queryEventCategoriesMessage = (
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-    return contents;
   }
   if (
     output["EventCategoriesMapList"] !== undefined &&
@@ -12134,7 +12097,6 @@ const deserializeAws_queryEventSubscription = (
   }
   if (output.EventCategoriesList === "") {
     contents.EventCategoriesList = [];
-    return contents;
   }
   if (
     output["EventCategoriesList"] !== undefined &&
@@ -12157,7 +12119,6 @@ const deserializeAws_queryEventSubscription = (
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
-    return contents;
   }
   if (
     output["SourceIdsList"] !== undefined &&
@@ -12204,7 +12165,6 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   };
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
-    return contents;
   }
   if (
     output["EventSubscriptionsList"] !== undefined &&
@@ -12236,7 +12196,6 @@ const deserializeAws_queryEventsMessage = (
   };
   if (output.Events === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["Events"] !== undefined &&
@@ -12419,7 +12378,6 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -12521,7 +12479,6 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   }
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
-    return contents;
   }
   if (
     output["OrderableDBInstanceOptions"] !== undefined &&
@@ -12612,7 +12569,6 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   };
   if (output.LogTypesToDisable === "") {
     contents.LogTypesToDisable = [];
-    return contents;
   }
   if (
     output["LogTypesToDisable"] !== undefined &&
@@ -12629,7 +12585,6 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   }
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
-    return contents;
   }
   if (
     output["LogTypesToEnable"] !== undefined &&
@@ -12713,7 +12668,6 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   }
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
-    return contents;
   }
   if (
     output["PendingMaintenanceActions"] !== undefined &&
@@ -12923,7 +12877,6 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   };
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
-    return contents;
   }
   if (
     output["PendingMaintenanceActionDetails"] !== undefined &&
@@ -13078,7 +13031,6 @@ const deserializeAws_queryTagListMessage = (
   };
   if (output.TagList === "") {
     contents.TagList = [];
-    return contents;
   }
   if (
     output["TagList"] !== undefined &&
@@ -13147,7 +13099,6 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   };
   if (output.Storage === "") {
     contents.Storage = [];
-    return contents;
   }
   if (
     output["Storage"] !== undefined &&
@@ -13178,7 +13129,6 @@ const deserializeAws_queryValidStorageOptions = (
   };
   if (output.IopsToStorageRatio === "") {
     contents.IopsToStorageRatio = [];
-    return contents;
   }
   if (
     output["IopsToStorageRatio"] !== undefined &&
@@ -13195,7 +13145,6 @@ const deserializeAws_queryValidStorageOptions = (
   }
   if (output.ProvisionedIops === "") {
     contents.ProvisionedIops = [];
-    return contents;
   }
   if (
     output["ProvisionedIops"] !== undefined &&
@@ -13212,7 +13161,6 @@ const deserializeAws_queryValidStorageOptions = (
   }
   if (output.StorageSize === "") {
     contents.StorageSize = [];
-    return contents;
   }
   if (
     output["StorageSize"] !== undefined &&

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -21206,7 +21206,6 @@ const deserializeAws_queryAccountAttributesMessage = (
   };
   if (output.AccountQuotas === "") {
     contents.AccountQuotas = [];
-    return contents;
   }
   if (
     output["AccountQuotas"] !== undefined &&
@@ -21438,7 +21437,6 @@ const deserializeAws_queryCertificateMessage = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-    return contents;
   }
   if (
     output["Certificates"] !== undefined &&
@@ -21507,7 +21505,6 @@ const deserializeAws_queryConnectionPoolConfigurationInfo = (
   }
   if (output.SessionPinningFilters === "") {
     contents.SessionPinningFilters = [];
-    return contents;
   }
   if (
     output["SessionPinningFilters"] !== undefined &&
@@ -21895,7 +21892,6 @@ const deserializeAws_queryCustomAvailabilityZoneMessage = (
   };
   if (output.CustomAvailabilityZones === "") {
     contents.CustomAvailabilityZones = [];
-    return contents;
   }
   if (
     output["CustomAvailabilityZones"] !== undefined &&
@@ -21993,7 +21989,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-    return contents;
   }
   if (
     output["AssociatedRoles"] !== undefined &&
@@ -22010,7 +22005,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -22056,7 +22050,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.CustomEndpoints === "") {
     contents.CustomEndpoints = [];
-    return contents;
   }
   if (
     output["CustomEndpoints"] !== undefined &&
@@ -22079,7 +22072,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.DBClusterMembers === "") {
     contents.DBClusterMembers = [];
-    return contents;
   }
   if (
     output["DBClusterMembers"] !== undefined &&
@@ -22096,7 +22088,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.DBClusterOptionGroupMemberships === "") {
     contents.DBClusterOptionGroupMemberships = [];
-    return contents;
   }
   if (
     output["DBClusterOptionGroupMemberships"] !== undefined &&
@@ -22139,7 +22130,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-    return contents;
   }
   if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
@@ -22202,7 +22192,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.ReadReplicaIdentifiers === "") {
     contents.ReadReplicaIdentifiers = [];
-    return contents;
   }
   if (
     output["ReadReplicaIdentifiers"] !== undefined &&
@@ -22238,7 +22227,6 @@ const deserializeAws_queryDBCluster = (
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroups"] !== undefined &&
@@ -22312,7 +22300,6 @@ const deserializeAws_queryDBClusterBacktrackMessage = (
   };
   if (output.DBClusterBacktracks === "") {
     contents.DBClusterBacktracks = [];
-    return contents;
   }
   if (
     output["DBClusterBacktracks"] !== undefined &&
@@ -22405,7 +22392,6 @@ const deserializeAws_queryDBClusterEndpoint = (
   }
   if (output.ExcludedMembers === "") {
     contents.ExcludedMembers = [];
-    return contents;
   }
   if (
     output["ExcludedMembers"] !== undefined &&
@@ -22422,7 +22408,6 @@ const deserializeAws_queryDBClusterEndpoint = (
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
-    return contents;
   }
   if (
     output["StaticMembers"] !== undefined &&
@@ -22463,7 +22448,6 @@ const deserializeAws_queryDBClusterEndpointMessage = (
   };
   if (output.DBClusterEndpoints === "") {
     contents.DBClusterEndpoints = [];
-    return contents;
   }
   if (
     output["DBClusterEndpoints"] !== undefined &&
@@ -22540,7 +22524,6 @@ const deserializeAws_queryDBClusterMessage = (
   };
   if (output.DBClusters === "") {
     contents.DBClusters = [];
-    return contents;
   }
   if (
     output["DBClusters"] !== undefined &&
@@ -22629,7 +22612,6 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -22682,7 +22664,6 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   };
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
-    return contents;
   }
   if (
     output["DBClusterParameterGroups"] !== undefined &&
@@ -22767,7 +22748,6 @@ const deserializeAws_queryDBClusterSnapshot = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -22855,7 +22835,6 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-    return contents;
   }
   if (
     output["AttributeValues"] !== undefined &&
@@ -22893,7 +22872,6 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   };
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
-    return contents;
   }
   if (
     output["DBClusterSnapshotAttributes"] !== undefined &&
@@ -22938,7 +22916,6 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   };
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
-    return contents;
   }
   if (
     output["DBClusterSnapshots"] !== undefined &&
@@ -23004,7 +22981,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.ExportableLogTypes === "") {
     contents.ExportableLogTypes = [];
-    return contents;
   }
   if (
     output["ExportableLogTypes"] !== undefined &&
@@ -23024,7 +23000,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.SupportedCharacterSets === "") {
     contents.SupportedCharacterSets = [];
-    return contents;
   }
   if (
     output["SupportedCharacterSets"] !== undefined &&
@@ -23041,7 +23016,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
-    return contents;
   }
   if (
     output["SupportedEngineModes"] !== undefined &&
@@ -23058,7 +23032,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.SupportedFeatureNames === "") {
     contents.SupportedFeatureNames = [];
-    return contents;
   }
   if (
     output["SupportedFeatureNames"] !== undefined &&
@@ -23075,7 +23048,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.SupportedTimezones === "") {
     contents.SupportedTimezones = [];
-    return contents;
   }
   if (
     output["SupportedTimezones"] !== undefined &&
@@ -23099,7 +23071,6 @@ const deserializeAws_queryDBEngineVersion = (
   }
   if (output.ValidUpgradeTarget === "") {
     contents.ValidUpgradeTarget = [];
-    return contents;
   }
   if (
     output["ValidUpgradeTarget"] !== undefined &&
@@ -23137,7 +23108,6 @@ const deserializeAws_queryDBEngineVersionMessage = (
   };
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
-    return contents;
   }
   if (
     output["DBEngineVersions"] !== undefined &&
@@ -23228,7 +23198,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-    return contents;
   }
   if (
     output["AssociatedRoles"] !== undefined &&
@@ -23282,7 +23251,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-    return contents;
   }
   if (
     output["DBParameterGroups"] !== undefined &&
@@ -23299,7 +23267,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.DBSecurityGroups === "") {
     contents.DBSecurityGroups = [];
-    return contents;
   }
   if (
     output["DBSecurityGroups"] !== undefined &&
@@ -23331,7 +23298,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.DomainMemberships === "") {
     contents.DomainMemberships = [];
-    return contents;
   }
   if (
     output["DomainMemberships"] !== undefined &&
@@ -23348,7 +23314,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-    return contents;
   }
   if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
@@ -23421,7 +23386,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.OptionGroupMemberships === "") {
     contents.OptionGroupMemberships = [];
-    return contents;
   }
   if (
     output["OptionGroupMemberships"] !== undefined &&
@@ -23463,7 +23427,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.ProcessorFeatures === "") {
     contents.ProcessorFeatures = [];
-    return contents;
   }
   if (
     output["ProcessorFeatures"] !== undefined &&
@@ -23486,7 +23449,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.ReadReplicaDBClusterIdentifiers === "") {
     contents.ReadReplicaDBClusterIdentifiers = [];
-    return contents;
   }
   if (
     output["ReadReplicaDBClusterIdentifiers"] !== undefined &&
@@ -23513,7 +23475,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.ReadReplicaDBInstanceIdentifiers === "") {
     contents.ReadReplicaDBInstanceIdentifiers = [];
-    return contents;
   }
   if (
     output["ReadReplicaDBInstanceIdentifiers"] !== undefined &&
@@ -23547,7 +23508,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.StatusInfos === "") {
     contents.StatusInfos = [];
-    return contents;
   }
   if (
     output["StatusInfos"] !== undefined &&
@@ -23576,7 +23536,6 @@ const deserializeAws_queryDBInstance = (
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroups"] !== undefined &&
@@ -23720,7 +23679,6 @@ const deserializeAws_queryDBInstanceAutomatedBackupMessage = (
   };
   if (output.DBInstanceAutomatedBackups === "") {
     contents.DBInstanceAutomatedBackups = [];
-    return contents;
   }
   if (
     output["DBInstanceAutomatedBackups"] !== undefined &&
@@ -23764,7 +23722,6 @@ const deserializeAws_queryDBInstanceMessage = (
   };
   if (output.DBInstances === "") {
     contents.DBInstances = [];
-    return contents;
   }
   if (
     output["DBInstances"] !== undefined &&
@@ -23891,7 +23848,6 @@ const deserializeAws_queryDBParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -23970,7 +23926,6 @@ const deserializeAws_queryDBParameterGroupsMessage = (
   };
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-    return contents;
   }
   if (
     output["DBParameterGroups"] !== undefined &&
@@ -24014,7 +23969,6 @@ const deserializeAws_queryDBProxy = (
   };
   if (output.Auth === "") {
     contents.Auth = [];
-    return contents;
   }
   if (output["Auth"] !== undefined && output["Auth"]["member"] !== undefined) {
     const wrappedItem =
@@ -24061,7 +24015,6 @@ const deserializeAws_queryDBProxy = (
   }
   if (output.VpcSecurityGroupIds === "") {
     contents.VpcSecurityGroupIds = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroupIds"] !== undefined &&
@@ -24078,7 +24031,6 @@ const deserializeAws_queryDBProxy = (
   }
   if (output.VpcSubnetIds === "") {
     contents.VpcSubnetIds = [];
-    return contents;
   }
   if (
     output["VpcSubnetIds"] !== undefined &&
@@ -24209,7 +24161,6 @@ const deserializeAws_queryDBSecurityGroup = (
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
-    return contents;
   }
   if (
     output["EC2SecurityGroups"] !== undefined &&
@@ -24226,7 +24177,6 @@ const deserializeAws_queryDBSecurityGroup = (
   }
   if (output.IPRanges === "") {
     contents.IPRanges = [];
-    return contents;
   }
   if (
     output["IPRanges"] !== undefined &&
@@ -24285,7 +24235,6 @@ const deserializeAws_queryDBSecurityGroupMessage = (
   };
   if (output.DBSecurityGroups === "") {
     contents.DBSecurityGroups = [];
-    return contents;
   }
   if (
     output["DBSecurityGroups"] !== undefined &&
@@ -24407,7 +24356,6 @@ const deserializeAws_queryDBSnapshot = (
   }
   if (output.ProcessorFeatures === "") {
     contents.ProcessorFeatures = [];
-    return contents;
   }
   if (
     output["ProcessorFeatures"] !== undefined &&
@@ -24466,7 +24414,6 @@ const deserializeAws_queryDBSnapshotAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-    return contents;
   }
   if (
     output["AttributeValues"] !== undefined &&
@@ -24504,7 +24451,6 @@ const deserializeAws_queryDBSnapshotAttributesResult = (
   };
   if (output.DBSnapshotAttributes === "") {
     contents.DBSnapshotAttributes = [];
-    return contents;
   }
   if (
     output["DBSnapshotAttributes"] !== undefined &&
@@ -24545,7 +24491,6 @@ const deserializeAws_queryDBSnapshotMessage = (
   };
   if (output.DBSnapshots === "") {
     contents.DBSnapshots = [];
-    return contents;
   }
   if (
     output["DBSnapshots"] !== undefined &&
@@ -24593,7 +24538,6 @@ const deserializeAws_queryDBSubnetGroup = (
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -24622,7 +24566,6 @@ const deserializeAws_queryDBSubnetGroupMessage = (
   };
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
-    return contents;
   }
   if (
     output["DBSubnetGroups"] !== undefined &&
@@ -24871,7 +24814,6 @@ const deserializeAws_queryDescribeDBLogFilesResponse = (
   };
   if (output.DescribeDBLogFiles === "") {
     contents.DescribeDBLogFiles = [];
-    return contents;
   }
   if (
     output["DescribeDBLogFiles"] !== undefined &&
@@ -24903,7 +24845,6 @@ const deserializeAws_queryDescribeDBProxiesResponse = (
   };
   if (output.DBProxies === "") {
     contents.DBProxies = [];
-    return contents;
   }
   if (
     output["DBProxies"] !== undefined &&
@@ -24935,7 +24876,6 @@ const deserializeAws_queryDescribeDBProxyTargetGroupsResponse = (
   }
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-    return contents;
   }
   if (
     output["TargetGroups"] !== undefined &&
@@ -24967,7 +24907,6 @@ const deserializeAws_queryDescribeDBProxyTargetsResponse = (
   }
   if (output.Targets === "") {
     contents.Targets = [];
-    return contents;
   }
   if (
     output["Targets"] !== undefined &&
@@ -25209,7 +25148,6 @@ const deserializeAws_queryEngineDefaults = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -25252,7 +25190,6 @@ const deserializeAws_queryEvent = (
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -25300,7 +25237,6 @@ const deserializeAws_queryEventCategoriesMap = (
   };
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -25340,7 +25276,6 @@ const deserializeAws_queryEventCategoriesMessage = (
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-    return contents;
   }
   if (
     output["EventCategoriesMapList"] !== undefined &&
@@ -25395,7 +25330,6 @@ const deserializeAws_queryEventSubscription = (
   }
   if (output.EventCategoriesList === "") {
     contents.EventCategoriesList = [];
-    return contents;
   }
   if (
     output["EventCategoriesList"] !== undefined &&
@@ -25418,7 +25352,6 @@ const deserializeAws_queryEventSubscription = (
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
-    return contents;
   }
   if (
     output["SourceIdsList"] !== undefined &&
@@ -25465,7 +25398,6 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   };
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
-    return contents;
   }
   if (
     output["EventSubscriptionsList"] !== undefined &&
@@ -25497,7 +25429,6 @@ const deserializeAws_queryEventsMessage = (
   };
   if (output.Events === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["Events"] !== undefined &&
@@ -25576,7 +25507,6 @@ const deserializeAws_queryGlobalCluster = (
   }
   if (output.GlobalClusterMembers === "") {
     contents.GlobalClusterMembers = [];
-    return contents;
   }
   if (
     output["GlobalClusterMembers"] !== undefined &&
@@ -25630,7 +25560,6 @@ const deserializeAws_queryGlobalClusterMember = (
   }
   if (output.Readers === "") {
     contents.Readers = [];
-    return contents;
   }
   if (
     output["Readers"] !== undefined &&
@@ -25665,7 +25594,6 @@ const deserializeAws_queryGlobalClustersMessage = (
   };
   if (output.GlobalClusters === "") {
     contents.GlobalClusters = [];
-    return contents;
   }
   if (
     output["GlobalClusters"] !== undefined &&
@@ -25793,7 +25721,6 @@ const deserializeAws_queryInstallationMediaMessage = (
   };
   if (output.InstallationMedia === "") {
     contents.InstallationMedia = [];
-    return contents;
   }
   if (
     output["InstallationMedia"] !== undefined &&
@@ -26067,7 +25994,6 @@ const deserializeAws_queryOption = (
   };
   if (output.DBSecurityGroupMemberships === "") {
     contents.DBSecurityGroupMemberships = [];
-    return contents;
   }
   if (
     output["DBSecurityGroupMemberships"] !== undefined &&
@@ -26090,7 +26016,6 @@ const deserializeAws_queryOption = (
   }
   if (output.OptionSettings === "") {
     contents.OptionSettings = [];
-    return contents;
   }
   if (
     output["OptionSettings"] !== undefined &&
@@ -26119,7 +26044,6 @@ const deserializeAws_queryOption = (
   }
   if (output.VpcSecurityGroupMemberships === "") {
     contents.VpcSecurityGroupMemberships = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroupMemberships"] !== undefined &&
@@ -26176,7 +26100,6 @@ const deserializeAws_queryOptionGroup = (
   }
   if (output.Options === "") {
     contents.Options = [];
-    return contents;
   }
   if (
     output["Options"] !== undefined &&
@@ -26265,7 +26188,6 @@ const deserializeAws_queryOptionGroupOption = (
   }
   if (output.OptionGroupOptionSettings === "") {
     contents.OptionGroupOptionSettings = [];
-    return contents;
   }
   if (
     output["OptionGroupOptionSettings"] !== undefined &&
@@ -26284,7 +26206,6 @@ const deserializeAws_queryOptionGroupOption = (
   }
   if (output.OptionGroupOptionVersions === "") {
     contents.OptionGroupOptionVersions = [];
-    return contents;
   }
   if (
     output["OptionGroupOptionVersions"] !== undefined &&
@@ -26301,7 +26222,6 @@ const deserializeAws_queryOptionGroupOption = (
   }
   if (output.OptionsConflictsWith === "") {
     contents.OptionsConflictsWith = [];
-    return contents;
   }
   if (
     output["OptionsConflictsWith"] !== undefined &&
@@ -26318,7 +26238,6 @@ const deserializeAws_queryOptionGroupOption = (
   }
   if (output.OptionsDependedOn === "") {
     contents.OptionsDependedOn = [];
-    return contents;
   }
   if (
     output["OptionsDependedOn"] !== undefined &&
@@ -26388,7 +26307,6 @@ const deserializeAws_queryOptionGroupOptionSetting = (
   }
   if (output.MinimumEngineVersionPerAllowedValue === "") {
     contents.MinimumEngineVersionPerAllowedValue = [];
-    return contents;
   }
   if (
     output["MinimumEngineVersionPerAllowedValue"] !== undefined &&
@@ -26463,7 +26381,6 @@ const deserializeAws_queryOptionGroupOptionsMessage = (
   }
   if (output.OptionGroupOptions === "") {
     contents.OptionGroupOptions = [];
-    return contents;
   }
   if (
     output["OptionGroupOptions"] !== undefined &&
@@ -26495,7 +26412,6 @@ const deserializeAws_queryOptionGroups = (
   }
   if (output.OptionGroupsList === "") {
     contents.OptionGroupsList = [];
-    return contents;
   }
   if (
     output["OptionGroupsList"] !== undefined &&
@@ -26651,7 +26567,6 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -26668,7 +26583,6 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.AvailableProcessorFeatures === "") {
     contents.AvailableProcessorFeatures = [];
-    return contents;
   }
   if (
     output["AvailableProcessorFeatures"] !== undefined &&
@@ -26727,7 +26641,6 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
-    return contents;
   }
   if (
     output["SupportedEngineModes"] !== undefined &&
@@ -26798,7 +26711,6 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   }
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
-    return contents;
   }
   if (
     output["OrderableDBInstanceOptions"] !== undefined &&
@@ -26869,7 +26781,6 @@ const deserializeAws_queryParameter = (
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
-    return contents;
   }
   if (
     output["SupportedEngineModes"] !== undefined &&
@@ -26907,7 +26818,6 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   };
   if (output.LogTypesToDisable === "") {
     contents.LogTypesToDisable = [];
-    return contents;
   }
   if (
     output["LogTypesToDisable"] !== undefined &&
@@ -26924,7 +26834,6 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   }
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
-    return contents;
   }
   if (
     output["LogTypesToEnable"] !== undefined &&
@@ -27008,7 +26917,6 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   }
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
-    return contents;
   }
   if (
     output["PendingMaintenanceActions"] !== undefined &&
@@ -27101,7 +27009,6 @@ const deserializeAws_queryPendingModifiedValues = (
   }
   if (output.ProcessorFeatures === "") {
     contents.ProcessorFeatures = [];
-    return contents;
   }
   if (
     output["ProcessorFeatures"] !== undefined &&
@@ -27315,7 +27222,6 @@ const deserializeAws_queryRegisterDBProxyTargetsResponse = (
   };
   if (output.DBProxyTargets === "") {
     contents.DBProxyTargets = [];
-    return contents;
   }
   if (
     output["DBProxyTargets"] !== undefined &&
@@ -27419,7 +27325,6 @@ const deserializeAws_queryReservedDBInstance = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["RecurringCharges"] !== undefined &&
@@ -27479,7 +27384,6 @@ const deserializeAws_queryReservedDBInstanceMessage = (
   }
   if (output.ReservedDBInstances === "") {
     contents.ReservedDBInstances = [];
-    return contents;
   }
   if (
     output["ReservedDBInstances"] !== undefined &&
@@ -27537,7 +27441,6 @@ const deserializeAws_queryReservedDBInstancesOffering = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["RecurringCharges"] !== undefined &&
@@ -27585,7 +27488,6 @@ const deserializeAws_queryReservedDBInstancesOfferingMessage = (
   }
   if (output.ReservedDBInstancesOfferings === "") {
     contents.ReservedDBInstancesOfferings = [];
-    return contents;
   }
   if (
     output["ReservedDBInstancesOfferings"] !== undefined &&
@@ -27621,7 +27523,6 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   };
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
-    return contents;
   }
   if (
     output["PendingMaintenanceActionDetails"] !== undefined &&
@@ -27868,7 +27769,6 @@ const deserializeAws_querySourceRegionMessage = (
   }
   if (output.SourceRegions === "") {
     contents.SourceRegions = [];
-    return contents;
   }
   if (
     output["SourceRegions"] !== undefined &&
@@ -28099,7 +27999,6 @@ const deserializeAws_queryTagListMessage = (
   };
   if (output.TagList === "") {
     contents.TagList = [];
-    return contents;
   }
   if (
     output["TagList"] !== undefined &&
@@ -28226,7 +28125,6 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   };
   if (output.Storage === "") {
     contents.Storage = [];
-    return contents;
   }
   if (
     output["Storage"] !== undefined &&
@@ -28243,7 +28141,6 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   }
   if (output.ValidProcessorFeatures === "") {
     contents.ValidProcessorFeatures = [];
-    return contents;
   }
   if (
     output["ValidProcessorFeatures"] !== undefined &&
@@ -28276,7 +28173,6 @@ const deserializeAws_queryValidStorageOptions = (
   };
   if (output.IopsToStorageRatio === "") {
     contents.IopsToStorageRatio = [];
-    return contents;
   }
   if (
     output["IopsToStorageRatio"] !== undefined &&
@@ -28293,7 +28189,6 @@ const deserializeAws_queryValidStorageOptions = (
   }
   if (output.ProvisionedIops === "") {
     contents.ProvisionedIops = [];
-    return contents;
   }
   if (
     output["ProvisionedIops"] !== undefined &&
@@ -28310,7 +28205,6 @@ const deserializeAws_queryValidStorageOptions = (
   }
   if (output.StorageSize === "") {
     contents.StorageSize = [];
-    return contents;
   }
   if (
     output["StorageSize"] !== undefined &&

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -15023,7 +15023,6 @@ const deserializeAws_queryAccountAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-    return contents;
   }
   if (
     output["AttributeValues"] !== undefined &&
@@ -15051,7 +15050,6 @@ const deserializeAws_queryAccountAttributeList = (
   };
   if (output.AccountAttributes === "") {
     contents.AccountAttributes = [];
-    return contents;
   }
   if (
     output["AccountAttributes"] !== undefined &&
@@ -15185,7 +15183,6 @@ const deserializeAws_queryAvailabilityZone = (
   }
   if (output.SupportedPlatforms === "") {
     contents.SupportedPlatforms = [];
-    return contents;
   }
   if (
     output["SupportedPlatforms"] !== undefined &&
@@ -15223,7 +15220,6 @@ const deserializeAws_queryBatchDeleteClusterSnapshotsResult = (
   };
   if (output.Errors === "") {
     contents.Errors = [];
-    return contents;
   }
   if (
     output["Errors"] !== undefined &&
@@ -15240,7 +15236,6 @@ const deserializeAws_queryBatchDeleteClusterSnapshotsResult = (
   }
   if (output.Resources === "") {
     contents.Resources = [];
-    return contents;
   }
   if (
     output["Resources"] !== undefined &&
@@ -15269,7 +15264,6 @@ const deserializeAws_queryBatchModifyClusterSnapshotsOutputMessage = (
   };
   if (output.Errors === "") {
     contents.Errors = [];
-    return contents;
   }
   if (
     output["Errors"] !== undefined &&
@@ -15286,7 +15280,6 @@ const deserializeAws_queryBatchModifyClusterSnapshotsOutputMessage = (
   }
   if (output.Resources === "") {
     contents.Resources = [];
-    return contents;
   }
   if (
     output["Resources"] !== undefined &&
@@ -15397,7 +15390,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.ClusterNodes === "") {
     contents.ClusterNodes = [];
-    return contents;
   }
   if (
     output["ClusterNodes"] !== undefined &&
@@ -15414,7 +15406,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.ClusterParameterGroups === "") {
     contents.ClusterParameterGroups = [];
-    return contents;
   }
   if (
     output["ClusterParameterGroups"] !== undefined &&
@@ -15437,7 +15428,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.ClusterSecurityGroups === "") {
     contents.ClusterSecurityGroups = [];
-    return contents;
   }
   if (
     output["ClusterSecurityGroups"] !== undefined &&
@@ -15478,7 +15468,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.DeferredMaintenanceWindows === "") {
     contents.DeferredMaintenanceWindows = [];
-    return contents;
   }
   if (
     output["DeferredMaintenanceWindows"] !== undefined &&
@@ -15535,7 +15524,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.IamRoles === "") {
     contents.IamRoles = [];
-    return contents;
   }
   if (
     output["IamRoles"] !== undefined &&
@@ -15580,7 +15568,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.PendingActions === "") {
     contents.PendingActions = [];
-    return contents;
   }
   if (
     output["PendingActions"] !== undefined &&
@@ -15627,7 +15614,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -15641,7 +15627,6 @@ const deserializeAws_queryCluster = (
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-    return contents;
   }
   if (
     output["VpcSecurityGroups"] !== undefined &&
@@ -15723,7 +15708,6 @@ const deserializeAws_queryClusterDbRevision = (
   }
   if (output.RevisionTargets === "") {
     contents.RevisionTargets = [];
-    return contents;
   }
   if (
     output["RevisionTargets"] !== undefined &&
@@ -15761,7 +15745,6 @@ const deserializeAws_queryClusterDbRevisionsMessage = (
   };
   if (output.ClusterDbRevisions === "") {
     contents.ClusterDbRevisions = [];
-    return contents;
   }
   if (
     output["ClusterDbRevisions"] !== undefined &&
@@ -15871,7 +15854,6 @@ const deserializeAws_queryClusterParameterGroup = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -15897,7 +15879,6 @@ const deserializeAws_queryClusterParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -15945,7 +15926,6 @@ const deserializeAws_queryClusterParameterGroupStatus = (
   };
   if (output.ClusterParameterStatusList === "") {
     contents.ClusterParameterStatusList = [];
-    return contents;
   }
   if (
     output["ClusterParameterStatusList"] !== undefined &&
@@ -15992,7 +15972,6 @@ const deserializeAws_queryClusterParameterGroupsMessage = (
   }
   if (output.ParameterGroups === "") {
     contents.ParameterGroups = [];
-    return contents;
   }
   if (
     output["ParameterGroups"] !== undefined &&
@@ -16062,7 +16041,6 @@ const deserializeAws_queryClusterSecurityGroup = (
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
-    return contents;
   }
   if (
     output["EC2SecurityGroups"] !== undefined &&
@@ -16079,7 +16057,6 @@ const deserializeAws_queryClusterSecurityGroup = (
   }
   if (output.IPRanges === "") {
     contents.IPRanges = [];
-    return contents;
   }
   if (
     output["IPRanges"] !== undefined &&
@@ -16093,7 +16070,6 @@ const deserializeAws_queryClusterSecurityGroup = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -16143,7 +16119,6 @@ const deserializeAws_queryClusterSecurityGroupMessage = (
   };
   if (output.ClusterSecurityGroups === "") {
     contents.ClusterSecurityGroups = [];
-    return contents;
   }
   if (
     output["ClusterSecurityGroups"] !== undefined &&
@@ -16225,7 +16200,6 @@ const deserializeAws_queryClusterSubnetGroup = (
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-    return contents;
   }
   if (
     output["Subnets"] !== undefined &&
@@ -16239,7 +16213,6 @@ const deserializeAws_queryClusterSubnetGroup = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -16265,7 +16238,6 @@ const deserializeAws_queryClusterSubnetGroupMessage = (
   };
   if (output.ClusterSubnetGroups === "") {
     contents.ClusterSubnetGroups = [];
-    return contents;
   }
   if (
     output["ClusterSubnetGroups"] !== undefined &&
@@ -16338,7 +16310,6 @@ const deserializeAws_queryClusterVersionsMessage = (
   };
   if (output.ClusterVersions === "") {
     contents.ClusterVersions = [];
-    return contents;
   }
   if (
     output["ClusterVersions"] !== undefined &&
@@ -16370,7 +16341,6 @@ const deserializeAws_queryClustersMessage = (
   };
   if (output.Clusters === "") {
     contents.Clusters = [];
-    return contents;
   }
   if (
     output["Clusters"] !== undefined &&
@@ -16635,7 +16605,6 @@ const deserializeAws_queryDefaultClusterParameters = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-    return contents;
   }
   if (
     output["Parameters"] !== undefined &&
@@ -16750,7 +16719,6 @@ const deserializeAws_queryDescribeSnapshotSchedulesOutputMessage = (
   }
   if (output.SnapshotSchedules === "") {
     contents.SnapshotSchedules = [];
-    return contents;
   }
   if (
     output["SnapshotSchedules"] !== undefined &&
@@ -16804,7 +16772,6 @@ const deserializeAws_queryEC2SecurityGroup = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -16903,7 +16870,6 @@ const deserializeAws_queryEvent = (
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -16954,7 +16920,6 @@ const deserializeAws_queryEventCategoriesMap = (
   };
   if (output.Events === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["Events"] !== undefined &&
@@ -16994,7 +16959,6 @@ const deserializeAws_queryEventCategoriesMessage = (
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-    return contents;
   }
   if (
     output["EventCategoriesMapList"] !== undefined &&
@@ -17025,7 +16989,6 @@ const deserializeAws_queryEventInfoMap = (
   };
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-    return contents;
   }
   if (
     output["EventCategories"] !== undefined &&
@@ -17099,7 +17062,6 @@ const deserializeAws_queryEventSubscription = (
   }
   if (output.EventCategoriesList === "") {
     contents.EventCategoriesList = [];
-    return contents;
   }
   if (
     output["EventCategoriesList"] !== undefined &&
@@ -17122,7 +17084,6 @@ const deserializeAws_queryEventSubscription = (
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
-    return contents;
   }
   if (
     output["SourceIdsList"] !== undefined &&
@@ -17150,7 +17111,6 @@ const deserializeAws_queryEventSubscription = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -17182,7 +17142,6 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   };
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
-    return contents;
   }
   if (
     output["EventSubscriptionsList"] !== undefined &&
@@ -17214,7 +17173,6 @@ const deserializeAws_queryEventsMessage = (
   };
   if (output.Events === "") {
     contents.Events = [];
-    return contents;
   }
   if (
     output["Events"] !== undefined &&
@@ -17246,7 +17204,6 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsOutputMessage = (
   }
   if (output.ReservedNodeOfferings === "") {
     contents.ReservedNodeOfferings = [];
-    return contents;
   }
   if (
     output["ReservedNodeOfferings"] !== undefined &&
@@ -17284,7 +17241,6 @@ const deserializeAws_queryHsmClientCertificate = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -17316,7 +17272,6 @@ const deserializeAws_queryHsmClientCertificateMessage = (
   };
   if (output.HsmClientCertificates === "") {
     contents.HsmClientCertificates = [];
-    return contents;
   }
   if (
     output["HsmClientCertificates"] !== undefined &&
@@ -17363,7 +17318,6 @@ const deserializeAws_queryHsmConfiguration = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -17395,7 +17349,6 @@ const deserializeAws_queryHsmConfigurationMessage = (
   };
   if (output.HsmConfigurations === "") {
     contents.HsmConfigurations = [];
-    return contents;
   }
   if (
     output["HsmConfigurations"] !== undefined &&
@@ -17457,7 +17410,6 @@ const deserializeAws_queryIPRange = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -17553,7 +17505,6 @@ const deserializeAws_queryMaintenanceTrack = (
   }
   if (output.UpdateTargets === "") {
     contents.UpdateTargets = [];
-    return contents;
   }
   if (
     output["UpdateTargets"] !== undefined &&
@@ -17743,7 +17694,6 @@ const deserializeAws_queryNodeConfigurationOptionsMessage = (
   }
   if (output.NodeConfigurationOptionList === "") {
     contents.NodeConfigurationOptionList = [];
-    return contents;
   }
   if (
     output["NodeConfigurationOptionList"] !== undefined &&
@@ -17777,7 +17727,6 @@ const deserializeAws_queryOrderableClusterOption = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-    return contents;
   }
   if (
     output["AvailabilityZones"] !== undefined &&
@@ -17827,7 +17776,6 @@ const deserializeAws_queryOrderableClusterOptionsMessage = (
   }
   if (output.OrderableClusterOptions === "") {
     contents.OrderableClusterOptions = [];
-    return contents;
   }
   if (
     output["OrderableClusterOptions"] !== undefined &&
@@ -18073,7 +18021,6 @@ const deserializeAws_queryReservedNode = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["RecurringCharges"] !== undefined &&
@@ -18151,7 +18098,6 @@ const deserializeAws_queryReservedNodeOffering = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-    return contents;
   }
   if (
     output["RecurringCharges"] !== undefined &&
@@ -18201,7 +18147,6 @@ const deserializeAws_queryReservedNodeOfferingsMessage = (
   }
   if (output.ReservedNodeOfferings === "") {
     contents.ReservedNodeOfferings = [];
-    return contents;
   }
   if (
     output["ReservedNodeOfferings"] !== undefined &&
@@ -18233,7 +18178,6 @@ const deserializeAws_queryReservedNodesMessage = (
   }
   if (output.ReservedNodes === "") {
     contents.ReservedNodes = [];
-    return contents;
   }
   if (
     output["ReservedNodes"] !== undefined &&
@@ -18356,7 +18300,6 @@ const deserializeAws_queryResizeProgressMessage = (
   }
   if (output.ImportTablesCompleted === "") {
     contents.ImportTablesCompleted = [];
-    return contents;
   }
   if (
     output["ImportTablesCompleted"] !== undefined &&
@@ -18373,7 +18316,6 @@ const deserializeAws_queryResizeProgressMessage = (
   }
   if (output.ImportTablesInProgress === "") {
     contents.ImportTablesInProgress = [];
-    return contents;
   }
   if (
     output["ImportTablesInProgress"] !== undefined &&
@@ -18390,7 +18332,6 @@ const deserializeAws_queryResizeProgressMessage = (
   }
   if (output.ImportTablesNotStarted === "") {
     contents.ImportTablesNotStarted = [];
-    return contents;
   }
   if (
     output["ImportTablesNotStarted"] !== undefined &&
@@ -18627,7 +18568,6 @@ const deserializeAws_queryScheduledAction = (
   }
   if (output.NextInvocations === "") {
     contents.NextInvocations = [];
-    return contents;
   }
   if (
     output["NextInvocations"] !== undefined &&
@@ -18713,7 +18653,6 @@ const deserializeAws_queryScheduledActionsMessage = (
   }
   if (output.ScheduledActions === "") {
     contents.ScheduledActions = [];
-    return contents;
   }
   if (
     output["ScheduledActions"] !== undefined &&
@@ -18780,7 +18719,6 @@ const deserializeAws_querySnapshot = (
   };
   if (output.AccountsWithRestoreAccess === "") {
     contents.AccountsWithRestoreAccess = [];
-    return contents;
   }
   if (
     output["AccountsWithRestoreAccess"] !== undefined &&
@@ -18877,7 +18815,6 @@ const deserializeAws_querySnapshot = (
   }
   if (output.RestorableNodeTypes === "") {
     contents.RestorableNodeTypes = [];
-    return contents;
   }
   if (
     output["RestorableNodeTypes"] !== undefined &&
@@ -18914,7 +18851,6 @@ const deserializeAws_querySnapshot = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -18952,7 +18888,6 @@ const deserializeAws_querySnapshotCopyGrant = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -18987,7 +18922,6 @@ const deserializeAws_querySnapshotCopyGrantMessage = (
   }
   if (output.SnapshotCopyGrants === "") {
     contents.SnapshotCopyGrants = [];
-    return contents;
   }
   if (
     output["SnapshotCopyGrants"] !== undefined &&
@@ -19061,7 +18995,6 @@ const deserializeAws_querySnapshotMessage = (
   }
   if (output.Snapshots === "") {
     contents.Snapshots = [];
-    return contents;
   }
   if (
     output["Snapshots"] !== undefined &&
@@ -19097,7 +19030,6 @@ const deserializeAws_querySnapshotSchedule = (
   }
   if (output.AssociatedClusters === "") {
     contents.AssociatedClusters = [];
-    return contents;
   }
   if (
     output["AssociatedClusters"] !== undefined &&
@@ -19115,7 +19047,6 @@ const deserializeAws_querySnapshotSchedule = (
   }
   if (output.NextInvocations === "") {
     contents.NextInvocations = [];
-    return contents;
   }
   if (
     output["NextInvocations"] !== undefined &&
@@ -19132,7 +19063,6 @@ const deserializeAws_querySnapshotSchedule = (
   }
   if (output.ScheduleDefinitions === "") {
     contents.ScheduleDefinitions = [];
-    return contents;
   }
   if (
     output["ScheduleDefinitions"] !== undefined &&
@@ -19155,7 +19085,6 @@ const deserializeAws_querySnapshotSchedule = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -19352,7 +19281,6 @@ const deserializeAws_queryTableRestoreStatusMessage = (
   }
   if (output.TableRestoreStatusDetails === "") {
     contents.TableRestoreStatusDetails = [];
-    return contents;
   }
   if (
     output["TableRestoreStatusDetails"] !== undefined &&
@@ -19439,7 +19367,6 @@ const deserializeAws_queryTaggedResourceListMessage = (
   }
   if (output.TaggedResources === "") {
     contents.TaggedResources = [];
-    return contents;
   }
   if (
     output["TaggedResources"] !== undefined &&
@@ -19477,7 +19404,6 @@ const deserializeAws_queryTrackListMessage = (
   };
   if (output.MaintenanceTracks === "") {
     contents.MaintenanceTracks = [];
-    return contents;
   }
   if (
     output["MaintenanceTracks"] !== undefined &&
@@ -19516,7 +19442,6 @@ const deserializeAws_queryUpdateTarget = (
   }
   if (output.SupportedOperations === "") {
     contents.SupportedOperations = [];
-    return contents;
   }
   if (
     output["SupportedOperations"] !== undefined &&

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -2440,7 +2440,7 @@ export async function deserializeAws_restXmlAssociateVPCWithHostedZoneCommand(
     __type: "AssociateVPCWithHostedZoneResponse",
     ChangeInfo: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -2544,7 +2544,7 @@ export async function deserializeAws_restXmlChangeResourceRecordSetsCommand(
     __type: "ChangeResourceRecordSetsResponse",
     ChangeInfo: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -2718,7 +2718,7 @@ export async function deserializeAws_restXmlCreateHealthCheckCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(
       data["HealthCheck"],
@@ -2798,7 +2798,7 @@ export async function deserializeAws_restXmlCreateHostedZoneCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -2935,7 +2935,7 @@ export async function deserializeAws_restXmlCreateQueryLoggingConfigCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(
       data["QueryLoggingConfig"],
@@ -3036,7 +3036,7 @@ export async function deserializeAws_restXmlCreateReusableDelegationSetCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(
       data["DelegationSet"],
@@ -3144,7 +3144,7 @@ export async function deserializeAws_restXmlCreateTrafficPolicyCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -3231,7 +3231,7 @@ export async function deserializeAws_restXmlCreateTrafficPolicyInstanceCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -3325,7 +3325,7 @@ export async function deserializeAws_restXmlCreateTrafficPolicyVersionCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -3416,7 +3416,7 @@ export async function deserializeAws_restXmlCreateVPCAssociationAuthorizationCom
     HostedZoneId: undefined,
     VPC: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = data["HostedZoneId"];
   }
@@ -3569,7 +3569,7 @@ export async function deserializeAws_restXmlDeleteHostedZoneCommand(
     __type: "DeleteHostedZoneResponse",
     ChangeInfo: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -4032,7 +4032,7 @@ export async function deserializeAws_restXmlDisassociateVPCFromHostedZoneCommand
     __type: "DisassociateVPCFromHostedZoneResponse",
     ChangeInfo: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -4120,7 +4120,7 @@ export async function deserializeAws_restXmlGetAccountLimitCommand(
     Count: undefined,
     Limit: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["Count"] !== undefined) {
     contents.Count = parseInt(data["Count"]);
   }
@@ -4179,7 +4179,7 @@ export async function deserializeAws_restXmlGetChangeCommand(
     __type: "GetChangeResponse",
     ChangeInfo: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -4248,7 +4248,7 @@ export async function deserializeAws_restXmlGetCheckerIpRangesCommand(
     __type: "GetCheckerIpRangesResponse",
     CheckerIpRanges: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.CheckerIpRanges === "") {
     contents.CheckerIpRanges = [];
   }
@@ -4310,7 +4310,7 @@ export async function deserializeAws_restXmlGetGeoLocationCommand(
     __type: "GetGeoLocationResponse",
     GeoLocationDetails: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["GeoLocationDetails"] !== undefined) {
     contents.GeoLocationDetails = deserializeAws_restXmlGeoLocationDetails(
       data["GeoLocationDetails"],
@@ -4376,7 +4376,7 @@ export async function deserializeAws_restXmlGetHealthCheckCommand(
     __type: "GetHealthCheckResponse",
     HealthCheck: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(
       data["HealthCheck"],
@@ -4452,7 +4452,7 @@ export async function deserializeAws_restXmlGetHealthCheckCountCommand(
     __type: "GetHealthCheckCountResponse",
     HealthCheckCount: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HealthCheckCount"] !== undefined) {
     contents.HealthCheckCount = parseInt(data["HealthCheckCount"]);
   }
@@ -4504,7 +4504,7 @@ export async function deserializeAws_restXmlGetHealthCheckLastFailureReasonComma
     __type: "GetHealthCheckLastFailureReasonResponse",
     HealthCheckObservations: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   }
@@ -4583,7 +4583,7 @@ export async function deserializeAws_restXmlGetHealthCheckStatusCommand(
     __type: "GetHealthCheckStatusResponse",
     HealthCheckObservations: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   }
@@ -4661,7 +4661,7 @@ export async function deserializeAws_restXmlGetHostedZoneCommand(
     HostedZone: undefined,
     VPCs: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(
       data["DelegationSet"],
@@ -4746,7 +4746,7 @@ export async function deserializeAws_restXmlGetHostedZoneCountCommand(
     __type: "GetHostedZoneCountResponse",
     HostedZoneCount: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HostedZoneCount"] !== undefined) {
     contents.HostedZoneCount = parseInt(data["HostedZoneCount"]);
   }
@@ -4806,7 +4806,7 @@ export async function deserializeAws_restXmlGetHostedZoneLimitCommand(
     Count: undefined,
     Limit: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["Count"] !== undefined) {
     contents.Count = parseInt(data["Count"]);
   }
@@ -4885,7 +4885,7 @@ export async function deserializeAws_restXmlGetQueryLoggingConfigCommand(
     __type: "GetQueryLoggingConfigResponse",
     QueryLoggingConfig: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(
       data["QueryLoggingConfig"],
@@ -4954,7 +4954,7 @@ export async function deserializeAws_restXmlGetReusableDelegationSetCommand(
     __type: "GetReusableDelegationSetResponse",
     DelegationSet: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(
       data["DelegationSet"],
@@ -5031,7 +5031,7 @@ export async function deserializeAws_restXmlGetReusableDelegationSetLimitCommand
     Count: undefined,
     Limit: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["Count"] !== undefined) {
     contents.Count = parseInt(data["Count"]);
   }
@@ -5100,7 +5100,7 @@ export async function deserializeAws_restXmlGetTrafficPolicyCommand(
     __type: "GetTrafficPolicyResponse",
     TrafficPolicy: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -5169,7 +5169,7 @@ export async function deserializeAws_restXmlGetTrafficPolicyInstanceCommand(
     __type: "GetTrafficPolicyInstanceResponse",
     TrafficPolicyInstance: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -5238,7 +5238,7 @@ export async function deserializeAws_restXmlGetTrafficPolicyInstanceCountCommand
     __type: "GetTrafficPolicyInstanceCountResponse",
     TrafficPolicyInstanceCount: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicyInstanceCount"] !== undefined) {
     contents.TrafficPolicyInstanceCount = parseInt(
       data["TrafficPolicyInstanceCount"]
@@ -5294,7 +5294,7 @@ export async function deserializeAws_restXmlListGeoLocationsCommand(
     NextCountryCode: undefined,
     NextSubdivisionCode: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.GeoLocationDetailsList === "") {
     contents.GeoLocationDetailsList = [];
   }
@@ -5382,7 +5382,7 @@ export async function deserializeAws_restXmlListHealthChecksCommand(
     MaxItems: undefined,
     NextMarker: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.HealthChecks === "") {
     contents.HealthChecks = [];
   }
@@ -5474,7 +5474,7 @@ export async function deserializeAws_restXmlListHostedZonesCommand(
     MaxItems: undefined,
     NextMarker: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.HostedZones === "") {
     contents.HostedZones = [];
   }
@@ -5578,7 +5578,7 @@ export async function deserializeAws_restXmlListHostedZonesByNameCommand(
     NextDNSName: undefined,
     NextHostedZoneId: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["DNSName"] !== undefined) {
     contents.DNSName = data["DNSName"];
   }
@@ -5676,7 +5676,7 @@ export async function deserializeAws_restXmlListQueryLoggingConfigsCommand(
     NextToken: undefined,
     QueryLoggingConfigs: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["NextToken"] !== undefined) {
     contents.NextToken = data["NextToken"];
   }
@@ -5770,7 +5770,7 @@ export async function deserializeAws_restXmlListResourceRecordSetsCommand(
     NextRecordType: undefined,
     ResourceRecordSets: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = data["IsTruncated"] == "true";
   }
@@ -5868,7 +5868,7 @@ export async function deserializeAws_restXmlListReusableDelegationSetsCommand(
     MaxItems: undefined,
     NextMarker: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.DelegationSets === "") {
     contents.DelegationSets = [];
   }
@@ -5952,7 +5952,7 @@ export async function deserializeAws_restXmlListTagsForResourceCommand(
     __type: "ListTagsForResourceResponse",
     ResourceTagSet: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["ResourceTagSet"] !== undefined) {
     contents.ResourceTagSet = deserializeAws_restXmlResourceTagSet(
       data["ResourceTagSet"],
@@ -6042,7 +6042,7 @@ export async function deserializeAws_restXmlListTagsForResourcesCommand(
     __type: "ListTagsForResourcesResponse",
     ResourceTagSets: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.ResourceTagSets === "") {
     contents.ResourceTagSets = [];
   }
@@ -6145,7 +6145,7 @@ export async function deserializeAws_restXmlListTrafficPoliciesCommand(
     TrafficPolicyIdMarker: undefined,
     TrafficPolicySummaries: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = data["IsTruncated"] == "true";
   }
@@ -6231,7 +6231,7 @@ export async function deserializeAws_restXmlListTrafficPolicyInstancesCommand(
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HostedZoneIdMarker"] !== undefined) {
     contents.HostedZoneIdMarker = data["HostedZoneIdMarker"];
   }
@@ -6331,7 +6331,7 @@ export async function deserializeAws_restXmlListTrafficPolicyInstancesByHostedZo
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = data["IsTruncated"] == "true";
   }
@@ -6436,7 +6436,7 @@ export async function deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCo
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HostedZoneIdMarker"] !== undefined) {
     contents.HostedZoneIdMarker = data["HostedZoneIdMarker"];
   }
@@ -6542,7 +6542,7 @@ export async function deserializeAws_restXmlListTrafficPolicyVersionsCommand(
     TrafficPolicies: undefined,
     TrafficPolicyVersionMarker: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = data["IsTruncated"] == "true";
   }
@@ -6632,7 +6632,7 @@ export async function deserializeAws_restXmlListVPCAssociationAuthorizationsComm
     NextToken: undefined,
     VPCs: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = data["HostedZoneId"];
   }
@@ -6720,7 +6720,7 @@ export async function deserializeAws_restXmlTestDNSAnswerCommand(
     RecordType: undefined,
     ResponseCode: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["Nameserver"] !== undefined) {
     contents.Nameserver = data["Nameserver"];
   }
@@ -6811,7 +6811,7 @@ export async function deserializeAws_restXmlUpdateHealthCheckCommand(
     __type: "UpdateHealthCheckResponse",
     HealthCheck: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(
       data["HealthCheck"],
@@ -6887,7 +6887,7 @@ export async function deserializeAws_restXmlUpdateHostedZoneCommentCommand(
     __type: "UpdateHostedZoneCommentResponse",
     HostedZone: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["HostedZone"] !== undefined) {
     contents.HostedZone = deserializeAws_restXmlHostedZone(
       data["HostedZone"],
@@ -6956,7 +6956,7 @@ export async function deserializeAws_restXmlUpdateTrafficPolicyCommentCommand(
     __type: "UpdateTrafficPolicyCommentResponse",
     TrafficPolicy: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -7032,7 +7032,7 @@ export async function deserializeAws_restXmlUpdateTrafficPolicyInstanceCommand(
     __type: "UpdateTrafficPolicyInstanceResponse",
     TrafficPolicyInstance: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -4251,7 +4251,6 @@ export async function deserializeAws_restXmlGetCheckerIpRangesCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.CheckerIpRanges === "") {
     contents.CheckerIpRanges = [];
-    return contents;
   }
   if (
     data["CheckerIpRanges"] !== undefined &&
@@ -4508,7 +4507,6 @@ export async function deserializeAws_restXmlGetHealthCheckLastFailureReasonComma
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
-    return contents;
   }
   if (
     data["HealthCheckObservations"] !== undefined &&
@@ -4588,7 +4586,6 @@ export async function deserializeAws_restXmlGetHealthCheckStatusCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
-    return contents;
   }
   if (
     data["HealthCheckObservations"] !== undefined &&
@@ -4679,7 +4676,6 @@ export async function deserializeAws_restXmlGetHostedZoneCommand(
   }
   if (data.VPCs === "") {
     contents.VPCs = [];
-    return contents;
   }
   if (data["VPCs"] !== undefined && data["VPCs"]["VPC"] !== undefined) {
     const wrappedItem =
@@ -5301,7 +5297,6 @@ export async function deserializeAws_restXmlListGeoLocationsCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.GeoLocationDetailsList === "") {
     contents.GeoLocationDetailsList = [];
-    return contents;
   }
   if (
     data["GeoLocationDetailsList"] !== undefined &&
@@ -5390,7 +5385,6 @@ export async function deserializeAws_restXmlListHealthChecksCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.HealthChecks === "") {
     contents.HealthChecks = [];
-    return contents;
   }
   if (
     data["HealthChecks"] !== undefined &&
@@ -5483,7 +5477,6 @@ export async function deserializeAws_restXmlListHostedZonesCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.HostedZones === "") {
     contents.HostedZones = [];
-    return contents;
   }
   if (
     data["HostedZones"] !== undefined &&
@@ -5594,7 +5587,6 @@ export async function deserializeAws_restXmlListHostedZonesByNameCommand(
   }
   if (data.HostedZones === "") {
     contents.HostedZones = [];
-    return contents;
   }
   if (
     data["HostedZones"] !== undefined &&
@@ -5690,7 +5682,6 @@ export async function deserializeAws_restXmlListQueryLoggingConfigsCommand(
   }
   if (data.QueryLoggingConfigs === "") {
     contents.QueryLoggingConfigs = [];
-    return contents;
   }
   if (
     data["QueryLoggingConfigs"] !== undefined &&
@@ -5797,7 +5788,6 @@ export async function deserializeAws_restXmlListResourceRecordSetsCommand(
   }
   if (data.ResourceRecordSets === "") {
     contents.ResourceRecordSets = [];
-    return contents;
   }
   if (
     data["ResourceRecordSets"] !== undefined &&
@@ -5881,7 +5871,6 @@ export async function deserializeAws_restXmlListReusableDelegationSetsCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.DelegationSets === "") {
     contents.DelegationSets = [];
-    return contents;
   }
   if (
     data["DelegationSets"] !== undefined &&
@@ -6056,7 +6045,6 @@ export async function deserializeAws_restXmlListTagsForResourcesCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.ResourceTagSets === "") {
     contents.ResourceTagSets = [];
-    return contents;
   }
   if (
     data["ResourceTagSets"] !== undefined &&
@@ -6169,7 +6157,6 @@ export async function deserializeAws_restXmlListTrafficPoliciesCommand(
   }
   if (data.TrafficPolicySummaries === "") {
     contents.TrafficPolicySummaries = [];
-    return contents;
   }
   if (
     data["TrafficPolicySummaries"] !== undefined &&
@@ -6264,7 +6251,6 @@ export async function deserializeAws_restXmlListTrafficPolicyInstancesCommand(
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
-    return contents;
   }
   if (
     data["TrafficPolicyInstances"] !== undefined &&
@@ -6362,7 +6348,6 @@ export async function deserializeAws_restXmlListTrafficPolicyInstancesByHostedZo
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
-    return contents;
   }
   if (
     data["TrafficPolicyInstances"] !== undefined &&
@@ -6471,7 +6456,6 @@ export async function deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCo
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
-    return contents;
   }
   if (
     data["TrafficPolicyInstances"] !== undefined &&
@@ -6567,7 +6551,6 @@ export async function deserializeAws_restXmlListTrafficPolicyVersionsCommand(
   }
   if (data.TrafficPolicies === "") {
     contents.TrafficPolicies = [];
-    return contents;
   }
   if (
     data["TrafficPolicies"] !== undefined &&
@@ -6658,7 +6641,6 @@ export async function deserializeAws_restXmlListVPCAssociationAuthorizationsComm
   }
   if (data.VPCs === "") {
     contents.VPCs = [];
-    return contents;
   }
   if (data["VPCs"] !== undefined && data["VPCs"]["VPC"] !== undefined) {
     const wrappedItem =
@@ -6747,7 +6729,6 @@ export async function deserializeAws_restXmlTestDNSAnswerCommand(
   }
   if (data.RecordData === "") {
     contents.RecordData = [];
-    return contents;
   }
   if (
     data["RecordData"] !== undefined &&
@@ -8460,7 +8441,6 @@ const deserializeAws_restXmlCloudWatchAlarmConfiguration = (
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-    return contents;
   }
   if (
     output["Dimensions"] !== undefined &&
@@ -8514,7 +8494,6 @@ const deserializeAws_restXmlDelegationSet = (
   }
   if (output.NameServers === "") {
     contents.NameServers = [];
-    return contents;
   }
   if (
     output["NameServers"] !== undefined &&
@@ -8722,7 +8701,6 @@ const deserializeAws_restXmlHealthCheckConfig = (
   }
   if (output.ChildHealthChecks === "") {
     contents.ChildHealthChecks = [];
-    return contents;
   }
   if (
     output["ChildHealthChecks"] !== undefined &&
@@ -8770,7 +8748,6 @@ const deserializeAws_restXmlHealthCheckConfig = (
   }
   if (output.Regions === "") {
     contents.Regions = [];
-    return contents;
   }
   if (
     output["Regions"] !== undefined &&
@@ -9056,7 +9033,6 @@ const deserializeAws_restXmlResourceRecordSet = (
   }
   if (output.ResourceRecords === "") {
     contents.ResourceRecords = [];
-    return contents;
   }
   if (
     output["ResourceRecords"] !== undefined &&
@@ -9125,7 +9101,6 @@ const deserializeAws_restXmlResourceTagSet = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     const wrappedItem =

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -753,7 +753,7 @@ export async function deserializeAws_restXmlCreateJobCommand(
     __type: "CreateJobResult",
     JobId: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["JobId"] !== undefined) {
     contents.JobId = data["JobId"];
   }
@@ -968,7 +968,7 @@ export async function deserializeAws_restXmlDescribeJobCommand(
     __type: "DescribeJobResult",
     Job: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["Job"] !== undefined) {
     contents.Job = deserializeAws_restXmlJobDescriptor(data["Job"], context);
   }
@@ -1050,7 +1050,7 @@ export async function deserializeAws_restXmlGetAccessPointCommand(
     PublicAccessBlockConfiguration: undefined,
     VpcConfiguration: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["Bucket"] !== undefined) {
     contents.Bucket = data["Bucket"];
   }
@@ -1123,7 +1123,7 @@ export async function deserializeAws_restXmlGetAccessPointPolicyCommand(
     __type: "GetAccessPointPolicyResult",
     Policy: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["Policy"] !== undefined) {
     contents.Policy = data["Policy"];
   }
@@ -1175,7 +1175,7 @@ export async function deserializeAws_restXmlGetAccessPointPolicyStatusCommand(
     __type: "GetAccessPointPolicyStatusResult",
     PolicyStatus: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["PolicyStatus"] !== undefined) {
     contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(
       data["PolicyStatus"],
@@ -1288,7 +1288,7 @@ export async function deserializeAws_restXmlListAccessPointsCommand(
     AccessPointList: undefined,
     NextToken: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.AccessPointList === "") {
     contents.AccessPointList = [];
   }
@@ -1354,7 +1354,7 @@ export async function deserializeAws_restXmlListJobsCommand(
     Jobs: undefined,
     NextToken: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data.Jobs === "") {
     contents.Jobs = [];
   }
@@ -1532,7 +1532,7 @@ export async function deserializeAws_restXmlUpdateJobPriorityCommand(
     JobId: undefined,
     Priority: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["JobId"] !== undefined) {
     contents.JobId = data["JobId"];
   }
@@ -1614,7 +1614,7 @@ export async function deserializeAws_restXmlUpdateJobStatusCommand(
     Status: undefined,
     StatusUpdateReason: undefined
   };
-  const data: any = (await parseBody(output.body, context)).Error;
+  const data: any = await parseBody(output.body, context);
   if (data["JobId"] !== undefined) {
     contents.JobId = data["JobId"];
   }

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -1291,7 +1291,6 @@ export async function deserializeAws_restXmlListAccessPointsCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.AccessPointList === "") {
     contents.AccessPointList = [];
-    return contents;
   }
   if (
     data["AccessPointList"] !== undefined &&
@@ -1358,7 +1357,6 @@ export async function deserializeAws_restXmlListJobsCommand(
   const data: any = (await parseBody(output.body, context)).Error;
   if (data.Jobs === "") {
     contents.Jobs = [];
-    return contents;
   }
   if (data["Jobs"] !== undefined && data["Jobs"]["member"] !== undefined) {
     const wrappedItem =
@@ -2535,7 +2533,6 @@ const deserializeAws_restXmlJobDescriptor = (
   }
   if (output.FailureReasons === "") {
     contents.FailureReasons = [];
-    return contents;
   }
   if (
     output["FailureReasons"] !== undefined &&
@@ -2749,7 +2746,6 @@ const deserializeAws_restXmlJobManifestSpec = (
   };
   if (output.Fields === "") {
     contents.Fields = [];
-    return contents;
   }
   if (
     output["Fields"] !== undefined &&
@@ -2934,7 +2930,6 @@ const deserializeAws_restXmlS3AccessControlList = (
   };
   if (output.Grants === "") {
     contents.Grants = [];
-    return contents;
   }
   if (
     output["Grants"] !== undefined &&
@@ -3001,7 +2996,6 @@ const deserializeAws_restXmlS3CopyObjectOperation = (
   };
   if (output.AccessControlGrants === "") {
     contents.AccessControlGrants = [];
-    return contents;
   }
   if (
     output["AccessControlGrants"] !== undefined &&
@@ -3035,7 +3029,6 @@ const deserializeAws_restXmlS3CopyObjectOperation = (
   }
   if (output.NewObjectTagging === "") {
     contents.NewObjectTagging = [];
-    return contents;
   }
   if (
     output["NewObjectTagging"] !== undefined &&
@@ -3207,7 +3200,6 @@ const deserializeAws_restXmlS3ObjectMetadata = (
   }
   if (output.UserMetadata === "") {
     contents.UserMetadata = {};
-    return contents;
   }
   if (
     output["UserMetadata"] !== undefined &&
@@ -3270,7 +3262,6 @@ const deserializeAws_restXmlS3SetObjectTaggingOperation = (
   };
   if (output.TagSet === "") {
     contents.TagSet = [];
-    return contents;
   }
   if (
     output["TagSet"] !== undefined &&

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -5708,7 +5708,6 @@ export async function deserializeAws_restXmlDeleteObjectsCommand(
   const data: any = await parseBody(output.body, context);
   if (data.Deleted === "") {
     contents.Deleted = [];
-    return contents;
   }
   if (data["Deleted"] !== undefined) {
     const wrappedItem =
@@ -5720,7 +5719,6 @@ export async function deserializeAws_restXmlDeleteObjectsCommand(
   }
   if (data.Error === "") {
     contents.Errors = [];
-    return contents;
   }
   if (data["Error"] !== undefined) {
     const wrappedItem =
@@ -5872,7 +5870,6 @@ export async function deserializeAws_restXmlGetBucketAclCommand(
   const data: any = await parseBody(output.body, context);
   if (data.AccessControlList === "") {
     contents.Grants = [];
-    return contents;
   }
   if (
     data["AccessControlList"] !== undefined &&
@@ -5986,7 +5983,6 @@ export async function deserializeAws_restXmlGetBucketCorsCommand(
   const data: any = await parseBody(output.body, context);
   if (data.CORSRule === "") {
     contents.CORSRules = [];
-    return contents;
   }
   if (data["CORSRule"] !== undefined) {
     const wrappedItem =
@@ -6147,7 +6143,6 @@ export async function deserializeAws_restXmlGetBucketLifecycleConfigurationComma
   const data: any = await parseBody(output.body, context);
   if (data.Rule === "") {
     contents.Rules = [];
-    return contents;
   }
   if (data["Rule"] !== undefined) {
     const wrappedItem =
@@ -6357,7 +6352,6 @@ export async function deserializeAws_restXmlGetBucketNotificationConfigurationCo
   const data: any = await parseBody(output.body, context);
   if (data.CloudFunctionConfiguration === "") {
     contents.LambdaFunctionConfigurations = [];
-    return contents;
   }
   if (data["CloudFunctionConfiguration"] !== undefined) {
     const wrappedItem =
@@ -6371,7 +6365,6 @@ export async function deserializeAws_restXmlGetBucketNotificationConfigurationCo
   }
   if (data.QueueConfiguration === "") {
     contents.QueueConfigurations = [];
-    return contents;
   }
   if (data["QueueConfiguration"] !== undefined) {
     const wrappedItem =
@@ -6385,7 +6378,6 @@ export async function deserializeAws_restXmlGetBucketNotificationConfigurationCo
   }
   if (data.TopicConfiguration === "") {
     contents.TopicConfigurations = [];
-    return contents;
   }
   if (data["TopicConfiguration"] !== undefined) {
     const wrappedItem =
@@ -6644,7 +6636,6 @@ export async function deserializeAws_restXmlGetBucketTaggingCommand(
   const data: any = await parseBody(output.body, context);
   if (data.TagSet === "") {
     contents.TagSet = [];
-    return contents;
   }
   if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -6776,7 +6767,6 @@ export async function deserializeAws_restXmlGetBucketWebsiteCommand(
   }
   if (data.RoutingRules === "") {
     contents.RoutingRules = [];
-    return contents;
   }
   if (
     data["RoutingRules"] !== undefined &&
@@ -7037,7 +7027,6 @@ export async function deserializeAws_restXmlGetObjectAclCommand(
   const data: any = await parseBody(output.body, context);
   if (data.AccessControlList === "") {
     contents.Grants = [];
-    return contents;
   }
   if (
     data["AccessControlList"] !== undefined &&
@@ -7260,7 +7249,6 @@ export async function deserializeAws_restXmlGetObjectTaggingCommand(
   const data: any = await parseBody(output.body, context);
   if (data.TagSet === "") {
     contents.TagSet = [];
-    return contents;
   }
   if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
     const wrappedItem =
@@ -7658,7 +7646,6 @@ export async function deserializeAws_restXmlListBucketAnalyticsConfigurationsCom
   const data: any = await parseBody(output.body, context);
   if (data.AnalyticsConfiguration === "") {
     contents.AnalyticsConfigurationList = [];
-    return contents;
   }
   if (data["AnalyticsConfiguration"] !== undefined) {
     const wrappedItem =
@@ -7735,7 +7722,6 @@ export async function deserializeAws_restXmlListBucketInventoryConfigurationsCom
   }
   if (data.InventoryConfiguration === "") {
     contents.InventoryConfigurationList = [];
-    return contents;
   }
   if (data["InventoryConfiguration"] !== undefined) {
     const wrappedItem =
@@ -7812,7 +7798,6 @@ export async function deserializeAws_restXmlListBucketMetricsConfigurationsComma
   }
   if (data.MetricsConfiguration === "") {
     contents.MetricsConfigurationList = [];
-    return contents;
   }
   if (data["MetricsConfiguration"] !== undefined) {
     const wrappedItem =
@@ -7875,7 +7860,6 @@ export async function deserializeAws_restXmlListBucketsCommand(
   const data: any = await parseBody(output.body, context);
   if (data.Buckets === "") {
     contents.Buckets = [];
-    return contents;
   }
   if (
     data["Buckets"] !== undefined &&
@@ -7954,7 +7938,6 @@ export async function deserializeAws_restXmlListMultipartUploadsCommand(
   }
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-    return contents;
   }
   if (data["CommonPrefixes"] !== undefined) {
     const wrappedItem =
@@ -7995,7 +7978,6 @@ export async function deserializeAws_restXmlListMultipartUploadsCommand(
   }
   if (data.Upload === "") {
     contents.Uploads = [];
-    return contents;
   }
   if (data["Upload"] !== undefined) {
     const wrappedItem =
@@ -8067,7 +8049,6 @@ export async function deserializeAws_restXmlListObjectVersionsCommand(
   const data: any = await parseBody(output.body, context);
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-    return contents;
   }
   if (data["CommonPrefixes"] !== undefined) {
     const wrappedItem =
@@ -8081,7 +8062,6 @@ export async function deserializeAws_restXmlListObjectVersionsCommand(
   }
   if (data.DeleteMarker === "") {
     contents.DeleteMarkers = [];
-    return contents;
   }
   if (data["DeleteMarker"] !== undefined) {
     const wrappedItem =
@@ -8125,7 +8105,6 @@ export async function deserializeAws_restXmlListObjectVersionsCommand(
   }
   if (data.Version === "") {
     contents.Versions = [];
-    return contents;
   }
   if (data["Version"] !== undefined) {
     const wrappedItem =
@@ -8191,7 +8170,6 @@ export async function deserializeAws_restXmlListObjectsCommand(
   const data: any = await parseBody(output.body, context);
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-    return contents;
   }
   if (data["CommonPrefixes"] !== undefined) {
     const wrappedItem =
@@ -8205,7 +8183,6 @@ export async function deserializeAws_restXmlListObjectsCommand(
   }
   if (data.Contents === "") {
     contents.Contents = [];
-    return contents;
   }
   if (data["Contents"] !== undefined) {
     const wrappedItem =
@@ -8301,7 +8278,6 @@ export async function deserializeAws_restXmlListObjectsV2Command(
   const data: any = await parseBody(output.body, context);
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-    return contents;
   }
   if (data["CommonPrefixes"] !== undefined) {
     const wrappedItem =
@@ -8315,7 +8291,6 @@ export async function deserializeAws_restXmlListObjectsV2Command(
   }
   if (data.Contents === "") {
     contents.Contents = [];
-    return contents;
   }
   if (data["Contents"] !== undefined) {
     const wrappedItem =
@@ -8455,7 +8430,6 @@ export async function deserializeAws_restXmlListPartsCommand(
   }
   if (data.Part === "") {
     contents.Parts = [];
-    return contents;
   }
   if (data["Part"] !== undefined) {
     const wrappedItem =
@@ -12750,7 +12724,6 @@ const deserializeAws_restXmlAnalyticsAndOperator = (
   }
   if (output.Tag === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tag"] !== undefined) {
     const wrappedItem =
@@ -12906,7 +12879,6 @@ const deserializeAws_restXmlCORSRule = (
   };
   if (output.AllowedHeader === "") {
     contents.AllowedHeaders = [];
-    return contents;
   }
   if (output["AllowedHeader"] !== undefined) {
     const wrappedItem =
@@ -12920,7 +12892,6 @@ const deserializeAws_restXmlCORSRule = (
   }
   if (output.AllowedMethod === "") {
     contents.AllowedMethods = [];
-    return contents;
   }
   if (output["AllowedMethod"] !== undefined) {
     const wrappedItem =
@@ -12934,7 +12905,6 @@ const deserializeAws_restXmlCORSRule = (
   }
   if (output.AllowedOrigin === "") {
     contents.AllowedOrigins = [];
-    return contents;
   }
   if (output["AllowedOrigin"] !== undefined) {
     const wrappedItem =
@@ -12948,7 +12918,6 @@ const deserializeAws_restXmlCORSRule = (
   }
   if (output.ExposeHeader === "") {
     contents.ExposeHeaders = [];
-    return contents;
   }
   if (output["ExposeHeader"] !== undefined) {
     const wrappedItem =
@@ -13460,7 +13429,6 @@ const deserializeAws_restXmlInventoryConfiguration = (
   }
   if (output.OptionalFields === "") {
     contents.OptionalFields = [];
-    return contents;
   }
   if (
     output["OptionalFields"] !== undefined &&
@@ -13609,7 +13577,6 @@ const deserializeAws_restXmlLambdaFunctionConfiguration = (
   };
   if (output.Event === "") {
     contents.Events = [];
-    return contents;
   }
   if (output["Event"] !== undefined) {
     const wrappedItem =
@@ -13708,7 +13675,6 @@ const deserializeAws_restXmlLifecycleRule = (
   }
   if (output.NoncurrentVersionTransition === "") {
     contents.NoncurrentVersionTransitions = [];
-    return contents;
   }
   if (output["NoncurrentVersionTransition"] !== undefined) {
     const wrappedItem =
@@ -13728,7 +13694,6 @@ const deserializeAws_restXmlLifecycleRule = (
   }
   if (output.Transition === "") {
     contents.Transitions = [];
-    return contents;
   }
   if (output["Transition"] !== undefined) {
     const wrappedItem =
@@ -13757,7 +13722,6 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
   }
   if (output.Tag === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tag"] !== undefined) {
     const wrappedItem =
@@ -13816,7 +13780,6 @@ const deserializeAws_restXmlLoggingEnabled = (
   }
   if (output.TargetGrants === "") {
     contents.TargetGrants = [];
-    return contents;
   }
   if (
     output["TargetGrants"] !== undefined &&
@@ -13872,7 +13835,6 @@ const deserializeAws_restXmlMetricsAndOperator = (
   }
   if (output.Tag === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tag"] !== undefined) {
     const wrappedItem =
@@ -14308,7 +14270,6 @@ const deserializeAws_restXmlQueueConfiguration = (
   };
   if (output.Event === "") {
     contents.Events = [];
-    return contents;
   }
   if (output["Event"] !== undefined) {
     const wrappedItem =
@@ -14401,7 +14362,6 @@ const deserializeAws_restXmlReplicationConfiguration = (
   }
   if (output.Rule === "") {
     contents.Rules = [];
-    return contents;
   }
   if (output["Rule"] !== undefined) {
     const wrappedItem =
@@ -14489,7 +14449,6 @@ const deserializeAws_restXmlReplicationRuleAndOperator = (
   }
   if (output.Tag === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tag"] !== undefined) {
     const wrappedItem =
@@ -14611,7 +14570,6 @@ const deserializeAws_restXmlS3KeyFilter = (
   };
   if (output.FilterRule === "") {
     contents.FilterRules = [];
-    return contents;
   }
   if (output["FilterRule"] !== undefined) {
     const wrappedItem =
@@ -14678,7 +14636,6 @@ const deserializeAws_restXmlServerSideEncryptionConfiguration = (
   };
   if (output.Rule === "") {
     contents.Rules = [];
-    return contents;
   }
   if (output["Rule"] !== undefined) {
     const wrappedItem =
@@ -14856,7 +14813,6 @@ const deserializeAws_restXmlTopicConfiguration = (
   };
   if (output.Event === "") {
     contents.Events = [];
-    return contents;
   }
   if (output["Event"] !== undefined) {
     const wrappedItem =

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -9022,7 +9022,6 @@ const deserializeAws_queryCloudWatchDestination = (
   };
   if (output.DimensionConfigurations === "") {
     contents.DimensionConfigurations = [];
-    return contents;
   }
   if (
     output["DimensionConfigurations"] !== undefined &&
@@ -9430,7 +9429,6 @@ const deserializeAws_queryDescribeActiveReceiptRuleSetResponse = (
   }
   if (output.Rules === "") {
     contents.Rules = [];
-    return contents;
   }
   if (
     output["Rules"] !== undefined &&
@@ -9471,7 +9469,6 @@ const deserializeAws_queryDescribeConfigurationSetResponse = (
   }
   if (output.EventDestinations === "") {
     contents.EventDestinations = [];
-    return contents;
   }
   if (
     output["EventDestinations"] !== undefined &&
@@ -9532,7 +9529,6 @@ const deserializeAws_queryDescribeReceiptRuleSetResponse = (
   }
   if (output.Rules === "") {
     contents.Rules = [];
-    return contents;
   }
   if (
     output["Rules"] !== undefined &&
@@ -9591,7 +9587,6 @@ const deserializeAws_queryEventDestination = (
   }
   if (output.MatchingEventTypes === "") {
     contents.MatchingEventTypes = [];
-    return contents;
   }
   if (
     output["MatchingEventTypes"] !== undefined &&
@@ -9754,7 +9749,6 @@ const deserializeAws_queryGetIdentityDkimAttributesResponse = (
   };
   if (output.DkimAttributes === "") {
     contents.DkimAttributes = {};
-    return contents;
   }
   if (
     output["DkimAttributes"] !== undefined &&
@@ -9782,7 +9776,6 @@ const deserializeAws_queryGetIdentityMailFromDomainAttributesResponse = (
   };
   if (output.MailFromDomainAttributes === "") {
     contents.MailFromDomainAttributes = {};
-    return contents;
   }
   if (
     output["MailFromDomainAttributes"] !== undefined &&
@@ -9810,7 +9803,6 @@ const deserializeAws_queryGetIdentityNotificationAttributesResponse = (
   };
   if (output.NotificationAttributes === "") {
     contents.NotificationAttributes = {};
-    return contents;
   }
   if (
     output["NotificationAttributes"] !== undefined &&
@@ -9838,7 +9830,6 @@ const deserializeAws_queryGetIdentityPoliciesResponse = (
   };
   if (output.Policies === "") {
     contents.Policies = {};
-    return contents;
   }
   if (
     output["Policies"] !== undefined &&
@@ -9863,7 +9854,6 @@ const deserializeAws_queryGetIdentityVerificationAttributesResponse = (
   };
   if (output.VerificationAttributes === "") {
     contents.VerificationAttributes = {};
-    return contents;
   }
   if (
     output["VerificationAttributes"] !== undefined &&
@@ -9913,7 +9903,6 @@ const deserializeAws_queryGetSendStatisticsResponse = (
   };
   if (output.SendDataPoints === "") {
     contents.SendDataPoints = [];
-    return contents;
   }
   if (
     output["SendDataPoints"] !== undefined &&
@@ -9963,7 +9952,6 @@ const deserializeAws_queryIdentityDkimAttributes = (
   }
   if (output.DkimTokens === "") {
     contents.DkimTokens = [];
-    return contents;
   }
   if (
     output["DkimTokens"] !== undefined &&
@@ -10349,7 +10337,6 @@ const deserializeAws_queryListConfigurationSetsResponse = (
   };
   if (output.ConfigurationSets === "") {
     contents.ConfigurationSets = [];
-    return contents;
   }
   if (
     output["ConfigurationSets"] !== undefined &&
@@ -10381,7 +10368,6 @@ const deserializeAws_queryListCustomVerificationEmailTemplatesResponse = (
   };
   if (output.CustomVerificationEmailTemplates === "") {
     contents.CustomVerificationEmailTemplates = [];
-    return contents;
   }
   if (
     output["CustomVerificationEmailTemplates"] !== undefined &&
@@ -10413,7 +10399,6 @@ const deserializeAws_queryListIdentitiesResponse = (
   };
   if (output.Identities === "") {
     contents.Identities = [];
-    return contents;
   }
   if (
     output["Identities"] !== undefined &&
@@ -10444,7 +10429,6 @@ const deserializeAws_queryListIdentityPoliciesResponse = (
   };
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-    return contents;
   }
   if (
     output["PolicyNames"] !== undefined &&
@@ -10472,7 +10456,6 @@ const deserializeAws_queryListReceiptFiltersResponse = (
   };
   if (output.Filters === "") {
     contents.Filters = [];
-    return contents;
   }
   if (
     output["Filters"] !== undefined &&
@@ -10504,7 +10487,6 @@ const deserializeAws_queryListReceiptRuleSetsResponse = (
   }
   if (output.RuleSets === "") {
     contents.RuleSets = [];
-    return contents;
   }
   if (
     output["RuleSets"] !== undefined &&
@@ -10536,7 +10518,6 @@ const deserializeAws_queryListTemplatesResponse = (
   }
   if (output.TemplatesMetadata === "") {
     contents.TemplatesMetadata = [];
-    return contents;
   }
   if (
     output["TemplatesMetadata"] !== undefined &&
@@ -10564,7 +10545,6 @@ const deserializeAws_queryListVerifiedEmailAddressesResponse = (
   };
   if (output.VerifiedEmailAddresses === "") {
     contents.VerifiedEmailAddresses = [];
-    return contents;
   }
   if (
     output["VerifiedEmailAddresses"] !== undefined &&
@@ -10839,7 +10819,6 @@ const deserializeAws_queryReceiptRule = (
   };
   if (output.Actions === "") {
     contents.Actions = [];
-    return contents;
   }
   if (
     output["Actions"] !== undefined &&
@@ -10862,7 +10841,6 @@ const deserializeAws_queryReceiptRule = (
   }
   if (output.Recipients === "") {
     contents.Recipients = [];
-    return contents;
   }
   if (
     output["Recipients"] !== undefined &&
@@ -11080,7 +11058,6 @@ const deserializeAws_querySendBulkTemplatedEmailResponse = (
   };
   if (output.Status === "") {
     contents.Status = [];
-    return contents;
   }
   if (
     output["Status"] !== undefined &&
@@ -11487,7 +11464,6 @@ const deserializeAws_queryVerifyDomainDkimResponse = (
   };
   if (output.DkimTokens === "") {
     contents.DkimTokens = [];
-    return contents;
   }
   if (
     output["DkimTokens"] !== undefined &&

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -4799,7 +4799,6 @@ const deserializeAws_queryEndpoint = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -4858,7 +4857,6 @@ const deserializeAws_queryGetEndpointAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -4886,7 +4884,6 @@ const deserializeAws_queryGetPlatformApplicationAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -4914,7 +4911,6 @@ const deserializeAws_queryGetSMSAttributesResponse = (
   };
   if (output.attributes === "") {
     contents.attributes = {};
-    return contents;
   }
   if (
     output["attributes"] !== undefined &&
@@ -4942,7 +4938,6 @@ const deserializeAws_queryGetSubscriptionAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -4970,7 +4965,6 @@ const deserializeAws_queryGetTopicAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&
@@ -5139,7 +5133,6 @@ const deserializeAws_queryListEndpointsByPlatformApplicationResponse = (
   };
   if (output.Endpoints === "") {
     contents.Endpoints = [];
-    return contents;
   }
   if (
     output["Endpoints"] !== undefined &&
@@ -5192,7 +5185,6 @@ const deserializeAws_queryListPhoneNumbersOptedOutResponse = (
   }
   if (output.phoneNumbers === "") {
     contents.phoneNumbers = [];
-    return contents;
   }
   if (
     output["phoneNumbers"] !== undefined &&
@@ -5224,7 +5216,6 @@ const deserializeAws_queryListPlatformApplicationsResponse = (
   }
   if (output.PlatformApplications === "") {
     contents.PlatformApplications = [];
-    return contents;
   }
   if (
     output["PlatformApplications"] !== undefined &&
@@ -5256,7 +5247,6 @@ const deserializeAws_queryListSubscriptionsByTopicResponse = (
   }
   if (output.Subscriptions === "") {
     contents.Subscriptions = [];
-    return contents;
   }
   if (
     output["Subscriptions"] !== undefined &&
@@ -5288,7 +5278,6 @@ const deserializeAws_queryListSubscriptionsResponse = (
   }
   if (output.Subscriptions === "") {
     contents.Subscriptions = [];
-    return contents;
   }
   if (
     output["Subscriptions"] !== undefined &&
@@ -5316,7 +5305,6 @@ const deserializeAws_queryListTagsForResourceResponse = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-    return contents;
   }
   if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     const wrappedItem =
@@ -5342,7 +5330,6 @@ const deserializeAws_queryListTopicsResponse = (
   }
   if (output.Topics === "") {
     contents.Topics = [];
-    return contents;
   }
   if (
     output["Topics"] !== undefined &&
@@ -5410,7 +5397,6 @@ const deserializeAws_queryPlatformApplication = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (
     output["Attributes"] !== undefined &&

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -2795,7 +2795,6 @@ const deserializeAws_queryChangeMessageVisibilityBatchResult = (
   };
   if (output.BatchResultErrorEntry === "") {
     contents.Failed = [];
-    return contents;
   }
   if (output["BatchResultErrorEntry"] !== undefined) {
     const wrappedItem =
@@ -2809,7 +2808,6 @@ const deserializeAws_queryChangeMessageVisibilityBatchResult = (
   }
   if (output.ChangeMessageVisibilityBatchResultEntry === "") {
     contents.Successful = [];
-    return contents;
   }
   if (output["ChangeMessageVisibilityBatchResultEntry"] !== undefined) {
     const wrappedItem =
@@ -2872,7 +2870,6 @@ const deserializeAws_queryDeleteMessageBatchResult = (
   };
   if (output.BatchResultErrorEntry === "") {
     contents.Failed = [];
-    return contents;
   }
   if (output["BatchResultErrorEntry"] !== undefined) {
     const wrappedItem =
@@ -2886,7 +2883,6 @@ const deserializeAws_queryDeleteMessageBatchResult = (
   }
   if (output.DeleteMessageBatchResultEntry === "") {
     contents.Successful = [];
-    return contents;
   }
   if (output["DeleteMessageBatchResultEntry"] !== undefined) {
     const wrappedItem =
@@ -2944,7 +2940,6 @@ const deserializeAws_queryGetQueueAttributesResult = (
   };
   if (output.Attribute === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (output["Attribute"] !== undefined) {
     const wrappedItem =
@@ -3023,7 +3018,6 @@ const deserializeAws_queryListDeadLetterSourceQueuesResult = (
   };
   if (output.QueueUrl === "") {
     contents.queueUrls = [];
-    return contents;
   }
   if (output["QueueUrl"] !== undefined) {
     const wrappedItem =
@@ -3045,7 +3039,6 @@ const deserializeAws_queryListQueueTagsResult = (
   };
   if (output.Tag === "") {
     contents.Tags = {};
-    return contents;
   }
   if (output["Tag"] !== undefined) {
     const wrappedItem =
@@ -3065,7 +3058,6 @@ const deserializeAws_queryListQueuesResult = (
   };
   if (output.QueueUrl === "") {
     contents.QueueUrls = [];
-    return contents;
   }
   if (output["QueueUrl"] !== undefined) {
     const wrappedItem =
@@ -3093,7 +3085,6 @@ const deserializeAws_queryMessage = (
   };
   if (output.Attribute === "") {
     contents.Attributes = {};
-    return contents;
   }
   if (output["Attribute"] !== undefined) {
     const wrappedItem =
@@ -3116,7 +3107,6 @@ const deserializeAws_queryMessage = (
   }
   if (output.MessageAttribute === "") {
     contents.MessageAttributes = {};
-    return contents;
   }
   if (output["MessageAttribute"] !== undefined) {
     const wrappedItem =
@@ -3151,7 +3141,6 @@ const deserializeAws_queryMessageAttributeValue = (
   };
   if (output.BinaryListValue === "") {
     contents.BinaryListValues = [];
-    return contents;
   }
   if (output["BinaryListValue"] !== undefined) {
     const wrappedItem =
@@ -3171,7 +3160,6 @@ const deserializeAws_queryMessageAttributeValue = (
   }
   if (output.StringListValue === "") {
     contents.StringListValues = [];
-    return contents;
   }
   if (output["StringListValue"] !== undefined) {
     const wrappedItem =
@@ -3321,7 +3309,6 @@ const deserializeAws_queryReceiveMessageResult = (
   };
   if (output.Message === "") {
     contents.Messages = [];
-    return contents;
   }
   if (output["Message"] !== undefined) {
     const wrappedItem =
@@ -3344,7 +3331,6 @@ const deserializeAws_querySendMessageBatchResult = (
   };
   if (output.BatchResultErrorEntry === "") {
     contents.Failed = [];
-    return contents;
   }
   if (output["BatchResultErrorEntry"] !== undefined) {
     const wrappedItem =
@@ -3358,7 +3344,6 @@ const deserializeAws_querySendMessageBatchResult = (
   }
   if (output.SendMessageBatchResultEntry === "") {
     contents.Successful = [];
-    return contents;
   }
   if (output["SendMessageBatchResultEntry"] !== undefined) {
     const wrappedItem =


### PR DESCRIPTION
Codegen for #951, #953 and https://github.com/awslabs/smithy-typescript/pull/137

* Only flatten lists, sets, and maps for aws.ec2
* Fix early return on empty xml tag, fixes #947
* Only apply error location adjustment for errors, fixes #949

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
