### PR TITLE
fix: test getCallerIdentity instead of getSession for STS

### DIFF
--- a/features/sts/step_definitions/sts.js
+++ b/features/sts/step_definitions/sts.js
@@ -21,15 +21,6 @@ module.exports = function() {
     }
   );
 
-  this.Then(
-    /^the result should contain an access key ID and secret access key$/,
-    function(callback) {
-      this.assert.compare(this.data.Credentials.AccessKeyId.length, ">", 0);
-      this.assert.compare(this.data.Credentials.SecretAccessKey.length, ">", 0);
-      callback();
-    }
-  );
-
   this.Given(/^I try to assume role with web identity$/, function(callback) {
     var params = {
       RoleArn: "arn:aws:iam::123456789:role/WebIdentity",

--- a/features/sts/sts.feature
+++ b/features/sts/sts.feature
@@ -5,9 +5,12 @@ Feature: AWS Security Token Service
   I want to use AWS Security Token Service
 
   @requiresakid @nosession
-  Scenario: Get a session token
-    Given I get an STS session token with a duration of 900 seconds
-    Then the result should contain an access key ID and secret access key
+  Scenario: Get caller identity
+    Given I run the "getCallerIdentity" operation
+    Then the request should be successful
+    Then the result should contain a property Account with a string
+    Then the result should contain a property Arn with a string
+    Then the result should contain a property UserId with a string
 
   Scenario: Error handling
     Given I get an STS session token with a duration of 60 seconds


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* test getCallerIdentity instead of getSession for STS
* we're using temporary credentials for running integration tests in release pipeline, and this test is failing with `AccessDenied: Cannot call GetSessionToken with session credentials` ([docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#getSessionToken-property))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
