### PR TITLE
fix: set serialization via loops

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -56,10 +56,11 @@ final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
         TypeScriptWriter writer = context.getWriter();
         Shape target = context.getModel().expectShape(shape.getMember().getTarget());
 
-        // Dispatch to the input value provider for any additional handling.
-        writer.openBlock("return (input || []).map(entry =>", ");", () -> {
-            writer.write(target.accept(getMemberVisitor("entry")));
-        });
+        writer.write("const contents = [];");
+        writer.openBlock("for (let entry of input) {", "}", () ->
+                // Dispatch to the input value provider for any additional handling.
+                writer.write("contents.push($L);", target.accept(getMemberVisitor("entry"))));
+        writer.write("return contents;");
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -64,8 +64,8 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
         writer.write("const entries: any = {};");
         // Set up a counter to increment the member entries.
         writer.write("let counter = 1;");
-        // Dispatch to the input value provider for any additional handling.
-        writer.openBlock("(input || []).map(entry => {", "});", () -> {
+        writer.openBlock("for (let entry of input) {", "}", () -> {
+            // Dispatch to the input value provider for any additional handling.
             serializeUnnamedMemberEntryList(context, target, "entry", locationName);
             writer.write("counter++;");
         });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
@@ -70,8 +70,8 @@ final class XmlShapeSerVisitor extends DocumentShapeSerVisitor {
 
         // Set up a location to store all of the child node(s).
         writer.write("const collectedNodes: any = [];");
-        // Dispatch to the input value provider for any additional handling.
-        writer.openBlock("(input || []).map(entry => {", "});", () -> {
+        writer.openBlock("for (let entry of input) {", "}", () -> {
+            // Dispatch to the input value provider for any additional handling.
             writer.write("const node = $L;", target.accept(getMemberVisitor("entry")));
             writer.write("collectedNodes.push(node.withName($S));", locationName);
         });


### PR DESCRIPTION
[`Set` doesn't have the ability to `.map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) so using a loop instead.

Old:
```
  return (input || []).map(entry =>
    entry
  );
```

New:
```
  const contents = [];
  for (let entry of input) {
    contents.push(entry);
  }
  return contents;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
