### PR TITLE
fix: Build Uint8Array from ReadableStream without experimental Response constructor

### DIFF
--- a/packages/stream-collector-browser/src/index.ts
+++ b/packages/stream-collector-browser/src/index.ts
@@ -1,9 +1,20 @@
 import { StreamCollector } from "@aws-sdk/types";
 
-export const streamCollector: StreamCollector = (
-  stream: ReadableStream
+export const streamCollector: StreamCollector = async (
+  stream: ReadableStream<Uint8Array>
 ): Promise<Uint8Array> => {
-  return new Response(stream)
-    .arrayBuffer()
-    .then(arrayBuffer => new Uint8Array(arrayBuffer));
+  let res = new Uint8Array(0);
+  const reader = stream.getReader();
+  let isDone = false;
+  while(!isDone) {
+    const { done, value } = await reader.read();
+    if(value) {
+      const prior = res;
+      res = new Uint8Array(prior.length + value.length);
+      res.set(prior);
+      res.set(value, prior.length);
+    }
+    isDone = done;
+  }
+  return res;
 };


### PR DESCRIPTION
*Issue #, if available:*
#1107

*Description of changes:*
Build Uint8Array from ReadableStream without experimental Response constructor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
