### PR TITLE
fix: no LocationConstraint for us-east-1 if not explicitly passed

### DIFF
--- a/packages/middleware-location-constraint/src/index.spec.ts
+++ b/packages/middleware-location-constraint/src/index.spec.ts
@@ -2,61 +2,63 @@ import { locationConstraintMiddleware } from "./";
 
 describe("locationConstrainMiddleware", () => {
   const next = jest.fn();
+  const basicInput = {
+    foo: "bar"
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should remove any CreateBucketConfiguration from requests directed at us-east-1", async () => {
+  describe("for region us-east-1", () => {
     const handler = locationConstraintMiddleware({
       region: () => Promise.resolve("us-east-1")
     })(next, {} as any);
-    const input = {
-      CreateBucketConfiguration: { LocationConstraint: "us-east-1" },
-      foo: "bar"
-    };
-    await handler({ input });
 
-    expect(next.mock.calls.length).toBe(1);
-    expect(next.mock.calls[0][0]).toEqual({
-      input: {
-        ...input,
-        CreateBucketConfiguration: undefined
-      }
+    it("should not update LocationConstraint if it's already set", async () => {
+      const input = {
+        ...basicInput,
+        CreateBucketConfiguration: { LocationConstraint: "us-east-1" }
+      };
+      await handler({ input });
+      expect(next.mock.calls.length).toBe(1);
+      expect(next.mock.calls[0][0]).toEqual({ input });
+    });
+
+    it("should not add LocationConstraint if it's not set", async () => {
+      const input = basicInput;
+      await handler({ input });
+      expect(next.mock.calls.length).toBe(1);
+      expect(next.mock.calls[0][0]).toEqual({ input });
     });
   });
 
-  it("should apply a CreateBucketConfiguration with a LocationConstraint of the target region for requests directed outside of us-east-1", async () => {
+  describe("for region not us-east-1", () => {
+    const region = "us-east-2";
     const handler = locationConstraintMiddleware({
-      region: () => Promise.resolve("us-east-2")
+      region: () => Promise.resolve(region)
     })(next, {} as any);
-    const input = {
-      foo: "bar"
-    };
 
-    await handler({ input });
-
-    expect(next.mock.calls.length).toBe(1);
-    expect(next.mock.calls[0][0]).toEqual({
-      input: {
-        ...input,
-        CreateBucketConfiguration: { LocationConstraint: "us-east-2" }
-      }
+    it("should not update LocationConstraint if it's already set", async () => {
+      const input = {
+        ...basicInput,
+        CreateBucketConfiguration: { LocationConstraint: "us-east-1" }
+      };
+      await handler({ input });
+      expect(next.mock.calls.length).toBe(1);
+      expect(next.mock.calls[0][0]).toEqual({ input });
     });
-  });
 
-  it("should do nothing if a LocationConstraint had already been set on a request directed outside of us-east-1", async () => {
-    const handler = locationConstraintMiddleware({
-      region: () => Promise.resolve("us-east-2")
-    })(next, {} as any);
-    const input = {
-      CreateBucketConfiguration: { LocationConstraint: "us-east-1" },
-      foo: "bar"
-    };
-
-    await handler({ input });
-
-    expect(next.mock.calls.length).toBe(1);
-    expect(next.mock.calls[0][0]).toEqual({ input });
+    it("should add region as LocationConstraint if it's not set", async () => {
+      const input = basicInput;
+      await handler({ input });
+      expect(next.mock.calls.length).toBe(1);
+      expect(next.mock.calls[0][0]).toEqual({
+        input: {
+          ...input,
+          CreateBucketConfiguration: { LocationConstraint: region }
+        }
+      });
+    });
   });
 });

--- a/packages/middleware-location-constraint/src/index.ts
+++ b/packages/middleware-location-constraint/src/index.ts
@@ -26,15 +26,7 @@ export function locationConstraintMiddleware(
     const { CreateBucketConfiguration } = args.input;
     //After region config resolution, region is a Provider<string>
     const region = await options.region();
-    if (region === "us-east-1") {
-      args = {
-        ...args,
-        input: {
-          ...args.input,
-          CreateBucketConfiguration: undefined
-        }
-      };
-    } else if (
+    if (
       !CreateBucketConfiguration ||
       !CreateBucketConfiguration.LocationConstraint
     ) {
@@ -42,7 +34,8 @@ export function locationConstraintMiddleware(
         ...args,
         input: {
           ...args.input,
-          CreateBucketConfiguration: { LocationConstraint: region }
+          CreateBucketConfiguration:
+            region === "us-east-1" ? undefined : { LocationConstraint: region }
         }
       };
     }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/983
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/838

*Description of changes:*
* no LocationConstraint for us-east-1 if not explicitly passed
* verified that this code change fixes both #983 and #838, verified by manually updating node_modules in test code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
