### PR TITLE
fix: codegen for using pure JS hasher in RN

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-accessanalyzer/runtimeConfig.rn.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-acm-pca/runtimeConfig.rn.ts
+++ b/clients/client-acm-pca/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-acm/runtimeConfig.rn.ts
+++ b/clients/client-acm/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-alexa-for-business/runtimeConfig.rn.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-amplify/runtimeConfig.rn.ts
+++ b/clients/client-amplify/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-api-gateway/runtimeConfig.rn.ts
+++ b/clients/client-api-gateway/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.rn.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-apigatewayv2/runtimeConfig.rn.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-app-mesh/runtimeConfig.rn.ts
+++ b/clients/client-app-mesh/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-appconfig/runtimeConfig.rn.ts
+++ b/clients/client-appconfig/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-application-auto-scaling/runtimeConfig.rn.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-application-discovery-service/runtimeConfig.rn.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-application-insights/runtimeConfig.rn.ts
+++ b/clients/client-application-insights/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-appstream/runtimeConfig.rn.ts
+++ b/clients/client-appstream/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-appsync/runtimeConfig.rn.ts
+++ b/clients/client-appsync/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-athena/runtimeConfig.rn.ts
+++ b/clients/client-athena/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-auto-scaling-plans/runtimeConfig.rn.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-auto-scaling/runtimeConfig.rn.ts
+++ b/clients/client-auto-scaling/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-backup/runtimeConfig.rn.ts
+++ b/clients/client-backup/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-batch/runtimeConfig.rn.ts
+++ b/clients/client-batch/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-budgets/runtimeConfig.rn.ts
+++ b/clients/client-budgets/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-chime/runtimeConfig.rn.ts
+++ b/clients/client-chime/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloud9/runtimeConfig.rn.ts
+++ b/clients/client-cloud9/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-clouddirectory/runtimeConfig.rn.ts
+++ b/clients/client-clouddirectory/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudformation/runtimeConfig.rn.ts
+++ b/clients/client-cloudformation/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudfront/runtimeConfig.rn.ts
+++ b/clients/client-cloudfront/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudhsm-v2/runtimeConfig.rn.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudhsm/runtimeConfig.rn.ts
+++ b/clients/client-cloudhsm/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudsearch-domain/runtimeConfig.rn.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudsearch/runtimeConfig.rn.ts
+++ b/clients/client-cloudsearch/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudtrail/runtimeConfig.rn.ts
+++ b/clients/client-cloudtrail/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudwatch-events/runtimeConfig.rn.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudwatch-logs/runtimeConfig.rn.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cloudwatch/runtimeConfig.rn.ts
+++ b/clients/client-cloudwatch/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codebuild/runtimeConfig.rn.ts
+++ b/clients/client-codebuild/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codecommit/runtimeConfig.rn.ts
+++ b/clients/client-codecommit/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codedeploy/runtimeConfig.rn.ts
+++ b/clients/client-codedeploy/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codeguru-reviewer/runtimeConfig.rn.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codeguruprofiler/runtimeConfig.rn.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codepipeline/runtimeConfig.rn.ts
+++ b/clients/client-codepipeline/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codestar-connections/runtimeConfig.rn.ts
+++ b/clients/client-codestar-connections/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codestar-notifications/runtimeConfig.rn.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-codestar/runtimeConfig.rn.ts
+++ b/clients/client-codestar/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cognito-identity-provider/runtimeConfig.rn.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cognito-identity/runtimeConfig.rn.ts
+++ b/clients/client-cognito-identity/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cognito-sync/runtimeConfig.rn.ts
+++ b/clients/client-cognito-sync/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-comprehend/runtimeConfig.rn.ts
+++ b/clients/client-comprehend/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-comprehendmedical/runtimeConfig.rn.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-compute-optimizer/runtimeConfig.rn.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-config-service/runtimeConfig.rn.ts
+++ b/clients/client-config-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-connect/runtimeConfig.rn.ts
+++ b/clients/client-connect/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-connectparticipant/runtimeConfig.rn.ts
+++ b/clients/client-connectparticipant/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.rn.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-cost-explorer/runtimeConfig.rn.ts
+++ b/clients/client-cost-explorer/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-data-pipeline/runtimeConfig.rn.ts
+++ b/clients/client-data-pipeline/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-database-migration-service/runtimeConfig.rn.ts
+++ b/clients/client-database-migration-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-dataexchange/runtimeConfig.rn.ts
+++ b/clients/client-dataexchange/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-datasync/runtimeConfig.rn.ts
+++ b/clients/client-datasync/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-dax/runtimeConfig.rn.ts
+++ b/clients/client-dax/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-detective/runtimeConfig.rn.ts
+++ b/clients/client-detective/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-device-farm/runtimeConfig.rn.ts
+++ b/clients/client-device-farm/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-direct-connect/runtimeConfig.rn.ts
+++ b/clients/client-direct-connect/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-directory-service/runtimeConfig.rn.ts
+++ b/clients/client-directory-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-dlm/runtimeConfig.rn.ts
+++ b/clients/client-dlm/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-docdb/runtimeConfig.rn.ts
+++ b/clients/client-docdb/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-dynamodb-streams/runtimeConfig.rn.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-dynamodb/runtimeConfig.rn.ts
+++ b/clients/client-dynamodb/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ebs/runtimeConfig.rn.ts
+++ b/clients/client-ebs/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ec2-instance-connect/runtimeConfig.rn.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ec2/runtimeConfig.rn.ts
+++ b/clients/client-ec2/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ecr/runtimeConfig.rn.ts
+++ b/clients/client-ecr/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ecs/runtimeConfig.rn.ts
+++ b/clients/client-ecs/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-efs/runtimeConfig.rn.ts
+++ b/clients/client-efs/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-eks/runtimeConfig.rn.ts
+++ b/clients/client-eks/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-elastic-beanstalk/runtimeConfig.rn.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-elastic-inference/runtimeConfig.rn.ts
+++ b/clients/client-elastic-inference/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.rn.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-elastic-load-balancing/runtimeConfig.rn.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-elastic-transcoder/runtimeConfig.rn.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-elasticache/runtimeConfig.rn.ts
+++ b/clients/client-elasticache/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-elasticsearch-service/runtimeConfig.rn.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-emr/runtimeConfig.rn.ts
+++ b/clients/client-emr/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-eventbridge/runtimeConfig.rn.ts
+++ b/clients/client-eventbridge/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-firehose/runtimeConfig.rn.ts
+++ b/clients/client-firehose/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-fms/runtimeConfig.rn.ts
+++ b/clients/client-fms/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-forecast/runtimeConfig.rn.ts
+++ b/clients/client-forecast/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-forecastquery/runtimeConfig.rn.ts
+++ b/clients/client-forecastquery/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-frauddetector/runtimeConfig.rn.ts
+++ b/clients/client-frauddetector/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-fsx/runtimeConfig.rn.ts
+++ b/clients/client-fsx/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-gamelift/runtimeConfig.rn.ts
+++ b/clients/client-gamelift/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/body-checksum-browser": "^1.0.0-alpha.4",
     "@aws-sdk/body-checksum-node": "^1.0.0-alpha.4",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",

