### PR TITLE
chore(deps-dev): bump jest to 25.1.0

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/uuid": "^7.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
     "typedoc": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@commitlint/cli": "^8.3.4",
     "@commitlint/config-conventional": "^8.3.4",
     "@types/fs-extra": "^8.0.1",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "codecov": "^3.4.0",
     "cucumber": "0.5.x",
     "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "^8.1.0",
     "generate-changelog": "^1.7.1",
     "husky": "^4.2.3",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "jmespath": "^0.15.0",
     "lerna": "3.20.2",
     "lint-staged": "^10.0.1",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-utf8-browser": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -25,7 +25,7 @@
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-utf8-browser": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-utf8-node": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -26,7 +26,7 @@
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-utf8-node": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typedoc": "^0.14.2",
     "typescript": "~3.8.3"
   }

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typedoc": "^0.14.2",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "tslib": "^1.8.0",
     "typescript": "~3.8.3"
   },

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "tslib": "^1.8.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -24,7 +24,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -24,7 +24,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@aws-sdk/shared-ini-file-loader": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/shared-ini-file-loader": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -25,7 +25,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-universal": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/util-utf8-universal": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "engines": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "engines": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "engines": {

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@aws-sdk/abort-controller": "^1.0.0-alpha.6",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/abort-controller": "^1.0.0-alpha.6",
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
     "jasmine-core": "^3.4.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "karma": "^4.1.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-jasmine": "^3.1.1",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jasmine-core": "^3.4.0",
     "jest": "^25.1.0",
     "karma": "^4.1.0",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "dependencies": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^25.1.0",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "main": "./build/index.js",
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -15,7 +15,7 @@
   "main": "./build/index.js",
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts",

--- a/packages/is-node/package.json
+++ b/packages/is-node/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts",

