### PR TITLE
chore: remove unused world.response from integ tests

### DIFF
--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -199,9 +199,9 @@ Given("my first request is corrupted with CRC checking (ON|OFF)", function (
 });
 
 Then("the request should( not)? be retried", function (retry, callback) {
-  if (retry && this.response.retryCount > 0)
+  if (retry && this.data.$metadata.retries > 0)
     callback(new Error("Request was incorrectly retried"));
-  if (!retry && this.response.retryCount == 0)
+  if (!retry && this.data.$metadata.retries == 0)
     callback(new Error("Request was incorrectly retried"));
   callback();
 });
@@ -224,7 +224,7 @@ Given("all of my requests are corrupted with CRC checking ON", function (
 });
 
 When("the request is retried the maximum number of times", function (callback) {
-  if (this.response.retryCount != 2)
+  if (this.data.$metadata.retries != 2)
     callback(new Error("Incorrect retry count"));
   callback();
 });

--- a/features/extra/helpers.js
+++ b/features/extra/helpers.js
@@ -69,7 +69,6 @@ module.exports = {
     if (typeof svc === "string") svc = this[svc];
 
     svc[operation](params, function (err, data) {
-      world.response = this;
       world.error = err;
       world.data = data;
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* remove unused world.response from integ tests
* integ tests now use values from `this.data.$metadata`
* verified that integ tests are successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
