### PR TITLE
Protocol tests

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -17,7 +17,7 @@ import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
 plugins {
-    id("software.amazon.smithy") version "0.4.1"
+    id("software.amazon.smithy") version "0.4.3"
 }
 
 dependencies {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -149,7 +149,8 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         writer.write("body = \"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\";");
 
         writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
-        writer.write("const bodyNode = new __XmlNode($S);", operation.getId().getName());
+        writer.write("const bodyNode = new __XmlNode($S);",
+                documentBindings.get(0).getMember().getContainer().getName());
 
         // Always add @xmlNamespace value of the service to the root node, since we're
         // creating a wrapper node not based on a structure.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcMemberDeserVisitor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Overrides the default implementation of BigDecimal and BigInteger shape
+ * deserialization to throw when encountered in AWS JSON RPC based protocols.
+ *
+ * Also converts any blob value to a Uint8Array.
+ */
+final class JsonRpcMemberDeserVisitor extends DocumentMemberDeserVisitor {
+
+    /**
+     * @inheritDoc
+     */
+    JsonRpcMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+        super(context, dataSource, defaultTimestampFormat);
+    }
+
+    @Override
+    public String blobShape(BlobShape shape) {
+        return "Uint8Array.from(" + getDataSource() + ")";
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    private String unsupportedShape(Shape shape) {
+        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
+                shape.getType(), shape.getId()));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcMemberSerVisitor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Overrides the default implementation of BigDecimal and BigInteger shape
+ * serialization to throw when encountered in AWS JSON RPC based protocols.
+ *
+ * Also turns any blob into a utf-8 encoded string for wire serialization.
+ *
+ * TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
+ */
+final class JsonRpcMemberSerVisitor extends DocumentMemberSerVisitor {
+
+    /**
+     * @inheritDoc
+     */
+    JsonRpcMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+        super(context, dataSource, defaultTimestampFormat);
+    }
+
+    @Override
+    public String blobShape(BlobShape shape) {
+        return "Buffer.from(" + getDataSource() + ").toString(\"utf-8\")";
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        // Fail instead of losing precision through Number.
+        return unsupportedShape(shape);
+    }
+
+    private String unsupportedShape(Shape shape) {
+        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
+                shape.getType(), shape.getId()));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -35,8 +35,8 @@ import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGene
  *
  * @see JsonShapeSerVisitor
  * @see JsonShapeDeserVisitor
- * @see JsonMemberSerVisitor
- * @see JsonMemberDeserVisitor
+ * @see JsonRpcMemberSerVisitor
+ * @see JsonRpcMemberDeserVisitor
  * @see AwsProtocolUtils
  */
 abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
@@ -60,12 +60,14 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
     @Override
     protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes,
+                new JsonShapeSerVisitor(context, dataSource -> getMemberSerVisitor(context, dataSource)));
     }
 
     @Override
     protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes,
+                new JsonShapeDeserVisitor(context, dataSource -> getMemberDeserVisitor(context, dataSource)));
     }
 
     @Override
@@ -99,7 +101,7 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     }
 
     private DocumentMemberSerVisitor getMemberSerVisitor(GenerationContext context, String dataSource) {
-        return new JsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
+        return new JsonRpcMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
     }
 
     @Override
@@ -122,6 +124,6 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     }
 
     private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
-        return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
+        return new JsonRpcMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.DocumentShape;
@@ -42,13 +43,18 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * Timestamps are deserialized from {@link Format}.EPOCH_SECONDS by default.
  */
 final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
+    private final Function<String, DocumentMemberDeserVisitor> memberDeserVisitorSupplier;
 
