### PR TITLE
chore(deps-dev): bump prettier to v2 with .prettierrc

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 **/*/CHANGELOG.md
-models/*
+codegen/*
 .github/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "arrowParens": "avoid",
+  "endOfLine": "auto",
+  "trailingComma": "none"
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,12 +1,6 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
+  extends: ["@commitlint/config-conventional"],
   rules: {
-    "type-enum": [2, "always", [
-      'feat',
-      'fix',
-      'docs',
-      'test',
-      'chore'
-    ]]
+    "type-enum": [2, "always", ["feat", "fix", "docs", "test", "chore"]]
   }
-}
+};

--- a/features/acm/step_definitions/acm.js
+++ b/features/acm/step_definitions/acm.js
@@ -1,7 +1,7 @@
 const { ACM } = require("../../../clients/client-acm");
 const { Before } = require("cucumber");
 
-Before({ tags: "@acm" }, function(scenario, callback) {
+Before({ tags: "@acm" }, function (scenario, callback) {
   this.service = new ACM({});
   callback();
 });

--- a/features/apigateway/step_definitions/apigateway.js
+++ b/features/apigateway/step_definitions/apigateway.js
@@ -1,7 +1,7 @@
 const { APIGateway } = require("../../../clients/client-api-gateway");
 const { Before } = require("cucumber");
 
-Before({ tags: "@apigateway" }, function(scenario, callback) {
+Before({ tags: "@apigateway" }, function (scenario, callback) {
   this.service = new APIGateway({});
   callback();
 });

--- a/features/autoscaling/step_definitions/autoscaling.js
+++ b/features/autoscaling/step_definitions/autoscaling.js
@@ -1,12 +1,12 @@
 const { AutoScaling } = require("../../../clients/client-auto-scaling");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@autoscaling" }, function(scenario, callback) {
+Before({ tags: "@autoscaling" }, function (scenario, callback) {
   this.service = new AutoScaling({ region: "us-east-1" });
   callback();
 });
 
-Given("I create a launch configuration with name {string}", function(
+Given("I create a launch configuration with name {string}", function (
   name,
   callback
 ) {
@@ -18,21 +18,23 @@ Given("I create a launch configuration with name {string}", function(
   this.request(null, "createLaunchConfiguration", params, callback, false);
 });
 
-Given("I describe launch configurations", function(callback) {
+Given("I describe launch configurations", function (callback) {
   this.request(null, "describeLaunchConfigurations", {}, callback);
 });
 
-Then("the list should contain the launch configuration {string}", function(
+Then("the list should contain the launch configuration {string}", function (
   name,
   callback
 ) {
-  this.assert.contains(this.data.LaunchConfigurations, function(configuration) {
+  this.assert.contains(this.data.LaunchConfigurations, function (
+    configuration
+  ) {
     return configuration.LaunchConfigurationName === name;
   });
   callback();
 });
 
-Then("I delete the launch configuration {string}", function(name, callback) {
+Then("I delete the launch configuration {string}", function (name, callback) {
   const params = { LaunchConfigurationName: name };
   this.request(null, "deleteLaunchConfiguration", params, callback);
 });

--- a/features/cloudformation/step_definitions/cloudformation.js
+++ b/features/cloudformation/step_definitions/cloudformation.js
@@ -1,12 +1,12 @@
 const { CloudFormation } = require("../../../clients/client-cloudformation");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@cloudformation" }, function(scenario, callback) {
+Before({ tags: "@cloudformation" }, function (scenario, callback) {
   this.service = new CloudFormation({});
   callback();
 });
 
-Given("I create a CloudFormation stack with name prefix {string}", function(
+Given("I create a CloudFormation stack with name prefix {string}", function (
   prefix,
   callback
 ) {

--- a/features/cloudfront/step_definitions/cloudfront.js
+++ b/features/cloudfront/step_definitions/cloudfront.js
@@ -52,13 +52,13 @@ const createParams = {
   Enabled: false
 };
 
-Before({ tags: "@cloudfront" }, function(scenario, callback) {
+Before({ tags: "@cloudfront" }, function (scenario, callback) {
   this.service = new CloudFront({});
   this.cfCreateParams = createParams;
   callback();
 });
 
-Given("I create a CloudFront distribution with name prefix {string}", function(
+Given("I create a CloudFront distribution with name prefix {string}", function (
   prefix,
   callback
 ) {
@@ -75,6 +75,6 @@ Given("I create a CloudFront distribution with name prefix {string}", function(
   );
 });
 
-Given("I list CloudFront distributions", function(callback) {
+Given("I list CloudFront distributions", function (callback) {
   this.request(null, "listDistributions", {}, callback);
 });

--- a/features/cloudsearch/step_definitions/cloudsearch.js
+++ b/features/cloudsearch/step_definitions/cloudsearch.js
@@ -1,12 +1,12 @@
 const { CloudSearch } = require("../../../clients/client-cloudsearch");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@cloudsearch" }, function(scenario, callback) {
+Before({ tags: "@cloudsearch" }, function (scenario, callback) {
   this.service = new CloudSearch({});
   callback();
 });
 
-Given("I create a domain with name prefix {string}", function(
+Given("I create a domain with name prefix {string}", function (
   prefix,
   callback
 ) {

--- a/features/cloudtrail/step_definitions/cloudtrail.js
+++ b/features/cloudtrail/step_definitions/cloudtrail.js
@@ -1,16 +1,16 @@
 const { CloudTrail } = require("../../../clients/client-cloudtrail");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@cloudtrail" }, function(scenario, callback) {
+Before({ tags: "@cloudtrail" }, function (scenario, callback) {
   this.service = new CloudTrail({});
   callback();
 });
 
-Given("I describe trails", function(callback) {
+Given("I describe trails", function (callback) {
   this.request(null, "describeTrails", {}, callback);
 });
 
-Given("I create a trail with an invalid name", function(callback) {
+Given("I create a trail with an invalid name", function (callback) {
   this.request(
     null,
     "createTrail",

--- a/features/cloudwatch/step_definitions/cloudwatch.js
+++ b/features/cloudwatch/step_definitions/cloudwatch.js
@@ -1,12 +1,12 @@
 const { CloudWatch } = require("../../../clients/client-cloudwatch");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@cloudwatch" }, function(scenario, callback) {
+Before({ tags: "@cloudwatch" }, function (scenario, callback) {
   this.service = new CloudWatch({});
   callback();
 });
 
-Given("I create a CloudWatch alarm with prefix {string}", function(
+Given("I create a CloudWatch alarm with prefix {string}", function (
   name,
   callback
 ) {
@@ -33,7 +33,7 @@ Given("I create a CloudWatch alarm with prefix {string}", function(
   );
 });
 
-Given("I create a CloudWatch alarm with name {string}", function(
+Given("I create a CloudWatch alarm with name {string}", function (
   name,
   callback
 ) {
@@ -52,7 +52,7 @@ Given("I create a CloudWatch alarm with name {string}", function(
   this.request(null, "putMetricAlarm", this.cloudWatchAlarm, callback, false);
 });
 
-Given("I list the CloudWatch alarms", function(callback) {
+Given("I list the CloudWatch alarms", function (callback) {
   const params = {
     MetricName: this.cloudWatchAlarm.MetricName,
     Namespace: this.cloudWatchAlarm.Namespace
@@ -60,15 +60,15 @@ Given("I list the CloudWatch alarms", function(callback) {
   this.request(null, "describeAlarmsForMetric", params, callback);
 });
 
-Then("the list should contain the CloudWatch alarm", function(callback) {
+Then("the list should contain the CloudWatch alarm", function (callback) {
   const name = this.cloudWatchAlarm.AlarmName;
-  this.assert.contains(this.data.MetricAlarms, function(alarm) {
+  this.assert.contains(this.data.MetricAlarms, function (alarm) {
     return alarm.AlarmName === name;
   });
   callback();
 });
 
-Then("I delete the CloudWatch alarm", function(callback) {
+Then("I delete the CloudWatch alarm", function (callback) {
   this.request(
     null,
     "deleteAlarms",

--- a/features/cloudwatchevents/step_definitions/cloudwatchevents.js
+++ b/features/cloudwatchevents/step_definitions/cloudwatchevents.js
@@ -3,7 +3,7 @@ const {
 } = require("../../../clients/client-cloudwatch-events");
 const { Before } = require("cucumber");
 
-Before({ tags: "@cloudwatchevents" }, function(scenario, callback) {
+Before({ tags: "@cloudwatchevents" }, function (scenario, callback) {
   this.service = new CloudWatchEvents({});
   callback();
 });

--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -1,12 +1,12 @@
 const { CloudWatchLogs } = require("../../../clients/client-cloudwatch-logs");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@cloudwatchlogs" }, function(scenario, callback) {
+Before({ tags: "@cloudwatchlogs" }, function (scenario, callback) {
   this.service = new CloudWatchLogs({});
   callback();
 });
 
-Given("I create a CloudWatch logGroup with prefix {string}", function(
+Given("I create a CloudWatch logGroup with prefix {string}", function (
   prefix,
   callback
 ) {
@@ -21,19 +21,19 @@ Given("I create a CloudWatch logGroup with prefix {string}", function(
   );
 });
 
-Given("I list the CloudWatch logGroups", function(callback) {
+Given("I list the CloudWatch logGroups", function (callback) {
   this.request(null, "describeLogGroups", {}, callback);
 });
 
-Then("the list should contain the CloudWatch logGroup", function(callback) {
+Then("the list should contain the CloudWatch logGroup", function (callback) {
   const name = this.logGroupName;
-  this.assert.contains(this.data.logGroups, function(alarm) {
+  this.assert.contains(this.data.logGroups, function (alarm) {
     return alarm.logGroupName === name;
   });
   callback();
 });
 
-Then("I delete the CloudWatch logGroup", function(callback) {
+Then("I delete the CloudWatch logGroup", function (callback) {
   this.request(
     null,
     "deleteLogGroup",

--- a/features/codecommit/step_definitions/codecommit.js
+++ b/features/codecommit/step_definitions/codecommit.js
@@ -1,7 +1,7 @@
 const { CodeCommit } = require("../../../clients/client-codecommit");
 const { Before } = require("cucumber");
 
-Before({ tags: "@codecommit" }, function(scenario, callback) {
+Before({ tags: "@codecommit" }, function (scenario, callback) {
   this.service = new CodeCommit({ region: "us-east-1" });
   callback();
 });

--- a/features/codedeploy/step_definitions/codedeploy.js
+++ b/features/codedeploy/step_definitions/codedeploy.js
@@ -1,7 +1,7 @@
 const { CodeDeploy } = require("../../../clients/client-codedeploy");
 const { Before } = require("cucumber");
 
-Before({ tags: "@codedeploy" }, function(scenario, callback) {
+Before({ tags: "@codedeploy" }, function (scenario, callback) {
   this.service = new CodeDeploy({});
   callback();
 });

--- a/features/codepipeline/step_definitions/codepipeline.js
+++ b/features/codepipeline/step_definitions/codepipeline.js
@@ -1,7 +1,7 @@
 const { CodePipeline } = require("../../../clients/client-codepipeline");
 const { Before } = require("cucumber");
 
-Before({ tags: "@codepipeline" }, function(scenario, callback) {
+Before({ tags: "@codepipeline" }, function (scenario, callback) {
   this.service = new CodePipeline({ region: "us-east-1" });
   callback();
 });

--- a/features/cognitoidentity/step_definitions/cognitoidentity.js
+++ b/features/cognitoidentity/step_definitions/cognitoidentity.js
@@ -1,12 +1,12 @@
 const { CognitoIdentity } = require("../../../clients/client-cognito-identity");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@cognitoidentity" }, function(scenario, callback) {
+Before({ tags: "@cognitoidentity" }, function (scenario, callback) {
   this.service = new CognitoIdentity({});
   callback();
 });
 
-Given("I create a Cognito identity pool with prefix {string}", function(
+Given("I create a Cognito identity pool with prefix {string}", function (
   prefix,
   callback
 ) {
@@ -18,7 +18,7 @@ Given("I create a Cognito identity pool with prefix {string}", function(
   this.request(null, "createIdentityPool", params, callback, expectError);
 });
 
-Given("I describe the Cognito identity pool ID", function(callback) {
+Given("I describe the Cognito identity pool ID", function (callback) {
   this.identityPoolId = this.data.IdentityPoolId;
   this.request(
     null,
@@ -28,7 +28,7 @@ Given("I describe the Cognito identity pool ID", function(callback) {
   );
 });
 
-Then("I delete the Cognito identity pool", function(callback) {
+Then("I delete the Cognito identity pool", function (callback) {
   this.request(
     null,
     "deleteIdentityPool",

--- a/features/cognitosync/step_definitions/cognitosync.js
+++ b/features/cognitosync/step_definitions/cognitosync.js
@@ -1,18 +1,18 @@
 const { CognitoSync } = require("../../../clients/client-cognito-sync");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@cognitosync" }, function(scenario, callback) {
+Before({ tags: "@cognitosync" }, function (scenario, callback) {
   this.service = new CognitoSync({});
   callback();
 });
 
-Given("I list Cognito identity pool usage", function(callback) {
+Given("I list Cognito identity pool usage", function (callback) {
   this.request(null, "listIdentityPoolUsage", {}, callback);
 });
 
 Given(
   "I list Cognito data sets with identity pool id {string} and identity id {string}",
-  function(idpid, idid, callback) {
+  function (idpid, idid, callback) {
     const params = { IdentityPoolId: idpid, IdentityId: idid };
     this.request(null, "listDatasets", params, callback, false);
   }

--- a/features/configservice/step_definitions/configservice.js
+++ b/features/configservice/step_definitions/configservice.js
@@ -1,7 +1,7 @@
 const { ConfigService } = require("../../../clients/client-config-service");
 const { Before } = require("cucumber");
 
-Before({ tags: "@configservice" }, function(scenario, callback) {
+Before({ tags: "@configservice" }, function (scenario, callback) {
   this.service = new ConfigService({});
   callback();
 });

--- a/features/datapipeline/step_definitions/datapipeline.js
+++ b/features/datapipeline/step_definitions/datapipeline.js
@@ -1,12 +1,12 @@
 const { DataPipeline } = require("../../../clients/client-data-pipeline");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@datapipeline" }, function(scenario, callback) {
+Before({ tags: "@datapipeline" }, function (scenario, callback) {
   this.service = new DataPipeline({});
   callback();
 });
 
-Given("I create a Data Pipeline with name prefix {string}", function(
+Given("I create a Data Pipeline with name prefix {string}", function (
   prefix,
   callback
 ) {

--- a/features/devicefarm/step_definitions/devicefarm.js
+++ b/features/devicefarm/step_definitions/devicefarm.js
@@ -1,7 +1,7 @@
 const { DeviceFarm } = require("../../../clients/client-device-farm");
 const { Before } = require("cucumber");
 
-Before({ tags: "@devicefarm" }, function(scenario, callback) {
+Before({ tags: "@devicefarm" }, function (scenario, callback) {
   this.service = new DeviceFarm({ region: "us-west-2" });
   callback();
 });

--- a/features/directconnect/step_definitions/directconnect.js
+++ b/features/directconnect/step_definitions/directconnect.js
@@ -1,18 +1,19 @@
 const { DirectConnect } = require("../../../clients/client-direct-connect");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@directconnect" }, function(scenario, callback) {
+Before({ tags: "@directconnect" }, function (scenario, callback) {
   this.service = new DirectConnect({});
   callback();
 });
 
-Given("I create a Direct Connect connection with an invalid location", function(
-  callback
-) {
-  const params = {
-    bandwidth: "1Gbps",
-    location: "INVALID_LOCATION",
-    connectionName: this.uniqueName("aws-sdk-js")
-  };
-  this.request(null, "createConnection", params, callback, false);
-});
+Given(
+  "I create a Direct Connect connection with an invalid location",
+  function (callback) {
+    const params = {
+      bandwidth: "1Gbps",
+      location: "INVALID_LOCATION",
+      connectionName: this.uniqueName("aws-sdk-js")
+    };
+    this.request(null, "createConnection", params, callback, false);
+  }
+);

--- a/features/directoryservice/step_definitions/directoryservice.js
+++ b/features/directoryservice/step_definitions/directoryservice.js
@@ -3,7 +3,7 @@ const {
 } = require("../../../clients/client-directory-service");
 const { Before } = require("cucumber");
 
-Before({ tags: "@directoryservice" }, function(scenario, callback) {
+Before({ tags: "@directoryservice" }, function (scenario, callback) {
   this.service = new DirectoryService({});
   callback();
 });

--- a/features/dms/step_definitions/dms.js
+++ b/features/dms/step_definitions/dms.js
@@ -3,7 +3,7 @@ const {
 } = require("../../../clients/client-database-migration-service");
 const { Before } = require("cucumber");
 
-Before({ tags: "@dms" }, function(scenario, callback) {
+Before({ tags: "@dms" }, function (scenario, callback) {
   this.service = new DatabaseMigrationService({});
   callback();
 });

--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -16,13 +16,13 @@ function waitForTableExists(world, callback) {
 
   const checkForTableExists = () => {
     currentAttempt++;
-    world.service.describeTable(params, function(err, data) {
+    world.service.describeTable(params, function (err, data) {
       if (currentAttempt > maxAttempts) {
         callback(new Error("waitForTableExists: max attempts exceeded"));
       } else if (data && data.Table && data.Table.TableStatus === "ACTIVE") {
         callback();
       } else {
-        setTimeout(function() {
+        setTimeout(function () {
           checkForTableExists();
         }, delay);
       }
@@ -46,13 +46,13 @@ function waitForTableNotExists(world, callback) {
 
   const checkForTableNotExists = () => {
     currentAttempt++;
-    world.service.describeTable(params, function(err, data) {
+    world.service.describeTable(params, function (err, data) {
       if (currentAttempt > maxAttempts) {
         callback(new Error("waitForTableNotExists: max attempts exceeded"));
       } else if (err && err.name === "ResourceNotFoundException") {
         callback();
       } else {
-        setTimeout(function() {
+        setTimeout(function () {
           checkForTableNotExists();
         }, delay);
       }
@@ -62,7 +62,7 @@ function waitForTableNotExists(world, callback) {
 }
 const { Before, Given, Then, When } = require("cucumber");
 
-Before({ tags: "@dynamodb" }, function(scenario, next) {
+Before({ tags: "@dynamodb" }, function (scenario, next) {
   this.service = new DynamoDB({
     maxRetries: 2
   });
@@ -80,7 +80,7 @@ function createTable(world, callback) {
     }
   };
 
-  world.service.createTable(params, function(err, data) {
+  world.service.createTable(params, function (err, data) {
     if (err) {
       callback(err);
       return;
@@ -89,9 +89,9 @@ function createTable(world, callback) {
   });
 }
 
-Given("I have a table", function(callback) {
+Given("I have a table", function (callback) {
   const world = this;
-  this.service.listTables({}, function(err, data) {
+  this.service.listTables({}, function (err, data) {
     for (let i = 0; i < data.TableNames.length; i++) {
       if (data.TableNames[i] == world.tableName) {
         callback();
@@ -102,10 +102,10 @@ Given("I have a table", function(callback) {
   });
 });
 
-When("I create a table", function(callback) {
+When("I create a table", function (callback) {
   const world = this;
   this.tableName = this.uniqueName("aws-sdk-js-integration");
-  this.service.listTables({}, function(err, data) {
+  this.service.listTables({}, function (err, data) {
     for (let i = 0; i < data.TableNames.length; i++) {
       if (data.TableNames[i] == world.tableName) {
         callback();
@@ -116,12 +116,12 @@ When("I create a table", function(callback) {
   });
 });
 
-When("I put the item:", function(string, next) {
+When("I put the item:", function (string, next) {
   const params = { TableName: this.tableName, Item: JSON.parse(string) };
   this.request(null, "putItem", params, next);
 });
 
-When("I put a recursive item", function(next) {
+When("I put a recursive item", function (next) {
   const params = {
     TableName: this.tableName,
     Item: {
@@ -146,12 +146,12 @@ When("I put a recursive item", function(next) {
   this.request(null, "putItem", params, next);
 });
 
-Then("the item with id {string} should exist", function(key, next) {
+Then("the item with id {string} should exist", function (key, next) {
   const params = { TableName: this.tableName, Key: { id: { S: key } } };
   this.request(null, "getItem", params, next);
 });
 
-Then("it should have attribute {string} containing {string}", function(
+Then("it should have attribute {string} containing {string}", function (
   attr,
   value,
   next
@@ -160,20 +160,20 @@ Then("it should have attribute {string} containing {string}", function(
   next();
 });
 
-When("I delete the table", function(next) {
+When("I delete the table", function (next) {
   const params = { TableName: this.tableName };
   this.request(null, "deleteTable", params, next);
 });
 
-Then("the table should eventually exist", function(callback) {
+Then("the table should eventually exist", function (callback) {
   waitForTableExists(this, callback);
 });
 
-Then("the table should eventually not exist", function(callback) {
+Then("the table should eventually not exist", function (callback) {
   waitForTableNotExists(this, callback);
 });
 
-Given("my first request is corrupted with CRC checking (ON|OFF)", function(
+Given("my first request is corrupted with CRC checking (ON|OFF)", function (
   toggle,
   callback
 ) {
@@ -182,14 +182,14 @@ Given("my first request is corrupted with CRC checking (ON|OFF)", function(
   const req = this.service.listTables();
   this.service.config.dynamoDbCrc32 = true;
   req.removeAllListeners("httpData");
-  req.on("httpData", function(chunk, resp) {
+  req.on("httpData", function (chunk, resp) {
     if (resp.retryCount == 0) {
       resp.httpResponse.body = Buffer.from('{"invalid":"response"}');
     } else {
       world.AWS.EventListeners.Core.HTTP_DATA.call(this, chunk, resp);
     }
   });
-  req.on("complete", function(resp) {
+  req.on("complete", function (resp) {
     world.error = resp.error;
     world.response = resp;
     if (resp.error) callback(resp.error);
@@ -198,7 +198,7 @@ Given("my first request is corrupted with CRC checking (ON|OFF)", function(
   req.send();
 });
 
-Then("the request should( not)? be retried", function(retry, callback) {
+Then("the request should( not)? be retried", function (retry, callback) {
   if (retry && this.response.retryCount > 0)
     callback(new Error("Request was incorrectly retried"));
   if (!retry && this.response.retryCount == 0)
@@ -206,16 +206,16 @@ Then("the request should( not)? be retried", function(retry, callback) {
   callback();
 });
 
-Given("all of my requests are corrupted with CRC checking ON", function(
+Given("all of my requests are corrupted with CRC checking ON", function (
   callback
 ) {
   const world = this;
   const req = this.service.listTables();
   req.removeAllListeners("httpData");
-  req.on("httpData", function(chunk, resp) {
+  req.on("httpData", function (chunk, resp) {
     resp.httpResponse.body = Buffer.from('{"invalid":"response"}');
   });
-  req.on("complete", function(resp) {
+  req.on("complete", function (resp) {
     world.error = resp.error;
     world.response = resp;
     callback();
@@ -223,13 +223,13 @@ Given("all of my requests are corrupted with CRC checking ON", function(
   req.send();
 });
 
-When("the request is retried the maximum number of times", function(callback) {
+When("the request is retried the maximum number of times", function (callback) {
   if (this.response.retryCount != 2)
     callback(new Error("Incorrect retry count"));
   callback();
 });
 
-Then("the request should( not)? fail with a CRC checking error", function(
+Then("the request should( not)? fail with a CRC checking error", function (
   failed,
   callback
 ) {
@@ -239,16 +239,15 @@ Then("the request should( not)? fail with a CRC checking error", function(
   callback();
 });
 
-Given("I try to delete an item with key {string} from table {string}", function(
-  key,
-  table,
-  callback
-) {
-  const params = { TableName: table, Key: { id: { S: key } } };
-  this.request(null, "deleteItem", params, callback, false);
-});
+Given(
+  "I try to delete an item with key {string} from table {string}",
+  function (key, table, callback) {
+    const params = { TableName: table, Key: { id: { S: key } } };
+    this.request(null, "deleteItem", params, callback, false);
+  }
+);
 
-Given("I try to delete a table with an empty table parameter", function(
+Given("I try to delete a table with an empty table parameter", function (
   callback
 ) {
   this.request(null, "deleteTable", { TableName: "" }, callback, false);

--- a/features/dynamodbstreams/step_definitions/dynamodbstreams.js
+++ b/features/dynamodbstreams/step_definitions/dynamodbstreams.js
@@ -1,7 +1,7 @@
 const { DynamoDBStreams } = require("../../../clients/client-dynamodb-streams");
 const { Before } = require("cucumber");
 
-Before({ tags: "@dynamodbstreams" }, function(scenario, callback) {
+Before({ tags: "@dynamodbstreams" }, function (scenario, callback) {
   this.service = new DynamoDBStreams({});
   callback();
 });

--- a/features/ec2/step_definitions/ec2.js
+++ b/features/ec2/step_definitions/ec2.js
@@ -25,12 +25,12 @@ const waitForVolumeAvailable = (ec2, volumeId, callback) => {
             )
           );
         } else {
-          setTimeout(function() {
+          setTimeout(function () {
             checkForVolumeAvailable();
           }, delay);
         }
       } else {
-        setTimeout(function() {
+        setTimeout(function () {
           checkForVolumeAvailable();
         }, delay);
       }
@@ -39,28 +39,28 @@ const waitForVolumeAvailable = (ec2, volumeId, callback) => {
   checkForVolumeAvailable();
 };
 
-Before({ tags: "@ec2" }, function(scenario, callback) {
+Before({ tags: "@ec2" }, function (scenario, callback) {
   this.service = new EC2({});
   callback();
 });
 
-Given("I describe EC2 regions {string}", function(regions, callback) {
+Given("I describe EC2 regions {string}", function (regions, callback) {
   regions = regions.split(/\s*,\s*/);
   this.request(null, "describeRegions", { RegionNames: regions }, callback);
 });
 