--- a/packages/is-node/package.json
+++ b/packages/is-node/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "main": "./build/index.js",
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "dependencies": {

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@aws-sdk/util-base64-universal": "^1.0.0-alpha.3",
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^25.1.0",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@aws-sdk/middleware-stack": "^1.0.0-alpha.6",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "^1.0.0-alpha.6",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@aws-sdk/types": "^1.0.0-alpha.6",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "^1.0.0-alpha.6",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "^1.0.0-alpha.6",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@aws-sdk/types": "^1.0.0-alpha.6",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "dependencies": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "jest": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -25,7 +25,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
     "@types/jest": "^24.0.12",
     "@types/node": "^12.0.2",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@aws-sdk/hash-node": "^1.0.0-alpha.6",
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^12.0.2",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.3",
     "@aws-sdk/util-utf8-node": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -21,7 +21,7 @@
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-hex-encoding": "^1.0.0-alpha.3",
     "@aws-sdk/util-utf8-node": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -5,7 +5,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "scripts": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
     "@aws-sdk/util-buffer-from": "^1.0.0-alpha.3",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./dist/cjs/index.d.ts"

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/http-serialization": "^1.0.0-alpha.5",
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
     "@aws-sdk/util-buffer-from": "^1.0.0-alpha.3",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/stream-collector-browser/package.json
+++ b/packages/stream-collector-browser/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jasmine-core": "^3.5.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/stream-collector-native/package.json
+++ b/packages/stream-collector-native/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jasmine-core": "^3.5.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/stream-collector-node/package.json
+++ b/packages/stream-collector-node/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/stream-collector-node/package.json
+++ b/packages/stream-collector-node/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/url-parser-browser/package.json
+++ b/packages/url-parser-browser/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/url-parser-browser/package.json
+++ b/packages/url-parser-browser/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/url-parser-node/package.json
+++ b/packages/url-parser-node/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "react-native": {

--- a/packages/url-parser-node/package.json
+++ b/packages/url-parser-node/package.json
@@ -20,7 +20,7 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-base64-universal/package.json
+++ b/packages/util-base64-universal/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/util-base64-universal/package.json
+++ b/packages/util-base64-universal/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "main": "./build/index.js",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -16,7 +16,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "main": "./build/index.js",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.3",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.3",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -19,7 +19,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -15,7 +15,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "main": "./build/index.js",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -21,7 +21,7 @@
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "^1.0.0-alpha.8",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "jest": {

--- a/packages/util-utf8-universal/package.json
+++ b/packages/util-utf8-universal/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/util-utf8-node": false
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "@types/node": "^10.0.0",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-utf8-universal/package.json
+++ b/packages/util-utf8-universal/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "@types/node": "^10.0.0",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "types": "./build/index.d.ts"

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -6,7 +6,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^25.1.4",
     "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "jest": "^24.7.1",
+    "jest": "^25.1.0",
     "typescript": "~3.8.3"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,12 +83,44 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.8.6", "@babel/generator@^7.8.7":
+"@babel/core@^7.7.5":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
+  integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helpers" "^7.9.0"
+    "@babel/parser" "^7.9.0"
+    "@babel/template" "^7.8.6"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.8.6", "@babel/generator@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.7.tgz#870b3cf7984f5297998152af625c4f3e341400f7"
   integrity sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==
   dependencies:
     "@babel/types" "^7.8.7"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.3.tgz#7c8b2956c6f68b3ab732bd16305916fbba521d94"
+  integrity sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==
+  dependencies:
+    "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -109,10 +141,62 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-member-expression-to-functions@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
+  integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-module-imports@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
+  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-module-transforms@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
+  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-simple-access" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/template" "^7.8.6"
+    "@babel/types" "^7.9.0"
+    lodash "^4.17.13"
+
+"@babel/helper-optimise-call-expression@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
+  integrity sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.8.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+
+"@babel/helper-replace-supers@^7.8.6":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz#5ada744fd5ad73203bf1d67459a27dcba67effc8"
+  integrity sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.8.3"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/traverse" "^7.8.6"
+    "@babel/types" "^7.8.6"
+
+"@babel/helper-simple-access@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
+  integrity sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
@@ -120,6 +204,11 @@
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
 
 "@babel/helpers@^7.8.4":
   version "7.8.4"
@@ -130,6 +219,15 @@
     "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
 
+"@babel/helpers@^7.9.0":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.2.tgz#b42a81a811f1e7313b88cba8adc66b3d9ae6c09f"
+  integrity sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
+
 "@babel/highlight@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
@@ -139,10 +237,22 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
+"@babel/parser@^7.1.0", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.7.tgz#7b8facf95d25fef9534aad51c4ffecde1a61e26a"
   integrity sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==
+
+"@babel/parser@^7.7.5", "@babel/parser@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.3.tgz#043a5fc2ad8b7ea9facddc4e802a1f0f25da7255"
+  integrity sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==
+
+"@babel/plugin-syntax-bigint@^7.0.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.8.3"
@@ -158,7 +268,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
+"@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
   integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
@@ -167,7 +277,7 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.8.4", "@babel/traverse@^7.8.6":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.8.4", "@babel/traverse@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.6.tgz#acfe0c64e1cd991b3e32eae813a6eb564954b5ff"
   integrity sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==
@@ -182,7 +292,22 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
+"@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
+  integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.7.tgz#1fc9729e1acbb2337d5b6977a63979b4819f5d1d"
   integrity sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
@@ -190,6 +315,20 @@
     esutils "^2.0.2"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
+  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -403,144 +542,169 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@jest/console@^24.7.1", "@jest/console@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
-  integrity sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==
+"@istanbuljs/load-nyc-config@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
+  integrity sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==
   dependencies:
-    "@jest/source-map" "^24.9.0"
-    chalk "^2.0.1"
-    slash "^2.0.0"
+    camelcase "^5.3.1"
+    find-up "^4.1.0"
+    js-yaml "^3.13.1"
+    resolve-from "^5.0.0"
 
-"@jest/core@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.9.0.tgz#2ceccd0b93181f9c4850e74f2a9ad43d351369c4"
-  integrity sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
+  integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@jest/console@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-25.1.0.tgz#1fc765d44a1e11aec5029c08e798246bd37075ab"
+  integrity sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==
   dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/reporters" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
+    "@jest/source-map" "^25.1.0"
+    chalk "^3.0.0"
+    jest-util "^25.1.0"
+    slash "^3.0.0"
+
+"@jest/core@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.1.0.tgz#3d4634fc3348bb2d7532915d67781cdac0869e47"
+  integrity sha512-iz05+NmwCmZRzMXvMo6KFipW7nzhbpEawrKrkkdJzgytavPse0biEnCNr2wRlyCsp3SmKaEY+SGv7YWYQnIdig==
+  dependencies:
+    "@jest/console" "^25.1.0"
+    "@jest/reporters" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
     exit "^0.1.2"
-    graceful-fs "^4.1.15"
-    jest-changed-files "^24.9.0"
-    jest-config "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-resolve-dependencies "^24.9.0"
-    jest-runner "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    jest-watcher "^24.9.0"
-    micromatch "^3.1.10"
-    p-each-series "^1.0.0"
+    graceful-fs "^4.2.3"
+    jest-changed-files "^25.1.0"
+    jest-config "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-resolve-dependencies "^25.1.0"
+    jest-runner "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    jest-watcher "^25.1.0"
+    micromatch "^4.0.2"
+    p-each-series "^2.1.0"
     realpath-native "^1.1.0"
-    rimraf "^2.5.4"
-    slash "^2.0.0"
-    strip-ansi "^5.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
 
-"@jest/environment@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.9.0.tgz#21e3afa2d65c0586cbd6cbefe208bafade44ab18"
-  integrity sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==
+"@jest/environment@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-25.1.0.tgz#4a97f64770c9d075f5d2b662b5169207f0a3f787"
+  integrity sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==
   dependencies:
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
 
-"@jest/fake-timers@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.9.0.tgz#ba3e6bf0eecd09a636049896434d306636540c93"
-  integrity sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==
+"@jest/fake-timers@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-25.1.0.tgz#a1e0eff51ffdbb13ee81f35b52e0c1c11a350ce8"
+  integrity sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==
   dependencies:
-    "@jest/types" "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-mock "^24.9.0"
+    "@jest/types" "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+    lolex "^5.0.0"
 
-"@jest/reporters@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.9.0.tgz#86660eff8e2b9661d042a8e98a028b8d631a5b43"
-  integrity sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==
+"@jest/reporters@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-25.1.0.tgz#9178ecf136c48f125674ac328f82ddea46e482b0"
+  integrity sha512-ORLT7hq2acJQa8N+NKfs68ZtHFnJPxsGqmofxW7v7urVhzJvpKZG9M7FAcgh9Ee1ZbCteMrirHA3m5JfBtAaDg==
   dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
     glob "^7.1.2"
-    istanbul-lib-coverage "^2.0.2"
-    istanbul-lib-instrument "^3.0.1"
-    istanbul-lib-report "^2.0.4"
-    istanbul-lib-source-maps "^3.0.1"
-    istanbul-reports "^2.2.6"
-    jest-haste-map "^24.9.0"
-    jest-resolve "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.6.0"
-    node-notifier "^5.4.2"
-    slash "^2.0.0"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.0"
+    jest-haste-map "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
+    slash "^3.0.0"
     source-map "^0.6.0"
-    string-length "^2.0.0"
+    string-length "^3.1.0"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^4.0.1"
+  optionalDependencies:
+    node-notifier "^6.0.0"
 
-"@jest/source-map@^24.3.0", "@jest/source-map@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.9.0.tgz#0e263a94430be4b41da683ccc1e6bffe2a191714"
-  integrity sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==
+"@jest/source-map@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-25.1.0.tgz#b012e6c469ccdbc379413f5c1b1ffb7ba7034fb0"
+  integrity sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==
   dependencies:
     callsites "^3.0.0"
-    graceful-fs "^4.1.15"
+    graceful-fs "^4.2.3"
     source-map "^0.6.0"
 
-"@jest/test-result@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.9.0.tgz#11796e8aa9dbf88ea025757b3152595ad06ba0ca"
-  integrity sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==
+"@jest/test-result@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-25.1.0.tgz#847af2972c1df9822a8200457e64be4ff62821f7"
+  integrity sha512-FZzSo36h++U93vNWZ0KgvlNuZ9pnDnztvaM7P/UcTx87aPDotG18bXifkf1Ji44B7k/eIatmMzkBapnAzjkJkg==
   dependencies:
-    "@jest/console" "^24.9.0"
-    "@jest/types" "^24.9.0"
+    "@jest/console" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz#f8f334f35b625a4f2f355f2fe7e6036dad2e6b31"
-  integrity sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==
+"@jest/test-sequencer@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-25.1.0.tgz#4df47208542f0065f356fcdb80026e3c042851ab"
+  integrity sha512-WgZLRgVr2b4l/7ED1J1RJQBOharxS11EFhmwDqknpknE0Pm87HLZVS2Asuuw+HQdfQvm2aXL2FvvBLxOD1D0iw==
   dependencies:
-    "@jest/test-result" "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-runner "^24.9.0"
-    jest-runtime "^24.9.0"
+    "@jest/test-result" "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-runner "^25.1.0"
+    jest-runtime "^25.1.0"
 
-"@jest/transform@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.9.0.tgz#4ae2768b296553fadab09e9ec119543c90b16c56"
-  integrity sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==
+"@jest/transform@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-25.1.0.tgz#221f354f512b4628d88ce776d5b9e601028ea9da"
+  integrity sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^24.9.0"
-    babel-plugin-istanbul "^5.1.0"
-    chalk "^2.0.1"
+    "@jest/types" "^25.1.0"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^3.0.0"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.1.15"
-    jest-haste-map "^24.9.0"
-    jest-regex-util "^24.9.0"
-    jest-util "^24.9.0"
-    micromatch "^3.1.10"
+    graceful-fs "^4.2.3"
+    jest-haste-map "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-util "^25.1.0"
+    micromatch "^4.0.2"
     pirates "^4.0.1"
     realpath-native "^1.1.0"
-    slash "^2.0.0"
+    slash "^3.0.0"
     source-map "^0.6.1"
-    write-file-atomic "2.4.1"
+    write-file-atomic "^3.0.0"
 
 "@jest/types@^24.9.0":
   version "24.9.0"
@@ -550,6 +714,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@jest/types@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
+  integrity sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
 
 "@lerna/add@3.20.0":
   version "3.20.0"
@@ -1358,6 +1532,13 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sinonjs/commons@^1.7.0":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
+  integrity sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==
+  dependencies:
+    type-detect "4.0.8"
+
 "@tootallnate/once@1":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
@@ -1441,7 +1622,7 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
   integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
   integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
@@ -1538,6 +1719,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^15.0.0":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
+  integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -1591,7 +1779,7 @@ accepts@~1.3.4:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-acorn-globals@^4.1.0:
+acorn-globals@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
   integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
@@ -1623,7 +1811,7 @@ acorn@^4.0.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
   integrity sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
 
-acorn@^5.2.1, acorn@^5.5.3:
+acorn@^5.2.1:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
@@ -1633,7 +1821,7 @@ acorn@^6.0.1, acorn@^6.0.5:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
   integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
-acorn@^7.0.0:
+acorn@^7.0.0, acorn@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -1703,6 +1891,13 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
+ansi-escapes@^4.2.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
+  integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+  dependencies:
+    type-fest "^0.11.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -1766,7 +1961,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@~3.1.1:
+anymatch@^3.0.3, anymatch@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
   integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
@@ -1978,33 +2173,34 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
-babel-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
-  integrity sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
+babel-jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.1.0.tgz#206093ac380a4b78c4404a05b3277391278f80fb"
+  integrity sha512-tz0VxUhhOE2y+g8R2oFrO/2VtVjA1lkJeavlhExuRBg3LdNJY9gwQ+Vcvqt9+cqy71MCTJhewvTB7Qtnnr9SWg==
   dependencies:
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
     "@types/babel__core" "^7.1.0"
-    babel-plugin-istanbul "^5.1.0"
-    babel-preset-jest "^24.9.0"
-    chalk "^2.4.2"
-    slash "^2.0.0"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^25.1.0"
+    chalk "^3.0.0"
+    slash "^3.0.0"
 
-babel-plugin-istanbul@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
-  integrity sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==
+babel-plugin-istanbul@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
+  integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    find-up "^3.0.0"
-    istanbul-lib-instrument "^3.3.0"
-    test-exclude "^5.2.3"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-instrument "^4.0.0"
+    test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz#4f837091eb407e01447c8843cbec546d0002d756"
-  integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
+babel-plugin-jest-hoist@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.1.0.tgz#fb62d7b3b53eb36c97d1bc7fec2072f9bd115981"
+  integrity sha512-oIsopO41vW4YFZ9yNYoLQATnnN46lp+MZ6H4VvPKFkcc2/fkl3CfE/NZZSmnEIEsJRmJAgkVEK0R7Zbl50CpTw==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
@@ -2017,13 +2213,14 @@ babel-polyfill@6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"
-  integrity sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==
+babel-preset-jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz#d0aebfebb2177a21cde710996fce8486d34f1d33"
+  integrity sha512-eCGn64olaqwUMaugXsTtGAM2I0QTahjEtnRu0ql8Ie+gDWAc1N6wqN0k2NilnyTunM69Pad7gJY7LOtwLimoFQ==
   dependencies:
+    "@babel/plugin-syntax-bigint" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
-    babel-plugin-jest-hoist "^24.9.0"
+    babel-plugin-jest-hoist "^25.1.0"
 
 babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
@@ -2106,13 +2303,6 @@ binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
-
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
 
 blob@0.0.5:
   version "0.0.5"
@@ -2687,6 +2877,11 @@ coffee-script@1.10.0:
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.10.0.tgz#12938bcf9be1948fa006f92e0c4c9e81705108c0"
   integrity sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=
 
+collect-v8-coverage@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz#150ee634ac3650b71d9c985eb7f608942334feb1"
+  integrity sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -3131,17 +3326,22 @@ crypto-browserify@^3.0.0, crypto-browserify@^3.12.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+cssom@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
+  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+
+cssom@~0.3.6:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
 
-cssstyle@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.4.0.tgz#9d31328229d3c565c61e586b02041a28fccdccf1"
-  integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
+cssstyle@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.2.0.tgz#e4c44debccd6b7911ed617a4395e5754bba59992"
+  integrity sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==
   dependencies:
-    cssom "0.3.x"
+    cssom "~0.3.6"
 
 cucumber-html@0.2.3:
   version "0.2.3"
@@ -3195,7 +3395,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-urls@^1.0.0:
+data-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
   integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
@@ -3382,10 +3582,10 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-newline@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
-  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 detective@^4.0.0:
   version "4.7.1"
@@ -3412,6 +3612,11 @@ diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
+diff-sequences@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.1.0.tgz#fd29a46f1c913fd66c22645dc75bffbe43051f32"
+  integrity sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -3689,7 +3894,7 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
-escodegen@^1.9.1:
+escodegen@^1.11.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
   integrity sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==
@@ -3772,7 +3977,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^3.4.0:
+execa@^3.2.0, execa@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
   integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
@@ -3806,17 +4011,17 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expect@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
-  integrity sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
+expect@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-25.1.0.tgz#7e8d7b06a53f7d66ec927278db3304254ee683ee"
+  integrity sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==
   dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-styles "^3.2.0"
-    jest-get-type "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-regex-util "^24.9.0"
+    "@jest/types" "^25.1.0"
+    ansi-styles "^4.0.0"
+    jest-get-type "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-regex-util "^25.1.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -3946,11 +4151,6 @@ figures@^2.0.0:
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
-
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -4113,15 +4313,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^1.2.7:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.11.tgz#67bf57f4758f02ede88fb2a1712fef4d15358be3"
-  integrity sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.12.1"
-
-fsevents@~2.1.2:
+fsevents@^2.1.2, fsevents@~2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
@@ -4375,7 +4567,7 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -4709,6 +4901,14 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
+import-local@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
+  integrity sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -4837,12 +5037,10 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
 ip@1.1.5:
   version "1.1.5"
@@ -5105,7 +5303,7 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -5120,10 +5318,10 @@ is-windows@^1.0.0, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 isarray@0.0.1, isarray@~0.0.1:
   version "0.0.1"
@@ -5174,50 +5372,49 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
-  integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
+istanbul-lib-coverage@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
+  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
 
-istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
-  integrity sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
+istanbul-lib-instrument@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz#61f13ac2c96cfefb076fe7131156cc05907874e6"
+  integrity sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==
   dependencies:
-    "@babel/generator" "^7.4.0"
-    "@babel/parser" "^7.4.3"
-    "@babel/template" "^7.4.0"
-    "@babel/traverse" "^7.4.3"
-    "@babel/types" "^7.4.0"
-    istanbul-lib-coverage "^2.0.5"
-    semver "^6.0.0"
+    "@babel/core" "^7.7.5"
+    "@babel/parser" "^7.7.5"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    semver "^6.3.0"
 
-istanbul-lib-report@^2.0.4:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
-  integrity sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
+istanbul-lib-report@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
+  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
   dependencies:
-    istanbul-lib-coverage "^2.0.5"
-    make-dir "^2.1.0"
-    supports-color "^6.1.0"
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^3.0.0"
+    supports-color "^7.1.0"
 
-istanbul-lib-source-maps@^3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
-  integrity sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9"
+  integrity sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==
   dependencies:
     debug "^4.1.1"
-    istanbul-lib-coverage "^2.0.5"
-    make-dir "^2.1.0"
-    rimraf "^2.6.3"
+    istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.7.tgz#5d939f6237d7b48393cc0959eab40cd4fd056931"
-  integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
+istanbul-reports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.0.tgz#d4d16d035db99581b6194e119bbf36c963c5eb70"
+  integrity sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==
   dependencies:
     html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 istanbul@0.4.5, istanbul@^0.4.0:
   version "0.4.5"
@@ -5244,58 +5441,58 @@ jasmine-core@^3.4.0, jasmine-core@^3.5.0:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
   integrity sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==
 
-jest-changed-files@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
-  integrity sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==
+jest-changed-files@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-25.1.0.tgz#73dae9a7d9949fdfa5c278438ce8f2ff3ec78131"
+  integrity sha512-bdL1aHjIVy3HaBO3eEQeemGttsq1BDlHgWcOjEOIAcga7OOEGWHD2WSu8HhL7I1F0mFFyci8VKU4tRNk+qtwDA==
   dependencies:
-    "@jest/types" "^24.9.0"
-    execa "^1.0.0"
-    throat "^4.0.0"
+    "@jest/types" "^25.1.0"
+    execa "^3.2.0"
+    throat "^5.0.0"
 
-jest-cli@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.9.0.tgz#ad2de62d07472d419c6abc301fc432b98b10d2af"
-  integrity sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==
+jest-cli@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.1.0.tgz#75f0b09cf6c4f39360906bf78d580be1048e4372"
+  integrity sha512-p+aOfczzzKdo3AsLJlhs8J5EW6ffVidfSZZxXedJ0mHPBOln1DccqFmGCoO8JWd4xRycfmwy1eoQkMsF8oekPg==
   dependencies:
-    "@jest/core" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
+    "@jest/core" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     exit "^0.1.2"
-    import-local "^2.0.0"
+    import-local "^3.0.2"
     is-ci "^2.0.0"
-    jest-config "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
+    jest-config "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
     prompts "^2.0.1"
     realpath-native "^1.1.0"
-    yargs "^13.3.0"
+    yargs "^15.0.0"
 
-jest-config@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.9.0.tgz#fb1bbc60c73a46af03590719efa4825e6e4dd1b5"
-  integrity sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==
+jest-config@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-25.1.0.tgz#d114e4778c045d3ef239452213b7ad3ec1cbea90"
+  integrity sha512-tLmsg4SZ5H7tuhBC5bOja0HEblM0coS3Wy5LTCb2C8ZV6eWLewHyK+3qSq9Bi29zmWQ7ojdCd3pxpx4l4d2uGw==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    babel-jest "^24.9.0"
-    chalk "^2.0.1"
+    "@jest/test-sequencer" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    babel-jest "^25.1.0"
+    chalk "^3.0.0"
     glob "^7.1.1"
-    jest-environment-jsdom "^24.9.0"
-    jest-environment-node "^24.9.0"
-    jest-get-type "^24.9.0"
-    jest-jasmine2 "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    micromatch "^3.1.10"
-    pretty-format "^24.9.0"
+    jest-environment-jsdom "^25.1.0"
+    jest-environment-node "^25.1.0"
+    jest-get-type "^25.1.0"
+    jest-jasmine2 "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    micromatch "^4.0.2"
+    pretty-format "^25.1.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.3.0, jest-diff@^24.9.0:
+jest-diff@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -5305,298 +5502,307 @@ jest-diff@^24.3.0, jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-docblock@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
-  integrity sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==
+jest-diff@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.1.0.tgz#58b827e63edea1bc80c1de952b80cec9ac50e1ad"
+  integrity sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==
   dependencies:
-    detect-newline "^2.1.0"
+    chalk "^3.0.0"
+    diff-sequences "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
-jest-each@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.9.0.tgz#eb2da602e2a610898dbc5f1f6df3ba86b55f8b05"
-  integrity sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==
+jest-docblock@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.1.0.tgz#0f44bea3d6ca6dfc38373d465b347c8818eccb64"
+  integrity sha512-370P/mh1wzoef6hUKiaMcsPtIapY25suP6JqM70V9RJvdKLrV4GaGbfUseUVk4FZJw4oTZ1qSCJNdrClKt5JQA==
   dependencies:
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    jest-get-type "^24.9.0"
-    jest-util "^24.9.0"
-    pretty-format "^24.9.0"
+    detect-newline "^3.0.0"
 
-jest-environment-jsdom@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz#4b0806c7fc94f95edb369a69cc2778eec2b7375b"
-  integrity sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==
+jest-each@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-25.1.0.tgz#a6b260992bdf451c2d64a0ccbb3ac25e9b44c26a"
+  integrity sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==
   dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-util "^24.9.0"
-    jsdom "^11.5.1"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    jest-get-type "^25.1.0"
+    jest-util "^25.1.0"
+    pretty-format "^25.1.0"
 
-jest-environment-node@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.9.0.tgz#333d2d2796f9687f2aeebf0742b519f33c1cbfd3"
-  integrity sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==
+jest-environment-jsdom@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.1.0.tgz#6777ab8b3e90fd076801efd3bff8e98694ab43c3"
+  integrity sha512-ILb4wdrwPAOHX6W82GGDUiaXSSOE274ciuov0lztOIymTChKFtC02ddyicRRCdZlB5YSrv3vzr1Z5xjpEe1OHQ==
   dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-util "^24.9.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+    jsdom "^15.1.1"
+
+jest-environment-node@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-25.1.0.tgz#797bd89b378cf0bd794dc8e3dca6ef21126776db"
+  integrity sha512-U9kFWTtAPvhgYY5upnH9rq8qZkj6mYLup5l1caAjjx9uNnkLHN2xgZy5mo4SyLdmrh/EtB9UPpKFShvfQHD0Iw==
+  dependencies:
+    "@jest/environment" "^25.1.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
 
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
-jest-haste-map@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.9.0.tgz#b38a5d64274934e21fa417ae9a9fbeb77ceaac7d"
-  integrity sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==
+jest-get-type@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.1.0.tgz#1cfe5fc34f148dc3a8a3b7275f6b9ce9e2e8a876"
+  integrity sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==
+
+jest-haste-map@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-25.1.0.tgz#ae12163d284f19906260aa51fd405b5b2e5a4ad3"
+  integrity sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==
   dependencies:
-    "@jest/types" "^24.9.0"
-    anymatch "^2.0.0"
+    "@jest/types" "^25.1.0"
+    anymatch "^3.0.3"
     fb-watchman "^2.0.0"
-    graceful-fs "^4.1.15"
-    invariant "^2.2.4"
-    jest-serializer "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.9.0"
-    micromatch "^3.1.10"
+    graceful-fs "^4.2.3"
+    jest-serializer "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
+    micromatch "^4.0.2"
     sane "^4.0.3"
     walker "^1.0.7"
   optionalDependencies:
-    fsevents "^1.2.7"
+    fsevents "^2.1.2"
 
-jest-jasmine2@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz#1f7b1bd3242c1774e62acabb3646d96afc3be6a0"
-  integrity sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==
+jest-jasmine2@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-25.1.0.tgz#681b59158a430f08d5d0c1cce4f01353e4b48137"
+  integrity sha512-GdncRq7jJ7sNIQ+dnXvpKO2MyP6j3naNK41DTTjEAhLEdpImaDA9zSAZwDhijjSF/D7cf4O5fdyUApGBZleaEg==
   dependencies:
     "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
+    "@jest/environment" "^25.1.0"
+    "@jest/source-map" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     co "^4.6.0"
-    expect "^24.9.0"
+    expect "^25.1.0"
     is-generator-fn "^2.0.0"
-    jest-each "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    pretty-format "^24.9.0"
-    throat "^4.0.0"
+    jest-each "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    pretty-format "^25.1.0"
+    throat "^5.0.0"
 
-jest-leak-detector@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
-  integrity sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==
+jest-leak-detector@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.1.0.tgz#ed6872d15aa1c72c0732d01bd073dacc7c38b5c6"
+  integrity sha512-3xRI264dnhGaMHRvkFyEKpDeaRzcEBhyNrOG5oT8xPxOyUAblIAQnpiR3QXu4wDor47MDTiHbiFcbypdLcLW5w==
   dependencies:
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
-jest-matcher-utils@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
-  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
+jest-matcher-utils@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz#fa5996c45c7193a3c24e73066fc14acdee020220"
+  integrity sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==
   dependencies:
-    chalk "^2.0.1"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
+    chalk "^3.0.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
-jest-message-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
-  integrity sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==
+jest-message-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-25.1.0.tgz#702a9a5cb05c144b9aa73f06e17faa219389845e"
+  integrity sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
     "@types/stack-utils" "^1.0.1"
-    chalk "^2.0.1"
-    micromatch "^3.1.10"
-    slash "^2.0.0"
+    chalk "^3.0.0"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
-  integrity sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
+jest-mock@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.1.0.tgz#411d549e1b326b7350b2e97303a64715c28615fd"
+  integrity sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==
   dependencies:
-    "@jest/types" "^24.9.0"
+    "@jest/types" "^25.1.0"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
   integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
-jest-regex-util@^24.3.0, jest-regex-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
-  integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
+jest-regex-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-25.1.0.tgz#efaf75914267741838e01de24da07b2192d16d87"
+  integrity sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==
 
-jest-resolve-dependencies@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz#ad055198959c4cfba8a4f066c673a3f0786507ab"
-  integrity sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==
+jest-resolve-dependencies@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-25.1.0.tgz#8a1789ec64eb6aaa77fd579a1066a783437e70d2"
+  integrity sha512-Cu/Je38GSsccNy4I2vL12ZnBlD170x2Oh1devzuM9TLH5rrnLW1x51lN8kpZLYTvzx9j+77Y5pqBaTqfdzVzrw==
   dependencies:
-    "@jest/types" "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-snapshot "^24.9.0"
+    "@jest/types" "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-snapshot "^25.1.0"
 
-jest-resolve@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.9.0.tgz#dff04c7687af34c4dd7e524892d9cf77e5d17321"
-  integrity sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
+jest-resolve@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-25.1.0.tgz#23d8b6a4892362baf2662877c66aa241fa2eaea3"
+  integrity sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==
   dependencies:
-    "@jest/types" "^24.9.0"
+    "@jest/types" "^25.1.0"
     browser-resolve "^1.11.3"
-    chalk "^2.0.1"
+    chalk "^3.0.0"
     jest-pnp-resolver "^1.2.1"
     realpath-native "^1.1.0"
 
-jest-runner@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.9.0.tgz#574fafdbd54455c2b34b4bdf4365a23857fcdf42"
-  integrity sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==
+jest-runner@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-25.1.0.tgz#fef433a4d42c89ab0a6b6b268e4a4fbe6b26e812"
+  integrity sha512-su3O5fy0ehwgt+e8Wy7A8CaxxAOCMzL4gUBftSs0Ip32S0epxyZPDov9Znvkl1nhVOJNf4UwAsnqfc3plfQH9w==
   dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.4.2"
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     exit "^0.1.2"
-    graceful-fs "^4.1.15"
-    jest-config "^24.9.0"
-    jest-docblock "^24.3.0"
-    jest-haste-map "^24.9.0"
-    jest-jasmine2 "^24.9.0"
-    jest-leak-detector "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-resolve "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.6.0"
+    graceful-fs "^4.2.3"
+    jest-config "^25.1.0"
+    jest-docblock "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-jasmine2 "^25.1.0"
+    jest-leak-detector "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
     source-map-support "^0.5.6"
-    throat "^4.0.0"
+    throat "^5.0.0"
 
-jest-runtime@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.9.0.tgz#9f14583af6a4f7314a6a9d9f0226e1a781c8e4ac"
-  integrity sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==
+jest-runtime@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-25.1.0.tgz#02683218f2f95aad0f2ec1c9cdb28c1dc0ec0314"
+  integrity sha512-mpPYYEdbExKBIBB16ryF6FLZTc1Rbk9Nx0ryIpIMiDDkOeGa0jQOKVI/QeGvVGlunKKm62ywcioeFVzIbK03bA==
   dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/environment" "^24.9.0"
-    "@jest/source-map" "^24.3.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/yargs" "^13.0.0"
-    chalk "^2.0.1"
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/source-map" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
     glob "^7.1.3"
-    graceful-fs "^4.1.15"
-    jest-config "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
+    graceful-fs "^4.2.3"
+    jest-config "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
     realpath-native "^1.1.0"
-    slash "^2.0.0"
-    strip-bom "^3.0.0"
-    yargs "^13.3.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.0.0"
 
-jest-serializer@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.9.0.tgz#e6d7d7ef96d31e8b9079a714754c5d5c58288e73"
-  integrity sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
+jest-serializer@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-25.1.0.tgz#73096ba90e07d19dec4a0c1dd89c355e2f129e5d"
+  integrity sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==
 
-jest-snapshot@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.9.0.tgz#ec8e9ca4f2ec0c5c87ae8f925cf97497b0e951ba"
-  integrity sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
+jest-snapshot@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-25.1.0.tgz#d5880bd4b31faea100454608e15f8d77b9d221d9"
+  integrity sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==
   dependencies:
     "@babel/types" "^7.0.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    expect "^24.9.0"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-resolve "^24.9.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    expect "^25.1.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-resolve "^25.1.0"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^24.9.0"
-    semver "^6.2.0"
+    pretty-format "^25.1.0"
+    semver "^7.1.1"
 
-jest-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"
-  integrity sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==
+jest-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.1.0.tgz#7bc56f7b2abd534910e9fa252692f50624c897d9"
+  integrity sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==
   dependencies:
-    "@jest/console" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/source-map" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    callsites "^3.0.0"
-    chalk "^2.0.1"
-    graceful-fs "^4.1.15"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     is-ci "^2.0.0"
     mkdirp "^0.5.1"
-    slash "^2.0.0"
-    source-map "^0.6.0"
 
-jest-validate@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.9.0.tgz#0775c55360d173cd854e40180756d4ff52def8ab"
-  integrity sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
+jest-validate@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-25.1.0.tgz#1469fa19f627bb0a9a98e289f3e9ab6a668c732a"
+  integrity sha512-kGbZq1f02/zVO2+t1KQGSVoCTERc5XeObLwITqC6BTRH3Adv7NZdYqCpKIZLUgpLXf2yISzQ465qOZpul8abXA==
   dependencies:
-    "@jest/types" "^24.9.0"
+    "@jest/types" "^25.1.0"
     camelcase "^5.3.1"
-    chalk "^2.0.1"
-    jest-get-type "^24.9.0"
+    chalk "^3.0.0"
+    jest-get-type "^25.1.0"
     leven "^3.1.0"
-    pretty-format "^24.9.0"
+    pretty-format "^25.1.0"
 
-jest-watcher@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.9.0.tgz#4b56e5d1ceff005f5b88e528dc9afc8dd4ed2b3b"
-  integrity sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==
+jest-watcher@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-25.1.0.tgz#97cb4a937f676f64c9fad2d07b824c56808e9806"
+  integrity sha512-Q9eZ7pyaIr6xfU24OeTg4z1fUqBF/4MP6J801lyQfg7CsnZ/TCzAPvCfckKdL5dlBBEKBeHV0AdyjFZ5eWj4ig==
   dependencies:
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/yargs" "^13.0.0"
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    jest-util "^24.9.0"
-    string-length "^2.0.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    jest-util "^25.1.0"
+    string-length "^3.1.0"
 
-jest-worker@^24.6.0, jest-worker@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
-  integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
+jest-worker@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.1.0.tgz#75d038bad6fdf58eba0d2ec1835856c497e3907a"
+  integrity sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==
   dependencies:
     merge-stream "^2.0.0"
-    supports-color "^6.1.0"
+    supports-color "^7.0.0"
 
-jest@^24.7.1:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
-  integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
+jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-25.1.0.tgz#b85ef1ddba2fdb00d295deebbd13567106d35be9"
+  integrity sha512-FV6jEruneBhokkt9MQk0WUFoNTwnF76CLXtwNMfsc0um0TlB/LG2yxUd0KqaFjEJ9laQmVWQWS0sG/t2GsuI0w==
   dependencies:
-    import-local "^2.0.0"
-    jest-cli "^24.9.0"
+    "@jest/core" "^25.1.0"
+    import-local "^3.0.2"
+    jest-cli "^25.1.0"
 
 jmespath@^0.15.0:
   version "0.15.0"
@@ -5608,7 +5814,7 @@ jquery@^3.4.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -5626,36 +5832,36 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdom@^11.5.1:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
-  integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
+jsdom@^15.1.1:
+  version "15.2.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
+  integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
   dependencies:
     abab "^2.0.0"
-    acorn "^5.5.3"
-    acorn-globals "^4.1.0"
+    acorn "^7.1.0"
+    acorn-globals "^4.3.2"
     array-equal "^1.0.0"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle "^1.0.0"
-    data-urls "^1.0.0"
+    cssom "^0.4.1"
+    cssstyle "^2.0.0"
+    data-urls "^1.1.0"
     domexception "^1.0.1"
-    escodegen "^1.9.1"
+    escodegen "^1.11.1"
     html-encoding-sniffer "^1.0.2"
-    left-pad "^1.3.0"
-    nwsapi "^2.0.7"
-    parse5 "4.0.0"
+    nwsapi "^2.2.0"
+    parse5 "5.1.0"
     pn "^1.1.0"
-    request "^2.87.0"
-    request-promise-native "^1.0.5"
-    sax "^1.2.4"
+    request "^2.88.0"
+    request-promise-native "^1.0.7"
+    saxes "^3.1.9"
     symbol-tree "^3.2.2"
-    tough-cookie "^2.3.4"
+    tough-cookie "^3.0.1"
     w3c-hr-time "^1.0.1"
+    w3c-xmlserializer "^1.1.2"
     webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.3"
-    whatwg-mimetype "^2.1.0"
-    whatwg-url "^6.4.1"
-    ws "^5.2.0"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^7.0.0"
+    ws "^7.0.0"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -5696,6 +5902,13 @@ json5@^2.1.0:
   integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
+  integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
+  dependencies:
+    minimist "^1.2.5"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -5870,11 +6083,6 @@ labeled-stream-splicer@^1.0.0:
     inherits "^2.0.1"
     isarray "~0.0.1"
     stream-splicer "^1.1.0"
-
-left-pad@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
-  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
 lerna@3.20.2:
   version "3.20.2"
@@ -6137,12 +6345,12 @@ log4js@^4.0.0, log4js@^4.0.1:
     rfdc "^1.1.4"
     streamroller "^1.0.6"
 
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+lolex@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
+    "@sinonjs/commons" "^1.7.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -6191,6 +6399,13 @@ make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392"
+  integrity sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==
+  dependencies:
+    semver "^6.0.0"
 
 make-fetch-happen@^5.0.0:
   version "5.0.2"
@@ -6422,6 +6637,11 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1, minimist@~0.0.7:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -6561,11 +6781,6 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.12.1:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -6644,16 +6859,16 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^5.4.2:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.3.tgz#cb72daf94c93904098e28b9c590fd866e464bd50"
-  integrity sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==
+node-notifier@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-6.0.0.tgz#cea319e06baa16deec8ce5cd7f133c4a46b68e12"
+  integrity sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==
   dependencies:
     growly "^1.3.0"
-    is-wsl "^1.1.0"
-    semver "^5.5.0"
+    is-wsl "^2.1.1"
+    semver "^6.3.0"
     shellwords "^0.1.1"
-    which "^1.3.0"
+    which "^1.3.1"
 
 nopt@3.0.4:
   version "3.0.4"
@@ -6787,7 +7002,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nwsapi@^2.0.7:
+nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
@@ -6964,12 +7179,10 @@ osenv@^0.1.4, osenv@^0.1.5:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-p-each-series@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
-  integrity sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=
-  dependencies:
-    p-reduce "^1.0.0"
+p-each-series@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
+  integrity sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -7169,10 +7382,10 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
-parse5@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+parse5@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
 parseqs@0.0.5:
   version "0.0.5"
@@ -7411,6 +7624,16 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.1.0.tgz#ed869bdaec1356fc5ae45de045e2c8ec7b07b0c8"
+  integrity sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -7638,6 +7861,11 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-is@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.8.4:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
@@ -7685,14 +7913,6 @@ read-pkg-up@^3.0.0:
   integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
   dependencies:
     find-up "^2.0.0"
-    read-pkg "^3.0.0"
-
-read-pkg-up@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
-  integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
-  dependencies:
-    find-up "^3.0.0"
     read-pkg "^3.0.0"
 
 read-pkg@^1.0.0:
@@ -7879,7 +8099,7 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise-native@^1.0.5:
+request-promise-native@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
   integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
@@ -7888,7 +8108,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0, request@^2.88.0:
+request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -7935,6 +8155,13 @@ resolve-cwd@^2.0.0:
   integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
   dependencies:
     resolve-from "^3.0.0"
+
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
 
 resolve-from@5.0.0, resolve-from@^5.0.0:
   version "5.0.0"
@@ -8109,10 +8336,12 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+saxes@^3.1.9:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-3.1.11.tgz#d59d1fd332ec92ad98a2e0b2ee644702384b1c5b"
+  integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
+  dependencies:
+    xmlchars "^2.1.1"
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -8129,10 +8358,15 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@6.3.0, semver@^6.0.0, semver@^6.2.0:
+semver@6.3.0, semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
+  integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -8629,13 +8863,13 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-string-length@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
-  integrity sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=
+string-length@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"
+  integrity sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==
   dependencies:
     astral-regex "^1.0.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.2.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -8761,6 +8995,11 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -8830,19 +9069,20 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+supports-hyperlinks@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
+  integrity sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
 
 symbol-observable@^1.1.0:
   version "1.2.0"
@@ -8902,15 +9142,22 @@ temp-write@^3.4.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
-test-exclude@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
-  integrity sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
+terminal-link@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
+  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
   dependencies:
-    glob "^7.1.3"
+    ansi-escapes "^4.2.1"
+    supports-hyperlinks "^2.0.0"
+
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
     minimatch "^3.0.4"
-    read-pkg-up "^4.0.0"
-    require-main-filename "^2.0.0"
 
 text-extensions@^1.0.0:
   version "1.9.0"
@@ -8931,10 +9178,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-throat@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
-  integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+throat@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
+  integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
 through2@3.0.0:
   version "3.0.0"
@@ -9060,11 +9307,20 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
+  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+  dependencies:
+    ip-regex "^2.1.0"
     psl "^1.1.28"
     punycode "^2.1.1"
 
@@ -9119,6 +9375,16 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
 type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
@@ -9131,6 +9397,13 @@ type-is@~1.6.17:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
@@ -9451,6 +9724,15 @@ uuid@^7.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
   integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
+v8-to-istanbul@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz#387d173be5383dbec209d21af033dcb892e3ac82"
+  integrity sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+    source-map "^0.7.3"
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -9499,6 +9781,15 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^1.0.0"
 
+w3c-xmlserializer@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz#30485ca7d70a6fd052420a3d12fd90e6339ce794"
+  integrity sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==
+  dependencies:
+    domexception "^1.0.1"
+    webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
+
 walkdir@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.10.tgz#36037cab663b5e1c0166007b5f7b918b3279a54f"
@@ -9523,26 +9814,17 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-
-whatwg-url@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
 
 whatwg-url@^7.0.0:
   version "7.1.0"
@@ -9563,7 +9845,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@^1.1.1, which@^1.2.1, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which@^1.1.1, which@^1.2.1, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -9647,15 +9929,6 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
-  integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
-
 write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
@@ -9664,6 +9937,16 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-json-file@^2.2.0:
   version "2.3.0"
@@ -9697,19 +9980,17 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-ws@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
-  dependencies:
-    async-limiter "~1.0.0"
-
 ws@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
 ws@~3.3.1:
   version "3.3.3"
@@ -9724,6 +10005,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xmlchars@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
@@ -9769,14 +10055,6 @@ yargs-parser@^10.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
-  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
@@ -9793,21 +10071,13 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs@^13.3.0:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
-  integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
+yargs-parser@^18.1.1:
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.1.tgz#bf7407b915427fc760fcbbccc6c82b4f0ffcbd37"
+  integrity sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==
   dependencies:
-    cliui "^5.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^13.1.1"
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs@^14.2.2:
   version "14.2.2"
@@ -9825,6 +10095,23 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.0"
+
+yargs@^15.0.0:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
 
 yargs@^15.1.0:
   version "15.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,15 +706,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^25.1.0":
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
@@ -1642,12 +1633,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^24.0.12":
-  version "24.9.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
-  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
+"@types/jest@^25.1.4":
+  version "25.1.4"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.4.tgz#9e9f1e59dda86d3fd56afce71d1ea1b331f6f760"
+  integrity sha512-QDDY2uNAhCV7TMCITrxz+MRk1EizcsevzfeS6LykIlq2V1E5oO4wXG8V2ZEd9w7Snxeeagk46YbMgZ8ESHx3sw==
   dependencies:
-    jest-diff "^24.3.0"
+    jest-diff "^25.1.0"
+    pretty-format "^25.1.0"
 
 "@types/lodash@^4.14.110":
   version "4.14.149"
@@ -1711,13 +1703,6 @@
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
-
-"@types/yargs@^13.0.0":
-  version "13.0.8"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.8.tgz#a38c22def2f1c2068f8971acb3ea734eb3c64a99"
-  integrity sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.4"
@@ -1908,7 +1893,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -3607,11 +3592,6 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
-
-diff-sequences@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^25.1.0:
   version "25.1.0"
@@ -5492,16 +5472,6 @@ jest-config@^25.1.0:
     pretty-format "^25.1.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
 jest-diff@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.1.0.tgz#58b827e63edea1bc80c1de952b80cec9ac50e1ad"
@@ -5552,11 +5522,6 @@ jest-environment-node@^25.1.0:
     "@jest/types" "^25.1.0"
     jest-mock "^25.1.0"
     jest-util "^25.1.0"
-
-jest-get-type@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
-  integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
 jest-get-type@^25.1.0:
   version "25.1.0"
@@ -7614,16 +7579,6 @@ prettier@1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-pretty-format@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
 pretty-format@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.1.0.tgz#ed869bdaec1356fc5ae45de045e2c8ec7b07b0c8"
@@ -7865,11 +7820,6 @@ react-is@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^16.8.4:
-  version "16.13.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
-  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* bump jest to 25.1.0
* blog post about jest 25 https://jestjs.io/blog/2020/01/21/jest-25

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
