### PR TITLE
fix: read from data["#text"] if documentBindings has one value

### DIFF
--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -7440,6 +7440,9 @@ const deserializeAws_restXmlAccessDeniedResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7457,6 +7460,9 @@ const deserializeAws_restXmlBatchTooLargeResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7474,6 +7480,9 @@ const deserializeAws_restXmlCNAMEAlreadyExistsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7491,6 +7500,9 @@ const deserializeAws_restXmlCannotChangeImmutablePublicKeyFieldsResponse = async
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7508,6 +7520,9 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityAlreadyExistsResponse 
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7525,6 +7540,9 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityInUseResponse = async 
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7542,6 +7560,9 @@ const deserializeAws_restXmlDistributionAlreadyExistsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7559,6 +7580,9 @@ const deserializeAws_restXmlDistributionNotDisabledResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7576,6 +7600,9 @@ const deserializeAws_restXmlFieldLevelEncryptionConfigAlreadyExistsResponse = as
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7593,6 +7620,9 @@ const deserializeAws_restXmlFieldLevelEncryptionConfigInUseResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7610,6 +7640,9 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileAlreadyExistsResponse = a
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7627,6 +7660,9 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileInUseResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7644,6 +7680,9 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileSizeExceededResponse = as
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7661,6 +7700,9 @@ const deserializeAws_restXmlIllegalFieldLevelEncryptionConfigAssociationWithCach
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7678,6 +7720,9 @@ const deserializeAws_restXmlIllegalUpdateResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7695,6 +7740,9 @@ const deserializeAws_restXmlInconsistentQuantitiesResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7712,6 +7760,9 @@ const deserializeAws_restXmlInvalidArgumentResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7729,6 +7780,9 @@ const deserializeAws_restXmlInvalidDefaultRootObjectResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7746,6 +7800,9 @@ const deserializeAws_restXmlInvalidErrorCodeResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7763,6 +7820,9 @@ const deserializeAws_restXmlInvalidForwardCookiesResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7780,6 +7840,9 @@ const deserializeAws_restXmlInvalidGeoRestrictionParameterResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7797,6 +7860,9 @@ const deserializeAws_restXmlInvalidHeadersForS3OriginResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7814,6 +7880,9 @@ const deserializeAws_restXmlInvalidIfMatchVersionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7831,6 +7900,9 @@ const deserializeAws_restXmlInvalidLambdaFunctionAssociationResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7848,6 +7920,9 @@ const deserializeAws_restXmlInvalidLocationCodeResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7865,6 +7940,9 @@ const deserializeAws_restXmlInvalidMinimumProtocolVersionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7882,6 +7960,9 @@ const deserializeAws_restXmlInvalidOriginResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7899,6 +7980,9 @@ const deserializeAws_restXmlInvalidOriginAccessIdentityResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7916,6 +8000,9 @@ const deserializeAws_restXmlInvalidOriginKeepaliveTimeoutResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7933,6 +8020,9 @@ const deserializeAws_restXmlInvalidOriginReadTimeoutResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7950,6 +8040,9 @@ const deserializeAws_restXmlInvalidProtocolSettingsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7967,6 +8060,9 @@ const deserializeAws_restXmlInvalidQueryStringParametersResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -7984,6 +8080,9 @@ const deserializeAws_restXmlInvalidRelativePathResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8001,6 +8100,9 @@ const deserializeAws_restXmlInvalidRequiredProtocolResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8018,6 +8120,9 @@ const deserializeAws_restXmlInvalidResponseCodeResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8035,6 +8140,9 @@ const deserializeAws_restXmlInvalidTTLOrderResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8052,6 +8160,9 @@ const deserializeAws_restXmlInvalidTaggingResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8069,6 +8180,9 @@ const deserializeAws_restXmlInvalidViewerCertificateResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8086,6 +8200,9 @@ const deserializeAws_restXmlInvalidWebACLIdResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8103,6 +8220,9 @@ const deserializeAws_restXmlMissingBodyResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8120,6 +8240,9 @@ const deserializeAws_restXmlNoSuchCloudFrontOriginAccessIdentityResponse = async
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8137,6 +8260,9 @@ const deserializeAws_restXmlNoSuchDistributionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8154,6 +8280,9 @@ const deserializeAws_restXmlNoSuchFieldLevelEncryptionConfigResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8171,6 +8300,9 @@ const deserializeAws_restXmlNoSuchFieldLevelEncryptionProfileResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8188,6 +8320,9 @@ const deserializeAws_restXmlNoSuchInvalidationResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8205,6 +8340,9 @@ const deserializeAws_restXmlNoSuchOriginResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8222,6 +8360,9 @@ const deserializeAws_restXmlNoSuchPublicKeyResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8239,6 +8380,9 @@ const deserializeAws_restXmlNoSuchResourceResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8256,6 +8400,9 @@ const deserializeAws_restXmlNoSuchStreamingDistributionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8273,6 +8420,9 @@ const deserializeAws_restXmlPreconditionFailedResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8290,6 +8440,9 @@ const deserializeAws_restXmlPublicKeyAlreadyExistsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8307,6 +8460,9 @@ const deserializeAws_restXmlPublicKeyInUseResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8324,6 +8480,9 @@ const deserializeAws_restXmlQueryArgProfileEmptyResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8341,6 +8500,9 @@ const deserializeAws_restXmlStreamingDistributionAlreadyExistsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8358,6 +8520,9 @@ const deserializeAws_restXmlStreamingDistributionNotDisabledResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8375,6 +8540,9 @@ const deserializeAws_restXmlTooManyCacheBehaviorsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8392,6 +8560,9 @@ const deserializeAws_restXmlTooManyCertificatesResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8409,6 +8580,9 @@ const deserializeAws_restXmlTooManyCloudFrontOriginAccessIdentitiesResponse = as
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8426,6 +8600,9 @@ const deserializeAws_restXmlTooManyCookieNamesInWhiteListResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8443,6 +8620,9 @@ const deserializeAws_restXmlTooManyDistributionCNAMEsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8460,6 +8640,9 @@ const deserializeAws_restXmlTooManyDistributionsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8477,6 +8660,9 @@ const deserializeAws_restXmlTooManyDistributionsAssociatedToFieldLevelEncryption
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8494,6 +8680,9 @@ const deserializeAws_restXmlTooManyDistributionsWithLambdaAssociationsResponse =
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8511,6 +8700,9 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionConfigsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8528,6 +8720,9 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionContentTypeProfilesRespon
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8545,6 +8740,9 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionEncryptionEntitiesRespons
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8562,6 +8760,9 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionFieldPatternsResponse = a
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8579,6 +8780,9 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionProfilesResponse = async 
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8596,6 +8800,9 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionQueryArgProfilesResponse 
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8613,6 +8820,9 @@ const deserializeAws_restXmlTooManyHeadersInForwardedValuesResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8630,6 +8840,9 @@ const deserializeAws_restXmlTooManyInvalidationsInProgressResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8647,6 +8860,9 @@ const deserializeAws_restXmlTooManyLambdaFunctionAssociationsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8664,6 +8880,9 @@ const deserializeAws_restXmlTooManyOriginCustomHeadersResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8681,6 +8900,9 @@ const deserializeAws_restXmlTooManyOriginGroupsPerDistributionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8698,6 +8920,9 @@ const deserializeAws_restXmlTooManyOriginsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8715,6 +8940,9 @@ const deserializeAws_restXmlTooManyPublicKeysResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8732,6 +8960,9 @@ const deserializeAws_restXmlTooManyQueryStringParametersResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8749,6 +8980,9 @@ const deserializeAws_restXmlTooManyStreamingDistributionCNAMEsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8766,6 +9000,9 @@ const deserializeAws_restXmlTooManyStreamingDistributionsResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8783,6 +9020,9 @@ const deserializeAws_restXmlTooManyTrustedSignersResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -8800,6 +9040,9 @@ const deserializeAws_restXmlTrustedSignerDoesNotExistResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -2441,6 +2441,9 @@ export async function deserializeAws_restXmlAssociateVPCWithHostedZoneCommand(
     ChangeInfo: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.ChangeInfo = data["#text"];
+  }
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -2566,6 +2569,9 @@ export async function deserializeAws_restXmlChangeResourceRecordSetsCommand(
     ChangeInfo: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.ChangeInfo = data["#text"];
+  }
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -2770,6 +2776,9 @@ export async function deserializeAws_restXmlCreateHealthCheckCommand(
     contents.Location = output.headers["location"];
   }
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HealthCheck = data["#text"];
+  }
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(
       data["HealthCheck"],
@@ -3023,6 +3032,9 @@ export async function deserializeAws_restXmlCreateQueryLoggingConfigCommand(
     contents.Location = output.headers["location"];
   }
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.QueryLoggingConfig = data["#text"];
+  }
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(
       data["QueryLoggingConfig"],
@@ -3142,6 +3154,9 @@ export async function deserializeAws_restXmlCreateReusableDelegationSetCommand(
     contents.Location = output.headers["location"];
   }
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.DelegationSet = data["#text"];
+  }
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(
       data["DelegationSet"],
@@ -3271,6 +3286,9 @@ export async function deserializeAws_restXmlCreateTrafficPolicyCommand(
     contents.Location = output.headers["location"];
   }
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicy = data["#text"];
+  }
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -3370,6 +3388,9 @@ export async function deserializeAws_restXmlCreateTrafficPolicyInstanceCommand(
     contents.Location = output.headers["location"];
   }
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicyInstance = data["#text"];
+  }
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -3479,6 +3500,9 @@ export async function deserializeAws_restXmlCreateTrafficPolicyVersionCommand(
     contents.Location = output.headers["location"];
   }
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicy = data["#text"];
+  }
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -3762,6 +3786,9 @@ export async function deserializeAws_restXmlDeleteHostedZoneCommand(
     ChangeInfo: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.ChangeInfo = data["#text"];
+  }
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -4297,6 +4324,9 @@ export async function deserializeAws_restXmlDisassociateVPCFromHostedZoneCommand
     ChangeInfo: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.ChangeInfo = data["#text"];
