### PR TITLE
fix(signature-v4): make x-amz-user-agent signable

### DIFF
--- a/packages/signature-v4/src/constants.ts
+++ b/packages/signature-v4/src/constants.ts
@@ -30,7 +30,6 @@ export const ALWAYS_UNSIGNABLE_HEADERS = {
   "transfer-encoding": true,
   upgrade: true,
   "user-agent": true,
-  "x-amz-user-agent": true,
   "x-amzn-trace-id": true
 };
 

--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -31,6 +31,7 @@ describe("getCanonicalHeaders", () => {
       protocol: "https:",
       path: "/",
       headers: {
+        "x-amz-user-agent": "aws-sdk-js-v3",
         host: "foo.us-east-1.amazonaws.com",
         foo: "bar"
       },
@@ -41,6 +42,7 @@ describe("getCanonicalHeaders", () => {
     }
 
     expect(getCanonicalHeaders(request)).toEqual({
+      "x-amz-user-agent": "aws-sdk-js-v3",
       host: "foo.us-east-1.amazonaws.com",
       foo: "bar"
     });


### PR DESCRIPTION
V2 doesn't mark the header as unsigned either:
https://github.com/aws/aws-sdk-js/blob/999ebda726224a67f0fe207702bf5b03609775a4/lib/signers/v4.js#L191-L199

Fixes #994 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
