### PR TITLE
feat: add default destroy function to clients

### DIFF
--- a/clients/client-accessanalyzer/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/AccessAnalyzerClient.ts
@@ -307,5 +307,7 @@ export class AccessAnalyzerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-acm-pca/ACMPCAClient.ts
+++ b/clients/client-acm-pca/ACMPCAClient.ts
@@ -324,5 +324,7 @@ export class ACMPCAClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-acm/ACMClient.ts
+++ b/clients/client-acm/ACMClient.ts
@@ -275,5 +275,7 @@ export class ACMClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-alexa-for-business/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/AlexaForBusinessClient.ts
@@ -757,5 +757,7 @@ export class AlexaForBusinessClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-amplify/AmplifyClient.ts
+++ b/clients/client-amplify/AmplifyClient.ts
@@ -416,5 +416,7 @@ export class AmplifyClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-api-gateway/APIGatewayClient.ts
+++ b/clients/client-api-gateway/APIGatewayClient.ts
@@ -915,5 +915,7 @@ export class APIGatewayClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
@@ -210,5 +210,7 @@ export class ApiGatewayManagementApiClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-apigatewayv2/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/ApiGatewayV2Client.ts
@@ -570,5 +570,7 @@ export class ApiGatewayV2Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-app-mesh/AppMeshClient.ts
+++ b/clients/client-app-mesh/AppMeshClient.ts
@@ -372,5 +372,7 @@ export class AppMeshClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-appconfig/AppConfigClient.ts
+++ b/clients/client-appconfig/AppConfigClient.ts
@@ -412,5 +412,7 @@ export class AppConfigClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
@@ -313,5 +313,7 @@ export class ApplicationAutoScalingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
@@ -468,5 +468,7 @@ export class ApplicationDiscoveryServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-application-insights/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/ApplicationInsightsClient.ts
@@ -366,5 +366,7 @@ export class ApplicationInsightsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-appstream/AppStreamClient.ts
+++ b/clients/client-appstream/AppStreamClient.ts
@@ -494,5 +494,7 @@ export class AppStreamClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-appsync/AppSyncClient.ts
+++ b/clients/client-appsync/AppSyncClient.ts
@@ -439,5 +439,7 @@ export class AppSyncClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-athena/AthenaClient.ts
+++ b/clients/client-athena/AthenaClient.ts
@@ -308,5 +308,7 @@ export class AthenaClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
@@ -235,5 +235,7 @@ export class AutoScalingPlansClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-auto-scaling/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/AutoScalingClient.ts
@@ -522,5 +522,7 @@ export class AutoScalingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-backup/BackupClient.ts
+++ b/clients/client-backup/BackupClient.ts
@@ -471,5 +471,7 @@ export class BackupClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-batch/BatchClient.ts
+++ b/clients/client-batch/BatchClient.ts
@@ -298,5 +298,7 @@ export class BatchClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-budgets/BudgetsClient.ts
+++ b/clients/client-budgets/BudgetsClient.ts
@@ -318,5 +318,7 @@ export class BudgetsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-chime/ChimeClient.ts
+++ b/clients/client-chime/ChimeClient.ts
@@ -792,5 +792,7 @@ export class ChimeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloud9/Cloud9Client.ts
+++ b/clients/client-cloud9/Cloud9Client.ts
@@ -297,5 +297,7 @@ export class Cloud9Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-clouddirectory/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/CloudDirectoryClient.ts
@@ -593,5 +593,7 @@ export class CloudDirectoryClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudformation/CloudFormationClient.ts
+++ b/clients/client-cloudformation/CloudFormationClient.ts
@@ -536,5 +536,7 @@ export class CloudFormationClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudfront/CloudFrontClient.ts
+++ b/clients/client-cloudfront/CloudFrontClient.ts
@@ -464,5 +464,7 @@ export class CloudFrontClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
@@ -271,5 +271,7 @@ export class CloudHSMV2Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudhsm/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/CloudHSMClient.ts
@@ -322,5 +322,7 @@ export class CloudHSMClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
@@ -213,5 +213,7 @@ export class CloudSearchDomainClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudsearch/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/CloudSearchClient.ts
@@ -354,5 +354,7 @@ export class CloudSearchClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudtrail/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/CloudTrailClient.ts
@@ -314,5 +314,7 @@ export class CloudTrailClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
@@ -398,5 +398,7 @@ export class CloudWatchEventsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
@@ -459,5 +459,7 @@ export class CloudWatchLogsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cloudwatch/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/CloudWatchClient.ts
@@ -380,5 +380,7 @@ export class CloudWatchClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codebuild/CodeBuildClient.ts
+++ b/clients/client-codebuild/CodeBuildClient.ts
@@ -575,5 +575,7 @@ export class CodeBuildClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codecommit/CodeCommitClient.ts
+++ b/clients/client-codecommit/CodeCommitClient.ts
@@ -1030,5 +1030,7 @@ export class CodeCommitClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codedeploy/CodeDeployClient.ts
+++ b/clients/client-codedeploy/CodeDeployClient.ts
@@ -567,5 +567,7 @@ export class CodeDeployClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
@@ -216,5 +216,7 @@ export class CodeGuruReviewerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
@@ -246,5 +246,7 @@ export class CodeGuruProfilerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codepipeline/CodePipelineClient.ts
+++ b/clients/client-codepipeline/CodePipelineClient.ts
@@ -608,5 +608,7 @@ export class CodePipelineClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codestar-connections/CodeStarconnectionsClient.ts
+++ b/clients/client-codestar-connections/CodeStarconnectionsClient.ts
@@ -253,5 +253,7 @@ export class CodeStarconnectionsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codestar-notifications/codestarnotificationsClient.ts
+++ b/clients/client-codestar-notifications/codestarnotificationsClient.ts
@@ -353,5 +353,7 @@ export class codestarnotificationsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-codestar/CodeStarClient.ts
+++ b/clients/client-codestar/CodeStarClient.ts
@@ -389,5 +389,7 @@ export class CodeStarClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -797,5 +797,7 @@ export class CognitoIdentityProviderClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cognito-identity/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/CognitoIdentityClient.ts
@@ -326,5 +326,7 @@ export class CognitoIdentityClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cognito-sync/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/CognitoSyncClient.ts
@@ -300,5 +300,7 @@ export class CognitoSyncClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-comprehend/ComprehendClient.ts
+++ b/clients/client-comprehend/ComprehendClient.ts
@@ -500,5 +500,7 @@ export class ComprehendClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-comprehendmedical/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/ComprehendMedicalClient.ts
@@ -271,5 +271,7 @@ export class ComprehendMedicalClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-compute-optimizer/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/ComputeOptimizerClient.ts
@@ -237,5 +237,7 @@ export class ComputeOptimizerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-config-service/ConfigServiceClient.ts
+++ b/clients/client-config-service/ConfigServiceClient.ts
@@ -683,5 +683,7 @@ export class ConfigServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-connect/ConnectClient.ts
+++ b/clients/client-connect/ConnectClient.ts
@@ -373,5 +373,7 @@ export class ConnectClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-connectparticipant/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/ConnectParticipantClient.ts
@@ -227,5 +227,7 @@ export class ConnectParticipantClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cost-and-usage-report-service/CostandUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/CostandUsageReportServiceClient.ts
@@ -234,5 +234,7 @@ export class CostandUsageReportServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-cost-explorer/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/CostExplorerClient.ts
@@ -319,5 +319,7 @@ export class CostExplorerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-data-pipeline/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/DataPipelineClient.ts
@@ -310,5 +310,7 @@ export class DataPipelineClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
@@ -483,5 +483,7 @@ export class DatabaseMigrationServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-dataexchange/DataExchangeClient.ts
+++ b/clients/client-dataexchange/DataExchangeClient.ts
@@ -324,5 +324,7 @@ export class DataExchangeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-datasync/DataSyncClient.ts
+++ b/clients/client-datasync/DataSyncClient.ts
@@ -360,5 +360,7 @@ export class DataSyncClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-dax/DAXClient.ts
+++ b/clients/client-dax/DAXClient.ts
@@ -323,5 +323,7 @@ export class DAXClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-detective/DetectiveClient.ts
+++ b/clients/client-detective/DetectiveClient.ts
@@ -302,5 +302,7 @@ export class DetectiveClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-device-farm/DeviceFarmClient.ts
+++ b/clients/client-device-farm/DeviceFarmClient.ts
@@ -668,5 +668,7 @@ export class DeviceFarmClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-direct-connect/DirectConnectClient.ts
+++ b/clients/client-direct-connect/DirectConnectClient.ts
@@ -515,5 +515,7 @@ export class DirectConnectClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-directory-service/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/DirectoryServiceClient.ts
@@ -539,5 +539,7 @@ export class DirectoryServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-dlm/DLMClient.ts
+++ b/clients/client-dlm/DLMClient.ts
@@ -240,5 +240,7 @@ export class DLMClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-docdb/DocDBClient.ts
+++ b/clients/client-docdb/DocDBClient.ts
@@ -444,5 +444,7 @@ export class DocDBClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
@@ -221,5 +221,7 @@ export class DynamoDBStreamsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -450,5 +450,7 @@ export class DynamoDBClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ebs/EBSClient.ts
+++ b/clients/client-ebs/EBSClient.ts
@@ -226,5 +226,7 @@ export class EBSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
@@ -198,5 +198,7 @@ export class EC2InstanceConnectClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ec2/EC2Client.ts
+++ b/clients/client-ec2/EC2Client.ts
@@ -2608,5 +2608,7 @@ export class EC2Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ecr/ECRClient.ts
+++ b/clients/client-ecr/ECRClient.ts
@@ -372,5 +372,7 @@ export class ECRClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ecs/ECSClient.ts
+++ b/clients/client-ecs/ECSClient.ts
@@ -494,5 +494,7 @@ export class ECSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-efs/EFSClient.ts
+++ b/clients/client-efs/EFSClient.ts
@@ -334,5 +334,7 @@ export class EFSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-eks/EKSClient.ts
+++ b/clients/client-eks/EKSClient.ts
@@ -327,5 +327,7 @@ export class EKSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
@@ -470,5 +470,7 @@ export class ElasticBeanstalkClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-elastic-inference/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/ElasticInferenceClient.ts
@@ -210,5 +210,7 @@ export class ElasticInferenceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingv2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingv2Client.ts
@@ -424,5 +424,7 @@ export class ElasticLoadBalancingv2Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
@@ -386,5 +386,7 @@ export class ElasticLoadBalancingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
@@ -295,5 +295,7 @@ export class ElasticTranscoderClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-elasticache/ElastiCacheClient.ts
+++ b/clients/client-elasticache/ElastiCacheClient.ts
@@ -489,5 +489,7 @@ export class ElastiCacheClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
@@ -336,5 +336,7 @@ export class ElasticsearchServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-emr/EMRClient.ts
+++ b/clients/client-emr/EMRClient.ts
@@ -372,5 +372,7 @@ export class EMRClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-eventbridge/EventBridgeClient.ts
+++ b/clients/client-eventbridge/EventBridgeClient.ts
@@ -398,5 +398,7 @@ export class EventBridgeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-firehose/FirehoseClient.ts
+++ b/clients/client-firehose/FirehoseClient.ts
@@ -267,5 +267,7 @@ export class FirehoseClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-fms/FMSClient.ts
+++ b/clients/client-fms/FMSClient.ts
@@ -299,5 +299,7 @@ export class FMSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-forecast/forecastClient.ts
+++ b/clients/client-forecast/forecastClient.ts
@@ -348,5 +348,7 @@ export class forecastClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-forecastquery/forecastqueryClient.ts
+++ b/clients/client-forecastquery/forecastqueryClient.ts
@@ -196,5 +196,7 @@ export class forecastqueryClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-frauddetector/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/FraudDetectorClient.ts
@@ -374,5 +374,7 @@ export class FraudDetectorClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-fsx/FSxClient.ts
+++ b/clients/client-fsx/FSxClient.ts
@@ -277,5 +277,7 @@ export class FSxClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-gamelift/GameLiftClient.ts
+++ b/clients/client-gamelift/GameLiftClient.ts
@@ -689,5 +689,7 @@ export class GameLiftClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-glacier/GlacierClient.ts
+++ b/clients/client-glacier/GlacierClient.ts
@@ -438,5 +438,7 @@ export class GlacierClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-global-accelerator/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/GlobalAcceleratorClient.ts
@@ -363,5 +363,7 @@ export class GlobalAcceleratorClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-glue/GlueClient.ts
+++ b/clients/client-glue/GlueClient.ts
@@ -931,5 +931,7 @@ export class GlueClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-greengrass/GreengrassClient.ts
+++ b/clients/client-greengrass/GreengrassClient.ts
@@ -732,5 +732,7 @@ export class GreengrassClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-groundstation/GroundStationClient.ts
+++ b/clients/client-groundstation/GroundStationClient.ts
@@ -345,5 +345,7 @@ export class GroundStationClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-guardduty/GuardDutyClient.ts
+++ b/clients/client-guardduty/GuardDutyClient.ts
@@ -504,5 +504,7 @@ export class GuardDutyClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-health/HealthClient.ts
+++ b/clients/client-health/HealthClient.ts
@@ -372,5 +372,7 @@ export class HealthClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iam/IAMClient.ts
+++ b/clients/client-iam/IAMClient.ts
@@ -1088,5 +1088,7 @@ export class IAMClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-imagebuilder/imagebuilderClient.ts
+++ b/clients/client-imagebuilder/imagebuilderClient.ts
@@ -444,5 +444,7 @@ export class imagebuilderClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-inspector/InspectorClient.ts
+++ b/clients/client-inspector/InspectorClient.ts
@@ -417,5 +417,7 @@ export class InspectorClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
@@ -272,5 +272,7 @@ export class IoT1ClickDevicesServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
@@ -288,5 +288,7 @@ export class IoT1ClickProjectsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -221,5 +221,7 @@ export class IoTDataPlaneClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iot-events-data/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/IoTEventsDataClient.ts
@@ -218,5 +218,7 @@ export class IoTEventsDataClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iot-events/IoTEventsClient.ts
+++ b/clients/client-iot-events/IoTEventsClient.ts
@@ -290,5 +290,7 @@ export class IoTEventsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
@@ -226,5 +226,7 @@ export class IoTJobsDataPlaneClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iot/IoTClient.ts
+++ b/clients/client-iot/IoTClient.ts
@@ -1407,5 +1407,7 @@ export class IoTClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iotanalytics/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/IoTAnalyticsClient.ts
@@ -414,5 +414,7 @@ export class IoTAnalyticsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
@@ -238,5 +238,7 @@ export class IoTSecureTunnelingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
@@ -406,5 +406,7 @@ export class IoTThingsGraphClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kafka/KafkaClient.ts
+++ b/clients/client-kafka/KafkaClient.ts
@@ -312,5 +312,7 @@ export class KafkaClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kendra/kendraClient.ts
+++ b/clients/client-kendra/kendraClient.ts
@@ -309,5 +309,7 @@ export class kendraClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
@@ -350,5 +350,7 @@ export class KinesisAnalyticsV2Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
@@ -321,5 +321,7 @@ export class KinesisAnalyticsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
@@ -216,5 +216,7 @@ export class KinesisVideoArchivedMediaClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
@@ -196,5 +196,7 @@ export class KinesisVideoMediaClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -206,5 +206,7 @@ export class KinesisVideoSignalingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kinesis-video/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/KinesisVideoClient.ts
@@ -306,5 +306,7 @@ export class KinesisVideoClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kinesis/KinesisClient.ts
+++ b/clients/client-kinesis/KinesisClient.ts
@@ -376,5 +376,7 @@ export class KinesisClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-kms/KMSClient.ts
+++ b/clients/client-kms/KMSClient.ts
@@ -553,5 +553,7 @@ export class KMSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-lakeformation/LakeFormationClient.ts
+++ b/clients/client-lakeformation/LakeFormationClient.ts
@@ -271,5 +271,7 @@ export class LakeFormationClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-lambda/LambdaClient.ts
+++ b/clients/client-lambda/LambdaClient.ts
@@ -492,5 +492,7 @@ export class LambdaClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
@@ -411,5 +411,7 @@ export class LexModelBuildingServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
@@ -230,5 +230,7 @@ export class LexRuntimeServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-license-manager/LicenseManagerClient.ts
+++ b/clients/client-license-manager/LicenseManagerClient.ts
@@ -290,5 +290,7 @@ export class LicenseManagerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-lightsail/LightsailClient.ts
+++ b/clients/client-lightsail/LightsailClient.ts
@@ -831,5 +831,7 @@ export class LightsailClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-machine-learning/MachineLearningClient.ts
+++ b/clients/client-machine-learning/MachineLearningClient.ts
@@ -361,5 +361,7 @@ export class MachineLearningClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-macie/MacieClient.ts
+++ b/clients/client-macie/MacieClient.ts
@@ -240,5 +240,7 @@ export class MacieClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-managedblockchain/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/ManagedBlockchainClient.ts
@@ -301,5 +301,7 @@ export class ManagedBlockchainClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
@@ -234,5 +234,7 @@ export class MarketplaceCatalogClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
@@ -204,5 +204,7 @@ export class MarketplaceCommerceAnalyticsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
@@ -212,5 +212,7 @@ export class MarketplaceEntitlementServiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
@@ -269,5 +269,7 @@ export class MarketplaceMeteringClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mediaconnect/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/MediaConnectClient.ts
@@ -294,5 +294,7 @@ export class MediaConnectClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mediaconvert/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/MediaConvertClient.ts
@@ -342,5 +342,7 @@ export class MediaConvertClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-medialive/MediaLiveClient.ts
+++ b/clients/client-medialive/MediaLiveClient.ts
@@ -450,5 +450,7 @@ export class MediaLiveClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mediapackage-vod/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/MediaPackageVodClient.ts
@@ -264,5 +264,7 @@ export class MediaPackageVodClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mediapackage/MediaPackageClient.ts
+++ b/clients/client-mediapackage/MediaPackageClient.ts
@@ -300,5 +300,7 @@ export class MediaPackageClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mediastore-data/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/MediaStoreDataClient.ts
@@ -224,5 +224,7 @@ export class MediaStoreDataClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mediastore/MediaStoreClient.ts
+++ b/clients/client-mediastore/MediaStoreClient.ts
@@ -301,5 +301,7 @@ export class MediaStoreClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mediatailor/MediaTailorClient.ts
+++ b/clients/client-mediatailor/MediaTailorClient.ts
@@ -234,5 +234,7 @@ export class MediaTailorClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-migration-hub/MigrationHubClient.ts
+++ b/clients/client-migration-hub/MigrationHubClient.ts
@@ -299,5 +299,7 @@ export class MigrationHubClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-migrationhub-config/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/MigrationHubConfigClient.ts
@@ -232,5 +232,7 @@ export class MigrationHubConfigClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mobile/MobileClient.ts
+++ b/clients/client-mobile/MobileClient.ts
@@ -250,5 +250,7 @@ export class MobileClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mq/mqClient.ts
+++ b/clients/client-mq/mqClient.ts
@@ -324,5 +324,7 @@ export class mqClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-mturk/MTurkClient.ts
+++ b/clients/client-mturk/MTurkClient.ts
@@ -426,5 +426,7 @@ export class MTurkClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-neptune/NeptuneClient.ts
+++ b/clients/client-neptune/NeptuneClient.ts
@@ -551,5 +551,7 @@ export class NeptuneClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-networkmanager/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/NetworkManagerClient.ts
@@ -361,5 +361,7 @@ export class NetworkManagerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-opsworks/OpsWorksClient.ts
+++ b/clients/client-opsworks/OpsWorksClient.ts
@@ -750,5 +750,7 @@ export class OpsWorksClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-opsworkscm/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/OpsWorksCMClient.ts
@@ -392,5 +392,7 @@ export class OpsWorksCMClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-organizations/OrganizationsClient.ts
+++ b/clients/client-organizations/OrganizationsClient.ts
@@ -474,5 +474,7 @@ export class OrganizationsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-outposts/OutpostsClient.ts
+++ b/clients/client-outposts/OutpostsClient.ts
@@ -227,5 +227,7 @@ export class OutpostsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-personalize-events/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/PersonalizeEventsClient.ts
@@ -196,5 +196,7 @@ export class PersonalizeEventsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
@@ -204,5 +204,7 @@ export class PersonalizeRuntimeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-personalize/PersonalizeClient.ts
+++ b/clients/client-personalize/PersonalizeClient.ts
@@ -427,5 +427,7 @@ export class PersonalizeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-pi/PIClient.ts
+++ b/clients/client-pi/PIClient.ts
@@ -217,5 +217,7 @@ export class PIClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-pinpoint-email/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/PinpointEmailClient.ts
@@ -472,5 +472,7 @@ export class PinpointEmailClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -240,5 +240,7 @@ export class PinpointSMSVoiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-pinpoint/PinpointClient.ts
+++ b/clients/client-pinpoint/PinpointClient.ts
@@ -834,5 +834,7 @@ export class PinpointClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-polly/PollyClient.ts
+++ b/clients/client-polly/PollyClient.ts
@@ -248,5 +248,7 @@ export class PollyClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-pricing/PricingClient.ts
+++ b/clients/client-pricing/PricingClient.ts
@@ -233,5 +233,7 @@ export class PricingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-qldb-session/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/QLDBSessionClient.ts
@@ -196,5 +196,7 @@ export class QLDBSessionClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -282,5 +282,7 @@ export class QLDBClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-quicksight/QuickSightClient.ts
+++ b/clients/client-quicksight/QuickSightClient.ts
@@ -586,5 +586,7 @@ export class QuickSightClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ram/RAMClient.ts
+++ b/clients/client-ram/RAMClient.ts
@@ -335,5 +335,7 @@ export class RAMClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-rds-data/RDSDataClient.ts
+++ b/clients/client-rds-data/RDSDataClient.ts
@@ -237,5 +237,7 @@ export class RDSDataClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-rds/RDSClient.ts
+++ b/clients/client-rds/RDSClient.ts
@@ -1010,5 +1010,7 @@ export class RDSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-redshift/RedshiftClient.ts
+++ b/clients/client-redshift/RedshiftClient.ts
@@ -729,5 +729,7 @@ export class RedshiftClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-rekognition/RekognitionClient.ts
+++ b/clients/client-rekognition/RekognitionClient.ts
@@ -438,5 +438,7 @@ export class RekognitionClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
@@ -571,5 +571,7 @@ export class ResourceGroupsTaggingAPIClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-resource-groups/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/ResourceGroupsClient.ts
@@ -290,5 +290,7 @@ export class ResourceGroupsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-robomaker/RoboMakerClient.ts
+++ b/clients/client-robomaker/RoboMakerClient.ts
@@ -408,5 +408,7 @@ export class RoboMakerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-route-53-domains/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/Route53DomainsClient.ts
@@ -336,5 +336,7 @@ export class Route53DomainsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-route-53/Route53Client.ts
+++ b/clients/client-route-53/Route53Client.ts
@@ -528,5 +528,7 @@ export class Route53Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-route53resolver/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/Route53ResolverClient.ts
@@ -366,5 +366,7 @@ export class Route53ResolverClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-s3-control/S3ControlClient.ts
+++ b/clients/client-s3-control/S3ControlClient.ts
@@ -292,5 +292,7 @@ export class S3ControlClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -741,5 +741,7 @@ export class S3Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
@@ -230,5 +230,7 @@ export class SageMakerA2IRuntimeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
@@ -196,5 +196,7 @@ export class SageMakerRuntimeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sagemaker/SageMakerClient.ts
+++ b/clients/client-sagemaker/SageMakerClient.ts
@@ -990,5 +990,7 @@ export class SageMakerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-savingsplans/savingsplansClient.ts
+++ b/clients/client-savingsplans/savingsplansClient.ts
@@ -243,5 +243,7 @@ export class savingsplansClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-schemas/schemasClient.ts
+++ b/clients/client-schemas/schemasClient.ts
@@ -366,5 +366,7 @@ export class schemasClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-secrets-manager/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/SecretsManagerClient.ts
@@ -365,5 +365,7 @@ export class SecretsManagerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-securityhub/SecurityHubClient.ts
+++ b/clients/client-securityhub/SecurityHubClient.ts
@@ -462,5 +462,7 @@ export class SecurityHubClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
@@ -289,5 +289,7 @@ export class ServerlessApplicationRepositoryClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-service-catalog/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/ServiceCatalogClient.ts
@@ -695,5 +695,7 @@ export class ServiceCatalogClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-service-quotas/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/ServiceQuotasClient.ts
@@ -299,5 +299,7 @@ export class ServiceQuotasClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-servicediscovery/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/ServiceDiscoveryClient.ts
@@ -316,5 +316,7 @@ export class ServiceDiscoveryClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ses/SESClient.ts
+++ b/clients/client-ses/SESClient.ts
@@ -626,5 +626,7 @@ export class SESClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sesv2/SESv2Client.ts
+++ b/clients/client-sesv2/SESv2Client.ts
@@ -505,5 +505,7 @@ export class SESv2Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sfn/SFNClient.ts
+++ b/clients/client-sfn/SFNClient.ts
@@ -339,5 +339,7 @@ export class SFNClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-shield/ShieldClient.ts
+++ b/clients/client-shield/ShieldClient.ts
@@ -303,5 +303,7 @@ export class ShieldClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-signer/signerClient.ts
+++ b/clients/client-signer/signerClient.ts
@@ -268,5 +268,7 @@ export class signerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sms/SMSClient.ts
+++ b/clients/client-sms/SMSClient.ts
@@ -380,5 +380,7 @@ export class SMSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-snowball/SnowballClient.ts
+++ b/clients/client-snowball/SnowballClient.ts
@@ -312,5 +312,7 @@ export class SnowballClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sns/SNSClient.ts
+++ b/clients/client-sns/SNSClient.ts
@@ -399,5 +399,7 @@ export class SNSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -382,5 +382,7 @@ export class SQSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-ssm/SSMClient.ts
+++ b/clients/client-ssm/SSMClient.ts
@@ -936,5 +936,7 @@ export class SSMClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -227,5 +227,7 @@ export class SSOOIDCClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -231,5 +231,7 @@ export class SSOClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-storage-gateway/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/StorageGatewayClient.ts
@@ -704,5 +704,7 @@ export class StorageGatewayClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -308,5 +308,7 @@ export class STSClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-support/SupportClient.ts
+++ b/clients/client-support/SupportClient.ts
@@ -338,5 +338,7 @@ export class SupportClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-swf/SWFClient.ts
+++ b/clients/client-swf/SWFClient.ts
@@ -429,5 +429,7 @@ export class SWFClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-textract/TextractClient.ts
+++ b/clients/client-textract/TextractClient.ts
@@ -230,5 +230,7 @@ export class TextractClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
@@ -210,5 +210,7 @@ export class TranscribeStreamingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-transcribe/TranscribeClient.ts
+++ b/clients/client-transcribe/TranscribeClient.ts
@@ -276,5 +276,7 @@ export class TranscribeClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-transfer/TransferClient.ts
+++ b/clients/client-transfer/TransferClient.ts
@@ -308,5 +308,7 @@ export class TransferClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-translate/TranslateClient.ts
+++ b/clients/client-translate/TranslateClient.ts
@@ -247,5 +247,7 @@ export class TranslateClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-waf-regional/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/WAFRegionalClient.ts
@@ -673,5 +673,7 @@ export class WAFRegionalClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-waf/WAFClient.ts
+++ b/clients/client-waf/WAFClient.ts
@@ -650,5 +650,7 @@ export class WAFClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-wafv2/WAFV2Client.ts
+++ b/clients/client-wafv2/WAFV2Client.ts
@@ -463,5 +463,7 @@ export class WAFV2Client extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-workdocs/WorkDocsClient.ts
+++ b/clients/client-workdocs/WorkDocsClient.ts
@@ -470,5 +470,7 @@ export class WorkDocsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-worklink/WorkLinkClient.ts
+++ b/clients/client-worklink/WorkLinkClient.ts
@@ -378,5 +378,7 @@ export class WorkLinkClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-workmail/WorkMailClient.ts
+++ b/clients/client-workmail/WorkMailClient.ts
@@ -424,5 +424,7 @@ export class WorkMailClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
@@ -200,5 +200,7 @@ export class WorkMailMessageFlowClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-workspaces/WorkSpacesClient.ts
+++ b/clients/client-workspaces/WorkSpacesClient.ts
@@ -440,5 +440,7 @@ export class WorkSpacesClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/clients/client-xray/XRayClient.ts
+++ b/clients/client-xray/XRayClient.ts
@@ -313,5 +313,7 @@ export class XRayClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
   }
 