+  }
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -4462,6 +4492,9 @@ export async function deserializeAws_restXmlGetChangeCommand(
     ChangeInfo: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.ChangeInfo = data["#text"];
+  }
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(
       data["ChangeInfo"],
@@ -4537,6 +4570,9 @@ export async function deserializeAws_restXmlGetCheckerIpRangesCommand(
     CheckerIpRanges: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.CheckerIpRanges = data["#text"];
+  }
   if (data.CheckerIpRanges === "") {
     contents.CheckerIpRanges = [];
   }
@@ -4599,6 +4635,9 @@ export async function deserializeAws_restXmlGetGeoLocationCommand(
     GeoLocationDetails: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.GeoLocationDetails = data["#text"];
+  }
   if (data["GeoLocationDetails"] !== undefined) {
     contents.GeoLocationDetails = deserializeAws_restXmlGeoLocationDetails(
       data["GeoLocationDetails"],
@@ -4671,6 +4710,9 @@ export async function deserializeAws_restXmlGetHealthCheckCommand(
     HealthCheck: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HealthCheck = data["#text"];
+  }
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(
       data["HealthCheck"],
@@ -4756,6 +4798,9 @@ export async function deserializeAws_restXmlGetHealthCheckCountCommand(
     HealthCheckCount: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HealthCheckCount = data["#text"];
+  }
   if (data["HealthCheckCount"] !== undefined) {
     contents.HealthCheckCount = parseInt(data["HealthCheckCount"]);
   }
@@ -4808,6 +4853,9 @@ export async function deserializeAws_restXmlGetHealthCheckLastFailureReasonComma
     HealthCheckObservations: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HealthCheckObservations = data["#text"];
+  }
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   }
@@ -4893,6 +4941,9 @@ export async function deserializeAws_restXmlGetHealthCheckStatusCommand(
     HealthCheckObservations: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HealthCheckObservations = data["#text"];
+  }
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   }
@@ -5068,6 +5119,9 @@ export async function deserializeAws_restXmlGetHostedZoneCountCommand(
     HostedZoneCount: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HostedZoneCount = data["#text"];
+  }
   if (data["HostedZoneCount"] !== undefined) {
     contents.HostedZoneCount = parseInt(data["HostedZoneCount"]);
   }
@@ -5219,6 +5273,9 @@ export async function deserializeAws_restXmlGetQueryLoggingConfigCommand(
     QueryLoggingConfig: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.QueryLoggingConfig = data["#text"];
+  }
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(
       data["QueryLoggingConfig"],
@@ -5294,6 +5351,9 @@ export async function deserializeAws_restXmlGetReusableDelegationSetCommand(
     DelegationSet: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.DelegationSet = data["#text"];
+  }
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(
       data["DelegationSet"],
@@ -5455,6 +5515,9 @@ export async function deserializeAws_restXmlGetTrafficPolicyCommand(
     TrafficPolicy: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicy = data["#text"];
+  }
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -5530,6 +5593,9 @@ export async function deserializeAws_restXmlGetTrafficPolicyInstanceCommand(
     TrafficPolicyInstance: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicyInstance = data["#text"];
+  }
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -5605,6 +5671,9 @@ export async function deserializeAws_restXmlGetTrafficPolicyInstanceCountCommand
     TrafficPolicyInstanceCount: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicyInstanceCount = data["#text"];
+  }
   if (data["TrafficPolicyInstanceCount"] !== undefined) {
     contents.TrafficPolicyInstanceCount = parseInt(
       data["TrafficPolicyInstanceCount"]
@@ -6361,6 +6430,9 @@ export async function deserializeAws_restXmlListTagsForResourceCommand(
     ResourceTagSet: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.ResourceTagSet = data["#text"];
+  }
   if (data["ResourceTagSet"] !== undefined) {
     contents.ResourceTagSet = deserializeAws_restXmlResourceTagSet(
       data["ResourceTagSet"],
@@ -6466,6 +6538,9 @@ export async function deserializeAws_restXmlListTagsForResourcesCommand(
     ResourceTagSets: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.ResourceTagSets = data["#text"];
+  }
   if (data.ResourceTagSets === "") {
     contents.ResourceTagSets = [];
   }
@@ -7298,6 +7373,9 @@ export async function deserializeAws_restXmlUpdateHealthCheckCommand(
     HealthCheck: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HealthCheck = data["#text"];
+  }
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(
       data["HealthCheck"],
@@ -7383,6 +7461,9 @@ export async function deserializeAws_restXmlUpdateHostedZoneCommentCommand(
     HostedZone: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.HostedZone = data["#text"];
+  }
   if (data["HostedZone"] !== undefined) {
     contents.HostedZone = deserializeAws_restXmlHostedZone(
       data["HostedZone"],
@@ -7458,6 +7539,9 @@ export async function deserializeAws_restXmlUpdateTrafficPolicyCommentCommand(
     TrafficPolicy: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicy = data["#text"];
+  }
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(
       data["TrafficPolicy"],
@@ -7543,6 +7627,9 @@ export async function deserializeAws_restXmlUpdateTrafficPolicyInstanceCommand(
     TrafficPolicyInstance: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TrafficPolicyInstance = data["#text"];
+  }
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -7643,6 +7730,9 @@ const deserializeAws_restXmlConcurrentModificationResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7660,6 +7750,9 @@ const deserializeAws_restXmlConflictingDomainExistsResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7677,6 +7770,9 @@ const deserializeAws_restXmlConflictingTypesResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7694,6 +7790,9 @@ const deserializeAws_restXmlDelegationSetAlreadyCreatedResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7711,6 +7810,9 @@ const deserializeAws_restXmlDelegationSetAlreadyReusableResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7728,6 +7830,9 @@ const deserializeAws_restXmlDelegationSetInUseResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7745,6 +7850,9 @@ const deserializeAws_restXmlDelegationSetNotAvailableResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7762,6 +7870,9 @@ const deserializeAws_restXmlDelegationSetNotReusableResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7779,6 +7890,9 @@ const deserializeAws_restXmlHealthCheckAlreadyExistsResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7796,6 +7910,9 @@ const deserializeAws_restXmlHealthCheckInUseResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7813,6 +7930,9 @@ const deserializeAws_restXmlHealthCheckVersionMismatchResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7830,6 +7950,9 @@ const deserializeAws_restXmlHostedZoneAlreadyExistsResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7847,6 +7970,9 @@ const deserializeAws_restXmlHostedZoneNotEmptyResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7864,6 +7990,9 @@ const deserializeAws_restXmlHostedZoneNotFoundResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7881,6 +8010,9 @@ const deserializeAws_restXmlHostedZoneNotPrivateResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7898,6 +8030,9 @@ const deserializeAws_restXmlIncompatibleVersionResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7915,6 +8050,9 @@ const deserializeAws_restXmlInsufficientCloudWatchLogsResourcePolicyResponse = a
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7932,6 +8070,9 @@ const deserializeAws_restXmlInvalidArgumentResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -7983,6 +8124,9 @@ const deserializeAws_restXmlInvalidDomainNameResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8000,6 +8144,9 @@ const deserializeAws_restXmlInvalidInputResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8017,6 +8164,9 @@ const deserializeAws_restXmlInvalidPaginationTokenResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8034,6 +8184,9 @@ const deserializeAws_restXmlInvalidTrafficPolicyDocumentResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8051,6 +8204,9 @@ const deserializeAws_restXmlInvalidVPCIdResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8068,6 +8224,9 @@ const deserializeAws_restXmlLastVPCAssociationResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8085,6 +8244,9 @@ const deserializeAws_restXmlLimitsExceededResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8102,6 +8264,9 @@ const deserializeAws_restXmlNoSuchChangeResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8119,6 +8284,9 @@ const deserializeAws_restXmlNoSuchCloudWatchLogsLogGroupResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8136,6 +8304,9 @@ const deserializeAws_restXmlNoSuchDelegationSetResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8153,6 +8324,9 @@ const deserializeAws_restXmlNoSuchGeoLocationResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8170,6 +8344,9 @@ const deserializeAws_restXmlNoSuchHealthCheckResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8187,6 +8364,9 @@ const deserializeAws_restXmlNoSuchHostedZoneResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8204,6 +8384,9 @@ const deserializeAws_restXmlNoSuchQueryLoggingConfigResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8221,6 +8404,9 @@ const deserializeAws_restXmlNoSuchTrafficPolicyResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8238,6 +8424,9 @@ const deserializeAws_restXmlNoSuchTrafficPolicyInstanceResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8255,6 +8444,9 @@ const deserializeAws_restXmlNotAuthorizedExceptionResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8272,6 +8464,9 @@ const deserializeAws_restXmlPriorRequestNotCompleteResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8289,6 +8484,9 @@ const deserializeAws_restXmlPublicZoneVPCAssociationResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8306,6 +8504,9 @@ const deserializeAws_restXmlQueryLoggingConfigAlreadyExistsResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8323,6 +8524,9 @@ const deserializeAws_restXmlThrottlingExceptionResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8340,6 +8544,9 @@ const deserializeAws_restXmlTooManyHealthChecksResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8357,6 +8564,9 @@ const deserializeAws_restXmlTooManyHostedZonesResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8374,6 +8584,9 @@ const deserializeAws_restXmlTooManyTrafficPoliciesResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8391,6 +8604,9 @@ const deserializeAws_restXmlTooManyTrafficPolicyInstancesResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8408,6 +8624,9 @@ const deserializeAws_restXmlTooManyTrafficPolicyVersionsForCurrentPolicyResponse
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8425,6 +8644,9 @@ const deserializeAws_restXmlTooManyVPCAssociationAuthorizationsResponse = async 
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8442,6 +8664,9 @@ const deserializeAws_restXmlTrafficPolicyAlreadyExistsResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8459,6 +8684,9 @@ const deserializeAws_restXmlTrafficPolicyInUseResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8476,6 +8704,9 @@ const deserializeAws_restXmlTrafficPolicyInstanceAlreadyExistsResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8493,6 +8724,9 @@ const deserializeAws_restXmlVPCAssociationAuthorizationNotFoundResponse = async 
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }
@@ -8510,6 +8744,9 @@ const deserializeAws_restXmlVPCAssociationNotFoundResponse = async (
     message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.message = data["#text"];
+  }
   if (data["message"] !== undefined) {
     contents.message = data["message"];
   }

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -754,6 +754,9 @@ export async function deserializeAws_restXmlCreateJobCommand(
     JobId: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.JobId = data["#text"];
+  }
   if (data["JobId"] !== undefined) {
     contents.JobId = data["JobId"];
   }
@@ -981,6 +984,9 @@ export async function deserializeAws_restXmlDescribeJobCommand(
     Job: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.Job = data["#text"];
+  }
   if (data["Job"] !== undefined) {
     contents.Job = deserializeAws_restXmlJobDescriptor(data["Job"], context);
   }
@@ -1148,6 +1154,9 @@ export async function deserializeAws_restXmlGetAccessPointPolicyCommand(
     Policy: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.Policy = data["#text"];
+  }
   if (data["Policy"] !== undefined) {
     contents.Policy = data["Policy"];
   }
@@ -1200,6 +1209,9 @@ export async function deserializeAws_restXmlGetAccessPointPolicyStatusCommand(
     PolicyStatus: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.PolicyStatus = data["#text"];
+  }
   if (data["PolicyStatus"] !== undefined) {
     contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(
       data["PolicyStatus"],
@@ -1766,6 +1778,9 @@ const deserializeAws_restXmlBadRequestExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1783,6 +1798,9 @@ const deserializeAws_restXmlIdempotencyExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1800,6 +1818,9 @@ const deserializeAws_restXmlInternalServiceExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1817,6 +1838,9 @@ const deserializeAws_restXmlInvalidNextTokenExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1834,6 +1858,9 @@ const deserializeAws_restXmlInvalidRequestExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1851,6 +1878,9 @@ const deserializeAws_restXmlJobStatusExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1868,6 +1898,9 @@ const deserializeAws_restXmlNoSuchPublicAccessBlockConfigurationResponse = async
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1885,6 +1918,9 @@ const deserializeAws_restXmlNotFoundExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }
@@ -1902,6 +1938,9 @@ const deserializeAws_restXmlTooManyRequestsExceptionResponse = async (
     Message: undefined
   };
   const data: any = parsedOutput.body.Error;
+  if (data["#text"] !== undefined) {
+    contents.Message = data["#text"];
+  }
   if (data["Message"] !== undefined) {
     contents.Message = data["Message"];
   }

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -5839,6 +5839,9 @@ export async function deserializeAws_restXmlGetBucketAccelerateConfigurationComm
     Status: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.Status = data["#text"];
+  }
   if (data["Status"] !== undefined) {
     contents.Status = data["Status"];
   }
@@ -6001,6 +6004,9 @@ export async function deserializeAws_restXmlGetBucketCorsCommand(
     CORSRules: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.CORSRules = data["#text"];
+  }
   if (data.CORSRule === "") {
     contents.CORSRules = [];
   }
@@ -6161,6 +6167,9 @@ export async function deserializeAws_restXmlGetBucketLifecycleConfigurationComma
     Rules: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.Rules = data["#text"];
+  }
   if (data.Rule === "") {
     contents.Rules = [];
   }
@@ -6214,6 +6223,9 @@ export async function deserializeAws_restXmlGetBucketLocationCommand(
     LocationConstraint: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.LocationConstraint = data["#text"];
+  }
   if (data["LocationConstraint"] !== undefined) {
     contents.LocationConstraint = data["LocationConstraint"];
   }
@@ -6262,6 +6274,9 @@ export async function deserializeAws_restXmlGetBucketLoggingCommand(
     LoggingEnabled: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.LoggingEnabled = data["#text"];
+  }
   if (data["LoggingEnabled"] !== undefined) {
     contents.LoggingEnabled = deserializeAws_restXmlLoggingEnabled(
       data["LoggingEnabled"],
@@ -6454,6 +6469,9 @@ export async function deserializeAws_restXmlGetBucketPolicyCommand(
     Policy: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.Policy = data["#text"];
+  }
   if (data["Policy"] !== undefined) {
     contents.Policy = data["Policy"];
   }
@@ -6606,6 +6624,9 @@ export async function deserializeAws_restXmlGetBucketRequestPaymentCommand(
     Payer: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.Payer = data["#text"];
+  }
   if (data["Payer"] !== undefined) {
     contents.Payer = data["Payer"];
   }
@@ -6654,6 +6675,9 @@ export async function deserializeAws_restXmlGetBucketTaggingCommand(
     TagSet: undefined
   };
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TagSet = data["#text"];
+  }
   if (data.TagSet === "") {
     contents.TagSet = [];
   }
@@ -7273,6 +7297,9 @@ export async function deserializeAws_restXmlGetObjectTaggingCommand(
     contents.VersionId = output.headers["x-amz-version-id"];
   }
   const data: any = await parseBody(output.body, context);
+  if (data["#text"] !== undefined) {
+    contents.TagSet = data["#text"];
+  }
   if (data.TagSet === "") {
     contents.TagSet = [];
   }


### PR DESCRIPTION
*Issue #, if available:*
Option 1 for fixing https://github.com/aws/aws-sdk-js-v3/issues/987

*Description of changes:*
* read from data["#text"] if documentBindings has one value
* Verified the fix by updating `node_modules/@aws-sdk/client-s3/dist/cjs/protocols/Aws_restXml.js` with the reproducible code given in https://github.com/aws/aws-sdk-js-v3/issues/987

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
