### PR TITLE
chore: remove yarn install from buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,8 +4,6 @@ phases:
   install:
     runtime-versions:
       nodejs: 10
-    commands:
-      - npm install -g yarn
   build:
     commands:
       - echo Building...


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
remove yarn install from buildspec, as it's already available on CodeBuild images with nodejs runtime
* Issue: https://github.com/aws/aws-codebuild-docker-images/issues/135
* Code for standard-3.0: https://github.com/aws/aws-codebuild-docker-images/blob/275b63f7d404d8da98f7f0b48c52d0d7521a2114/al2/x86_64/standard/3.0/Dockerfile#L310-L312

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