-  destroy(): void {}
+  destroy(): void {
+    super.destroy();
+  }
 }

--- a/packages/config-resolver/src/HandlerConfig.ts
+++ b/packages/config-resolver/src/HandlerConfig.ts
@@ -1,7 +1,0 @@
-import { RequestHandler } from "@aws-sdk/types";
-
-export function destroyRequestHandlerConfig(config: {
-  requestHandler: RequestHandler<any, any, any>;
-}): void {
-  if (config.requestHandler.destroy) config.requestHandler.destroy();
-}

--- a/packages/config-resolver/src/index.ts
+++ b/packages/config-resolver/src/index.ts
@@ -1,3 +1,2 @@
 export * from "./EndpointsConfig";
 export * from "./RegionConfig";
-export * from "./HandlerConfig";

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -95,4 +95,9 @@ export class Client<
       return handler(command).then(result => result.output);
     }
   }
+
+  destroy() {
+    if (this.config.requestHandler.destroy)
+      this.config.requestHandler.destroy();
+  }
 }

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -46,6 +46,8 @@ interface InvokeFunction<
 
 /**
  * A general interface for service clients, idempotent to browser or node clients
+ * This type corresponds to SmithyClient(https://github.com/aws/aws-sdk-js-v3/blob/master/packages/smithy-client/src/client.ts).
+ * It's provided for using without importing the SmithyClient class.
  */
 export interface Client<
   Input extends object,
