### PR TITLE
fix: issues in protocol codegen

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -142,8 +142,14 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             OperationShape operation,
             List<HttpBinding> documentBindings
     ) {
-        SymbolProvider symbolProvider = context.getSymbolProvider();
+        // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
+        if (documentBindings.isEmpty()) {
+            writer.write("body = \"\";");
+            return;
+        }
+
+        SymbolProvider symbolProvider = context.getSymbolProvider();
 
         // Start with the XML declaration.
         writer.write("body = \"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\";");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -95,8 +95,14 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             OperationShape operation,
             List<HttpBinding> documentBindings
     ) {
-        SymbolProvider symbolProvider = context.getSymbolProvider();
+        // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
+        if (documentBindings.isEmpty()) {
+            writer.write("body = \"{}\";");
+            return;
+        }
+
+        SymbolProvider symbolProvider = context.getSymbolProvider();
 
         writer.write("const bodyParams: any = {};");
         for (HttpBinding binding : documentBindings) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -68,26 +68,29 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
         // Dispatch to the output value provider for any additional handling.
         writer.write("const contents: any = [];");
         writer.openBlock("(output || []).map((entry: any) => {", "});", () -> {
-            String dataSource = handleTargetWrapping(context, target, "entry");
+            String dataSource = handleUnnamedTargetWrapping(context, target, "entry");
             writer.write("contents.push($L);", target.accept(getMemberVisitor(dataSource)));
         });
         writer.write("return contents;");
     }
 
-    private boolean deserializationReturnsArray(Shape shape) {
-        return (shape instanceof CollectionShape) || (shape instanceof MapShape);
-    }
-
-    private String handleTargetWrapping(GenerationContext context, Shape shape, String dataSource) {
-        if (!deserializationReturnsArray(shape)) {
+    private String handleUnnamedTargetWrapping(GenerationContext context, Shape target, String dataSource) {
+        if (!deserializationReturnsArray(target)) {
             return dataSource;
         }
 
         TypeScriptWriter writer = context.getWriter();
         // The XML parser will set one K:V for a member that could
         // return multiple entries but only has one.
-        writer.write("const wrappedItem = ($1L instanceof Array) ? $1L : [$1L];", dataSource);
+        // Update the target element if we target another level of collection.
+        String targetLocation = getUnnamedAggregateTargetLocation(context.getModel(), target);
+        writer.write("const wrappedItem = ($1L[$2S] instanceof Array) ? $1L[$2S] : [$1L[$2S]];",
+                dataSource, targetLocation);
         return "wrappedItem";
+    }
+
+    private boolean deserializationReturnsArray(Shape shape) {
+        return (shape instanceof CollectionShape) || (shape instanceof MapShape);
     }
 
     @Override
@@ -109,7 +112,7 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
         writer.write("const mapParams: any = {};");
         writer.openBlock("output.forEach((pair: any) => {", "});", () -> {
             // Dispatch to the output value provider for any additional handling.
-            String dataSource = handleTargetWrapping(context, target, "pair[\"" + valueLocation + "\"]");
+            String dataSource = handleUnnamedTargetWrapping(context, target, "pair[\"" + valueLocation + "\"]");
             writer.write("mapParams[pair[$S]] = $L;", keyLocation, target.accept(getMemberVisitor(dataSource)));
         });
         writer.write("return mapParams;");
@@ -209,9 +212,21 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
                 .map(location -> location + " !== undefined")
                 .collect(Collectors.joining(" && "));
         writer.openBlock("if ($L) {", "}", validationStatement, () -> {
-            String dataSource = handleTargetWrapping(context, target, source);
+            String dataSource = handleNamedTargetWrapping(context, target, source);
             statementBodyGenerator.accept(dataSource, getMemberVisitor(dataSource));
         });
+    }
+
+    private String handleNamedTargetWrapping(GenerationContext context, Shape target, String dataSource) {
+        if (!deserializationReturnsArray(target)) {
+            return dataSource;
+        }
+
+        TypeScriptWriter writer = context.getWriter();
+        // The XML parser will set one K:V for a member that could
+        // return multiple entries but only has one.
+        writer.write("const wrappedItem = ($1L instanceof Array) ? $1L : [$1L];", dataSource);
+        return "wrappedItem";
     }
 
     private String getUnnamedAggregateTargetLocation(Model model, Shape shape) {


### PR DESCRIPTION
The following is a collection of fixes, broken down to individual commits, to AWS specific protocol code generation discovered while running the AWS protocol tests.

* Fix issue deserializing nested xml collections
* Fix issue in serializing nested xml collections
* Fix document body ser if no bindings present

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