-Then("the EC2 endpoint for {string} should be {string}", function(
+Then("the EC2 endpoint for {string} should be {string}", function (
   region,
   endpoint,
   callback
 ) {
-  this.assert.contains(this.data.Regions, function(region) {
+  this.assert.contains(this.data.Regions, function (region) {
     return region.Endpoint === endpoint;
   });
   callback();
 });
 
-Given("I describe the EC2 instance {string}", function(instanceId, callback) {
+Given("I describe the EC2 instance {string}", function (instanceId, callback) {
   this.request(
     null,
     "describeInstances",
@@ -70,7 +70,7 @@ Given("I describe the EC2 instance {string}", function(instanceId, callback) {
   );
 });
 
-Given("I attempt to copy an encrypted snapshot across regions", function(
+Given("I attempt to copy an encrypted snapshot across regions", function (
   callback
 ) {
   const self = this;
@@ -91,32 +91,32 @@ Given("I attempt to copy an encrypted snapshot across regions", function(
     Size: 10,
     Encrypted: true
   };
-  srcEc2.createVolume(params, function(err, data) {
+  srcEc2.createVolume(params, function (err, data) {
     if (err) {
       teardown();
       return callback(err);
     }
     volId = data.VolumeId;
 
-    waitForVolumeAvailable(srcEc2, volId, function(err) {
+    waitForVolumeAvailable(srcEc2, volId, function (err) {
       if (err) {
         teardown();
         return callback(err);
       }
 
-      srcEc2.createSnapshot({ VolumeId: volId }, function(err, data) {
+      srcEc2.createSnapshot({ VolumeId: volId }, function (err, data) {
         if (err) {
           teardown();
           return callback(err);
         }
         srcSnapId = data.SnapshotId;
 
-        setTimeout(function() {
+        setTimeout(function () {
           params = {
             SourceRegion: sourceRegion,
             SourceSnapshotId: srcSnapId
           };
-          dstEc2.copySnapshot(params, function(err, data) {
+          dstEc2.copySnapshot(params, function (err, data) {
             if (data) dstSnapId = data.SnapshotId;
             self.success = true;
             callback();
@@ -128,7 +128,7 @@ Given("I attempt to copy an encrypted snapshot across regions", function(
   });
 });
 
-Then("the copy snapshot attempt should be successful", function(callback) {
+Then("the copy snapshot attempt should be successful", function (callback) {
   this.assert.equal(this.success, true);
   callback();
 });

--- a/features/ecr/step_definitions/ecr.js
+++ b/features/ecr/step_definitions/ecr.js
@@ -1,7 +1,7 @@
 const { ECR } = require("../../../clients/client-ecr");
 const { Before } = require("cucumber");
 
-Before({ tags: "@ecr" }, function(scenario, callback) {
+Before({ tags: "@ecr" }, function (scenario, callback) {
   this.service = new ECR({});
   callback();
 });

--- a/features/ecs/step_definitions/ecs.js
+++ b/features/ecs/step_definitions/ecs.js
@@ -1,7 +1,7 @@
 const { ECS } = require("../../../clients/client-ecs");
 const { Before } = require("cucumber");
 
-Before({ tags: "@ecs" }, function(scenario, callback) {
+Before({ tags: "@ecs" }, function (scenario, callback) {
   this.service = new ECS({});
   callback();
 });

--- a/features/efs/step_definitions/efs.js
+++ b/features/efs/step_definitions/efs.js
@@ -1,7 +1,7 @@
 const { EFS } = require("../../../clients/client-efs");
 const { Before } = require("cucumber");
 
-Before({ tags: "@efs" }, function(scenario, callback) {
+Before({ tags: "@efs" }, function (scenario, callback) {
   this.service = new EFS({ region: "us-west-2" });
   callback();
 });

--- a/features/elasticache/step_definitions/elasticache.js
+++ b/features/elasticache/step_definitions/elasticache.js
@@ -1,12 +1,12 @@
 const { ElastiCache } = require("../../../clients/client-elasticache");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@elasticache" }, function(scenario, callback) {
+Before({ tags: "@elasticache" }, function (scenario, callback) {
   this.service = new ElastiCache({});
   callback();
 });
 
-Given("I create a cache parameter group with name prefix {string}", function(
+Given("I create a cache parameter group with name prefix {string}", function (
   prefix,
   callback
 ) {
@@ -19,26 +19,26 @@ Given("I create a cache parameter group with name prefix {string}", function(
   this.request(null, "createCacheParameterGroup", params, callback, false);
 });
 
-Given("the cache parameter group name is in the result", function(callback) {
+Given("the cache parameter group name is in the result", function (callback) {
   const name = this.data.CacheParameterGroup.CacheParameterGroupName;
   this.assert.equal(name, this.cacheGroupName);
   callback();
 });
 
-Given("I describe the cache parameter groups", function(callback) {
+Given("I describe the cache parameter groups", function (callback) {
   const params = {
     CacheParameterGroupName: this.cacheGroupName
   };
   this.request(null, "describeCacheParameterGroups", params, callback);
 });
 
-Then("the cache parameter group should be described", function(callback) {
+Then("the cache parameter group should be described", function (callback) {
   const item = this.data.CacheParameterGroups[0];
   this.assert.equal(item.CacheParameterGroupName, this.cacheGroupName);
   callback();
 });
 
-Then("I delete the cache parameter group", function(callback) {
+Then("I delete the cache parameter group", function (callback) {
   const params = {
     CacheParameterGroupName: this.cacheGroupName
   };

--- a/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
+++ b/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
@@ -3,14 +3,14 @@ const {
 } = require("../../../clients/client-elastic-beanstalk");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@elasticbeanstalk" }, function(scenario, callback) {
+Before({ tags: "@elasticbeanstalk" }, function (scenario, callback) {
   this.service = new ElasticBeanstalk({});
   callback();
 });
 
 Given(
   "I create an Elastic Beanstalk application with name prefix {string}",
-  function(prefix, callback) {
+  function (prefix, callback) {
     this.appName = this.uniqueName(prefix);
     const params = { ApplicationName: this.appName };
     this.request(null, "createApplication", params, callback, false);
@@ -19,7 +19,7 @@ Given(
 
 Given(
   "I create an Elastic Beanstalk application version with label {string}",
-  function(label, callback) {
+  function (label, callback) {
     this.appVersion = label;
     const params = {
       ApplicationName: this.appName,
@@ -29,14 +29,14 @@ Given(
   }
 );
 
-Given("I describe the Elastic Beanstalk application", function(callback) {
+Given("I describe the Elastic Beanstalk application", function (callback) {
   const params = { ApplicationNames: [this.appName] };
   this.request(null, "describeApplications", params, callback);
 });
 
 Then(
   "the result should contain the Elastic Beanstalk application version",
-  function(callback) {
+  function (callback) {
     this.assert.deepEqual(this.data.Applications[0].Versions, [
       this.appVersion
     ]);
@@ -46,13 +46,13 @@ Then(
 
 Then(
   "the result should contain the Elastic Beanstalk application name",
-  function(callback) {
+  function (callback) {
     this.assert.equal(this.data.Applications[0].ApplicationName, this.appName);
     callback();
   }
 );
 
-Then("I delete the Elastic Beanstalk application", function(callback) {
+Then("I delete the Elastic Beanstalk application", function (callback) {
   const params = { ApplicationName: this.appName };
   this.request(null, "deleteApplication", params, callback);
 });

--- a/features/elastictranscoder/step_definitions/elastictranscoder.js
+++ b/features/elastictranscoder/step_definitions/elastictranscoder.js
@@ -5,7 +5,7 @@ const { S3 } = require("../../../clients/client-s3");
 const { IAM } = require("../../../clients/client-iam");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@elastictranscoder" }, function(scenario, callback) {
+Before({ tags: "@elastictranscoder" }, function (scenario, callback) {
   this.iam = new IAM({});
   this.s3 = new S3({});
   this.service = new ElasticTranscoder({});
@@ -14,7 +14,7 @@ Before({ tags: "@elastictranscoder" }, function(scenario, callback) {
 
 Given(
   "I create an Elastic Transcoder pipeline with name prefix {string}",
-  function(prefix, callback) {
+  function (prefix, callback) {
     this.pipelineName = this.uniqueName(prefix);
     const params = {
       Name: this.pipelineName,
@@ -30,7 +30,7 @@ Given(
     };
 
     const world = this;
-    const next = function() {
+    const next = function () {
       if (world.data) world.pipelineId = world.data.Pipeline.Id;
       callback();
     };
@@ -39,19 +39,19 @@ Given(
   }
 );
 
-Given("I list pipelines", function(callback) {
+Given("I list pipelines", function (callback) {
   this.request(null, "listPipelines", {}, callback);
 });
 
-Then("the list should contain the pipeline", function(callback) {
+Then("the list should contain the pipeline", function (callback) {
   const id = this.pipelineId;
-  this.assert.contains(this.data.Pipelines, function(pipeline) {
+  this.assert.contains(this.data.Pipelines, function (pipeline) {
     return pipeline.Id === id;
   });
   callback();
 });
 
-Then("I pause the pipeline", function(callback) {
+Then("I pause the pipeline", function (callback) {
   this.request(
     null,
     "updatePipelineStatus",
@@ -63,7 +63,7 @@ Then("I pause the pipeline", function(callback) {
   );
 });
 
-Then("I read the pipeline", function(callback) {
+Then("I read the pipeline", function (callback) {
   this.request(
     null,
     "readPipeline",
@@ -74,12 +74,12 @@ Then("I read the pipeline", function(callback) {
   );
 });
 
-Then("the pipeline status should be {string}", function(status, callback) {
+Then("the pipeline status should be {string}", function (status, callback) {
   this.assert.equal(this.data.Pipeline.Status, status);
   callback();
 });
 
-Then("I delete the pipeline", function(callback) {
+Then("I delete the pipeline", function (callback) {
   this.request(
     null,
     "deletePipeline",

--- a/features/elb/step_definitions/elb.js
+++ b/features/elb/step_definitions/elb.js
@@ -3,12 +3,12 @@ const {
 } = require("../../../clients/client-elastic-load-balancing");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@elb" }, function(scenario, callback) {
+Before({ tags: "@elb" }, function (scenario, callback) {
   this.service = new ElasticLoadBalancing({});
   callback();
 });
 
-Given("I create a load balancer with name prefix {string}", function(
+Given("I create a load balancer with name prefix {string}", function (
   prefix,
   callback
 ) {
@@ -28,7 +28,7 @@ Given("I create a load balancer with name prefix {string}", function(
   this.request(null, "createLoadBalancer", params, callback, false);
 });
 
-Given("I describe load balancers with the load balancer name", function(
+Given("I describe load balancers with the load balancer name", function (
   callback
 ) {
   const params = {
@@ -37,19 +37,19 @@ Given("I describe load balancers with the load balancer name", function(
   this.request(null, "describeLoadBalancers", params, callback);
 });
 
-Then("the load balancer should be in the list", function(callback) {
+Then("the load balancer should be in the list", function (callback) {
   const name = this.data.LoadBalancerDescriptions[0].LoadBalancerName;
   this.assert.equal(name, this.loadBalancerName);
   callback();
 });
 
-Then("I delete the load balancer", function(callback) {
+Then("I delete the load balancer", function (callback) {
   const params = {
     LoadBalancerName: this.loadBalancerName
   };
   this.request(null, "deleteLoadBalancer", params, callback);
 });
 
-Given("I try to create a load balancer with no name", function(callback) {
+Given("I try to create a load balancer with no name", function (callback) {
   this.request(null, "createLoadBalancer", {}, callback);
 });

--- a/features/elbv2/step_definitions/elbv2.js
+++ b/features/elbv2/step_definitions/elbv2.js
@@ -3,7 +3,7 @@ const {
 } = require("../../../clients/client-elastic-load-balancing-v2");
 const { Before } = require("cucumber");
 
-Before({ tags: "@elbv2" }, function(scenario, callback) {
+Before({ tags: "@elbv2" }, function (scenario, callback) {
   this.service = new ElasticLoadBalancingv2({});
   callback();
 });

--- a/features/emr/step_definitions/emr.js
+++ b/features/emr/step_definitions/emr.js
@@ -1,12 +1,12 @@
 const { EMR } = require("../../../clients/client-emr");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@emr" }, function(scenario, callback) {
+Before({ tags: "@emr" }, function (scenario, callback) {
   this.service = new EMR({});
   callback();
 });
 
-Given("I run an EMR job flow with invalid parameters", function(callback) {
+Given("I run an EMR job flow with invalid parameters", function (callback) {
   this.service = new EMR({});
   const params = { Name: "", Instances: { MasterInstanceType: "invalid" } };
   this.request(null, "runJobFlow", params, callback, false);

--- a/features/es/step_definitions/es.js
+++ b/features/es/step_definitions/es.js
@@ -3,7 +3,7 @@ const {
 } = require("../../../clients/client-elasticsearch-service");
 const { Before } = require("cucumber");
 
-Before({ tags: "@es" }, function(scenario, callback) {
+Before({ tags: "@es" }, function (scenario, callback) {
   this.service = new ElasticsearchService({});
   callback();
 });

--- a/features/extra/cleanup.js
+++ b/features/extra/cleanup.js
@@ -35,12 +35,12 @@ AfterAll(async () => {
 /**
  * Delete fixtures
  */
-const deleteFixtures = function() {
+const deleteFixtures = function () {
   const fs = require("fs");
   const path = require("path");
   const fixturePath = path.resolve("./features/extra/fixtures/tmp");
   if (fs.existsSync(fixturePath)) {
-    fs.readdirSync(fixturePath).forEach(function(file) {
+    fs.readdirSync(fixturePath).forEach(function (file) {
       fs.unlinkSync(path.join(fixturePath, file));
     });
     fs.rmdirSync(fixturePath);
@@ -75,7 +75,7 @@ const deleteObjects = async bucket => {
   const data = await s3.listObjects(params);
   if (data.Contents && data.Contents.length > 0) {
     params.Delete = { Objects: [] };
-    data.Contents.forEach(function(item) {
+    data.Contents.forEach(function (item) {
       params.Delete.Objects.push({ Key: item.Key });
     });
     await s3.deleteObjects(params);

--- a/features/extra/helpers.js
+++ b/features/extra/helpers.js
@@ -40,13 +40,13 @@ module.exports = {
     const started = new Date();
 
     const self = this;
-    const retry = function() {
+    const retry = function () {
       callback();
     };
-    retry.fail = function(err) {
+    retry.fail = function (err) {
       const now = self.AWS.util.date.getDate();
       if (now - started < options.maxTime * 1000) {
-        setTimeout(function() {
+        setTimeout(function () {
           delay += options.backoff;
           block.call(self, retry);
         }, delay);
@@ -68,7 +68,7 @@ module.exports = {
     if (!svc) svc = this.service;
     if (typeof svc === "string") svc = this[svc];
 
-    svc[operation](params, function(err, data) {
+    svc[operation](params, function (err, data) {
       world.response = this;
       world.error = err;
       world.data = data;
@@ -116,7 +116,7 @@ module.exports = {
   /**
    * Cache bucket names used for cleanup after all features have run.
    */
-  cacheBucketName: function(bucket) {
+  cacheBucketName: function (bucket) {
     const fs = require("fs");
     const path = require("path");
     const filePath = path.resolve("integ.buckets.json");
@@ -139,7 +139,7 @@ module.exports = {
   /**
    * Creates a fixture file of given size and returns the path.
    */
-  createFile: function(size, name) {
+  createFile: function (size, name) {
     const fs = require("fs");
     const path = require("path");
     name = this.uniqueName(name);
@@ -172,7 +172,7 @@ module.exports = {
   /**
    * Creates and returns a buffer of given size
    */
-  createBuffer: function(size) {
+  createBuffer: function (size) {
     let match;
     let buffer;
     if ((match = size.match(/(\d+)KB/))) {
@@ -202,20 +202,20 @@ module.exports = {
    * Waits for the bucketExists state by periodically calling the underlying S3.headBucket() operation
    * every 5 seconds (at most 20 times).
    */
-  waitForBucketExists: function(s3client, params, callback) {
+  waitForBucketExists: function (s3client, params, callback) {
     const maxAttempts = 20;
     let currentAttempt = 0;
     const delay = 5000;
 
     const checkForBucketExists = () => {
       currentAttempt++;
-      s3client.headBucket(params, function(err, data) {
+      s3client.headBucket(params, function (err, data) {
         if (currentAttempt > maxAttempts) {
           callback(new Error("waitForBucketExists: max attempts exceeded"));
         } else if (data) {
           callback();
         } else {
-          setTimeout(function() {
+          setTimeout(function () {
             checkForBucketExists();
           }, delay);
         }
@@ -228,20 +228,20 @@ module.exports = {
    * Waits for the bucketNotExists state by periodically calling the underlying S3.headBucket() operation
    * every 5 seconds (at most 20 times).
    */
-  waitForBucketNotExists: function(s3client, params, callback) {
+  waitForBucketNotExists: function (s3client, params, callback) {
     const maxAttempts = 20;
     let currentAttempt = 0;
     const delay = 5000;
 
     const checkForBucketNotExists = () => {
       currentAttempt++;
-      s3client.headBucket(params, function(err, data) {
+      s3client.headBucket(params, function (err, data) {
         if (currentAttempt > maxAttempts) {
           callback(new Error("waitForBucketNotExists: max attempts exceeded"));
         } else if (err && err.name === "NotFound") {
           callback();
         } else {
-          setTimeout(function() {
+          setTimeout(function () {
             checkForBucketNotExists();
           }, delay);
         }

--- a/features/extra/hooks.js
+++ b/features/extra/hooks.js
@@ -19,19 +19,19 @@ const {
 setDefaultTimeout(180 * 1000);
 setWorldConstructor(require("./world.js").World);
 
-Before(function(scenario, callback) {
+Before(function (scenario, callback) {
   this.params = {};
   callback();
 });
 
 /* Global S3 steps */
-Given("I create a shared bucket", function(callback) {
+Given("I create a shared bucket", function (callback) {
   if (this.sharedBucket) return callback();
 
   const bucket = (this.sharedBucket = this.uniqueName(
     "aws-sdk-js-shared-integration"
   ));
-  this.request("s3", "createBucket", { Bucket: this.sharedBucket }, function(
+  this.request("s3", "createBucket", { Bucket: this.sharedBucket }, function (
     err
   ) {
     this.cacheBucketName(this.sharedBucket);
@@ -46,9 +46,9 @@ Given("I create a shared bucket", function(callback) {
   });
 });
 
-Given("I create a bucket", function(callback) {
+Given("I create a bucket", function (callback) {
   const bucket = (this.bucket = this.uniqueName("aws-sdk-js-integration"));
-  this.request("s3", "createBucket", { Bucket: this.bucket }, function(
+  this.request("s3", "createBucket", { Bucket: this.bucket }, function (
     err,
     data
   ) {
@@ -59,25 +59,25 @@ Given("I create a bucket", function(callback) {
   });
 });
 
-When("I delete the bucket", function(callback) {
+When("I delete the bucket", function (callback) {
   this.request("s3", "deleteBucket", { Bucket: this.bucket }, callback);
 });
 
-Then("the bucket should exist", function(next) {
+Then("the bucket should exist", function (next) {
   this.waitForBucketExists(this.s3, { Bucket: this.bucket }, next);
 });
 
-Then("the bucket should not exist", function(callback) {
+Then("the bucket should not exist", function (callback) {
   this.waitForBucketNotExists(this.s3, { Bucket: this.bucket }, callback);
 });
 
 /* Global error code steps */
 
-Given("I run the {string} operation", function(operation, callback) {
+Given("I run the {string} operation", function (operation, callback) {
   this.request(null, operation, {}, callback, false);
 });
 
-Given("I run the {string} operation with params:", function(
+Given("I run the {string} operation with params:", function (
   operation,
   params,
   callback
@@ -85,12 +85,12 @@ Given("I run the {string} operation with params:", function(
   this.request(null, operation, JSON.parse(params), callback, false);
 });
 
-Then("the request should be successful", function(callback) {
+Then("the request should be successful", function (callback) {
   this.assert.ok(!this.error, "Response was not successful");
   callback();
 });
 
-Then("the value at {string} should be a list", function(path, callback) {
+Then("the value at {string} should be a list", function (path, callback) {
   const value = jmespath.search(this.data, path);
   this.assert.ok(
     Array.isArray(value),
@@ -99,7 +99,7 @@ Then("the value at {string} should be a list", function(path, callback) {
   callback();
 });
 
-Then("the value at {string} should be a number", function(path, callback) {
+Then("the value at {string} should be a number", function (path, callback) {
   const value = jmespath.search(this.data, path);
   this.assert.ok(
     typeof value === "number",
@@ -108,7 +108,7 @@ Then("the value at {string} should be a number", function(path, callback) {
   callback();
 });
 
-Then("the value at {string} should be a string", function(path, callback) {
+Then("the value at {string} should be a string", function (path, callback) {
   const value = jmespath.search(this.data, path);
   this.assert.ok(
     typeof value === "string",
@@ -117,13 +117,13 @@ Then("the value at {string} should be a string", function(path, callback) {
   callback();
 });
 
-Then("the error code should be {string}", function(code, callback) {
+Then("the error code should be {string}", function (code, callback) {
   this.assert.ok(this.error, "Response does not contain an error");
   this.assert.equal(this.error.name, code);
   callback();
 });
 
-Then("the error message should {word}:", function(matcher, message, callback) {
+Then("the error message should {word}:", function (matcher, message, callback) {
   if (matcher === "be") matcher = "equal";
   if (matcher === "contain") matcher = "match";
   this.assert.ok(this.error, "Response does not contain an error");
@@ -131,24 +131,24 @@ Then("the error message should {word}:", function(matcher, message, callback) {
   callback();
 });
 
-Then("the status code should be {int}", function(status, callback) {
+Then("the status code should be {int}", function (status, callback) {
   this.assert.equal(this.data.$metadata.httpStatusCode, parseInt(status));
   callback();
 });
 
-Then("the error status code should be {int}", function(status, callback) {
+Then("the error status code should be {int}", function (status, callback) {
   this.assert.equal(this.error.$metadata.httpStatusCode, parseInt(status));
   callback();
 });
 
-Then("I should get the error:", function(table, callback) {
+Then("I should get the error:", function (table, callback) {
   const err = table.hashes()[0];
   this.assert.equal(this.error.name, err.name);
   this.assert.equal(this.error.message, err.message);
   callback();
 });
 
-Given("I have a {string} service in the {string} region", function(
+Given("I have a {string} service in the {string} region", function (
   svc,
   region,
   callback
@@ -159,7 +159,7 @@ Given("I have a {string} service in the {string} region", function(
 
 Given(
   /^I paginate the "([^"]*)" operation(?: with limit (\d+))?(?: and max pages (\d+))?$/,
-  function(operation, limit, maxPages, callback) {
+  function (operation, limit, maxPages, callback) {
     limit = parseInt(limit);
     if (maxPages) maxPages = parseInt(maxPages);
 
@@ -174,7 +174,7 @@ Given(
     if (this.paginationConfig.limitKey) {
       this.params[this.paginationConfig.limitKey] = limit;
     }
-    this.service[operation](this.params).eachPage(function(err, data) {
+    this.service[operation](this.params).eachPage(function (err, data) {
       if (err) callback(err);
       else if (data === null) callback();
       else if (maxPages && world.numPages === maxPages) {
@@ -189,27 +189,27 @@ Given(
   }
 );
 
-Then("I should get more than one page", function(callback) {
+Then("I should get more than one page", function (callback) {
   this.assert.compare(this.numPages, ">", 1);
   callback();
 });
 
-Then("I should get at least one page", function(callback) {
+Then("I should get at least one page", function (callback) {
   this.assert.compare(this.numPages, ">=", 1);
   callback();
 });
 
-Then("I should get {int} pages", function(numPages, callback) {
+Then("I should get {int} pages", function (numPages, callback) {
   this.assert.equal(this.numPages, parseInt(numPages));
   callback();
 });
 
-Then("I should get numPages - 1 markers", function(callback) {
+Then("I should get numPages - 1 markers", function (callback) {
   this.assert.equal(this.numMarkers, this.numPages - 1);
   callback();
 });
 
-Then("the last page should not contain a marker", function(callback) {
+Then("the last page should not contain a marker", function (callback) {
   const marker = this.paginationConfig.outputToken;
   this.assert.equal(this.data[marker], null);
   callback();
@@ -217,7 +217,7 @@ Then("the last page should not contain a marker", function(callback) {
 
 Then(
   "the result at {word} should contain a property {word} with a(n) {word}",
-  function(wrapper, property, type, callback) {
+  function (wrapper, property, type, callback) {
     if (type === "Array" || type === "Date") {
       this.assert.equal(isType(this.data[wrapper][property], type), true);
     } else {
@@ -227,7 +227,7 @@ Then(
   }
 );
 
-Then("the result should contain a property {word} with a(n) {word}", function(
+Then("the result should contain a property {word} with a(n) {word}", function (
   property,
   type,
   callback

--- a/features/gamelift/step_definitions/gamelift.js
+++ b/features/gamelift/step_definitions/gamelift.js
@@ -1,7 +1,7 @@
 const { GameLift } = require("../../../clients/client-gamelift");
 const { Before } = require("cucumber");
 
-Before({ tags: "@gamelift" }, function(scenario, callback) {
+Before({ tags: "@gamelift" }, function (scenario, callback) {
   this.service = new GameLift({});
   callback();
 });

--- a/features/glacier/step_definitions/glacier.js
+++ b/features/glacier/step_definitions/glacier.js
@@ -1,12 +1,12 @@
 const { Glacier } = require("../../../clients/client-glacier");
 const { Before, Given, Then, When } = require("cucumber");
 
-Before({ tags: "@glacier" }, function(scenario, callback) {
+Before({ tags: "@glacier" }, function (scenario, callback) {
   this.service = new Glacier({});
   callback();
 });
 
-Given("I have a Glacier vault", function(callback) {
+Given("I have a Glacier vault", function (callback) {
   this.vaultName = "aws-sdk-js-integration";
   const params = {
     vaultName: this.vaultName
@@ -16,7 +16,7 @@ Given("I have a Glacier vault", function(callback) {
 
 Given(
   /^I upload a (\d+(?:\.\d+)?)MB Glacier archive to the vault( with (?:invalid|incorrect) checksum)?$/,
-  function(size, invalid, callback) {
+  function (size, invalid, callback) {
     const data = Buffer.alloc(parseFloat(size) * 1024 * 1024);
     data.fill("0");
     const params = {
@@ -31,12 +31,12 @@ Given(
   }
 );
 
-Then("the result should contain the Glacier archive ID", function(callback) {
+Then("the result should contain the Glacier archive ID", function (callback) {
   this.archiveId = this.data.archiveId;
   callback();
 });
 
-Then("the result should contain the same tree hash checksum", function(
+Then("the result should contain the same tree hash checksum", function (
   callback
 ) {
   const hash = this.data.$metadata.httpHeaders["x-amz-sha256-tree-hash"];
@@ -44,14 +44,14 @@ Then("the result should contain the same tree hash checksum", function(
   callback();
 });
 
-When("I describe the Glacier vault", function(callback) {
+When("I describe the Glacier vault", function (callback) {
   const params = {
     vaultName: this.vaultName
   };
   this.request(null, "describeVault", params, callback);
 });
 
-Then("I delete the Glacier archive", function(callback) {
+Then("I delete the Glacier archive", function (callback) {
   const params = {
     vaultName: this.vaultName,
     archiveId: this.archiveId
@@ -59,18 +59,18 @@ Then("I delete the Glacier archive", function(callback) {
   this.request(null, "deleteArchive", params, callback);
 });
 
-Then("I delete the Glacier vault", function(callback) {
+Then("I delete the Glacier vault", function (callback) {
   const params = {
     vaultName: this.vaultName
   };
-  this.eventually(callback, function(next) {
+  this.eventually(callback, function (next) {
     this.request(null, "deleteVault", params, next);
   });
 });
 
 When(
   /^I initiate a Glacier multi-part upload on a (\d+(?:\.\d+)?)MB archive in (\d+)MB chunks$/,
-  function(totalSize, partSize, callback) {
+  function (totalSize, partSize, callback) {
     // setup multi-part upload
     this.uploadData = Buffer.alloc(totalSize * 1024 * 1024);
     this.uploadData.fill("0");
@@ -88,14 +88,14 @@ When(
   }
 );
 
-Then("the result should contain the Glacier multi-part upload ID", function(
+Then("the result should contain the Glacier multi-part upload ID", function (
   callback
 ) {
   this.uploadId = this.data.uploadId;
   callback();
 });
 
-Then("I send the next part", function(callback) {
+Then("I send the next part", function (callback) {
   const start = this.partCounter;
   const end = Math.min(start + this.partSize, this.uploadData.length);
   const buf = this.uploadData.slice(start, end);
@@ -110,7 +110,7 @@ Then("I send the next part", function(callback) {
   this.partCounter += this.partSize;
 });
 
-Then("I send the Glacier archive data in chunks", function(callback) {
+Then("I send the Glacier archive data in chunks", function (callback) {
   let numPartsLeft = Math.ceil(this.uploadData.length / this.partSize);
   for (let i = 0; i < this.uploadData.length; i += this.partSize) {
     const end = Math.min(i + this.partSize, this.uploadData.length);
@@ -122,13 +122,13 @@ Then("I send the Glacier archive data in chunks", function(callback) {
       range: range,
       body: buf
     };
-    this.service.uploadMultipartPart(params, function() {
+    this.service.uploadMultipartPart(params, function () {
       if (--numPartsLeft === 0) callback();
     });
   }
 });
 
-Then("I complete the Glacier multi-part upload", function(callback) {
+Then("I complete the Glacier multi-part upload", function (callback) {
   const params = {
     vaultName: this.vaultName,
     uploadId: this.uploadId,

--- a/features/iam/step_definitions/iam.js
+++ b/features/iam/step_definitions/iam.js
@@ -1,20 +1,20 @@
 const { IAM } = require("../../../clients/client-iam");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@iam" }, function(scenario, callback) {
+Before({ tags: "@iam" }, function (scenario, callback) {
   this.iam = new IAM({});
   callback();
 });
 
-Given("I have an IAM username {string}", function(name, callback) {
+Given("I have an IAM username {string}", function (name, callback) {
   this.iamUserArn = "";
   this.iamUser = this.uniqueName(name);
   callback();
 });
 
-Given("I create an IAM user with the username", function(callback) {
+Given("I create an IAM user with the username", function (callback) {
   const world = this;
-  const next = function() {
+  const next = function () {
     if (world.data) this.iamUserArn = world.data.User.Arn;
     else this.iamUserArn = null;
     callback();
@@ -31,19 +31,19 @@ Given("I create an IAM user with the username", function(callback) {
   );
 });
 
-Given("I list the IAM users", function(callback) {
+Given("I list the IAM users", function (callback) {
   this.request("iam", "listUsers", {}, callback);
 });
 
-Then("the list should contain the user", function(callback) {
+Then("the list should contain the user", function (callback) {
   const name = this.iamUser;
-  this.assert.contains(this.data.Users, function(user) {
+  this.assert.contains(this.data.Users, function (user) {
     return user.UserName === name;
   });
   callback();
 });
 
-Then("I delete the IAM user", function(callback) {
+Then("I delete the IAM user", function (callback) {
   this.request(
     "iam",
     "deleteUser",
@@ -54,7 +54,7 @@ Then("I delete the IAM user", function(callback) {
   );
 });
 
-Given("I create an IAM role with name prefix {string}", function(
+Given("I create an IAM role with name prefix {string}", function (
   name,
   callback
 ) {
@@ -69,7 +69,7 @@ Given("I create an IAM role with name prefix {string}", function(
     RoleName: this.iamRoleName,
     AssumeRolePolicyDocument: assumeRolePolicyDocument
   };
-  const next = function() {
+  const next = function () {
     world.iamRoleArn = world.data.Role.Arn;
     callback();
   };
@@ -78,12 +78,12 @@ Given("I create an IAM role with name prefix {string}", function(
   this.request("iam", "createRole", params, next);
 });
 
-Then("the IAM role should exist", function(callback) {
+Then("the IAM role should exist", function (callback) {
   this.assert.compare(this.iamRoleArn.length, ">", 0);
   callback();
 });
 
-Then("I delete the IAM role", function(callback) {
+Then("I delete the IAM role", function (callback) {
   this.request(
     "iam",
     "deleteRole",

--- a/features/inspector/step_definitions/inspector.js
+++ b/features/inspector/step_definitions/inspector.js
@@ -1,7 +1,7 @@
 const { Inspector } = require("../../../clients/client-inspector");
 const { Before } = require("cucumber");
 
-Before({ tags: "@inspector" }, function(scenario, callback) {
+Before({ tags: "@inspector" }, function (scenario, callback) {
   this.service = new Inspector({ region: "us-west-2" });
   callback();
 });

--- a/features/iot/step_definitions/iot.js
+++ b/features/iot/step_definitions/iot.js
@@ -1,7 +1,7 @@
 const { IoT } = require("../../../clients/client-iot");
 const { Before } = require("cucumber");
 
-Before({ tags: "@iot" }, function(scenario, callback) {
+Before({ tags: "@iot" }, function (scenario, callback) {
   this.service = new IoT({});
   callback();
 });

--- a/features/kinesis/step_definitions/kinesis.js
+++ b/features/kinesis/step_definitions/kinesis.js
@@ -1,12 +1,12 @@
 const { Kinesis } = require("../../../clients/client-kinesis");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@kinesis" }, function(scenario, callback) {
+Before({ tags: "@kinesis" }, function (scenario, callback) {
   this.service = new Kinesis({});
   callback();
 });
 
-Given("I try to describe a stream in Kinesis", function(callback) {
+Given("I try to describe a stream in Kinesis", function (callback) {
   this.request(
     null,
     "describeStream",

--- a/features/kms/step_definitions/kms.js
+++ b/features/kms/step_definitions/kms.js
@@ -1,7 +1,7 @@
 const { KMS } = require("../../../clients/client-kms");
 const { Before } = require("cucumber");
 
-Before({ tags: "@kms" }, function(scenario, callback) {
+Before({ tags: "@kms" }, function (scenario, callback) {
   this.service = new KMS({});
   callback();
 });

--- a/features/lambda/step_definitions/lambda.js
+++ b/features/lambda/step_definitions/lambda.js
@@ -1,7 +1,7 @@
 const { Lambda } = require("../../../clients/client-lambda");
 const { Before } = require("cucumber");
 
-Before({ tags: "@lambda" }, function(scenario, callback) {
+Before({ tags: "@lambda" }, function (scenario, callback) {
   this.service = new Lambda({});
   callback();
 });

--- a/features/opsworks/step_definitions/opsworks.js
+++ b/features/opsworks/step_definitions/opsworks.js
@@ -2,13 +2,13 @@ const { IAM } = require("../../../clients/client-iam");
 const { OpsWorks } = require("../../../clients/client-opsworks");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@opsworks" }, function(scenario, callback) {
+Before({ tags: "@opsworks" }, function (scenario, callback) {
   this.iam = new IAM({});
   this.service = new OpsWorks({});
   callback();
 });
 
-Given("I create an OpsWorks user profile with the IAM user ARN", function(
+Given("I create an OpsWorks user profile with the IAM user ARN", function (
   callback
 ) {
   const params = {
@@ -17,36 +17,36 @@ Given("I create an OpsWorks user profile with the IAM user ARN", function(
   this.request(null, "createUserProfile", params, callback, false);
 });
 
-Given("the IAM user ARN is in the result", function(callback) {
+Given("the IAM user ARN is in the result", function (callback) {
   this.assert.equal(this.data.IamUserArn, this.iamUserArn);
   callback();
 });
 
-Given("I describe the OpsWorks user profiles", function(callback) {
+Given("I describe the OpsWorks user profiles", function (callback) {
   const params = {
     IamUserArns: [this.iamUserArn]
   };
   this.request(null, "describeUserProfiles", params, callback);
 });
 
-Then("the IAM user ARN should be in the result", function(callback) {
+Then("the IAM user ARN should be in the result", function (callback) {
   this.assert.equal(this.data.UserProfiles[0].IamUserArn, this.iamUserArn);
   callback();
 });
 
-Then("the name should be equal to the IAM username", function(callback) {
+Then("the name should be equal to the IAM username", function (callback) {
   this.assert.equal(this.data.UserProfiles[0].Name, this.iamUser);
   callback();
 });
 
-Then("the SSH username should be equal to the IAM username", function(
+Then("the SSH username should be equal to the IAM username", function (
   callback
 ) {
   this.assert.equal(this.data.UserProfiles[0].SshUsername, this.iamUser);
   callback();
 });
 
-Then("I delete the OpsWorks user profile", function(callback) {
+Then("I delete the OpsWorks user profile", function (callback) {
   const params = {
     IamUserArn: this.iamUserArn
   };

--- a/features/pinpoint/step_definitions/pinpoint.js
+++ b/features/pinpoint/step_definitions/pinpoint.js
@@ -1,18 +1,18 @@
 const { Pinpoint } = require("../../../clients/client-pinpoint");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@pinpoint" }, function(scenario, callback) {
+Before({ tags: "@pinpoint" }, function (scenario, callback) {
   this.service = new Pinpoint({});
   callback();
 });
 
-Given("I create an application", function(callback) {
+Given("I create an application", function (callback) {
   const params = {
     CreateApplicationRequest: {
       Name: this.uniqueName("aws-sdk-js-integration")
     }
   };
-  this.request(null, "createApp", params, function(err, data) {
+  this.request(null, "createApp", params, function (err, data) {
     if (err) {
       callback(err);
     }
@@ -21,7 +21,7 @@ Given("I create an application", function(callback) {
   });
 });
 
-Given('I run the "putEvents" operation with EventsRequest:', function(
+Given('I run the "putEvents" operation with EventsRequest:', function (
   eventsRequest,
   callback
 ) {
@@ -37,7 +37,7 @@ Given('I run the "putEvents" operation with EventsRequest:', function(
   );
 });
 
-Given("I delete the application", function(callback) {
+Given("I delete the application", function (callback) {
   this.request(
     null,
     "deleteApp",

--- a/features/rds/step_definitions/rds.js
+++ b/features/rds/step_definitions/rds.js
@@ -2,12 +2,12 @@ const jmespath = require("jmespath");
 const { RDS } = require("../../../clients/client-rds");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@rds" }, function(scenario, callback) {
+Before({ tags: "@rds" }, function (scenario, callback) {
   this.service = new RDS({});
   callback();
 });
 
-Given("I create a RDS security group with prefix name {string}", function(
+Given("I create a RDS security group with prefix name {string}", function (
   prefix,
   callback
 ) {
@@ -19,7 +19,7 @@ Given("I create a RDS security group with prefix name {string}", function(
   this.request(null, "createDBSecurityGroup", params, callback, false);
 });
 
-Then("the value at {string} should contain {string} with {string}", function(
+Then("the value at {string} should contain {string} with {string}", function (
   path,
   key,
   value,
@@ -27,7 +27,7 @@ Then("the value at {string} should contain {string} with {string}", function(
 ) {
   const member = jmespath.search(this.data, path);
   let containDefault = false;
-  member.forEach(function(config) {
+  member.forEach(function (config) {
     if (config[key] === value) {
       containDefault = true;
     }
@@ -41,7 +41,7 @@ Then("the value at {string} should contain {string} with {string}", function(
 
 Given(
   "I paginate the {string} operation asynchronously with limit {int}",
-  function(operation, limit, callback) {
+  function (operation, limit, callback) {
     const maxPages = 3;
     limit = parseInt(limit);
 
@@ -57,8 +57,8 @@ Given(
     if (this.paginationConfig.limitKey) {
       this.params[this.paginationConfig.limitKey] = limit;
     }
-    this.service[operation](this.params).eachPage(function(err, data, done) {
-      process.nextTick(function() {
+    this.service[operation](this.params).eachPage(function (err, data, done) {
+      process.nextTick(function () {
         if (err) callback(err);
         else if (data === null || world.numPages === maxPages) {
           world.finishedPagination = true;
@@ -76,7 +76,7 @@ Given(
   }
 );
 
-Then("I should be able to asynchronously paginate all pages", function(
+Then("I should be able to asynchronously paginate all pages", function (
   callback
 ) {
   this.assert.equal(this.finishedPagination, true);

--- a/features/redshift/step_definitions/redshift.js
+++ b/features/redshift/step_definitions/redshift.js
@@ -1,14 +1,14 @@
 const { Redshift } = require("../../../clients/client-redshift");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@redshift" }, function(scenario, callback) {
+Before({ tags: "@redshift" }, function (scenario, callback) {
   this.service = new Redshift({});
   callback();
 });
 
 Given(
   "I create a Redshift cluster parameter group with prefix name {string}",
-  function(prefix, callback) {
+  function (prefix, callback) {
     this.parameterGroupName = this.uniqueName(prefix);
     const params = {
       Description: "Description",

--- a/features/route53/step_definitions/route53.js
+++ b/features/route53/step_definitions/route53.js
@@ -1,12 +1,12 @@
 const { Route53 } = require("../../../clients/client-route-53");
 const { Before, Then, When } = require("cucumber");
 
-Before({ tags: "@route53" }, function(scenario, callback) {
+Before({ tags: "@route53" }, function (scenario, callback) {
   this.service = new Route53({});
   callback();
 });
 
-When("I create a Route53 hosted zone with name prefix {string}", function(
+When("I create a Route53 hosted zone with name prefix {string}", function (
   prefix,
   callback
 ) {
@@ -21,22 +21,22 @@ When("I create a Route53 hosted zone with name prefix {string}", function(
   this.request(null, "createHostedZone", params, callback, false);
 });
 
-Then("the result should contain the hosted zone ID", function(callback) {
+Then("the result should contain the hosted zone ID", function (callback) {
   this.hostedZoneId = this.data.HostedZone.Id;
   callback();
 });
 
-Then("the result should contain the change ID", function(callback) {
+Then("the result should contain the change ID", function (callback) {
   this.changeInfoId = this.data.ChangeInfo.Id;
   callback();
 });
 
-Then("the result should contain the hosted zone name", function(callback) {
+Then("the result should contain the hosted zone name", function (callback) {
   this.assert.equal(this.data.HostedZone.Name, this.zoneName + ".");
   callback();
 });
 
-When("I get information about the Route53 change ID", function(callback) {
+When("I get information about the Route53 change ID", function (callback) {
   this.request(
     null,
     "getChange",
@@ -47,12 +47,12 @@ When("I get information about the Route53 change ID", function(callback) {
   );
 });
 
-Then("the change status should be PENDING or INSYNC", function(callback) {
+Then("the change status should be PENDING or INSYNC", function (callback) {
   this.assert.match(this.data.ChangeInfo.Status, "(PENDING|INSYNC)");
   callback();
 });
 
-When("I get information about the Route53 hosted zone ID", function(callback) {
+When("I get information about the Route53 hosted zone ID", function (callback) {
   this.request(
     null,
     "getHostedZone",
@@ -63,13 +63,13 @@ When("I get information about the Route53 hosted zone ID", function(callback) {
   );
 });
 
-Then("the result should contain multiple nameservers", function(callback) {
+Then("the result should contain multiple nameservers", function (callback) {
   this.assert.compare(this.data.DelegationSet.NameServers.length, ">=", 0);
   this.assert.equal(typeof this.data.DelegationSet.NameServers[0], "string");
   callback();
 });
 
-Then("I delete the Route53 hosted zone", function(callback) {
+Then("I delete the Route53 hosted zone", function (callback) {
   this.request(
     null,
     "deleteHostedZone",
@@ -80,7 +80,7 @@ Then("I delete the Route53 hosted zone", function(callback) {
   );
 });
 
-When("I create a Route53 TCP health check with name prefix {string}", function(
+When("I create a Route53 TCP health check with name prefix {string}", function (
   prefix,
   callback
 ) {
@@ -95,17 +95,17 @@ When("I create a Route53 TCP health check with name prefix {string}", function(
   this.request(null, "createHealthCheck", params, callback);
 });
 
-Then("the result should contain health check information", function(callback) {
+Then("the result should contain health check information", function (callback) {
   this.healthCheckInfo = this.data.HealthCheck;
   callback();
 });
 
-Then("the result should contain the health check ID", function(callback) {
+Then("the result should contain the health check ID", function (callback) {
   this.healthCheckId = this.data.HealthCheck.Id;
   callback();
 });
 
-When("I get information about the health check ID", function(callback) {
+When("I get information about the health check ID", function (callback) {
   const params = {
     HealthCheckId: this.healthCheckId
   };
@@ -114,19 +114,19 @@ When("I get information about the health check ID", function(callback) {
 
 Then(
   "the result should contain the previous health check information",
-  function(callback) {
+  function (callback) {
     this.assert.deepEqual(this.data.HealthCheck, this.healthCheckInfo);
     callback();
   }
 );
 
-Then("I delete the Route53 TCP health check", function(callback) {
+Then("I delete the Route53 TCP health check", function (callback) {
   const params = {
     HealthCheckId: this.healthCheckId
   };
   this.request(null, "deleteHealthCheck", params, callback);
 });
 
-When("I list Route53 hosted zones", function(callback) {
+When("I list Route53 hosted zones", function (callback) {
   this.request(null, "listHostedZones", {}, callback);
 });

--- a/features/route53domains/step_definitions/route53domains.js
+++ b/features/route53domains/step_definitions/route53domains.js
@@ -1,16 +1,16 @@
 const { Route53Domains } = require("../../../clients/client-route-53-domains");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@route53domains" }, function(scenario, callback) {
+Before({ tags: "@route53domains" }, function (scenario, callback) {
   this.service = new Route53Domains({ region: "us-east-1" });
   callback();
 });
 
-Given("I list Route53 domains", function(callback) {
+Given("I list Route53 domains", function (callback) {
   this.request(null, "listDomains", {}, callback);
 });
 
-Given("I try to register a Route53 domain with invalid parameters", function(
+Given("I try to register a Route53 domain with invalid parameters", function (
   callback
 ) {
   const params = {

--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -1,7 +1,7 @@
 const { S3 } = require("../../../clients/client-s3");
 const { Given, Then, When } = require("cucumber");
 
-Given("I am using the S3 {string} region", function(region, callback) {
+Given("I am using the S3 {string} region", function (region, callback) {
   this.s3 = new S3({
     region: region
   });
@@ -10,7 +10,7 @@ Given("I am using the S3 {string} region", function(region, callback) {
 
 Given(
   "I am using the S3 {string} region with signatureVersion {string}",
-  function(region, signatureVersion, callback) {
+  function (region, signatureVersion, callback) {
     this.s3 = new S3({
       region: region,
       signatureVersion: signatureVersion
@@ -19,7 +19,7 @@ Given(
   }
 );
 
-When("I create a bucket with the location constraint {string}", function(
+When("I create a bucket with the location constraint {string}", function (
   location,
   callback
 ) {
@@ -30,7 +30,7 @@ When("I create a bucket with the location constraint {string}", function(
       LocationConstraint: location
     }
   };
-  this.request("s3", "createBucket", params, function(err, data) {
+  this.request("s3", "createBucket", params, function (err, data) {
     if (err) {
       return callback(err);
     }
@@ -44,7 +44,7 @@ When("I create a bucket with the location constraint {string}", function(
   });
 });
 
-Then("the bucket should have a location constraint of {string}", function(
+Then("the bucket should have a location constraint of {string}", function (
   loc,
   callback
 ) {
@@ -53,7 +53,7 @@ Then("the bucket should have a location constraint of {string}", function(
     {
       Bucket: self.bucket
     },
-    function(err, data) {
+    function (err, data) {
       if (err) callback(err);
       self.assert.equal(data.LocationConstraint, loc);
       callback();
@@ -63,7 +63,7 @@ Then("the bucket should have a location constraint of {string}", function(
 
 When(
   "I put a transition lifecycle configuration on the bucket with prefix {string}",
-  function(prefix, callback) {
+  function (prefix, callback) {
     const params = {
       Bucket: this.bucket,
       LifecycleConfiguration: {
@@ -87,10 +87,10 @@ When(
   }
 );
 
-When("I get the transition lifecycle configuration on the bucket", function(
+When("I get the transition lifecycle configuration on the bucket", function (
   callback
 ) {
-  this.eventually(callback, function(next) {
+  this.eventually(callback, function (next) {
     this.request(
       "s3",
       "getBucketLifecycleConfiguration",
@@ -104,7 +104,7 @@ When("I get the transition lifecycle configuration on the bucket", function(
 
 Then(
   "the lifecycle configuration should have transition days of {int}",
-  function(days, callback) {
+  function (days, callback) {
     this.assert.equal(this.data.Rules[0].Transitions[0].Days, 0);
     callback();
   }
@@ -112,13 +112,13 @@ Then(
 
 Then(
   "the lifecycle configuration should have transition storage class of {string}",
-  function(value, callback) {
+  function (value, callback) {
     this.assert.equal(this.data.Rules[0].Transitions[0].StorageClass, value);
     callback();
   }
 );
 
-When("I put a bucket CORS configuration", function(callback) {
+When("I put a bucket CORS configuration", function (callback) {
   const params = {
     Bucket: this.bucket,
     CORSConfiguration: {
@@ -136,7 +136,7 @@ When("I put a bucket CORS configuration", function(callback) {
   this.request("s3", "putBucketCors", params, callback);
 });
 
-When("I get the bucket CORS configuration", function(callback) {
+When("I get the bucket CORS configuration", function (callback) {
   this.request(
     "s3",
     "getBucketCors",
@@ -147,7 +147,7 @@ When("I get the bucket CORS configuration", function(callback) {
   );
 });
 
-Then("the AllowedMethods list should inclue {string}", function(
+Then("the AllowedMethods list should inclue {string}", function (
   value,
   callback
 ) {
@@ -158,7 +158,7 @@ Then("the AllowedMethods list should inclue {string}", function(
   callback();
 });
 
-Then("the AllowedOrigin value should equal {string}", function(
+Then("the AllowedOrigin value should equal {string}", function (
   value,
   callback
 ) {
@@ -166,7 +166,7 @@ Then("the AllowedOrigin value should equal {string}", function(
   callback();
 });
 
-Then("the AllowedHeader value should equal {string}", function(
+Then("the AllowedHeader value should equal {string}", function (
   value,
   callback
 ) {
@@ -174,17 +174,20 @@ Then("the AllowedHeader value should equal {string}", function(
   callback();
 });
 
-Then("the ExposeHeader value should equal {string}", function(value, callback) {
+Then("the ExposeHeader value should equal {string}", function (
+  value,
+  callback
+) {
   this.assert.equal(this.data.CORSRules[0].ExposeHeaders[0], value);
   callback();
 });
 
-Then("the MaxAgeSeconds value should equal {int}", function(value, callback) {
+Then("the MaxAgeSeconds value should equal {int}", function (value, callback) {
   this.assert.equal(this.data.CORSRules[0].MaxAgeSeconds, parseInt(value));
   callback();
 });
 
-When("I put a bucket tag with key {string} and value {string}", function(
+When("I put a bucket tag with key {string} and value {string}", function (
   key,
   value,
   callback
@@ -204,7 +207,7 @@ When("I put a bucket tag with key {string} and value {string}", function(
   this.request("s3", "putBucketTagging", params, callback);
 });
 
-When("I get the bucket tagging", function(callback) {
+When("I get the bucket tagging", function (callback) {
   this.request(
     "s3",
     "getBucketTagging",
@@ -217,7 +220,7 @@ When("I get the bucket tagging", function(callback) {
 
 Then(
   "the first tag in the tag set should have key and value {string}, {string}",
-  function(key, value, callback) {
+  function (key, value, callback) {
     this.assert.equal(this.data.TagSet[0].Key, key);
     this.assert.equal(this.data.TagSet[0].Value, value);
     callback();
@@ -226,7 +229,7 @@ Then(
 
 When(
   "I create a bucket with a DNS compatible name that contains a dot",
-  function(callback) {
+  function (callback) {
     const bucket = (this.bucket = this.uniqueName("aws-sdk-js.integration"));
     this.request(
       "s3",
@@ -234,7 +237,7 @@ When(
       {
         Bucket: this.bucket
       },
-      function(err, data) {
+      function (err, data) {
         if (err) {
           return callback(err);
         }
@@ -250,26 +253,26 @@ When(
   }
 );
 
-Given("I force path style requests", function(callback) {
+Given("I force path style requests", function (callback) {
   this.s3 = new S3({
     forcePathStyle: true
   });
   callback();
 });
 
-Then("the bucket name should be in the request path", function(callback) {
+Then("the bucket name should be in the request path", function (callback) {
   const path = this.data.Body.req.path.split("/");
   this.assert.equal(path[1], this.bucket);
   callback();
 });
 
-Then("the bucket name should not be in the request host", function(callback) {
+Then("the bucket name should not be in the request host", function (callback) {
   const host = this.data.Body.client.servername;
   this.assert.compare(host.indexOf(this.bucket), "<", 0);
   callback();
 });
 
-When("I put {string} to the key {string} in the bucket", function(
+When("I put {string} to the key {string} in the bucket", function (
   data,
   key,
   next
@@ -282,7 +285,7 @@ When("I put {string} to the key {string} in the bucket", function(
   this.request("s3", "putObject", params, next, false);
 });
 
-When("I get the key {string} in the bucket", function(key, next) {
+When("I get the key {string} in the bucket", function (key, next) {
   const params = {
     Bucket: this.bucket,
     Key: key
@@ -290,7 +293,7 @@ When("I get the key {string} in the bucket", function(key, next) {
   this.request("s3", "getObject", params, next, false);
 });
 
-Then("I delete the object {string} from the bucket", function(key, next) {
+Then("I delete the object {string} from the bucket", function (key, next) {
   const params = {
     Bucket: this.bucket,
     Key: key
@@ -300,7 +303,7 @@ Then("I delete the object {string} from the bucket", function(key, next) {
 
 When(
   /^I put a (small|large) buffer to the key "([^"]*)" in the bucket$/,
-  function(size, key, next) {
+  function (size, key, next) {
     const body = this.createBuffer(size);
     const params = {
       Bucket: this.bucket,
@@ -311,7 +314,7 @@ When(
   }
 );
 
-Then(/^the object "([^"]*)" should (not )?exist in the bucket$/, function(
+Then(/^the object "([^"]*)" should (not )?exist in the bucket$/, function (
   key,
   shouldNotExist,
   next
@@ -320,8 +323,8 @@ Then(/^the object "([^"]*)" should (not )?exist in the bucket$/, function(
     Bucket: this.bucket,
     Key: key
   };
-  this.eventually(next, function(retry) {
-    retry.condition = function() {
+  this.eventually(next, function (retry) {
+    retry.condition = function () {
       if (shouldNotExist) {
         return this.error && this.error.code === "NotFound";
       } else {

--- a/features/s3/step_definitions/hooks.js
+++ b/features/s3/step_definitions/hooks.js
@@ -1,7 +1,7 @@
 const { S3 } = require("../../../clients/client-s3");
 const { Before } = require("cucumber");
 
-Before({ tags: "@s3" }, function(scenario, callback) {
+Before({ tags: "@s3" }, function (scenario, callback) {
   this.service = this.s3 = new S3({
     maxRetries: 100
   });

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -33,7 +33,7 @@ function getSignedUrl(client, command, params, callback) {
     });
 }
 
-When("I put {string} to the key {string}", function(data, key, next) {
+When("I put {string} to the key {string}", function (data, key, next) {
   const params = {
     Bucket: this.sharedBucket,
     Key: key,
@@ -42,7 +42,7 @@ When("I put {string} to the key {string}", function(data, key, next) {
   this.request("s3", "putObject", params, next, false);
 });
 
-When("I get the object {string}", function(key, next) {
+When("I get the object {string}", function (key, next) {
   const params = {
     Bucket: this.sharedBucket,
     Key: key
@@ -52,7 +52,7 @@ When("I get the object {string}", function(key, next) {
 
 When(
   /^I put (?:a |an )(empty|small|large|\d+KB|\d+MB) buffer to the key "([^"]*)"$/,
-  function(size, key, next) {
+  function (size, key, next) {
     const body = this.createBuffer(size);
     const params = {
       Bucket: this.sharedBucket,
@@ -65,7 +65,7 @@ When(
 
 When(
   /^I put (?:a |an )(empty|small|large) file to the key "([^"]*)"$/,
-  function(size, key, next) {
+  function (size, key, next) {
     const fs = require("fs");
     const filename = this.createFile(size, key);
     const params = {
@@ -77,7 +77,7 @@ When(
   }
 );
 
-When("I put {string} to the key {string} with ContentLength {int}", function(
+When("I put {string} to the key {string} with ContentLength {int}", function (
   contents,
   key,
   contentLength,
@@ -95,7 +95,7 @@ When("I put {string} to the key {string} with ContentLength {int}", function(
   this.request("s3nochecksums", "putObject", params, next);
 });
 
-Then("the object {string} should contain {string}", function(
+Then("the object {string} should contain {string}", function (
   key,
   contents,
   next
@@ -106,7 +106,7 @@ Then("the object {string} should contain {string}", function(
   });
 });
 
-Then("the HTTP response should have a content length of {int}", function(
+Then("the HTTP response should have a content length of {int}", function (
   contentLength,
   next
 ) {
@@ -114,7 +114,7 @@ Then("the HTTP response should have a content length of {int}", function(
   next();
 });
 
-When("I copy the object {string} to {string}", function(key1, key2, next) {
+When("I copy the object {string} to {string}", function (key1, key2, next) {
   const params = {
     Bucket: this.sharedBucket,
     Key: key2,
@@ -123,7 +123,7 @@ When("I copy the object {string} to {string}", function(key1, key2, next) {
   this.request("s3", "copyObject", params, next);
 });
 
-When("I delete the object {string}", function(key, next) {
+When("I delete the object {string}", function (key, next) {
   const params = {
     Bucket: this.sharedBucket,
     Key: key
@@ -131,7 +131,7 @@ When("I delete the object {string}", function(key, next) {
   this.request("s3", "deleteObject", params, next);
 });
 
-Then(/^the object "([^"]*)" should (not )?exist$/, function(
+Then(/^the object "([^"]*)" should (not )?exist$/, function (
   key,
   shouldNotExist,
   next
@@ -140,8 +140,8 @@ Then(/^the object "([^"]*)" should (not )?exist$/, function(
     Bucket: this.sharedBucket,
     Key: key
   };
-  this.eventually(next, function(retry) {
-    retry.condition = function() {
+  this.eventually(next, function (retry) {
+    retry.condition = function () {
       if (shouldNotExist) {
         return this.error && this.error.name === "NotFound";
       } else {
@@ -152,7 +152,7 @@ Then(/^the object "([^"]*)" should (not )?exist$/, function(
   });
 });
 
-When("I stream key {string}", function(key, callback) {
+When("I stream key {string}", function (key, callback) {
   const params = {
     Bucket: this.sharedBucket,
     Key: key
@@ -161,17 +161,17 @@ When("I stream key {string}", function(key, callback) {
   this.result = "";
   const s = this.service.getObject(params);
 
-  setTimeout(function() {
-    s.on("end", function() {
+  setTimeout(function () {
+    s.on("end", function () {
       callback();
     });
-    s.on("data", function(d) {
+    s.on("data", function (d) {
       world.result += d.toString();
     });
   }, 2000); // delay streaming to ensure it is buffered
 });
 
-When("I stream2 key {string}", function(key, callback) {
+When("I stream2 key {string}", function (key, callback) {
   if (!require("stream").Readable) return callback();
   const params = {
     Bucket: this.sharedBucket,
@@ -180,23 +180,23 @@ When("I stream2 key {string}", function(key, callback) {
   const world = this;
   this.result = "";
   const stream = this.service.getObject(params).createReadStream();
-  setTimeout(function() {
-    stream.on("end", function() {
+  setTimeout(function () {
+    stream.on("end", function () {
       callback();
     });
-    stream.on("readable", function() {
+    stream.on("readable", function () {
       const v = stream.read();
       if (v) world.result += v;
     });
   }, 2000); // delay streaming to ensure it is buffered
 });
 
-Then("the streamed data should contain {string}", function(data, callback) {
+Then("the streamed data should contain {string}", function (data, callback) {
   this.assert.equal(this.result.replace("\n", ""), data);
   callback();
 });
 
-Then("the streamed data content length should equal {int}", function(
+Then("the streamed data content length should equal {int}", function (
   length,
   callback
 ) {
@@ -204,7 +204,10 @@ Then("the streamed data content length should equal {int}", function(
   callback();
 });
 
-When("I get a pre-signed URL to GET the key {string}", function(key, callback) {
+When("I get a pre-signed URL to GET the key {string}", function (
+  key,
+  callback
+) {
   const world = this;
   getSignedUrl(
     this.s3,
@@ -213,20 +216,20 @@ When("I get a pre-signed URL to GET the key {string}", function(key, callback) {
       Bucket: this.sharedBucket,
       Key: key
     },
-    function(err, url) {
+    function (err, url) {
       world.signedUrl = url;
       callback();
     }
   );
 });
 
-When("I access the URL via HTTP GET", function(callback) {
+When("I access the URL via HTTP GET", function (callback) {
   const world = this;
   this.data = "";
   require("https")
-    .get(this.signedUrl, function(res) {
+    .get(this.signedUrl, function (res) {
       res
-        .on("data", function(chunk) {
+        .on("data", function (chunk) {
           world.data += chunk.toString();
         })
         .on("end", callback);
@@ -236,21 +239,21 @@ When("I access the URL via HTTP GET", function(callback) {
 
 Given(
   "I get a pre-signed URL to PUT the key {string} with data {string}",
-  function(key, body, callback) {
+  function (key, body, callback) {
     const world = this;
     const params = {
       Bucket: this.sharedBucket,
       Key: key
     };
     if (body) params.Body = body;
-    getSignedUrl(this.s3, PutObjectCommand, params, function(err, url) {
+    getSignedUrl(this.s3, PutObjectCommand, params, function (err, url) {
       world.signedUrl = url;
       callback();
     });
   }
 );
 
-Given("I access the URL via HTTP PUT with data {string}", function(
+Given("I access the URL via HTTP PUT with data {string}", function (
   body,
   callback
 ) {
@@ -265,9 +268,9 @@ Given("I access the URL via HTTP PUT with data {string}", function(
   };
 
   require("https")
-    .request(options, function(res) {
+    .request(options, function (res) {
       res
-        .on("data", function(chunk) {
+        .on("data", function (chunk) {
           world.data += chunk.toString();
         })
         .on("end", callback);
@@ -278,7 +281,7 @@ Given("I access the URL via HTTP PUT with data {string}", function(
 
 Given(
   "I create a presigned form to POST the key {string} with the data {string}",
-  function(key, data, callback) {
+  function (key, data, callback) {
     const world = this;
     const boundary = (this.postBoundary =
       "----WebKitFormBoundaryLL0mBKIuuLUKr7be");
@@ -292,8 +295,8 @@ Given(
         },
         Conditions: conditions
       };
-    this.s3.createPresignedPost(params, function(err, postData) {
-      const body = Object.keys(postData.fields).reduce(function(
+    this.s3.createPresignedPost(params, function (err, postData) {
+      const body = Object.keys(postData.fields).reduce(function (
         body,
         fieldName
       ) {
@@ -322,7 +325,7 @@ Given(
   }
 );
 
-Given("I POST the form", function(callback) {
+Given("I POST the form", function (callback) {
   const world = this;
   const options = require("url").parse(this.postAction);
   options.method = "POST";
@@ -331,9 +334,9 @@ Given("I POST the form", function(callback) {
     "Content-Length": this.postBody.length
   };
   require("https")
-    .request(options, function(res) {
+    .request(options, function (res) {
       res
-        .on("data", function(chunk) {
+        .on("data", function (chunk) {
           world.data += chunk.toString();
         })
         .on("end", callback);
@@ -342,17 +345,17 @@ Given("I POST the form", function(callback) {
     .end(this.postBody);
 });
 
-Then("the HTTP response should equal {string}", function(data, callback) {
+Then("the HTTP response should equal {string}", function (data, callback) {
   this.assert.equal(this.data, data);
   callback();
 });
 
-Then("the HTTP response should contain {string}", function(data, callback) {
+Then("the HTTP response should contain {string}", function (data, callback) {
   this.assert.match(this.data, data);
   callback();
 });
 
-Given("I setup the listObjects request for the bucket", function(callback) {
+Given("I setup the listObjects request for the bucket", function (callback) {
   this.params = {
     Bucket: this.sharedBucket
   };
@@ -363,7 +366,7 @@ Given("I setup the listObjects request for the bucket", function(callback) {
 
 When(
   /^I put (?:a |an )(empty|small|large|\d+KB|\d+MB) buffer to the key "([^"]*)" with progress events$/,
-  function(size, key, callback) {
+  function (size, key, callback) {
     const self = this;
     const body = self.createBuffer(size);
     this.progress = [];
@@ -372,14 +375,14 @@ When(
       Key: key,
       Body: body
     });
-    req.on("httpUploadProgress", function(p) {
+    req.on("httpUploadProgress", function (p) {
       self.progress.push(p);
     });
     req.send(callback);
   }
 );
 
-Then("more than {int} {string} event should fire", function(
+Then("more than {int} {string} event should fire", function (
   numEvents,
   eventName,
   callback
@@ -388,7 +391,7 @@ Then("more than {int} {string} event should fire", function(
   callback();
 });
 
-Then("the {string} value of the progress event should equal {int}MB", function(
+Then("the {string} value of the progress event should equal {int}MB", function (
   prop,
   mb,
   callback
@@ -399,26 +402,26 @@ Then("the {string} value of the progress event should equal {int}MB", function(
 
 Then(
   "the {string} value of the first progress event should be greater than {int} bytes",
-  function(prop, bytes, callback) {
+  function (prop, bytes, callback) {
     this.assert.compare(this.progress[0][prop], ">", bytes);
     callback();
   }
 );
 
-When("I read the key {string} with progress events", function(key, callback) {
+When("I read the key {string} with progress events", function (key, callback) {
   const self = this;
   this.progress = [];
   const req = this.s3.getObject({
     Bucket: this.sharedBucket,
     Key: key
   });
-  req.on("httpDownloadProgress", function(p) {
+  req.on("httpDownloadProgress", function (p) {
     self.progress.push(p);
   });
   req.send(callback);
 });
 
-When("I put {string} to the (public|private) key {string}", function(
+When("I put {string} to the (public|private) key {string}", function (
   data,
   access,
   key,
@@ -436,7 +439,7 @@ When("I put {string} to the (public|private) key {string}", function(
   this.request("s3", "putObject", params, next);
 });
 
-When("I put {string} to the key {string} with an AES key", function(
+When("I put {string} to the key {string} with an AES key", function (
   data,
   key,
   next
@@ -451,7 +454,7 @@ When("I put {string} to the key {string} with an AES key", function(
   this.request("s3", "putObject", params, next);
 });
 
-When("I read the object {string} with the AES key", function(key, next) {
+When("I read the object {string} with the AES key", function (key, next) {
   const params = {
     Bucket: this.sharedBucket,
     Key: key,
@@ -461,7 +464,7 @@ When("I read the object {string} with the AES key", function(key, next) {
   this.request("s3", "getObject", params, next);
 });
 
-Then("I make an unauthenticated request to read object {string}", function(
+Then("I make an unauthenticated request to read object {string}", function (
   key,
   next
 ) {
@@ -472,7 +475,7 @@ Then("I make an unauthenticated request to read object {string}", function(
   this.s3.makeUnauthenticatedRequest(
     "getObject",
     params,
-    function(err, data) {
+    function (err, data) {
       if (err) return next(err);
       this.data = data;
       next();
@@ -480,7 +483,7 @@ Then("I make an unauthenticated request to read object {string}", function(
   );
 });
 
-Given("I generate the MD5 checksum of {string}", function(data, next) {
+Given("I generate the MD5 checksum of {string}", function (data, next) {
   const hash = new Md5();
   hash.update(data);
   this.sentContentMD5 = hash.digest().toString();
@@ -489,7 +492,7 @@ Given("I generate the MD5 checksum of {string}", function(data, next) {
 
 Then(
   "the MD5 checksum of the response data should equal the generated checksum",
-  function(next) {
+  function (next) {
     const hash = new Md5();
     streamCollector(this.data.Body).then(body => {
       hash.update(body);
@@ -499,18 +502,18 @@ Then(
   }
 );
 
-Given("an empty bucket", function(next) {
+Given("an empty bucket", function (next) {
   const self = this;
   const params = {
     Bucket: this.sharedBucket
   };
-  self.s3.listObjects(params, function(err, data) {
+  self.s3.listObjects(params, function (err, data) {
     if (err) return next(err);
     if (data.Contents.length > 0) {
       params.Delete = {
         Objects: []
       };
-      data.Contents.forEach(function(item) {
+      data.Contents.forEach(function (item) {
         params.Delete.Objects.push({
           Key: item.Key
         });

--- a/features/s3/step_definitions/proxy.js
+++ b/features/s3/step_definitions/proxy.js
@@ -3,7 +3,7 @@ const http = require("http");
 const { S3 } = require("../../../clients/client-s3");
 const { Before, Then } = require("cucumber");
 
-Before({ tags: "@s3 or @proxy" }, function(scenario, callback) {
+Before({ tags: "@s3 or @proxy" }, function (scenario, callback) {
   setupProxyServer.call(this);
 
   this.service = this.s3 = new S3({
@@ -15,7 +15,7 @@ Before({ tags: "@s3 or @proxy" }, function(scenario, callback) {
   callback();
 });
 
-Then("I teardown the local proxy server", function(callback) {
+Then("I teardown the local proxy server", function (callback) {
   this.service = this.s3 = new S3();
   this.proxyServer.close(callback);
 });
@@ -23,7 +23,7 @@ Then("I teardown the local proxy server", function(callback) {
 function setupProxyServer() {
   if (this.proxyServer) return;
   this.proxyPort = 8000 + parseInt(Math.random() * 100);
-  this.proxyServer = http.createServer(function(req, res) {
+  this.proxyServer = http.createServer(function (req, res) {
     const uri = url.parse(req.url);
     const options = {
       host: uri.hostname,
@@ -34,13 +34,13 @@ function setupProxyServer() {
     };
     options.headers.host = uri.hostname;
 
-    const s = http.request(options, function(res2) {
+    const s = http.request(options, function (res2) {
       res.writeHead(res2.statusCode, res2.headers);
       res2
-        .on("data", function(ch) {
+        .on("data", function (ch) {
           res.write(ch);
         })
-        .on("end", function() {
+        .on("end", function () {
           res.end();
         });
     });

--- a/features/sagemaker/step_definitions/sagemaker.js
+++ b/features/sagemaker/step_definitions/sagemaker.js
@@ -1,7 +1,7 @@
 const { SageMaker } = require("../../../clients/client-sagemaker");
 const { Before } = require("cucumber");
 
-Before({ tags: "@sagemaker" }, function(scenario, callback) {
+Before({ tags: "@sagemaker" }, function (scenario, callback) {
   this.service = new SageMaker({});
   callback();
 });

--- a/features/ses/step_definitions/ses.js
+++ b/features/ses/step_definitions/ses.js
@@ -1,22 +1,22 @@
 const { SES } = require("../../../clients/client-ses");
 const { Before, Then, When } = require("cucumber");
 
-Before({ tags: "@ses" }, function(scenario, callback) {
+Before({ tags: "@ses" }, function (scenario, callback) {
   this.service = new SES({});
   callback();
 });
 
-When("I check quota", function(next) {
+When("I check quota", function (next) {
   this.request(null, "getSendQuota", {}, next);
 });
 
-Then("the result should include {word} {string}", function(type, attr, next) {
+Then("the result should include {word} {string}", function (type, attr, next) {
   if (this.data[attr] === undefined) next.fail("Missing " + attr);
   if (typeof this.data[attr] !== type) next.fail("Incorrect type " + attr);
   next();
 });
 
-When("I ask to verify the email address {string}", function(email, next) {
+When("I ask to verify the email address {string}", function (email, next) {
   this.request(
     null,
     "verifyEmailAddress",
@@ -24,7 +24,7 @@ When("I ask to verify the email address {string}", function(email, next) {
       EmailAddress: email
     },
     next,
-    function() {
+    function () {
       // do nothing
     }
   );

--- a/features/sns/step_definitions/sns.js
+++ b/features/sns/step_definitions/sns.js
@@ -1,12 +1,12 @@
 const { SNS } = require("../../../clients/client-sns");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@sns" }, function(scenario, callback) {
+Before({ tags: "@sns" }, function (scenario, callback) {
   this.service = new SNS({});
   callback();
 });
 
-Given("I create an SNS topic with name {string}", function(name, callback) {
+Given("I create an SNS topic with name {string}", function (name, callback) {
   const world = this;
   this.request(
     null,
@@ -15,25 +15,25 @@ Given("I create an SNS topic with name {string}", function(name, callback) {
       Name: name
     },
     callback,
-    function(data) {
+    function (data) {
       world.topicArn = data.TopicArn;
     }
   );
 });
 
-Given("I list the SNS topics", function(callback) {
+Given("I list the SNS topics", function (callback) {
   this.request(null, "listTopics", {}, callback);
 });
 
-Then("the list should contain the topic ARN", function(callback) {
+Then("the list should contain the topic ARN", function (callback) {
   const arn = this.topicArn;
-  this.assert.contains(this.data.Topics, function(topic) {
+  this.assert.contains(this.data.Topics, function (topic) {
     return topic.TopicArn === arn;
   });
   callback();
 });
 
-Then("I delete the SNS topic", function(callback) {
+Then("I delete the SNS topic", function (callback) {
   this.request(
     null,
     "deleteTopic",
@@ -44,7 +44,7 @@ Then("I delete the SNS topic", function(callback) {
   );
 });
 
-Given("I get SNS topic attributes with an invalid ARN", function(callback) {
+Given("I get SNS topic attributes with an invalid ARN", function (callback) {
   this.request(
     null,
     "getTopicAttributes",

--- a/features/sqs/step_definitions/messages.js
+++ b/features/sqs/step_definitions/messages.js
@@ -1,6 +1,6 @@
 const { Then, When } = require("cucumber");
 
-When("I send the message {string}", function(message, callback) {
+When("I send the message {string}", function (message, callback) {
   this.request(
     null,
     "sendMessage",
@@ -9,12 +9,12 @@ When("I send the message {string}", function(message, callback) {
   );
 });
 
-Then("the result should include a message ID", function(callback) {
+Then("the result should include a message ID", function (callback) {
   this.assert.compare(this.data.MessageId.length, ">", 0);
   callback();
 });
 
-Then("the result should have an MD5 digest of {string}", function(
+Then("the result should have an MD5 digest of {string}", function (
   digest,
   callback
 ) {
@@ -22,19 +22,19 @@ Then("the result should have an MD5 digest of {string}", function(
   callback();
 });
 
-Then("I should eventually be able to receive {string} from the queue", function(
-  message,
-  callback
-) {
-  this.eventually(callback, function(next) {
-    next.condition = function() {
-      return this.data.Messages[0].Body === message;
-    };
-    this.request(null, "receiveMessage", { QueueUrl: this.queueUrl }, next);
-  });
-});
+Then(
+  "I should eventually be able to receive {string} from the queue",
+  function (message, callback) {
+    this.eventually(callback, function (next) {
+      next.condition = function () {
+        return this.data.Messages[0].Body === message;
+      };
+      this.request(null, "receiveMessage", { QueueUrl: this.queueUrl }, next);
+    });
+  }
+);
 
-When("I send the message {string} with a binary attribute", function(
+When("I send the message {string} with a binary attribute", function (
   message,
   callback
 ) {
@@ -50,9 +50,9 @@ When("I send the message {string} with a binary attribute", function(
 
 Then(
   "I should eventually be able to receive {string} from the queue with a binary attribute",
-  function(message, callback) {
-    this.eventually(callback, function(next) {
-      next.condition = function() {
+  function (message, callback) {
+    this.eventually(callback, function (next) {
+      next.condition = function () {
         return (
           this.data.Messages[0].MessageAttributes.binary.BinaryValue.toString() ===
           "1,2,3"

--- a/features/sqs/step_definitions/queues.js
+++ b/features/sqs/step_definitions/queues.js
@@ -1,21 +1,23 @@
 const { Given, Then } = require("cucumber");
 
-Given("I create a queue with the prefix name {string}", function(
+Given("I create a queue with the prefix name {string}", function (
   prefix,
   callback
 ) {
   const name = this.uniqueName(prefix);
-  this.request(null, "createQueue", { QueueName: name }, callback, function() {
+  this.request(null, "createQueue", { QueueName: name }, callback, function () {
     this.queueUrl = this.data.QueueUrl;
     this.createdQueues.push(this.queueUrl);
   });
 });
 
-Then("list queues should eventually return the queue urls", function(callback) {
+Then("list queues should eventually return the queue urls", function (
+  callback
+) {
   this.eventually(
     callback,
-    function(next) {
-      next.condition = function() {
+    function (next) {
+      next.condition = function () {
         let matchingCount = 0;
         for (let i = 0; i < this.createdQueues.length; ++i) {
           for (let j = 0; j < this.data.QueueUrls.length; ++j) {
@@ -32,7 +34,7 @@ Then("list queues should eventually return the queue urls", function(callback) {
   );
 });
 
-Then("I delete the SQS queue", function(callback) {
+Then("I delete the SQS queue", function (callback) {
   const url = this.createdQueues.pop();
   this.request(null, "deleteQueue", { QueueUrl: url }, callback);
 });

--- a/features/sqs/step_definitions/sqs.js
+++ b/features/sqs/step_definitions/sqs.js
@@ -1,7 +1,7 @@
 const { SQS } = require("../../../clients/client-sqs");
 const { Before } = require("cucumber");
 
-Before({ tags: "@sqs" }, function(scenario, callback) {
+Before({ tags: "@sqs" }, function (scenario, callback) {
   this.service = new SQS({
     region: "us-east-1"
   });

--- a/features/ssm/step_definitions/ssm.js
+++ b/features/ssm/step_definitions/ssm.js
@@ -1,7 +1,7 @@
 const { SSM } = require("../../../clients/client-ssm");
 const { Before } = require("cucumber");
 
-Before({ tags: "@ssm" }, function(scenario, callback) {
+Before({ tags: "@ssm" }, function (scenario, callback) {
   this.service = new SSM({});
   callback();
 });

--- a/features/storagegateway/step_definitions/storagegateway.js
+++ b/features/storagegateway/step_definitions/storagegateway.js
@@ -1,12 +1,12 @@
 const { StorageGateway } = require("../../../clients/client-storage-gateway");
 const { Before, When } = require("cucumber");
 
-Before({ tags: "@storagegateway" }, function(scenario, callback) {
+Before({ tags: "@storagegateway" }, function (scenario, callback) {
   this.service = new StorageGateway({ region: "us-east-1" });
   callback();
 });
 
-When("I try to activate a Storage Gateway", function(callback) {
+When("I try to activate a Storage Gateway", function (callback) {
   const params = {
     ActivationKey: "INVALIDKEY",
     GatewayName: this.uniqueName("aws-sdk-js"),

--- a/features/sts/step_definitions/sts.js
+++ b/features/sts/step_definitions/sts.js
@@ -1,12 +1,12 @@
 const { STS } = require("../../../clients/client-sts");
 const { Before, Given } = require("cucumber");
 
-Before({ tags: "@sts" }, function(scenario, callback) {
+Before({ tags: "@sts" }, function (scenario, callback) {
   this.service = new STS({});
   callback();
 });
 
-Given("I get an STS session token with a duration of {int} seconds", function(
+Given("I get an STS session token with a duration of {int} seconds", function (
   duration,
   callback
 ) {
@@ -21,7 +21,7 @@ Given("I get an STS session token with a duration of {int} seconds", function(
   );
 });
 
-Given("I try to assume role with web identity", function(callback) {
+Given("I try to assume role with web identity", function (callback) {
   const params = {
     RoleArn: "arn:aws:iam::123456789:role/WebIdentity",
     RoleSessionName: "name",
@@ -30,7 +30,7 @@ Given("I try to assume role with web identity", function(callback) {
   this.request(null, "assumeRoleWithWebIdentity", params, callback, false);
 });
 
-Given("I try to assume role with SAML", function(callback) {
+Given("I try to assume role with SAML", function (callback) {
   const arn = "arn:aws:iam::123456789:role/Role";
   const token = "TOKENVALUETOKENVALUETOKENVALUETOKENVALUE";
   const params = {

--- a/features/support/step_definitions/support.js
+++ b/features/support/step_definitions/support.js
@@ -1,19 +1,19 @@
 const { Support } = require("../../../clients/client-support");
 const { Before, Given, Then } = require("cucumber");
 
-Before({ tags: "@support" }, function(scenario, callback) {
+Before({ tags: "@support" }, function (scenario, callback) {
   this.service = new Support({ region: "us-east-1" });
   callback();
 });
 
-Given("I describe Support services", function(callback) {
+Given("I describe Support services", function (callback) {
   this.request(null, "describeServices", {}, callback);
 });
 
 Then(
   "the Supported services list should contain a service with code {string}",
-  function(code, callback) {
-    this.assert.contains(this.data.services, function(svc) {
+  function (code, callback) {
+    this.assert.contains(this.data.services, function (svc) {
       return svc.code == code;
     });
     callback();
@@ -22,15 +22,15 @@ Then(
 
 Then(
   "the Supported services list should contain a service with name {string}",
-  function(name, callback) {
-    this.assert.contains(this.data.services, function(svc) {
+  function (name, callback) {
+    this.assert.contains(this.data.services, function (svc) {
       return svc.name == name;
     });
     callback();
   }
 );
 
-Given("I create a case with an invalid category", function(callback) {
+Given("I create a case with an invalid category", function (callback) {
   const params = {
     subject: "Subject",
     serviceCode: "INVALID-CODE",

--- a/features/swf/step_definitions/swf.js
+++ b/features/swf/step_definitions/swf.js
@@ -1,7 +1,7 @@
 const { SWF } = require("../../../clients/client-swf");
 const { Before, Given, Then, When } = require("cucumber");
 
-Before({ tags: "@swf" }, function(scenario, callback) {
+Before({ tags: "@swf" }, function (scenario, callback) {
   this.service = new SWF({});
   callback();
 });

--- a/features/waf/step_definitions/waf.js
+++ b/features/waf/step_definitions/waf.js
@@ -1,7 +1,7 @@
 const { WAF } = require("../../../clients/client-waf");
 const { Before } = require("cucumber");
 
-Before({ tags: "@waf" }, function(scenario, callback) {
+Before({ tags: "@waf" }, function (scenario, callback) {
   this.service = new WAF({});
   callback();
 });

--- a/features/workspaces/step_definitions/workspaces.js
+++ b/features/workspaces/step_definitions/workspaces.js
@@ -1,7 +1,7 @@
 const { WorkSpaces } = require("../../../clients/client-workspaces");
 const { Before } = require("cucumber");
 
-Before({ tags: "@workspaces" }, function(scenario, callback) {
+Before({ tags: "@workspaces" }, function (scenario, callback) {
   this.service = new WorkSpaces({});
   callback();
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,10 @@ const base = require("./jest.config.base.js");
 
 module.exports = {
   ...base,
-  projects: ["<rootDir>/protocol_tests/*/jest.config.js", "<rootDir>/packages/*/jest.config.js"],
+  projects: [
+    "<rootDir>/protocol_tests/*/jest.config.js",
+    "<rootDir>/packages/*/jest.config.js"
+  ],
   testPathIgnorePatterns: ["/node_modules/", "<rootDir>/clients/client-.*"],
   coveragePathIgnorePatterns: [
     "/node_modules/",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jmespath": "^0.15.0",
     "lerna": "3.20.2",
     "lint-staged": "^10.0.1",
-    "prettier": "1.19.1",
+    "prettier": "2.0.3",
     "typescript": "~3.8.3",
     "yarn": "1.22.4"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jmespath": "^0.15.0",
     "lerna": "3.20.2",
     "lint-staged": "^10.0.1",
-    "prettier": "2.0.3",
+    "prettier": "2.0.4",
     "typescript": "~3.8.3",
     "yarn": "1.22.4"
   },

--- a/packages/credential-provider-ini/src/index.spec.ts
+++ b/packages/credential-provider-ini/src/index.spec.ts
@@ -33,10 +33,10 @@ jest.mock("fs", () => {
     callback(new Error("ENOENT: no such file or directory"));
   }
 
-  fs.__addMatcher = function(toMatch: string, toReturn: string): void {
+  fs.__addMatcher = function (toMatch: string, toReturn: string): void {
     matchers.set(toMatch, toReturn);
   };
-  fs.__clearMatchers = function(): void {
+  fs.__clearMatchers = function (): void {
     matchers.clear();
   };
   fs.readFile = readFile;

--- a/packages/credential-provider-process/src/index.spec.ts
+++ b/packages/credential-provider-process/src/index.spec.ts
@@ -32,10 +32,10 @@ jest.mock("fs", () => {
     callback(new Error("ENOENT: no such file or directory"));
   }
 
-  fs.__addFsMatcher = function(toMatch: string, toReturn: string): void {
+  fs.__addFsMatcher = function (toMatch: string, toReturn: string): void {
     matchers.set(toMatch, toReturn);
   };
-  fs.__clearFsMatchers = function(): void {
+  fs.__clearFsMatchers = function (): void {
     matchers.clear();
   };
   fs.readFile = readFile;
@@ -86,13 +86,13 @@ jest.mock("child_process", () => {
     callback(new Error("ENOENT: no such file or directory"));
   }
 
-  child_process.__addChildProcessMatcher = function(
+  child_process.__addChildProcessMatcher = function (
     command: string,
     json: string
   ): void {
     matchers.set(command, json);
   };
-  child_process.__clearChildProcessMatchers = function(): void {
+  child_process.__clearChildProcessMatchers = function (): void {
     matchers.clear();
   };
 

--- a/packages/credential-provider-process/src/index.ts
+++ b/packages/credential-provider-process/src/index.ts
@@ -120,7 +120,7 @@ async function resolveProcessCredentials(
 }
 
 function execPromise(command: string) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     exec(command, (error, stdout, stderr) => {
       if (error) {
         reject(error);

--- a/packages/eventstream-serde-browser/src/getChunkedStream.ts
+++ b/packages/eventstream-serde-browser/src/getChunkedStream.ts
@@ -6,7 +6,7 @@ export function getChunkedStream(
   let currentMessagePendingLength = 0;
   let currentMessage: Uint8Array | null = null;
   let messageLengthBuffer: Uint8Array | null = null;
-  const allocateMessage = function(size: number) {
+  const allocateMessage = function (size: number) {
     if (typeof size !== "number") {
       throw new Error(
         "Attempted to allocate an event message where size was not a number: " +

--- a/packages/eventstream-serde-node/src/EventMessageChunkerStream.spec.ts
+++ b/packages/eventstream-serde-node/src/EventMessageChunkerStream.spec.ts
@@ -23,7 +23,7 @@ describe("EventMessageChunkerStream", () => {
     chunkerStream.on("data", msg => {
       messages.push(msg);
     });
-    chunkerStream.on("end", function() {
+    chunkerStream.on("end", function () {
       expect(messages.length).toBe(3);
       done();
     });
@@ -46,7 +46,7 @@ describe("EventMessageChunkerStream", () => {
     chunkerStream.on("data", msg => {
       messages.push(msg);
     });
-    chunkerStream.on("end", function() {
+    chunkerStream.on("end", function () {
       expect(messages.length).toBe(4);
       for (let i = 0; i < mockMessages.length; i++) {
         expect(messages[i].toString("base64")).toEqual(
@@ -75,7 +75,7 @@ describe("EventMessageChunkerStream", () => {
     chunkerStream.on("data", msg => {
       messages.push(msg);
     });
-    chunkerStream.on("end", function() {
+    chunkerStream.on("end", function () {
       expect(messages.length).toBe(3);
       done();
     });
@@ -97,7 +97,7 @@ describe("EventMessageChunkerStream", () => {
     chunkerStream.on("data", msg => {
       messages.push(msg);
     });
-    chunkerStream.on("end", function() {
+    chunkerStream.on("end", function () {
       expect(messages.length).toBe(3);
       done();
     });
@@ -119,7 +119,7 @@ describe("EventMessageChunkerStream", () => {
     chunkerStream.on("data", msg => {
       messages.push(msg);
     });
-    chunkerStream.on("end", function() {
+    chunkerStream.on("end", function () {
       expect(messages.length).toBe(3);
       done();
     });

--- a/packages/eventstream-serde-node/src/fixtures/MockEventMessageSource.fixture.ts
+++ b/packages/eventstream-serde-node/src/fixtures/MockEventMessageSource.fixture.ts
@@ -22,7 +22,7 @@ export class MockEventMessageSource extends Readable {
     const self = this;
     if (this.readCount === this.data.length) {
       if (this.throwError) {
-        process.nextTick(function() {
+        process.nextTick(function () {
           self.emit("error", new Error("Throwing an error!"));
         });
         return;

--- a/packages/hash-blob-browser/karma.conf.js
+++ b/packages/hash-blob-browser/karma.conf.js
@@ -2,7 +2,7 @@
 
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "",

--- a/packages/hash-stream-node/src/index.ts
+++ b/packages/hash-stream-node/src/index.ts
@@ -28,11 +28,8 @@ export const fileStreamHasher: StreamHasher<Readable> = function fileStreamHashe
       reject(err);
     });
     hashCalculator.on("error", reject);
-    hashCalculator.on("finish", function(this: HashCalculator) {
-      hash
-        .digest()
-        .then(resolve)
-        .catch(reject);
+    hashCalculator.on("finish", function (this: HashCalculator) {
+      hash.digest().then(resolve).catch(reject);
     });
   });
 };

--- a/packages/middleware-sdk-route53/src/change-resource-record-sets.spec.ts
+++ b/packages/middleware-sdk-route53/src/change-resource-record-sets.spec.ts
@@ -8,7 +8,7 @@ describe("changeResourceRecordSetsMiddleware", () => {
       const next = jest.fn();
       const input = {
         ChangeBatch: {
-          Changes: (function*() {
+          Changes: (function* () {
             for (let i = 0; i < 6; i++) {
               yield {
                 ResourceRecordSet: {

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -23,7 +23,7 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
   return (
     next: FinalizeHandler<Input, Output>
   ): FinalizeHandler<Input, Output> =>
-    async function(
+    async function (
       args: FinalizeHandlerArguments<Input>
     ): Promise<FinalizeHandlerOutput<Output>> {
       if (!HttpRequest.isInstance(args.request)) return next(args);

--- a/packages/node-http-handler/src/server.mock.ts
+++ b/packages/node-http-handler/src/server.mock.ts
@@ -18,7 +18,7 @@ import { HttpResponse } from "@aws-sdk/types";
 const fixturesDir = join(__dirname, "..", "fixtures");
 
 export function createResponseFunction(httpResp: HttpResponse) {
-  return function(request: IncomingMessage, response: ServerResponse) {
+  return function (request: IncomingMessage, response: ServerResponse) {
     response.statusCode = httpResp.statusCode;
     for (let name of Object.keys(httpResp.headers)) {
       let values = httpResp.headers[name];
@@ -33,7 +33,7 @@ export function createResponseFunction(httpResp: HttpResponse) {
 }
 
 export function createContinueResponseFunction(httpResp: HttpResponse) {
-  return function(request: IncomingMessage, response: ServerResponse) {
+  return function (request: IncomingMessage, response: ServerResponse) {
     response.writeContinue();
     setTimeout(() => {
       createResponseFunction(httpResp)(request, response);

--- a/packages/node-http-handler/src/set-connection-timeout.ts
+++ b/packages/node-http-handler/src/set-connection-timeout.ts
@@ -10,7 +10,7 @@ export function setConnectionTimeout(
     return;
   }
 
-  request.on("socket", function(this: ClientRequest, socket: Socket) {
+  request.on("socket", function (this: ClientRequest, socket: Socket) {
     if (socket.connecting) {
       // Throw a connecting timeout error unless a connection is made within x time
       let timeoutId = setTimeout(() => {

--- a/packages/node-http-handler/src/set-socket-timeout.ts
+++ b/packages/node-http-handler/src/set-socket-timeout.ts
@@ -5,7 +5,7 @@ export function setSocketTimeout(
   reject: (err: Error) => void,
   timeoutInMs: number = 0
 ) {
-  request.setTimeout(timeoutInMs, function(this: ClientRequest) {
+  request.setTimeout(timeoutInMs, function (this: ClientRequest) {
     // abort the request to destroy it
     this.abort();
     const timeoutError = new Error(

--- a/packages/shared-ini-file-loader/src/index.spec.ts
+++ b/packages/shared-ini-file-loader/src/index.spec.ts
@@ -32,10 +32,10 @@ jest.mock("fs", () => {
     callback(new Error("ENOENT: no such file or directory"));
   }
 
-  fs.__addMatcher = function(toMatch: string, toReturn: string): void {
+  fs.__addMatcher = function (toMatch: string, toReturn: string): void {
     matchers.set(toMatch, toReturn);
   };
-  fs.__clearMatchers = function(): void {
+  fs.__clearMatchers = function (): void {
     matchers.clear();
   };
   fs.readFile = readFile;

--- a/packages/shared-ini-file-loader/src/index.ts
+++ b/packages/shared-ini-file-loader/src/index.ts
@@ -51,9 +51,7 @@ export function loadSharedConfigFiles(
       .then(parseIni)
       .then(normalizeConfigFile)
       .catch(swallowError),
-    slurpFile(filepath)
-      .then(parseIni)
-      .catch(swallowError)
+    slurpFile(filepath).then(parseIni).catch(swallowError)
   ]).then((parsedFiles: Array<ParsedIniData>) => {
     const [configFile, credentialsFile] = parsedFiles;
     return {

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -383,7 +383,5 @@ function formatDate(now: DateInput): { longDate: string; shortDate: string } {
 }
 
 function getCanonicalHeaderList(headers: object): string {
-  return Object.keys(headers)
-    .sort()
-    .join(";");
+  return Object.keys(headers).sort().join(";");
 }

--- a/packages/stream-collector-browser/karma.conf.js
+++ b/packages/stream-collector-browser/karma.conf.js
@@ -1,5 +1,5 @@
 process.env.CHROME_BIN = require("puppeteer").executablePath();
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     frameworks: ["jasmine", "karma-typescript"],
     files: ["src/**/*.ts"],

--- a/packages/stream-collector-native/karma.conf.js
+++ b/packages/stream-collector-native/karma.conf.js
@@ -1,5 +1,5 @@
 process.env.CHROME_BIN = require("puppeteer").executablePath();
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     frameworks: ["jasmine", "karma-typescript"],
     files: ["src/**/*.ts"],

--- a/packages/stream-collector-node/src/index.ts
+++ b/packages/stream-collector-node/src/index.ts
@@ -14,7 +14,7 @@ export const streamCollector: StreamCollector = (
       reject(err);
     });
     collector.on("error", reject);
-    collector.on("finish", function(this: Collector) {
+    collector.on("finish", function (this: Collector) {
       const bytes = new Uint8Array(Buffer.concat(this.bufferedBytes));
       resolve(bytes);
     });

--- a/packages/util-uri-escape/src/escape-uri.ts
+++ b/packages/util-uri-escape/src/escape-uri.ts
@@ -8,8 +8,5 @@ export function escapeUri(uri: string): string {
 }
 
 function hexEncode(c: string) {
-  return `%${c
-    .charCodeAt(0)
-    .toString(16)
-    .toUpperCase()}`;
+  return `%${c.charCodeAt(0).toString(16).toUpperCase()}`;
 }

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -23,12 +23,14 @@ const getOverwritablePredicate = packageName => pathName => {
     "endpoints.ts"
   ];
   return (
-    pathName.toLowerCase().indexOf(
-      packageName
-        .toLowerCase()
-        .replace("@aws-sdk/client-", "")
-        .replace(/-/g, "")
-    ) >= 0 || overwritablePathnames.indexOf(pathName) >= 0
+    pathName
+      .toLowerCase()
+      .indexOf(
+        packageName
+          .toLowerCase()
+          .replace("@aws-sdk/client-", "")
+          .replace(/-/g, "")
+      ) >= 0 || overwritablePathnames.indexOf(pathName) >= 0
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7227,10 +7227,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.3.tgz#9a06f0e94a51420e78b6925568b5bec72afe41ea"
-  integrity sha512-5qpBDBHO9fpE0zruKiTZm8Gxmz7kknO+WlQR/ivV+RMwgDw/WjOgmxLDn66MPrxq/WZPx/EgEZzh87xJO5E6Fw==
+prettier@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
+  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
 
 pretty-format@^25.1.0:
   version "25.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7227,10 +7227,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.3.tgz#9a06f0e94a51420e78b6925568b5bec72afe41ea"
+  integrity sha512-5qpBDBHO9fpE0zruKiTZm8Gxmz7kknO+WlQR/ivV+RMwgDw/WjOgmxLDn66MPrxq/WZPx/EgEZzh87xJO5E6Fw==
 
 pretty-format@^25.1.0:
   version "25.1.0"


### PR DESCRIPTION
*Issue #, if available:*
* prettier-vscode@4.0.0 is not backward compatible https://github.com/prettier/prettier-vscode/issues/1290
* New syntax of TypeScript 3.8 is only supported on prettier@2 https://prettier.io/blog/2020/03/21/2.0.0.html#typescript

*Description of changes:*
* bumps prettier to v2 in root package.json
* retains default prettier config from v1 in .prettierrc

Manually restored following folders, as it contains files which are not prettified (to be done separately):
* packages/smithy-client/
* protocol_tests/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
