### PR TITLE
feat: Add util func to split over n delimiters

### DIFF
--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -6,3 +6,4 @@ export * from "./isa";
 export * from "./lazy-json";
 export * from "./extended-encode-uri-component";
 export * from "./date-utils";
+export * from "./split-every";

--- a/packages/smithy-client/src/split-every.spec.ts
+++ b/packages/smithy-client/src/split-every.spec.ts
@@ -1,0 +1,60 @@
+import { splitEvery } from "./split-every";
+describe("splitEvery", () => {
+  const m1 = "foo";
+  const m2 = "foo, bar";
+  const m3 = "foo, bar, baz";
+  const m4 = "foo, bar, baz, qux";
+  const m5 = "foo, bar, baz, qux, coo";
+  const m6 = "foo, bar, baz, qux, coo, tan";
+  const delim = ", ";
+
+  it("Errors on <= 0", () => {
+    expect(() => {
+      splitEvery(m2, delim, -1)
+    }).toThrow("Invalid number of delimiters");
+
+    expect(() => {
+      splitEvery(m2, delim, 0)
+    }).toThrow("Invalid number of delimiters");
+  });
+
+  it("Errors on non-integer", () => {
+    expect(() => {
+      splitEvery(m2, delim, 1.3)
+    }).toThrow("Invalid number of delimiters");
+
+    expect(() => {
+      splitEvery(m2, delim, 4.9)
+    }).toThrow("Invalid number of delimiters");
+  })
+
+  it("Handles splitting on 1", () => {
+    const count = 1;
+    expect(splitEvery(m1, delim, count)).toMatchObject(m1.split(delim));
+    expect(splitEvery(m2, delim, count)).toMatchObject(m2.split(delim));
+    expect(splitEvery(m3, delim, count)).toMatchObject(m3.split(delim));
+    expect(splitEvery(m4, delim, count)).toMatchObject(m4.split(delim));
+    expect(splitEvery(m5, delim, count)).toMatchObject(m5.split(delim));
+    expect(splitEvery(m6, delim, count)).toMatchObject(m6.split(delim));
+  })
+
+  it("Handles splitting on 2", () => {
+    const count = 2;
+    expect(splitEvery(m1, delim, count)).toMatchObject(["foo"]);
+    expect(splitEvery(m2, delim, count)).toMatchObject(["foo, bar"]);
+    expect(splitEvery(m3, delim, count)).toMatchObject(["foo, bar", "baz"]);
+    expect(splitEvery(m4, delim, count)).toMatchObject(["foo, bar", "baz, qux"]);
+    expect(splitEvery(m5, delim, count)).toMatchObject(["foo, bar", "baz, qux", "coo"]);
+    expect(splitEvery(m6, delim, count)).toMatchObject(["foo, bar", "baz, qux", "coo, tan"]);
+  })
+
+  it("Handles splitting on 3", () => {
+    const count = 3;
+    expect(splitEvery(m1, delim, count)).toMatchObject(["foo"]);
+    expect(splitEvery(m2, delim, count)).toMatchObject(["foo, bar"]);
+    expect(splitEvery(m3, delim, count)).toMatchObject(["foo, bar, baz"]);
+    expect(splitEvery(m4, delim, count)).toMatchObject(["foo, bar, baz", "qux"]);
+    expect(splitEvery(m5, delim, count)).toMatchObject(["foo, bar, baz", "qux, coo"]);
+    expect(splitEvery(m6, delim, count)).toMatchObject(["foo, bar, baz", "qux, coo, tan"]);
+  })
+});

--- a/packages/smithy-client/src/split-every.ts
+++ b/packages/smithy-client/src/split-every.ts
@@ -1,0 +1,46 @@
+/**
+ * Given an input string, splits based on the delimiter after a given
+ * number of delimiters has been encountered.
+ *
+ * @param value The input string to split.
+ * @param delimiter The delimiter to split on.
+ * @param numDelimiters The number of delimiters to have encountered to split.
+ */
+export function splitEvery(value: string, delimiter: string, numDelimiters: number): Array<string> {
+  // Fail if we don't have a clear number to split on.
+  if (numDelimiters <= 0 || !Number.isInteger(numDelimiters)) {
+    throw new Error("Invalid number of delimiters (" + numDelimiters + ") for splitEvery.");
+  }
+
+  const segments = value.split(delimiter);
+  // Short circuit extra logic for the simple case.
+  if (numDelimiters === 1) {
+    return segments;
+  }
+
+  const compoundSegments: Array<string> = [];
+  let currentSegment = "";
+  for (let i = 0; i < segments.length; i++) {
+    if (currentSegment === "") {
+      // Start a new segment.
+      currentSegment = segments[i];
+    } else {
+      // Compound the current segment with the delimiter.
+      currentSegment += delimiter + segments[i];
+    }
+
+    if ((i + 1) % numDelimiters === 0) {
+      // We encountered the right number of delimiters, so add the entry.
+      compoundSegments.push(currentSegment);
+      // And reset the current segment.
+      currentSegment = "";
+    }
+  }
+
+  // Handle any leftover segment portion.
+  if (currentSegment !== "") {
+    compoundSegments.push(currentSegment);
+  }
+
+  return compoundSegments;
+}


### PR DESCRIPTION
Adds a function that given an input string, splits based on the delimiter after a given
number of delimiters has been encountered.

-----

This function is useful for splitting header lists of timestamps in the HTTP_DATE format.

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
