### PR TITLE
chore: move expiration under RequestPresigningArguments

### DIFF
--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -62,10 +62,9 @@ export function copySnapshotPresignedUrlMiddleware(
         sha256: options.sha256,
         uriEscapePath: options.signingEscapePath
       });
-      const presignedRequest = await signer.presign(
-        request,
-        expirationTime(3600)
-      );
+      const presignedRequest = await signer.presign(request, {
+        expiration: expirationTime(3600)
+      });
 
       args = {
         ...args,

--- a/packages/middleware-sdk-rds/src/index.ts
+++ b/packages/middleware-sdk-rds/src/index.ts
@@ -97,10 +97,9 @@ export function crossRegionPresignedUrlMiddleware(
         sha256: options.sha256,
         uriEscapePath: options.signingEscapePath
       });
-      const presignedRequest = await signer.presign(
-        request,
-        expirationTime(3600)
-      );
+      const presignedRequest = await signer.presign(request, {
+        expiration: expirationTime(3600)
+      });
       args = {
         ...args,
         input: {

--- a/packages/s3-request-presigner/README.md
+++ b/packages/s3-request-presigner/README.md
@@ -16,9 +16,7 @@ const signer = new S3Presigner({
   credentials: credentialsProvider,
   sha256: nodeSha256 //if the signer is used in browser, use `browserSha256` then
 });
-const Day = 24 * 60 * 60 * 1000;
-const expiration = new Date(Date.now() + 1 * Day);
-const url = signer.presign(request, expiration);
+const url = signer.presign(request);
 ```
 
 Typescript Example:
@@ -32,9 +30,7 @@ const signer = new S3RequestPresigner({
   credentials: credentialsProvider,
   sha256: nodeSha256 //if the signer is used in browser, use `browserSha256` then
 });
-const Day = 24 * 60 * 60 * 1000;
-const expiration = new Date(Date.now() + 1 * Day);
-const url = signer.presign(request, expiration);
+const url = signer.presign(request);
 ```
 
 To avoid redundant construction parameters when instantiate the s3 presigner,

--- a/packages/s3-request-presigner/src/index.spec.ts
+++ b/packages/s3-request-presigner/src/index.spec.ts
@@ -84,4 +84,12 @@ describe("s3 presigner", () => {
       [SIGNED_HEADERS_QUERY_PARAM]: HOST_HEADER
     });
   });
+
+  it("should default expiration to 900 seconds if not explicitly passed", async () => {
+    const signer = new S3RequestPresigner(s3ResolvedConfig);
+    const signed = await signer.presign(minimalRequest);
+    expect(signed.query).toMatchObject({
+      [EXPIRES_QUERY_PARAM]: "900"
+    });
+  });
 });