--- a/clients/client-glacier/runtimeConfig.rn.ts
+++ b/clients/client-glacier/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-global-accelerator/runtimeConfig.rn.ts
+++ b/clients/client-global-accelerator/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-glue/runtimeConfig.rn.ts
+++ b/clients/client-glue/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-greengrass/runtimeConfig.rn.ts
+++ b/clients/client-greengrass/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-groundstation/runtimeConfig.rn.ts
+++ b/clients/client-groundstation/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-guardduty/runtimeConfig.rn.ts
+++ b/clients/client-guardduty/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-health/runtimeConfig.rn.ts
+++ b/clients/client-health/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iam/runtimeConfig.rn.ts
+++ b/clients/client-iam/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-imagebuilder/runtimeConfig.rn.ts
+++ b/clients/client-imagebuilder/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-inspector/runtimeConfig.rn.ts
+++ b/clients/client-inspector/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iot-1click-devices-service/runtimeConfig.rn.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iot-1click-projects/runtimeConfig.rn.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iot-data-plane/runtimeConfig.rn.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iot-events-data/runtimeConfig.rn.ts
+++ b/clients/client-iot-events-data/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iot-events/runtimeConfig.rn.ts
+++ b/clients/client-iot-events/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.rn.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iot/runtimeConfig.rn.ts
+++ b/clients/client-iot/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iotanalytics/runtimeConfig.rn.ts
+++ b/clients/client-iotanalytics/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iotsecuretunneling/runtimeConfig.rn.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-iotthingsgraph/runtimeConfig.rn.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kafka/runtimeConfig.rn.ts
+++ b/clients/client-kafka/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kendra/runtimeConfig.rn.ts
+++ b/clients/client-kendra/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.rn.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kinesis-analytics/runtimeConfig.rn.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.rn.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kinesis-video-media/runtimeConfig.rn.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kinesis-video-signaling/runtimeConfig.rn.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kinesis-video/runtimeConfig.rn.ts
+++ b/clients/client-kinesis-video/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/eventstream-serde-browser": "^1.0.0-alpha.1",

