### PR TITLE
fix: prettierignore only aws-models

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 **/*/CHANGELOG.md
-codegen/*
+codegen/sdk-codegen/aws-models/*
 .github/*


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/aws-sdk-js-v3/issues/1115

*Description of changes:*
* `codegen/*` was added to `.prettierignore` in #1083 as the checked-in code from codegen folder should not be prettified.
* This impacted prettification of temporary code which is stored in `codegen/sdk-codegen/build/smithyprojections/sdk-codegen` folder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
