### PR TITLE
fix: treehash of whole MB body

### DIFF
--- a/packages/sha256-tree-hash/src/index.spec.ts
+++ b/packages/sha256-tree-hash/src/index.spec.ts
@@ -35,6 +35,19 @@ describe("ChecksumGenerator", () => {
     );
   });
 
+  it("computes tree hashes of bodies = 1 MB", async () => {
+    const treeHash = new TreeHash(Sha256, fromUtf8);
+    const payload = new Uint8Array(1024 * 1024);
+    payload.fill(0);
+
+    treeHash.update(payload);
+    let results = await treeHash.digest();
+
+    expect(toHex(results)).toEqual(
+      "30e14955ebf1352266dc2ff8067e68104607e750abb9d3b36582b8af909fcb58"
+    );
+  });
+
   it("computes tree hashes of chunked bodies", async () => {
     const treeHash = new TreeHash(Sha256, fromUtf8);
     const payload = new Uint8Array(1024 * 1024 * 5.5);

--- a/packages/sha256-tree-hash/src/index.ts
+++ b/packages/sha256-tree-hash/src/index.ts
@@ -71,7 +71,7 @@ export class TreeHash implements Hash {
     this.collectedHashDigests = [];
 
     // loop through collected hashes
-    if (this.buffer) {
+    if (this.buffer && this.buffer.byteLength > 0) {
       const smallHash = new this.Sha256();
       smallHash.update(this.buffer);
       collectedHashDigests.push(smallHash.digest());


### PR DESCRIPTION
Fixes incorrectly calculated tree hashes of bodies equaling 1MB or multiples of 1MB.

Adds test for body = 1MB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