-    JsonShapeDeserVisitor(GenerationContext context) {
+    JsonShapeDeserVisitor(
+            GenerationContext context,
+            Function<String, DocumentMemberDeserVisitor> memberDeserVisitorSupplier
+    ) {
         super(context);
+        this.memberDeserVisitorSupplier = memberDeserVisitorSupplier;
     }
 
     private DocumentMemberDeserVisitor getMemberVisitor(String dataSource) {
-        return new JsonMemberDeserVisitor(getContext(), dataSource, Format.EPOCH_SECONDS);
+        return memberDeserVisitorSupplier.apply(dataSource);
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.DocumentShape;
@@ -42,13 +43,19 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * Timestamps are serialized to {@link Format}.EPOCH_SECONDS by default.
  */
 final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
+    private static final Format TIMESTAMP_FORMAT = Format.EPOCH_SECONDS;
+    private final Function<String, DocumentMemberSerVisitor> memberSerVisitorSupplier;
 
-    JsonShapeSerVisitor(GenerationContext context) {
+    JsonShapeSerVisitor(
+            GenerationContext context,
+            Function<String, DocumentMemberSerVisitor> memberSerVisitorSupplier
+    ) {
         super(context);
+        this.memberSerVisitorSupplier = memberSerVisitorSupplier;
     }
 
     private DocumentMemberSerVisitor getMemberVisitor(String dataSource) {
-        return new JsonMemberSerVisitor(getContext(), dataSource, Format.EPOCH_SECONDS);
+        return memberSerVisitorSupplier.apply(dataSource);
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonMemberDeserVisitor.java
@@ -20,21 +20,19 @@ import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
-import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
  * Overrides the default implementation of BigDecimal and BigInteger shape
- * serialization to throw when encountered in AWS JSON based protocols.
- *
- * TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
+ * deserialization to throw when encountered in AWS REST JSON based protocols.
  */
-final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
+final class RestJsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
 
     /**
      * @inheritDoc
      */
-    JsonMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    RestJsonMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
     }
 
@@ -51,7 +49,7 @@ final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
+        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
                 shape.getType(), shape.getId()));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonMemberSerVisitor.java
@@ -20,19 +20,21 @@ import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
-import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
  * Overrides the default implementation of BigDecimal and BigInteger shape
- * deserialization to throw when encountered in AWS JSON based protocols.
+ * serialization to throw when encountered in AWS REST-JSON based protocols.
+ *
+ * TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
  */
-final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
+final class RestJsonMemberSerVisitor extends DocumentMemberSerVisitor {
 
     /**
      * @inheritDoc
      */
-    JsonMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    RestJsonMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
     }
 
@@ -49,7 +51,7 @@ final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
+        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
                 shape.getType(), shape.getId()));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -41,8 +41,8 @@ import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocol
  *
  * @see JsonShapeSerVisitor
  * @see JsonShapeDeserVisitor
- * @see JsonMemberSerVisitor
- * @see JsonMemberDeserVisitor
+ * @see RestJsonMemberSerVisitor
+ * @see RestJsonMemberDeserVisitor
  * @see AwsProtocolUtils
  * @see <a href="https://awslabs.github.io/smithy/spec/http.html">Smithy HTTP protocol bindings.</a>
  */
@@ -61,12 +61,14 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes,
+                new JsonShapeSerVisitor(context, dataSource -> getMemberSerVisitor(context, dataSource)));
     }
 
     @Override
     protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes,
+                new JsonShapeDeserVisitor(context, dataSource -> getMemberDeserVisitor(context, dataSource)));
     }
 
     @Override
@@ -138,7 +140,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     private DocumentMemberSerVisitor getMemberSerVisitor(GenerationContext context, String dataSource) {
-        return new JsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
+        return new RestJsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
     }
 
     @Override
@@ -175,6 +177,6 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
-        return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
+        return new RestJsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -115,8 +115,14 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
             // Generate an if statement to set the bodyParam if the member is set.
             writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
-                writer.write("bodyParams['$L'] = $L;", locationName,
-                        target.accept(getMemberSerVisitor(context, inputLocation)));
+                // Handle @timestampFormat on members not just the targeted shape.
+                String valueProvider = memberShape.hasTrait(TimestampFormatTrait.class)
+                        ? AwsProtocolUtils.getInputTimestampValueProvider(context, memberShape,
+                                getDocumentTimestampFormat(), inputLocation)
+                        : target.accept(getMemberSerVisitor(context, inputLocation));
+
+                // Dispatch to the input value provider for any additional handling.
+                writer.write("bodyParams['$L'] = $L;", locationName, valueProvider);
             });
         }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.BooleanShape;
 import software.amazon.smithy.model.shapes.ByteShape;
 import software.amazon.smithy.model.shapes.DoubleShape;
@@ -56,6 +57,11 @@ final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
     @Override
     public String stringShape(StringShape shape) {
         return getAsXmlText(shape, super.stringShape(shape));
+    }
+
+    @Override
+    public String blobShape(BlobShape shape) {
+        return getAsXmlText(shape, super.blobShape(shape));
     }
 
     @Override
@@ -102,7 +108,7 @@ final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
         return getAsXmlText(shape, "String(" + getDataSource() + ")");
     }
 