--- a/packages/s3-request-presigner/src/index.spec.ts
+++ b/packages/s3-request-presigner/src/index.spec.ts
@@ -27,6 +27,7 @@ describe("s3 presigner", () => {
     (new Date("2000-01-01T00:00:00.000Z").valueOf() + 60 * 60 * 1000) / 1000
   );
   const presigningOptions = {
+    expiration,
     signingDate: new Date("2000-01-01T00:00:00.000Z")
   };
   const minimalRequest = new HttpRequest({
@@ -41,32 +42,20 @@ describe("s3 presigner", () => {
 
   it("should not double uri encode the path", async () => {
     const signer = new S3RequestPresigner(s3ResolvedConfig);
-    const signed = await signer.presign(
-      minimalRequest,
-      expiration,
-      presigningOptions
-    );
+    const signed = await signer.presign(minimalRequest, presigningOptions);
     expect(signed.path).toEqual(minimalRequest.path);
   });
 
   it("should set the body digest to 'UNSIGNED_PAYLOAD'", async () => {
     const signer = new S3RequestPresigner(s3ResolvedConfig);
-    const signed = await signer.presign(
-      minimalRequest,
-      expiration,
-      presigningOptions
-    );
+    const signed = await signer.presign(minimalRequest, presigningOptions);
     expect(signed.query).toMatchObject({ [SHA256_HEADER]: UNSIGNED_PAYLOAD });
   });
 
   it("should not change original request", async () => {
     const signer = new S3RequestPresigner(s3ResolvedConfig);
     const originalRequest = { ...minimalRequest };
-    const signed = await signer.presign(
-      minimalRequest,
-      expiration,
-      presigningOptions
-    );
+    const signed = await signer.presign(minimalRequest, presigningOptions);
     expect(signed.query).toMatchObject({
       [SHA256_HEADER]: UNSIGNED_PAYLOAD,
       [ALGORITHM_QUERY_PARAM]: ALGORITHM_IDENTIFIER,
@@ -89,7 +78,6 @@ describe("s3 presigner", () => {
     };
     const signed = await signer.presign(
       requestWithContentTypeHeader,
-      expiration,
       presigningOptions
     );
     expect(signed.query).toMatchObject({

--- a/packages/s3-request-presigner/src/index.ts
+++ b/packages/s3-request-presigner/src/index.ts
@@ -34,16 +34,12 @@ export class S3RequestPresigner implements RequestPresigner {
 
   public async presign(
     requestToSign: IHttpRequest,
-    {
-      expiration = new Date(Date.now() + 900 * 1000),
-      unsignableHeaders = new Set(),
-      ...options
-    }: RequestSigningArguments = {}
+    { unsignableHeaders = new Set(), ...options }: RequestSigningArguments = {}
   ): Promise<IHttpRequest> {
     unsignableHeaders.add("content-type");
     requestToSign.headers[SHA256_HEADER] = UNSIGNED_PAYLOAD;
     return this.signer.presign(requestToSign, {
-      expiration,
+      expiration: new Date(Date.now() + 900 * 1000),
       unsignableHeaders,
       ...options
     });

--- a/packages/s3-request-presigner/src/index.ts
+++ b/packages/s3-request-presigner/src/index.ts
@@ -1,8 +1,4 @@
-import {
-  DateInput,
-  RequestPresigner,
-  RequestSigningArguments
-} from "@aws-sdk/types";
+import { RequestPresigner, RequestSigningArguments } from "@aws-sdk/types";
 import {
   SignatureV4,
   SignatureV4Init,
@@ -38,11 +34,16 @@ export class S3RequestPresigner implements RequestPresigner {
 
   public async presign(
     requestToSign: IHttpRequest,
-    { unsignableHeaders = new Set(), ...options }: RequestSigningArguments = {}
+    {
+      expiration = new Date(Date.now() + 900 * 1000),
+      unsignableHeaders = new Set(),
+      ...options
+    }: RequestSigningArguments = {}
   ): Promise<IHttpRequest> {
     unsignableHeaders.add("content-type");
     requestToSign.headers[SHA256_HEADER] = UNSIGNED_PAYLOAD;
     return this.signer.presign(requestToSign, {
+      expiration,
       unsignableHeaders,
       ...options
     });

--- a/packages/s3-request-presigner/src/index.ts
+++ b/packages/s3-request-presigner/src/index.ts
@@ -38,12 +38,11 @@ export class S3RequestPresigner implements RequestPresigner {
 
   public async presign(
     requestToSign: IHttpRequest,
-    expiration: DateInput,
     { unsignableHeaders = new Set(), ...options }: RequestSigningArguments = {}
   ): Promise<IHttpRequest> {
     unsignableHeaders.add("content-type");
     requestToSign.headers[SHA256_HEADER] = UNSIGNED_PAYLOAD;
-    return this.signer.presign(requestToSign, expiration, {
+    return this.signer.presign(requestToSign, {
       unsignableHeaders,
       ...options
     });

--- a/packages/s3-request-presigner/src/index.ts
+++ b/packages/s3-request-presigner/src/index.ts
@@ -1,4 +1,4 @@
-import { RequestPresigner, RequestSigningArguments } from "@aws-sdk/types";
+import { RequestPresigner, RequestPresigningArguments } from "@aws-sdk/types";
 import {
   SignatureV4,
   SignatureV4Init,
@@ -34,7 +34,10 @@ export class S3RequestPresigner implements RequestPresigner {
 
   public async presign(
     requestToSign: IHttpRequest,
-    { unsignableHeaders = new Set(), ...options }: RequestSigningArguments = {}
+    {
+      unsignableHeaders = new Set(),
+      ...options
+    }: RequestPresigningArguments = {}
   ): Promise<IHttpRequest> {
     unsignableHeaders.add("content-type");
     requestToSign.headers[SHA256_HEADER] = UNSIGNED_PAYLOAD;

--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -50,15 +50,12 @@ describe("SignatureV4", () => {
       (new Date("2000-01-01T00:00:00.000Z").valueOf() + 60 * 60 * 1000) / 1000
     );
     const presigningOptions = {
+      expiration,
       signingDate: new Date("2000-01-01T00:00:00.000Z")
     };
 
     it("should sign requests without bodies", async () => {
-      const { query } = await signer.presign(
-        minimalRequest,
-        expiration,
-        presigningOptions
-      );
+      const { query } = await signer.presign(minimalRequest, presigningOptions);
       expect(query).toEqual({
         [ALGORITHM_QUERY_PARAM]: ALGORITHM_IDENTIFIER,
         [CREDENTIAL_QUERY_PARAM]: "foo/20000101/us-bar-1/foo/aws4_request",
@@ -76,7 +73,6 @@ describe("SignatureV4", () => {
           ...minimalRequest,
           body: "It was the best of times, it was the worst of times"
         }),
-        expiration,
         presigningOptions
       );
       expect(query).toEqual({
@@ -96,7 +92,6 @@ describe("SignatureV4", () => {
           ...minimalRequest,
           body: new Uint8Array([0xde, 0xad, 0xbe, 0xef])
         }),
-        expiration,
         presigningOptions
       );
       expect(query).toEqual({
@@ -121,7 +116,6 @@ describe("SignatureV4", () => {
           ...minimalRequest,
           body: new ExoticStream() as any
         }),
-        expiration,
         presigningOptions
       );
       expect(query).toEqual({
@@ -145,11 +139,7 @@ describe("SignatureV4", () => {
           sessionToken: "baz"
         }
       });
-      const { query } = await signer.presign(
-        minimalRequest,
-        expiration,
-        presigningOptions
-      );
+      const { query } = await signer.presign(minimalRequest, presigningOptions);
 
       expect(query).toEqual({
         [TOKEN_QUERY_PARAM]: "baz",
@@ -180,7 +170,6 @@ describe("SignatureV4", () => {
             "X-Amz-Content-Sha256": "UNSIGNED-PAYLOAD"
           }
         }),
-        expiration,
         presigningOptions
       );
 
@@ -207,7 +196,6 @@ describe("SignatureV4", () => {
           ...minimalRequest,
           headers
         }),
-        expiration,
         {
           ...presigningOptions,
           unsignableHeaders: new Set(["foo"])
@@ -219,7 +207,10 @@ describe("SignatureV4", () => {
 
     it("should return a rejected promise if the expiration is more than one week in the future", async () => {
       await expect(
-        signer.presign(minimalRequest, new Date(), presigningOptions)
+        signer.presign(minimalRequest, {
+          ...presigningOptions,
+          expiration: new Date()
+        })
       ).rejects.toMatch(/less than one week in the future/);
     });
 
@@ -237,11 +228,7 @@ describe("SignatureV4", () => {
         credentials: credsProvider
       });
 
-      const { query } = await signer.presign(
-        minimalRequest,
-        expiration,
-        presigningOptions
-      );
+      const { query } = await signer.presign(minimalRequest, presigningOptions);
 
       expect(query).toMatchObject({
         [CREDENTIAL_QUERY_PARAM]: "foo/20000101/us-bar-1/foo/aws4_request"
@@ -261,11 +248,7 @@ describe("SignatureV4", () => {
         }
       });
 
-      const { query } = await signer.presign(
-        minimalRequest,
-        expiration,
-        presigningOptions
-      );
+      const { query } = await signer.presign(minimalRequest, presigningOptions);
 
       expect(query).toMatchObject({
         [CREDENTIAL_QUERY_PARAM]: "foo/20000101/us-bar-1/foo/aws4_request"
@@ -286,7 +269,6 @@ describe("SignatureV4", () => {
       it("should URI-encode the path by default", async () => {
         const { query = {} } = await signer.presign(
           minimalRequest,
-          expiration,
           presigningOptions
         );
         expect(query[SIGNATURE_QUERY_PARAM]).toBe(
@@ -320,7 +302,6 @@ describe("SignatureV4", () => {
               "X-Amz-Content-Sha256": "UNSIGNED-PAYLOAD"
             }
           }),
-          expiration,
           presigningOptions
         );
         expect(query[SIGNATURE_QUERY_PARAM]).toBe(
@@ -661,10 +642,9 @@ describe("SignatureV4", () => {
 
     it("should use the current date for presigning if no signing date was supplied", async () => {
       const date = new Date();
-      const { query } = await signer.presign(
-        minimalRequest,
-        Math.floor((date.valueOf() + 60 * 60 * 1000) / 1000)
-      );
+      const { query } = await signer.presign(minimalRequest, {
+        expiration: Math.floor((date.valueOf() + 60 * 60 * 1000) / 1000)
+      });
       expect((query as any)[AMZ_DATE_QUERY_PARAM]).toBe(
         iso8601(date).replace(/[\-:]/g, "")
       );

--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -67,6 +67,13 @@ describe("SignatureV4", () => {
       });
     });
 
+    it("should default expires to 3600 seconds if not explicitly passed", async () => {
+      const { query } = await signer.presign(minimalRequest);
+      expect(query).toMatchObject({
+        [EXPIRES_QUERY_PARAM]: "3600"
+      });
+    });
+
     it("should sign requests with string bodies", async () => {
       const { query } = await signer.presign(
         new HttpRequest({

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -129,7 +129,6 @@ export class SignatureV4
 
   public async presign(
     originalRequest: HttpRequest,
-    expiration: DateInput,
     options: RequestSigningArguments = {}
   ): Promise<HttpRequest> {
     const [region, credentials] = await Promise.all([
@@ -139,6 +138,7 @@ export class SignatureV4
 
     const {
       signingDate = new Date(),
+      expiration = new Date(Date.now() + 3600 * 1000),
       unsignableHeaders,
       signableHeaders
     } = options;

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -28,6 +28,7 @@ import {
   RequestPresigner,
   RequestSigner,
   RequestSigningArguments,
+  RequestPresigningArguments,
   SigningArguments,
   StringSigner,
   EventSigner,
@@ -129,7 +130,7 @@ export class SignatureV4
 
   public async presign(
     originalRequest: HttpRequest,
-    options: RequestSigningArguments = {}
+    options: RequestPresigningArguments = {}
   ): Promise<HttpRequest> {
     const [region, credentials] = await Promise.all([
       this.regionProvider(),

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -18,11 +18,6 @@ export interface SigningArguments {
 
 export interface RequestSigningArguments extends SigningArguments {
   /**
-   * The time at which the signed request should no longer be honored.
-   */
-  expiration?: DateInput;
-
-  /**
    * A set of strings whose members represents headers that cannot be signed.
    * All headers in the provided request will have their names converted to
    * lower case and then checked for existence in the unsignableHeaders set.
@@ -38,6 +33,13 @@ export interface RequestSigningArguments extends SigningArguments {
    * lower case before signing.
    */
   signableHeaders?: Set<string>;
+}
+
+export interface RequestPresigningArguments extends RequestSigningArguments {
+  /**
+   * The time at which the signed request should no longer be honored.
+   */
+  expiration?: DateInput;
 }
 
 export interface EventSigningArguments extends SigningArguments {
@@ -56,7 +58,7 @@ export interface RequestPresigner {
    */
   presign(
     requestToSign: HttpRequest,
-    options?: RequestSigningArguments
+    options?: RequestPresigningArguments
   ): Promise<HttpRequest>;
 }
 

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -18,6 +18,11 @@ export interface SigningArguments {
 
 export interface RequestSigningArguments extends SigningArguments {
   /**
+   * The time at which the signed request should no longer be honored.
+   */
+  expiration?: DateInput;
+
+  /**
    * A set of strings whose members represents headers that cannot be signed.
    * All headers in the provided request will have their names converted to
    * lower case and then checked for existence in the unsignableHeaders set.
@@ -47,13 +52,10 @@ export interface RequestPresigner {
    * passed or the underlying credentials have expired.
    *
    * @param requestToSign The request that should be signed.
-   * @param expiration    The time at which the signed request should no
-   *                      longer be honored.
    * @param options       Additional signing options.
    */
   presign(
     requestToSign: HttpRequest,
-    expiration: DateInput,
     options?: RequestSigningArguments
   ): Promise<HttpRequest>;
 }


### PR DESCRIPTION
*Issue #, if available:*
* Fixes https://github.com/aws/aws-sdk-js-v3/issues/1006
* Fixes https://github.com/aws/aws-sdk-js-v3/issues/1007

*Description of changes:*
Move expiration under RequestSigningArguments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