--- a/clients/client-kinesis/runtimeConfig.rn.ts
+++ b/clients/client-kinesis/runtimeConfig.rn.ts
@@ -1,5 +1,6 @@
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -9,6 +10,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-kms/runtimeConfig.rn.ts
+++ b/clients/client-kms/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-lakeformation/runtimeConfig.rn.ts
+++ b/clients/client-lakeformation/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-lambda/runtimeConfig.rn.ts
+++ b/clients/client-lambda/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-lex-model-building-service/runtimeConfig.rn.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-lex-runtime-service/runtimeConfig.rn.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-license-manager/runtimeConfig.rn.ts
+++ b/clients/client-license-manager/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-lightsail/runtimeConfig.rn.ts
+++ b/clients/client-lightsail/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-machine-learning/runtimeConfig.rn.ts
+++ b/clients/client-machine-learning/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-macie/runtimeConfig.rn.ts
+++ b/clients/client-macie/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-managedblockchain/runtimeConfig.rn.ts
+++ b/clients/client-managedblockchain/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-marketplace-catalog/runtimeConfig.rn.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.rn.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.rn.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-marketplace-metering/runtimeConfig.rn.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mediaconnect/runtimeConfig.rn.ts
+++ b/clients/client-mediaconnect/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mediaconvert/runtimeConfig.rn.ts
+++ b/clients/client-mediaconvert/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-medialive/runtimeConfig.rn.ts
+++ b/clients/client-medialive/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mediapackage-vod/runtimeConfig.rn.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mediapackage/runtimeConfig.rn.ts
+++ b/clients/client-mediapackage/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mediastore-data/runtimeConfig.rn.ts
+++ b/clients/client-mediastore-data/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mediastore/runtimeConfig.rn.ts
+++ b/clients/client-mediastore/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mediatailor/runtimeConfig.rn.ts
+++ b/clients/client-mediatailor/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-migration-hub/runtimeConfig.rn.ts
+++ b/clients/client-migration-hub/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-migrationhub-config/runtimeConfig.rn.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mobile/runtimeConfig.rn.ts
+++ b/clients/client-mobile/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mq/runtimeConfig.rn.ts
+++ b/clients/client-mq/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-mturk/runtimeConfig.rn.ts
+++ b/clients/client-mturk/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-neptune/runtimeConfig.rn.ts
+++ b/clients/client-neptune/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-networkmanager/runtimeConfig.rn.ts
+++ b/clients/client-networkmanager/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-opsworks/runtimeConfig.rn.ts
+++ b/clients/client-opsworks/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-opsworkscm/runtimeConfig.rn.ts
+++ b/clients/client-opsworkscm/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-organizations/runtimeConfig.rn.ts
+++ b/clients/client-organizations/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-outposts/runtimeConfig.rn.ts
+++ b/clients/client-outposts/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-personalize-events/runtimeConfig.rn.ts
+++ b/clients/client-personalize-events/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-personalize-runtime/runtimeConfig.rn.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-personalize/runtimeConfig.rn.ts
+++ b/clients/client-personalize/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-pi/runtimeConfig.rn.ts
+++ b/clients/client-pi/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-pinpoint-email/runtimeConfig.rn.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.rn.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-pinpoint/runtimeConfig.rn.ts
+++ b/clients/client-pinpoint/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-polly/runtimeConfig.rn.ts
+++ b/clients/client-polly/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-pricing/runtimeConfig.rn.ts
+++ b/clients/client-pricing/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-qldb-session/runtimeConfig.rn.ts
+++ b/clients/client-qldb-session/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-qldb/runtimeConfig.rn.ts
+++ b/clients/client-qldb/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-quicksight/runtimeConfig.rn.ts
+++ b/clients/client-quicksight/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ram/runtimeConfig.rn.ts
+++ b/clients/client-ram/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-rds-data/runtimeConfig.rn.ts
+++ b/clients/client-rds-data/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-rds/runtimeConfig.rn.ts
+++ b/clients/client-rds/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-redshift/runtimeConfig.rn.ts
+++ b/clients/client-redshift/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-rekognition/runtimeConfig.rn.ts
+++ b/clients/client-rekognition/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.rn.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-resource-groups/runtimeConfig.rn.ts
+++ b/clients/client-resource-groups/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-robomaker/runtimeConfig.rn.ts
+++ b/clients/client-robomaker/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-route-53-domains/runtimeConfig.rn.ts
+++ b/clients/client-route-53-domains/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-route-53/runtimeConfig.rn.ts
+++ b/clients/client-route-53/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-route53resolver/runtimeConfig.rn.ts
+++ b/clients/client-route53resolver/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-s3-control/runtimeConfig.rn.ts
+++ b/clients/client-s3-control/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/eventstream-serde-browser": "^1.0.0-alpha.1",

