### PR TITLE
chore: change credentials.expiration from number to Date

### DIFF
--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
@@ -31,7 +31,7 @@ describe("fromCognitoIdentity", () => {
       accessKeyId: "foo",
       secretAccessKey: "bar",
       sessionToken: "baz",
-      expiration: Math.floor(expiration.valueOf() / 1000)
+      expiration
     });
 
     expect(send.mock.calls[0][0]).toEqual(

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -36,8 +36,6 @@ export function fromCognitoIdentity(
       secretAccessKey: SecretKey,
       sessionToken: SessionToken,
       expiration: Expiration
-        ? Math.floor(Expiration.valueOf() / 1000)
-        : undefined
     };
   };
 }

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
@@ -2,12 +2,13 @@ import { fromCognitoIdentityPool } from "./fromCognitoIdentityPool";
 import { ProviderError } from "@aws-sdk/property-provider";
 import { GetIdCommand } from "@aws-sdk/client-cognito-identity";
 
+const expiration = new Date();
 jest.mock("./fromCognitoIdentity", () => {
   const promiseFunc = jest.fn().mockResolvedValue({
     accessKeyId: "foo",
     secretAccessKey: "bar",
     sessionToken: "baz",
-    expiration: 946684800
+    expiration
   });
   return { fromCognitoIdentity: jest.fn().mockReturnValue(promiseFunc) };
 });
@@ -53,7 +54,7 @@ describe("fromCognitoIdentityPool", () => {
       accessKeyId: "foo",
       secretAccessKey: "bar",
       sessionToken: "baz",
-      expiration: 946684800
+      expiration
     });
 
     expect(send.mock.calls.length).toBe(1);
@@ -110,7 +111,7 @@ describe("fromCognitoIdentityPool", () => {
         accessKeyId: "foo",
         secretAccessKey: "bar",
         sessionToken: "baz",
-        expiration: 946684800
+        expiration
       });
     }
 

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
@@ -2,13 +2,11 @@ import { fromCognitoIdentityPool } from "./fromCognitoIdentityPool";
 import { ProviderError } from "@aws-sdk/property-provider";
 import { GetIdCommand } from "@aws-sdk/client-cognito-identity";
 
-const expiration = new Date();
 jest.mock("./fromCognitoIdentity", () => {
   const promiseFunc = jest.fn().mockResolvedValue({
     accessKeyId: "foo",
     secretAccessKey: "bar",
-    sessionToken: "baz",
-    expiration
+    sessionToken: "baz"
   });
   return { fromCognitoIdentity: jest.fn().mockReturnValue(promiseFunc) };
 });
@@ -53,8 +51,7 @@ describe("fromCognitoIdentityPool", () => {
     ).toEqual({
       accessKeyId: "foo",
       secretAccessKey: "bar",
-      sessionToken: "baz",
-      expiration
+      sessionToken: "baz"
     });
 
     expect(send.mock.calls.length).toBe(1);
@@ -110,8 +107,7 @@ describe("fromCognitoIdentityPool", () => {
       expect(await provider()).toEqual({
         accessKeyId: "foo",
         secretAccessKey: "bar",
-        sessionToken: "baz",
-        expiration
+        sessionToken: "baz"
       });
     }
 

--- a/packages/credential-provider-env/src/index.spec.ts
+++ b/packages/credential-provider-env/src/index.spec.ts
@@ -22,16 +22,17 @@ afterAll(() => {
 
 describe("fromEnv", () => {
   it("should read credentials from known environment variables", async () => {
+    const dateString = "1970-01-01T07:00:00Z";
     process.env[ENV_KEY] = "foo";
     process.env[ENV_SECRET] = "bar";
     process.env[ENV_SESSION] = "baz";
-    process.env[ENV_EXPIRATION] = "1970-01-01T07:00:00Z";
+    process.env[ENV_EXPIRATION] = dateString;
 
     expect(await fromEnv()()).toEqual({
       accessKeyId: "foo",
       secretAccessKey: "bar",
       sessionToken: "baz",
-      expiration: 25200
+      expiration: new Date(dateString)
     });
   });
 

--- a/packages/credential-provider-env/src/index.ts
+++ b/packages/credential-provider-env/src/index.ts
@@ -21,7 +21,7 @@ export function fromEnv(): CredentialProvider {
         accessKeyId,
         secretAccessKey,
         sessionToken: process.env[ENV_SESSION],
-        expiration: expiry ? Math.floor(Date.parse(expiry) / 1000) : undefined
+        expiration: expiry ? new Date(expiry) : undefined
       });
     }
 

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
@@ -48,8 +48,6 @@ describe("fromImdsCredentials", () => {
     expect(converted.accessKeyId).toEqual(creds.AccessKeyId);
     expect(converted.secretAccessKey).toEqual(creds.SecretAccessKey);
     expect(converted.sessionToken).toEqual(creds.Token);
-    expect(converted.expiration).toEqual(
-      Math.floor(new Date(creds.Expiration).valueOf() / 1000)
-    );
+    expect(converted.expiration).toEqual(new Date(creds.Expiration));
   });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
@@ -23,6 +23,6 @@ export function fromImdsCredentials(creds: ImdsCredentials): Credentials {
     accessKeyId: creds.AccessKeyId,
     secretAccessKey: creds.SecretAccessKey,
     sessionToken: creds.Token,
-    expiration: Math.floor(new Date(creds.Expiration).valueOf() / 1000)
+    expiration: new Date(creds.Expiration)
   };
 }

--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -393,7 +393,7 @@ describe("defaultProvider", () => {
         Promise.resolve({
           accessKeyId: "foo",
           secretAccessKey: "bar",
-          expiration: Date.now() + 600 // expires in ten minutes
+          expiration: new Date(Date.now() + 600000) // expires in ten minutes
         })
       );
       const memoized = defaultProvider();

--- a/packages/credential-provider-node/src/index.ts
+++ b/packages/credential-provider-node/src/index.ts
@@ -60,13 +60,9 @@ export function defaultProvider(
     providerChain,
     credentials =>
       credentials.expiration !== undefined &&
-      credentials.expiration - getEpochTs() < 300,
+      credentials.expiration.getTime() - Date.now() < 300000,
     credentials => credentials.expiration !== undefined
   );
-}
-
-function getEpochTs() {
-  return Math.floor(Date.now() / 1000);
 }
 
 function remoteProvider(init: RemoteProviderInit): CredentialProvider {

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -21,10 +21,9 @@ export interface Credentials {
   readonly sessionToken?: string;
 
   /**
-   * UNIX epoch timestamp (seconds since 1 January, 1970 00:00:00 GMT) when
-   * these credentials will no longer be accepted.
+   * A {Date} when these credentials will no longer be accepted.
    */
-  readonly expiration?: number;
+  readonly expiration?: Date;
 }
 
 export type CredentialProvider = Provider<Credentials>;


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/aws-sdk-js-v3/issues/1037

*Description of changes:*
chore: change credentials.expiration from number to Date

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