-    private String getAsXmlText(Shape shape, String dataSource) {
+    String getAsXmlText(Shape shape, String dataSource) {
         // Handle the @xmlName trait for the shape itself.
         String nodeName = shape.getTrait(XmlNameTrait.class)
                 .map(XmlNameTrait::getValue)

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/load-rest-json-error-code-stub.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/load-rest-json-error-code-stub.ts
@@ -1,0 +1,36 @@
+/**
+ * Load an error code for the aws.rest-json-1.1 protocol.
+ */
+const loadRestJsonErrorCode = (
+  output: __HttpResponse,
+  data: any
+): string => {
+  const findKey = (object: any, key: string) =>
+    Object.keys(object).find(k => k.toLowerCase() === key.toLowerCase());
+
+  const sanitizeErrorCode = (rawValue: string): string => {
+    let cleanValue = rawValue;
+    if (cleanValue.indexOf(':') >= 0) {
+      cleanValue = cleanValue.split(':')[0];
+    }
+    if (cleanValue.indexOf('#') >= 0) {
+      cleanValue = cleanValue.split('#')[1];
+    }
+    return cleanValue;
+  };
+
+  const headerKey = findKey(output.headers, "x-amzn-errortype");
+  if (headerKey !== undefined) {
+    return sanitizeErrorCode(output.headers[headerKey]);
+  }
+
+  if (data.code !== undefined) {
+    return sanitizeErrorCode(data.code);
+  }
+
+  if (data['__type'] !== undefined) {
+    return sanitizeErrorCode(data['__type']);
+  }
+
+  return '';
+}

--- a/packages/smithy-client/src/date-utils.ts
+++ b/packages/smithy-client/src/date-utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Builds a proper UTC HttpDate timestamp from a Date object
+ * since not all environments will have this as the expected
+ * format.
+ * 
+ * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
+ * > Prior to ECMAScript 2018, the format of the return value
+ * > varied according to the platform. The most common return
+ * > value was an RFC-1123 formatted date stamp, which is a
+ * > slightly updated version of RFC-822 date stamps.
+ */
+
+// Build indexes outside so we allocate them once.
+const days: Array<String> = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const months: Array<String> = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export function dateToUtcString(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const dayOfWeek = date.getUTCDay();
+  const dayOfMonthInt = date.getUTCDate();
+  const hoursInt = date.getUTCHours();
+  const minutesInt = date.getUTCMinutes();
+  const secondsInt = date.getUTCSeconds();
+
+  // Build 0 prefixed strings for contents that need to be
+  // two digits and where we get an integer back.
+  const dayOfMonthString = dayOfMonthInt < 10 ? `0${dayOfMonthInt}` : `${dayOfMonthInt}`;
+  const hoursString = hoursInt < 10 ? `0${hoursInt}` : `${hoursInt}`;
+  const minutesString = minutesInt < 10 ? `0${minutesInt}` : `${minutesInt}`;
+  const secondsString = secondsInt < 10 ? `0${secondsInt}` : `${secondsInt}`;
+
+  return `${days[dayOfWeek]}, ${dayOfMonthString} ${months[month]} ${year} ${hoursString}:${minutesString}:${secondsString} GMT`;
+}

--- a/packages/smithy-client/src/extended-encode-uri-component.ts
+++ b/packages/smithy-client/src/extended-encode-uri-component.ts
@@ -3,7 +3,7 @@
  * to fully adhere to RFC 3986.
  */
 export function extendedEncodeURIComponent(str: string): string {
-  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
     return "%" + c.charCodeAt(0).toString(16);
-  });
+  }).replace(/%20/g, "+");
 }

--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -5,3 +5,4 @@ export * from "./exception";
 export * from "./isa";
 export * from "./lazy-json";
 export * from "./extended-encode-uri-component";
+export * from "./date-utils";

--- a/packages/smithy-client/src/isa.ts
+++ b/packages/smithy-client/src/isa.ts
@@ -3,6 +3,10 @@
  */
 export function isa<T>(o: any, ...ids: string[]): o is T {
   return (
-    typeof o === "object" && "__type" in o && ids.indexOf(o["__type"]) > -1
+    typeof o === "object" && (
+      // Checks for name after __type, as name is used instead for errors.
+      "__type" in o && ids.indexOf(o["__type"]) > -1
+      || "name" in o && ids.indexOf(o["name"]) > -1
+    )
   );
 }


### PR DESCRIPTION
The following is a collection of fixes, broken down to individual commits, to AWS specific protocol code generation discovered while running the AWS protocol tests. Some of these commits are to the shared `smithy-client` package as well.

* Add RFC 7231 date formatter
* Update isa to work for errors
* Use + for spaces in encoding
* Use 0.4.3 smithy gradle plugin
* Fix request root node name
* Add timestamp input supplier helper
* Fix several aws.query serialization issues
This commit fixes naming and counting issues when serializing list,
set, and map types. It also fixes an issue with serializing timestamp
shapes within list, set, and map types.
* Fix issues with aws.rest-xml serialization
This commit fixes an issue with map serialization. It also fixes an
issue where timestamps were not being formatted properly when the
timestampFormat trait was applied to the member. It also fixes an
issue where blob shapes wouldn't be rendered in XML elements.
* Fix XML collection/map deserialization
* Update member deser strategy for JSON protocols
This commit splits the member serialization for the aws.json and
aws.rest-json protocols due to a difference in blob serialization
methods around b64 encoding. The JsonShape[Deser|Ser]Visitor classes
have been updated to take a member visitor supplier function, and the
protocols themselves pass that in.
* Use a function for rest-json error deser
* Fix JSON timestampFormat on member ser

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
