### PR TITLE
fix(smithy-client): string.toString requires this be a String

### DIFF
--- a/packages/smithy-client/src/lazy-json.spec.ts
+++ b/packages/smithy-client/src/lazy-json.spec.ts
@@ -1,0 +1,36 @@
+import { LazyJsonString } from "./lazy-json";
+describe("LazyJsonString", () => {
+  it("should has string methods", () => {
+    const jsonValue = new LazyJsonString('"foo"');
+    expect(jsonValue.length).toBe(5);
+    expect(jsonValue.toString()).toBe('"foo"');
+  });
+
+  it("should deserialize json properly", () => {
+    const jsonValue = new LazyJsonString('"foo"');
+    expect(jsonValue.deserializeJSON()).toBe("foo");
+    const wrongJsonValue = new LazyJsonString("foo");
+    expect(() => wrongJsonValue.deserializeJSON()).toThrow();
+  });
+
+  it("should get JSON string properly", () => {
+    const jsonValue = new LazyJsonString('{"foo", "bar"}');
+    expect(jsonValue.toJSON()).toBe('{"foo", "bar"}');
+  });
+
+  it("can instantiate from LazyJsonString class", () => {
+    const original = new LazyJsonString('"foo"');
+    const newOne = LazyJsonString.fromObject(original);
+    expect(newOne.toString()).toBe('"foo"');
+  });
+
+  it("can instantiate from String class", () => {
+    const jsonValue = LazyJsonString.fromObject(new String('"foo"'));
+    expect(jsonValue.toString()).toBe('"foo"');
+  });
+
+  it("can instantiate from object", () => {
+    const jsonValue = LazyJsonString.fromObject({ foo: "bar" });
+    expect(jsonValue.toString()).toBe('{"foo":"bar"}');
+  });
+});

--- a/packages/smithy-client/src/lazy-json.ts
+++ b/packages/smithy-client/src/lazy-json.ts
@@ -12,9 +12,9 @@ interface StringWrapper {
  * So here we create StringWrapper that duplicate everything from String
  * class including its prototype chain. So we can extend from here.
  */
-// @ts-ignore
+// @ts-ignore StringWrapper implementation is not a simple constructor
 export const StringWrapper: StringWrapper = function() {
-  //@ts-ignore 'this' cannot be assigned to any, but Object.getPrototypeOf accespts any
+  //@ts-ignore 'this' cannot be assigned to any, but Object.getPrototypeOf accepts any
   const Class = Object.getPrototypeOf(this).constructor;
   const Constructor = Function.bind.apply(String, [null as any, ...arguments]);
   //@ts-ignore Call wrapped String constructor directly, don't bother typing it.

--- a/packages/smithy-client/src/lazy-json.ts
+++ b/packages/smithy-client/src/lazy-json.ts
@@ -1,7 +1,38 @@
 /**
  * Lazy String holder for JSON typed contents.
  */
-export class LazyJsonString extends String {
+
+interface StringWrapper {
+  new (arg: any): String;
+}
+
+/**
+ * Because of https://github.com/microsoft/tslib/issues/95,
+ * TS 'extends' shim doesn't support extending native types like String.
+ * So here we create StringWrapper that duplicate everything from String
+ * class including its prototype chain. So we can extend from here.
+ */
+// @ts-ignore
+export const StringWrapper: StringWrapper = function() {
+  //@ts-ignore 'this' cannot be assigned to any, but Object.getPrototypeOf accespts any
+  const Class = Object.getPrototypeOf(this).constructor;
+  const Constructor = Function.bind.apply(String, [null as any, ...arguments]);
+  //@ts-ignore Call wrapped String constructor directly, don't bother typing it.
+  const instance = new Constructor();
+  Object.setPrototypeOf(instance, Class.prototype);
+  return instance as String;
+};
+StringWrapper.prototype = Object.create(String.prototype, {
+  constructor: {
+    value: StringWrapper,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+Object.setPrototypeOf(StringWrapper, String);
+
+export class LazyJsonString extends StringWrapper {
   deserializeJSON(): any {
     return JSON.parse(super.toString());
   }
@@ -13,7 +44,7 @@ export class LazyJsonString extends String {
   static fromObject(object: any): LazyJsonString {
     if (object instanceof LazyJsonString) {
       return object;
-    } else if (object instanceof String || typeof object === 'string') {
+    } else if (object instanceof String || typeof object === "string") {
       return new LazyJsonString(object);
     }
     return new LazyJsonString(JSON.stringify(object));


### PR DESCRIPTION
Because of https://github.com/microsoft/tslib/issues/95,
TS 'extends' shim doesn't support extending native types like String.
So here we create StringWrapper that duplicate everything from String
class including its prototype chain. So we can extend from here.

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1004


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