@@ -55,4 +57,5 @@ export interface Client<
   readonly config: ResolvedClientConfiguration;
   middlewareStack: MiddlewareStack<Input, Output>;
   send: InvokeFunction<Input, Output, ResolvedClientConfiguration>;
+  destroy: () => void;
 }

--- a/packages/util-create-request/src/foo.fixture.ts
+++ b/packages/util-create-request/src/foo.fixture.ts
@@ -36,7 +36,8 @@ export const fooClient: Client<any, InputTypesUnion, OutputTypesUnion, any> = {
       this.middlewareStack,
       this.config,
       undefined
-    )({ input })
+    )({ input }),
+  destroy: () => {}
 };
 
 export const operationCommand: Command<


### PR DESCRIPTION
Currently all the clientRuntimeCustomization can have a `destroy()` function. But the default configs in smithy client doesn't have one: https://github.com/aws/aws-sdk-js-v3/blob/77386f6fac5fe2644f1b60a77050975c0327b6e0/packages/smithy-client/src/client.ts#L27.

This change adds a `destroy` function to the Smithy client. When every service client extends the Smithy client, it has a default `destroy` function. In the service clients' `destroy` function, it will call the function from its super class Smithy client. This is necessary as you can destroy the Smithy resolved config just like destroying other client customization.

The last commit is client generation diff. You can ignore it when reviewing it. 

Related: https://github.com/awslabs/smithy-typescript/pull/156


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