--- a/clients/client-s3/runtimeConfig.rn.ts
+++ b/clients/client-s3/runtimeConfig.rn.ts
@@ -1,5 +1,6 @@
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -9,6 +10,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.rn.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sagemaker-runtime/runtimeConfig.rn.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sagemaker/runtimeConfig.rn.ts
+++ b/clients/client-sagemaker/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-savingsplans/runtimeConfig.rn.ts
+++ b/clients/client-savingsplans/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-schemas/runtimeConfig.rn.ts
+++ b/clients/client-schemas/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-secrets-manager/runtimeConfig.rn.ts
+++ b/clients/client-secrets-manager/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-securityhub/runtimeConfig.rn.ts
+++ b/clients/client-securityhub/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.rn.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-service-catalog/runtimeConfig.rn.ts
+++ b/clients/client-service-catalog/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-service-quotas/runtimeConfig.rn.ts
+++ b/clients/client-service-quotas/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-servicediscovery/runtimeConfig.rn.ts
+++ b/clients/client-servicediscovery/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ses/runtimeConfig.rn.ts
+++ b/clients/client-ses/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sesv2/runtimeConfig.rn.ts
+++ b/clients/client-sesv2/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sfn/runtimeConfig.rn.ts
+++ b/clients/client-sfn/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-shield/runtimeConfig.rn.ts
+++ b/clients/client-shield/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-signer/runtimeConfig.rn.ts
+++ b/clients/client-signer/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sms/runtimeConfig.rn.ts
+++ b/clients/client-sms/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-snowball/runtimeConfig.rn.ts
+++ b/clients/client-snowball/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sns/runtimeConfig.rn.ts
+++ b/clients/client-sns/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sqs/runtimeConfig.rn.ts
+++ b/clients/client-sqs/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-ssm/runtimeConfig.rn.ts
+++ b/clients/client-ssm/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sso-oidc/runtimeConfig.rn.ts
+++ b/clients/client-sso-oidc/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sso/runtimeConfig.rn.ts
+++ b/clients/client-sso/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-storage-gateway/runtimeConfig.rn.ts
+++ b/clients/client-storage-gateway/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-sts/runtimeConfig.rn.ts
+++ b/clients/client-sts/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-support/runtimeConfig.rn.ts
+++ b/clients/client-support/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-swf/runtimeConfig.rn.ts
+++ b/clients/client-swf/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-textract/runtimeConfig.rn.ts
+++ b/clients/client-textract/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/eventstream-serde-browser": "^1.0.0-alpha.1",

--- a/clients/client-transcribe-streaming/runtimeConfig.rn.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.rn.ts
@@ -1,5 +1,6 @@
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -9,6 +10,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-transcribe/runtimeConfig.rn.ts
+++ b/clients/client-transcribe/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-transfer/runtimeConfig.rn.ts
+++ b/clients/client-transfer/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-translate/runtimeConfig.rn.ts
+++ b/clients/client-translate/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-waf-regional/runtimeConfig.rn.ts
+++ b/clients/client-waf-regional/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-waf/runtimeConfig.rn.ts
+++ b/clients/client-waf/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-wafv2/runtimeConfig.rn.ts
+++ b/clients/client-wafv2/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-workdocs/runtimeConfig.rn.ts
+++ b/clients/client-workdocs/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-worklink/runtimeConfig.rn.ts
+++ b/clients/client-worklink/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-workmail/runtimeConfig.rn.ts
+++ b/clients/client-workmail/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-workmailmessageflow/runtimeConfig.rn.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-workspaces/runtimeConfig.rn.ts
+++ b/clients/client-workspaces/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -29,6 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/config-resolver": "^1.0.0-alpha.13",
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.6",
     "@aws-sdk/fetch-http-handler": "^1.0.0-alpha.8",

--- a/clients/client-xray/runtimeConfig.rn.ts
+++ b/clients/client-xray/runtimeConfig.rn.ts
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,


### PR DESCRIPTION
*Issue #, if available:*
#929
*Description of changes:*
Codegen for https://github.com/awslabs/smithy-typescript/pull/144.
The `@aws-crypto/sha256-browser` package doesn't work properly in ReactNative. So we use replace it will pure JS hasher(`@aws-crypto/sha256-js`) instead. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
