### PR TITLE
fix: return readable stream with async iterators properly

### DIFF
--- a/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
@@ -6,7 +6,7 @@ import {
   EventStreamMarshaller as IEventStreamMarshaller
 } from "@aws-sdk/types";
 import { Readable, pipeline } from "stream";
-import { ReadabletoIterable } from "./utils";
+import { readabletoIterable } from "./utils";
 import { EventMessageChunkerStream } from "./EventMessageChunkerStream";
 import { MessageUnmarshallerStream } from "./MessageUnmarshallerStream";
 import { EventDeserializerStream } from "./EventDeserializerStream";
@@ -44,7 +44,11 @@ export class EventStreamMarshaller {
     );
     //should use stream[Symbol.asyncIterable] when the api is stable
     //reference: https://nodejs.org/docs/latest-v11.x/api/stream.html#stream_readable_symbol_asynciterator
-    return ReadabletoIterable(eventDeserializerStream);
+    if (typeof eventDeserializerStream[Symbol.asyncIterator] === "function") {
+      // use the experimental feature if available.
+      return eventDeserializerStream;
+    }
+    return readabletoIterable(eventDeserializerStream);
   }
 
   serialize<T>(

--- a/packages/eventstream-serde-node/src/utils.ts
+++ b/packages/eventstream-serde-node/src/utils.ts
@@ -18,13 +18,9 @@ export function getSignatureBinary(signature: string): Uint8Array {
  * Reference: https://nodejs.org/docs/latest-v11.x/api/stream.html#stream_readable_symbol_asynciterator
  */
 
-export async function* ReadabletoIterable<T>(
+export async function* readabletoIterable<T>(
   readStream: Readable
 ): AsyncIterable<T> {
-  if (typeof readStream[Symbol.asyncIterator] === "function") {
-    // use the experimental feature if available.
-    throw readStream;
-  }
   let streamEnded = false;
   let generationEnded = false;
   const records = new Array<T>();


### PR DESCRIPTION
In eventstream for NodeJS, users running the application on newer NodeJS version where the stream API supplies async iterator, they should get the original Readable stream. We shouldn't convert Readable stream to async iterator on the behalf of users. 

The previous implementation has a bug that returned async iterator is empty. Possibly because it returns from an async function. There was also a typo `throw` should be `return`. 

This PR fix the problem. Confirmed event stream works on Node >= 10


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
