### PR TITLE
fix: do not sign content-type in s3-request-presigner

### DIFF
--- a/packages/s3-request-presigner/src/index.spec.ts
+++ b/packages/s3-request-presigner/src/index.spec.ts
@@ -77,4 +77,23 @@ describe("s3 presigner", () => {
     });
     expect(minimalRequest).toMatchObject(originalRequest);
   });
+
+  it("should not sign content-type header", async () => {
+    const signer = new S3RequestPresigner(s3ResolvedConfig);
+    const requestWithContentTypeHeader = {
+      ...minimalRequest,
+      headers: {
+        ...minimalRequest.headers,
+        "Content-Type": "application/octet-stream"
+      }
+    };
+    const signed = await signer.presignRequest(
+      requestWithContentTypeHeader,
+      expiration,
+      presigningOptions
+    );
+    expect(signed.query).toMatchObject({
+      [SIGNED_HEADERS_QUERY_PARAM]: HOST_HEADER
+    });
+  });
 });

--- a/packages/s3-request-presigner/src/index.ts
+++ b/packages/s3-request-presigner/src/index.ts
@@ -39,9 +39,13 @@ export class S3RequestPresigner implements RequestPresigner {
   public async presignRequest(
     requestToSign: IHttpRequest,
     expiration: DateInput,
-    options?: RequestSigningArguments
+    { unsignableHeaders = new Set(), ...options }: RequestSigningArguments = {}
   ): Promise<IHttpRequest> {
+    unsignableHeaders.add("content-type");
     requestToSign.headers[SHA256_HEADER] = UNSIGNED_PAYLOAD;
-    return this.signer.presignRequest(requestToSign, expiration, options);
+    return this.signer.presignRequest(requestToSign, expiration, {
+      unsignableHeaders,
+      ...options
+    });
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1000

*Description of changes:*
Do not sign content-type in s3-request-presigner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
