### PR TITLE
chore: copy dependabot config from dashboard

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    version_requirement_updates: "increase_versions_if_necessary"


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/625

*Description of changes:*
* copy dependabot config from dashboard https://app.dependabot.com/accounts/aws/projects/131620
* we've been updating various settings on dependabot dashboard, and plan to stick with the following:
  * update_schedule: "weekly" ([docs](https://dependabot.com/docs/config-file/#update_schedule-required))
  * version_requirement_updates: "increase_versions_if_necessary" ([docs](https://dependabot.com/docs/config-file/#version_requirement_updates))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
