### PR TITLE
fix(fast-xml-parser): populate contents from '#text' if available

### DIFF
--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -9544,8 +9544,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -9544,7 +9544,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -10730,7 +10730,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -10730,8 +10730,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -13650,8 +13650,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -13650,7 +13650,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -5856,8 +5856,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -5856,7 +5856,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -6066,7 +6066,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -6066,8 +6066,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -10102,7 +10102,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -10102,8 +10102,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -73139,8 +73139,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -73139,7 +73139,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -8918,8 +8918,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -8918,7 +8918,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -9164,8 +9164,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -9164,7 +9164,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -6334,8 +6334,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -6334,7 +6334,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -12805,7 +12805,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -12805,8 +12805,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -21920,8 +21920,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -21920,7 +21920,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -13923,7 +13923,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -13923,8 +13923,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -29806,8 +29806,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -29806,7 +29806,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -20549,7 +20549,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -20549,8 +20549,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -10089,8 +10089,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -10089,7 +10089,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -3465,7 +3465,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -3465,8 +3465,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -14965,7 +14965,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -14965,8 +14965,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -11913,7 +11913,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -11913,8 +11913,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -6245,8 +6245,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -6245,7 +6245,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -3625,7 +3625,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -3625,8 +3625,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -1712,8 +1712,14 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
+      const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
-      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return parsedObjToReturn;
     }
     return {};
   });

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -1712,7 +1712,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any => {
         parseNodeValue: false,
         tagValueProcessor: (val, tagName) => decodeEscapedXML(val)
       });
-      return parsedObj[Object.keys(parsedObj)[0]];
+      const key = Object.keys(parsedObj)[0];
+      return { [key]: parsedObj[key]["#text"], ...parsedObj[key] };
     }
     return {};
   });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -126,7 +126,8 @@ final class AwsProtocolUtils {
                     writer.write("const parsedObj = xmlParse(encoded, { attributeNamePrefix: '', "
                             + "ignoreAttributes: false, parseNodeValue: false, tagValueProcessor: (val, tagName) "
                             + "=> decodeEscapedXML(val) });");
-                    writer.write("return parsedObj[Object.keys(parsedObj)[0]];");
+                    writer.write("const key = Object.keys(parsedObj)[0];");
+                    writer.write("return { [key]: parsedObj[key][\"#text\"], ...parsedObj[key] };");
                 });
                 writer.write("return {};");
             });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -126,8 +126,14 @@ final class AwsProtocolUtils {
                     writer.write("const parsedObj = xmlParse(encoded, { attributeNamePrefix: '', "
                             + "ignoreAttributes: false, parseNodeValue: false, tagValueProcessor: (val, tagName) "
                             + "=> decodeEscapedXML(val) });");
+                    writer.write("const textNodeName = '#text';");
                     writer.write("const key = Object.keys(parsedObj)[0];");
-                    writer.write("return { [key]: parsedObj[key][\"#text\"], ...parsedObj[key] };");
+                    writer.write("const parsedObjToReturn = parsedObj[key];");
+                    writer.openBlock("if (parsedObjToReturn[textNodeName]) {", "}", () -> {
+                        writer.write("parsedObjToReturn[key] = parsedObjToReturn[textNodeName];");
+                        writer.write("delete parsedObjToReturn[textNodeName];");
+                    });
+                    writer.write("return parsedObjToReturn;");
                 });
                 writer.write("return {};");
             });


### PR DESCRIPTION
*Issue #, if available:*
Option 2 for fixing https://github.com/aws/aws-sdk-js-v3/issues/987

*Description of changes:*
* fix(fast-xml-parser): populate contents from '#text' if available
* Verified the fix by updating `node_modules/@aws-sdk/client-s3/dist/cjs/protocols/Aws_restXml.js` with the reproducible code given in https://github.com/aws/aws-sdk-js-v3/issues/987
* Ran integration tests in https://github.com/trivikr/aws-sdk-js-v3/tree/s3-bucketLocation-parser-fix-integ-test:
  * Verified that the failing test in https://github.com/aws/aws-sdk-js-v3/issues/987 is successful
  * Verified that all other tests succeeding before this code change are also succeeding after this code change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
