### PR TITLE
fix(browser): unsigned payload header

### DIFF
--- a/clients/browser/client-lex-runtime-service-browser/commands/PostContentCommand.ts
+++ b/clients/browser/client-lex-runtime-service-browser/commands/PostContentCommand.ts
@@ -47,7 +47,7 @@ export class PostContentCommand
     };
     stack.add(
       __aws_sdk_middleware_header_default.headerDefault({
-        "X-Amz-Content-Sha256": "UNSIGNED_PAYLOAD"
+        "X-Amz-Content-Sha256": "UNSIGNED-PAYLOAD"
       }),
       {
         step: "build",

--- a/clients/browser/client-mediastore-data-browser/commands/PutObjectCommand.ts
+++ b/clients/browser/client-mediastore-data-browser/commands/PutObjectCommand.ts
@@ -47,7 +47,7 @@ export class PutObjectCommand
     };
     stack.add(
       __aws_sdk_middleware_header_default.headerDefault({
-        "X-Amz-Content-Sha256": "UNSIGNED_PAYLOAD"
+        "X-Amz-Content-Sha256": "UNSIGNED-PAYLOAD"
       }),
       {
         step: "build",

--- a/clients/node/client-lex-runtime-service-node/commands/PostContentCommand.ts
+++ b/clients/node/client-lex-runtime-service-node/commands/PostContentCommand.ts
@@ -48,7 +48,7 @@ export class PostContentCommand
     };
     stack.add(
       __aws_sdk_middleware_header_default.headerDefault({
-        "X-Amz-Content-Sha256": "UNSIGNED_PAYLOAD"
+        "X-Amz-Content-Sha256": "UNSIGNED-PAYLOAD"
       }),
       {
         step: "build",

--- a/clients/node/client-mediastore-data-node/commands/PutObjectCommand.ts
+++ b/clients/node/client-mediastore-data-node/commands/PutObjectCommand.ts
@@ -48,7 +48,7 @@ export class PutObjectCommand
     };
     stack.add(
       __aws_sdk_middleware_header_default.headerDefault({
-        "X-Amz-Content-Sha256": "UNSIGNED_PAYLOAD"
+        "X-Amz-Content-Sha256": "UNSIGNED-PAYLOAD"
       }),
       {
         step: "build",

--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/signatureCustomizations.ts
@@ -185,7 +185,7 @@ function clientCustomizationsForAuthType(
       tags: "{UNSIGNED_PAYLOAD: true}",
       expression: `${packageNameToVariable(
         "@aws-sdk/middleware-header-default"
-      )}.headerDefault({'X-Amz-Content-Sha256': 'UNSIGNED_PAYLOAD'})`
+      )}.headerDefault({'X-Amz-Content-Sha256': 'UNSIGNED-PAYLOAD'})`
     });
   }
 
@@ -235,7 +235,7 @@ function commandCustomizationsForAuthType(
       tags: "{UNSIGNED_PAYLOAD: true}",
       expression: `${packageNameToVariable(
         "@aws-sdk/middleware-header-default"
-      )}.headerDefault({'X-Amz-Content-Sha256': 'UNSIGNED_PAYLOAD'})`
+      )}.headerDefault({'X-Amz-Content-Sha256': 'UNSIGNED-PAYLOAD'})`
     });
   }
 


### PR DESCRIPTION
*Description of changes:*
Using the current `@aws-sdk/client-lex-runtime-service-browser` library, when I attempt to send a `PostContentCommand`, I get an HTTP 400 response from the Lex runtime API with the following response body:

```
{"message":"Invalid Request: The header x-amz-content-sha256 must be set to the literal string UNSIGNED-PAYLOAD."}
```

Upon inspecting the SDK code, I found that the Lex client was setting this header to `UNSIGNED_PAYLOAD` rather than `UNSIGNED-PAYLOAD`. Simply changing the underscore to a dash fixed this for me. I searched the repo for other instances of the underscore and fixed those up as well. I have only manually tested the `PostContentCommand` though.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.