### PR TITLE
chore: prettify smithy-client

### DIFF
--- a/packages/smithy-client/src/date-utils.ts
+++ b/packages/smithy-client/src/date-utils.ts
@@ -2,7 +2,7 @@
  * Builds a proper UTC HttpDate timestamp from a Date object
  * since not all environments will have this as the expected
  * format.
- * 
+ *
  * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
  * > Prior to ECMAScript 2018, the format of the return value
  * > varied according to the platform. The most common return
@@ -12,7 +12,20 @@
 
 // Build indexes outside so we allocate them once.
 const days: Array<String> = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-const months: Array<String> = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const months: Array<String> = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
 
 export function dateToUtcString(date: Date): string {
   const year = date.getUTCFullYear();
@@ -25,7 +38,8 @@ export function dateToUtcString(date: Date): string {
 
   // Build 0 prefixed strings for contents that need to be
   // two digits and where we get an integer back.
-  const dayOfMonthString = dayOfMonthInt < 10 ? `0${dayOfMonthInt}` : `${dayOfMonthInt}`;
+  const dayOfMonthString =
+    dayOfMonthInt < 10 ? `0${dayOfMonthInt}` : `${dayOfMonthInt}`;
   const hoursString = hoursInt < 10 ? `0${hoursInt}` : `${hoursInt}`;
   const minutesString = minutesInt < 10 ? `0${minutesInt}` : `${minutesInt}`;
   const secondsString = secondsInt < 10 ? `0${secondsInt}` : `${secondsInt}`;

--- a/packages/smithy-client/src/date-utils.ts
+++ b/packages/smithy-client/src/date-utils.ts
@@ -12,20 +12,8 @@
 
 // Build indexes outside so we allocate them once.
 const days: Array<String> = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-const months: Array<String> = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
+// prettier-ignore
+const months: Array<String> = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 export function dateToUtcString(date: Date): string {
   const year = date.getUTCFullYear();

--- a/packages/smithy-client/src/isa.ts
+++ b/packages/smithy-client/src/isa.ts
@@ -3,10 +3,9 @@
  */
 export function isa<T>(o: any, ...ids: string[]): o is T {
   return (
-    typeof o === "object" && (
-      // Checks for name after __type, as name is used instead for errors.
-      "__type" in o && ids.indexOf(o["__type"]) > -1
-      || "name" in o && ids.indexOf(o["name"]) > -1
-    )
+    typeof o === "object" &&
+    // Checks for name after __type, as name is used instead for errors.
+    (("__type" in o && ids.indexOf(o["__type"]) > -1) ||
+      ("name" in o && ids.indexOf(o["name"]) > -1))
   );
 }

--- a/packages/smithy-client/src/lazy-json.ts
+++ b/packages/smithy-client/src/lazy-json.ts
@@ -13,7 +13,7 @@ interface StringWrapper {
  * class including its prototype chain. So we can extend from here.
  */
 // @ts-ignore StringWrapper implementation is not a simple constructor
-export const StringWrapper: StringWrapper = function() {
+export const StringWrapper: StringWrapper = function () {
   //@ts-ignore 'this' cannot be assigned to any, but Object.getPrototypeOf accepts any
   const Class = Object.getPrototypeOf(this).constructor;
   const Constructor = Function.bind.apply(String, [null as any, ...arguments]);
@@ -27,8 +27,8 @@ StringWrapper.prototype = Object.create(String.prototype, {
     value: StringWrapper,
     enumerable: false,
     writable: true,
-    configurable: true
-  }
+    configurable: true,
+  },
 });
 Object.setPrototypeOf(StringWrapper, String);
 

--- a/packages/smithy-client/src/lazy-json.ts
+++ b/packages/smithy-client/src/lazy-json.ts
@@ -27,8 +27,8 @@ StringWrapper.prototype = Object.create(String.prototype, {
     value: StringWrapper,
     enumerable: false,
     writable: true,
-    configurable: true,
-  },
+    configurable: true
+  }
 });
 Object.setPrototypeOf(StringWrapper, String);
 

--- a/packages/smithy-client/src/split-every.spec.ts
+++ b/packages/smithy-client/src/split-every.spec.ts
@@ -10,23 +10,23 @@ describe("splitEvery", () => {
 
   it("Errors on <= 0", () => {
     expect(() => {
-      splitEvery(m2, delim, -1)
+      splitEvery(m2, delim, -1);
     }).toThrow("Invalid number of delimiters");
 
     expect(() => {
-      splitEvery(m2, delim, 0)
+      splitEvery(m2, delim, 0);
     }).toThrow("Invalid number of delimiters");
   });
 
   it("Errors on non-integer", () => {
     expect(() => {
-      splitEvery(m2, delim, 1.3)
+      splitEvery(m2, delim, 1.3);
     }).toThrow("Invalid number of delimiters");
 
     expect(() => {
-      splitEvery(m2, delim, 4.9)
+      splitEvery(m2, delim, 4.9);
     }).toThrow("Invalid number of delimiters");
-  })
+  });
 
   it("Handles splitting on 1", () => {
     const count = 1;
@@ -36,25 +36,45 @@ describe("splitEvery", () => {
     expect(splitEvery(m4, delim, count)).toMatchObject(m4.split(delim));
     expect(splitEvery(m5, delim, count)).toMatchObject(m5.split(delim));
     expect(splitEvery(m6, delim, count)).toMatchObject(m6.split(delim));
-  })
+  });
 
   it("Handles splitting on 2", () => {
     const count = 2;
     expect(splitEvery(m1, delim, count)).toMatchObject(["foo"]);
     expect(splitEvery(m2, delim, count)).toMatchObject(["foo, bar"]);
     expect(splitEvery(m3, delim, count)).toMatchObject(["foo, bar", "baz"]);
-    expect(splitEvery(m4, delim, count)).toMatchObject(["foo, bar", "baz, qux"]);
-    expect(splitEvery(m5, delim, count)).toMatchObject(["foo, bar", "baz, qux", "coo"]);
-    expect(splitEvery(m6, delim, count)).toMatchObject(["foo, bar", "baz, qux", "coo, tan"]);
-  })
+    expect(splitEvery(m4, delim, count)).toMatchObject([
+      "foo, bar",
+      "baz, qux",
+    ]);
+    expect(splitEvery(m5, delim, count)).toMatchObject([
+      "foo, bar",
+      "baz, qux",
+      "coo",
+    ]);
+    expect(splitEvery(m6, delim, count)).toMatchObject([
+      "foo, bar",
+      "baz, qux",
+      "coo, tan",
+    ]);
+  });
 
   it("Handles splitting on 3", () => {
     const count = 3;
     expect(splitEvery(m1, delim, count)).toMatchObject(["foo"]);
     expect(splitEvery(m2, delim, count)).toMatchObject(["foo, bar"]);
     expect(splitEvery(m3, delim, count)).toMatchObject(["foo, bar, baz"]);
-    expect(splitEvery(m4, delim, count)).toMatchObject(["foo, bar, baz", "qux"]);
-    expect(splitEvery(m5, delim, count)).toMatchObject(["foo, bar, baz", "qux, coo"]);
-    expect(splitEvery(m6, delim, count)).toMatchObject(["foo, bar, baz", "qux, coo, tan"]);
-  })
+    expect(splitEvery(m4, delim, count)).toMatchObject([
+      "foo, bar, baz",
+      "qux",
+    ]);
+    expect(splitEvery(m5, delim, count)).toMatchObject([
+      "foo, bar, baz",
+      "qux, coo",
+    ]);
+    expect(splitEvery(m6, delim, count)).toMatchObject([
+      "foo, bar, baz",
+      "qux, coo, tan",
+    ]);
+  });
 });

