### PR TITLE
fix: use relative path in gradle codegen task

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -42,7 +42,7 @@ tasks.register("generate-smithy-build") {
     doLast {
         val projectionsBuilder = Node.objectNodeBuilder()
         val modelsDirProp: String by project
-        val models = File(modelsDirProp)
+        val models = project.file(modelsDirProp);
 
         fileTree(models).filter { it.isFile }.files.forEach { file ->
             val (sdkId, version, remaining) = file.name.split(".")

--- a/scripts/generate-clients/code-gen-dir.js
+++ b/scripts/generate-clients/code-gen-dir.js
@@ -2,6 +2,8 @@ const { join, normalize } = require("path");
 
 const CODE_GEN_ROOT = normalize(join(__dirname, "..", "..", "codegen"));
 
+const CODE_GEN_TASK_ROOT = join(CODE_GEN_ROOT, "sdk-codegen");
+
 const TEMP_CODE_GEN_INPUT_DIR = normalize(join(__dirname, ".aws-models"));
 
 const CODE_GEN_OUTPUT_DIR = normalize(
@@ -19,6 +21,7 @@ const CODE_GEN_OUTPUT_DIR = normalize(
 
 module.exports = {
   CODE_GEN_ROOT,
+  CODE_GEN_TASK_ROOT,
   CODE_GEN_OUTPUT_DIR,
   TEMP_CODE_GEN_INPUT_DIR
 };

--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -2,7 +2,11 @@ const path = require("path");
 const { copyFileSync, emptyDirSync } = require("fs-extra");
 const { readdirSync, lstatSync } = require("fs");
 const { spawnProcess } = require("./spawn-process");
-const { CODE_GEN_ROOT, TEMP_CODE_GEN_INPUT_DIR } = require("./code-gen-dir");
+const {
+  CODE_GEN_ROOT,
+  CODE_GEN_TASK_ROOT,
+  TEMP_CODE_GEN_INPUT_DIR
+} = require("./code-gen-dir");
 const Glob = require("glob");
 
 async function generateClients(models) {
@@ -47,7 +51,12 @@ async function generateClients(models) {
   }
   const options = [":sdk-codegen:clean", ":sdk-codegen:build"];
   if (designatedModels) {
-    options.push(`-PmodelsDirProp=${TEMP_CODE_GEN_INPUT_DIR}`);
+    options.push(
+      `-PmodelsDirProp=${path.relative(
+        CODE_GEN_TASK_ROOT,
+        TEMP_CODE_GEN_INPUT_DIR
+      )}`
+    );
   }
   await spawnProcess("./gradlew", options, {
     cwd: CODE_GEN_ROOT

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -14,7 +14,7 @@ const CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
 const { models, globs, output: clientsDir } = yargs
   .alias("m", "models")
   .string("m")
-  .describe("m", "The directory of models.")
+  .describe("m", "The path to directory with models.")
   .alias("g", "globs")
   .array("g")
   .describe("g", "A list of smithy model globs")


### PR DESCRIPTION
Fixes a bug in #976. It breaks the script calling Gradle task directly:
```
./gradlew clean build
```
This will result in empty directory because the default model path is `aws-models` but in reality should be `sdk-codegen/aws-models`. This is because Gradle defaults to use relative path from where `gradlew` is called. 

So this change fix the relative path root from  `gradlew` location to project root(`codegen/sdk-codegen`). Moreover, I changed the JS script to process the supplied path to make it relative path from the project root(`codegen/sdk-codegen`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
