### PR TITLE
fix: add Content-Type and Content-Length to unsignable headers

### DIFF
--- a/packages/signature-v4/src/constants.ts
+++ b/packages/signature-v4/src/constants.ts
@@ -19,6 +19,8 @@ export const ALWAYS_UNSIGNABLE_HEADERS = {
   authorization: true,
   "cache-control": true,
   connection: true,
+  "content-type": true,
+  "content-length": true,
   expect: true,
   from: true,
   "keep-alive": true,

--- a/packages/signature-v4/src/suite.fixture.ts
+++ b/packages/signature-v4/src/suite.fixture.ts
@@ -413,7 +413,7 @@ export const requests: Array<TestCase> = [
       path: "/"
     },
     authorization:
-      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=ff11897932ad3f4e8b18135d722051e5ac45fc38421b1da7b9d196a0fe09473a"
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=ff11897932ad3f4e8b18135d722051e5ac45fc38421b1da7b9d196a0fe09473a"
   },
   {
     name: "post-x-www-form-urlencoded-parameters",
@@ -431,6 +431,6 @@ export const requests: Array<TestCase> = [
       path: "/"
     },
     authorization:
-      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=1a72ec8f64bd914b0e42e42607c7fbce7fb2c7465f63e3092b3b0d39fa77a6fe"
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=1a72ec8f64bd914b0e42e42607c7fbce7fb2c7465f63e3092b3b0d39fa77a6fe"
   }
 ];


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1000

*Description of changes:*
add Content-Type and Content-Length to unsignable headers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
