### PR TITLE
fix: multi-byte body lengths for browser

### DIFF
--- a/packages/util-body-length-browser/src/index.spec.ts
+++ b/packages/util-body-length-browser/src/index.spec.ts
@@ -1,0 +1,23 @@
+import { calculateBodyLength } from "./";
+
+const arrayBuffer = new ArrayBuffer(1);
+const typedArray = new Uint8Array(1);
+const view = new DataView(arrayBuffer);
+
+describe("caclulateBodyLength", () => {
+  it("should handle string inputs", () => {
+    expect(calculateBodyLength("foo")).toEqual(3);
+  });
+
+  it("should handle string inputs with multi-byte characters", () => {
+    expect(calculateBodyLength("2。")).toEqual(4);
+  });
+
+  it("should handle inputs with byteLengths", () => {
+    expect(calculateBodyLength(arrayBuffer)).toEqual(1);
+  });
+
+  it("should handle TypedArray inputs", () => {
+    expect(calculateBodyLength(typedArray)).toEqual(1);
+  });
+});

--- a/packages/util-body-length-browser/src/index.ts
+++ b/packages/util-body-length-browser/src/index.ts
@@ -1,6 +1,6 @@
 export function calculateBodyLength(body: any): number | undefined {
   if (typeof body === "string") {
-    return body.length;
+    return new Blob([body]).size;
   } else if (typeof body.byteLength === "number") {
     // handles Uint8Array, ArrayBuffer, Buffer, and ArrayBufferView
     return body.byteLength;

--- a/packages/util-body-length-browser/tsconfig.json
+++ b/packages/util-body-length-browser/tsconfig.json
@@ -11,7 +11,8 @@
       "es2015.promise",
       "es2015.collection",
       "es2015.iterable",
-      "es2015.symbol.wellknown"
+      "es2015.symbol.wellknown",
+      "dom"
     ],
     "rootDir": "./src",
     "outDir": "./build",


### PR DESCRIPTION
*Issue #, if available:*
#1100 

*Description of changes:*
Change implementation of calculateBodyLength for a browser so that multi byte body can be handled. 
Add a test for this change as well as ones for this function (since there was no test).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
