### PR TITLE
fix: xml map deser

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -79,13 +79,17 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
     protected void deserializeMap(GenerationContext context, MapShape shape) {
         TypeScriptWriter writer = context.getWriter();
         Shape target = context.getModel().expectShape(shape.getValue().getTarget());
+        String keyLocation = shape.getKey().getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse("key");
+        String valueLocation = shape.getValue().getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue)
+                .orElse("value");
 
         // Get the right serialization for each entry in the map. Undefined
         // outputs won't have this deserializer invoked.
         writer.write("const mapParams: any = {};");
-        writer.openBlock("Object.keys(output).forEach(key => {", "});", () -> {
+        writer.openBlock("output.forEach((pair: any) => {", "});", () -> {
             // Dispatch to the output value provider for any additional handling.
-            writer.write("mapParams[key] = $L;", target.accept(getMemberVisitor("output[key]")));
+            writer.write("mapParams[pair[$S]] = $L;", keyLocation, target.accept(
+                    getMemberVisitor("pair[\"" + valueLocation + "\"]")));
         });
         writer.write("return mapParams;");
     }


### PR DESCRIPTION
Fixes XML map deserialzation by using correct key and value locations in wrapped map.

Currently, maps are returned incorrectly with array keys (0, 1, 2, etc) as the key instead of the actual key.

Current codegen:
```
const mapParams: any = {};
Object.keys(output).forEach(key => {
  mapParams[key] = deserializeAws_queryMessageAttributeValue(
    output[key],
    context
  );
});
return mapParams;
```

Fixed codegen:
```
const mapParams: any = {};
output.forEach((pair: any) => {
  mapParams[pair["Name"]] = deserializeAws_queryMessageAttributeValue(pair["Value"], context);
});
return mapParams;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