--- a/packages/smithy-client/src/split-every.spec.ts
+++ b/packages/smithy-client/src/split-every.spec.ts
@@ -45,17 +45,17 @@ describe("splitEvery", () => {
     expect(splitEvery(m3, delim, count)).toMatchObject(["foo, bar", "baz"]);
     expect(splitEvery(m4, delim, count)).toMatchObject([
       "foo, bar",
-      "baz, qux",
+      "baz, qux"
     ]);
     expect(splitEvery(m5, delim, count)).toMatchObject([
       "foo, bar",
       "baz, qux",
-      "coo",
+      "coo"
     ]);
     expect(splitEvery(m6, delim, count)).toMatchObject([
       "foo, bar",
       "baz, qux",
-      "coo, tan",
+      "coo, tan"
     ]);
   });
 
@@ -66,15 +66,15 @@ describe("splitEvery", () => {
     expect(splitEvery(m3, delim, count)).toMatchObject(["foo, bar, baz"]);
     expect(splitEvery(m4, delim, count)).toMatchObject([
       "foo, bar, baz",
-      "qux",
+      "qux"
     ]);
     expect(splitEvery(m5, delim, count)).toMatchObject([
       "foo, bar, baz",
-      "qux, coo",
+      "qux, coo"
     ]);
     expect(splitEvery(m6, delim, count)).toMatchObject([
       "foo, bar, baz",
-      "qux, coo, tan",
+      "qux, coo, tan"
     ]);
   });
 });

--- a/packages/smithy-client/src/split-every.ts
+++ b/packages/smithy-client/src/split-every.ts
@@ -6,10 +6,16 @@
  * @param delimiter The delimiter to split on.
  * @param numDelimiters The number of delimiters to have encountered to split.
  */
-export function splitEvery(value: string, delimiter: string, numDelimiters: number): Array<string> {
+export function splitEvery(
+  value: string,
+  delimiter: string,
+  numDelimiters: number
+): Array<string> {
   // Fail if we don't have a clear number to split on.
   if (numDelimiters <= 0 || !Number.isInteger(numDelimiters)) {
-    throw new Error("Invalid number of delimiters (" + numDelimiters + ") for splitEvery.");
+    throw new Error(
+      "Invalid number of delimiters (" + numDelimiters + ") for splitEvery."
+    );
   }
 
   const segments = value.split(delimiter);


### PR DESCRIPTION
*Issue #, if available:*
* prettier was never run on smithy-client ([history](https://github.com/aws/aws-sdk-js-v3/commits/master/packages/smithy-client))
* this was noticed while bumping the repo to prettier@2 in https://github.com/aws/aws-sdk-js-v3/pull/1079

*Description of changes:*
chore: prettify smithy-client

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
