### PR TITLE
fix: use JS url parser in ReactNative

### DIFF
--- a/clients/client-accessanalyzer/runtimeConfig.native.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AccessAnalyzerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-acm-pca/runtimeConfig.native.ts
+++ b/clients/client-acm-pca/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ACMPCAClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-acm/runtimeConfig.native.ts
+++ b/clients/client-acm/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ACMClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-alexa-for-business/runtimeConfig.native.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AlexaForBusinessClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-amplify/runtimeConfig.native.ts
+++ b/clients/client-amplify/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AmplifyClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-api-gateway/runtimeConfig.native.ts
+++ b/clients/client-api-gateway/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./APIGatewayClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.native.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApiGatewayManagementApiClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-apigatewayv2/runtimeConfig.native.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApiGatewayV2Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-app-mesh/runtimeConfig.native.ts
+++ b/clients/client-app-mesh/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppMeshClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-appconfig/runtimeConfig.native.ts
+++ b/clients/client-appconfig/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppConfigClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-application-auto-scaling/runtimeConfig.native.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationAutoScalingClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-application-discovery-service/runtimeConfig.native.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationDiscoveryServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-application-insights/runtimeConfig.native.ts
+++ b/clients/client-application-insights/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationInsightsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-appstream/runtimeConfig.native.ts
+++ b/clients/client-appstream/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppStreamClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-appsync/runtimeConfig.native.ts
+++ b/clients/client-appsync/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppSyncClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-athena/runtimeConfig.native.ts
+++ b/clients/client-athena/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AthenaClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-auto-scaling-plans/runtimeConfig.native.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AutoScalingPlansClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-auto-scaling/runtimeConfig.native.ts
+++ b/clients/client-auto-scaling/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AutoScalingClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-backup/runtimeConfig.native.ts
+++ b/clients/client-backup/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BackupClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-batch/runtimeConfig.native.ts
+++ b/clients/client-batch/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BatchClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-budgets/runtimeConfig.native.ts
+++ b/clients/client-budgets/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BudgetsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-chime/runtimeConfig.native.ts
+++ b/clients/client-chime/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ChimeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloud9/runtimeConfig.native.ts
+++ b/clients/client-cloud9/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Cloud9Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-clouddirectory/runtimeConfig.native.ts
+++ b/clients/client-clouddirectory/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudDirectoryClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudformation/runtimeConfig.native.ts
+++ b/clients/client-cloudformation/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudFormationClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudfront/runtimeConfig.native.ts
+++ b/clients/client-cloudfront/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudFrontClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudhsm-v2/runtimeConfig.native.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudHSMV2Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudhsm/runtimeConfig.native.ts
+++ b/clients/client-cloudhsm/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudHSMClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudsearch-domain/runtimeConfig.native.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudSearchDomainClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudsearch/runtimeConfig.native.ts
+++ b/clients/client-cloudsearch/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudSearchClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudtrail/runtimeConfig.native.ts
+++ b/clients/client-cloudtrail/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudTrailClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudwatch-events/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchEventsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudwatch-logs/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchLogsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cloudwatch/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codebuild/runtimeConfig.native.ts
+++ b/clients/client-codebuild/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeBuildClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codecommit/runtimeConfig.native.ts
+++ b/clients/client-codecommit/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeCommitClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codedeploy/runtimeConfig.native.ts
+++ b/clients/client-codedeploy/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeDeployClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codeguru-reviewer/runtimeConfig.native.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeGuruReviewerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codeguruprofiler/runtimeConfig.native.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeGuruProfilerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codepipeline/runtimeConfig.native.ts
+++ b/clients/client-codepipeline/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodePipelineClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codestar-connections/runtimeConfig.native.ts
+++ b/clients/client-codestar-connections/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeStarconnectionsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codestar-notifications/runtimeConfig.native.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./codestarnotificationsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-codestar/runtimeConfig.native.ts
+++ b/clients/client-codestar/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeStarClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cognito-identity-provider/runtimeConfig.native.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoIdentityProviderClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cognito-identity/runtimeConfig.native.ts
+++ b/clients/client-cognito-identity/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoIdentityClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cognito-sync/runtimeConfig.native.ts
+++ b/clients/client-cognito-sync/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoSyncClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-comprehend/runtimeConfig.native.ts
+++ b/clients/client-comprehend/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComprehendClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-comprehendmedical/runtimeConfig.native.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComprehendMedicalClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-compute-optimizer/runtimeConfig.native.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComputeOptimizerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-config-service/runtimeConfig.native.ts
+++ b/clients/client-config-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConfigServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-connect/runtimeConfig.native.ts
+++ b/clients/client-connect/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConnectClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-connectparticipant/runtimeConfig.native.ts
+++ b/clients/client-connectparticipant/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConnectParticipantClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.native.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CostandUsageReportServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-cost-explorer/runtimeConfig.native.ts
+++ b/clients/client-cost-explorer/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CostExplorerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-data-pipeline/runtimeConfig.native.ts
+++ b/clients/client-data-pipeline/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataPipelineClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-database-migration-service/runtimeConfig.native.ts
+++ b/clients/client-database-migration-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DatabaseMigrationServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-dataexchange/runtimeConfig.native.ts
+++ b/clients/client-dataexchange/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataExchangeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-datasync/runtimeConfig.native.ts
+++ b/clients/client-datasync/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataSyncClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-dax/runtimeConfig.native.ts
+++ b/clients/client-dax/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DAXClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-detective/runtimeConfig.native.ts
+++ b/clients/client-detective/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DetectiveClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-device-farm/runtimeConfig.native.ts
+++ b/clients/client-device-farm/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DeviceFarmClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-direct-connect/runtimeConfig.native.ts
+++ b/clients/client-direct-connect/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DirectConnectClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-directory-service/runtimeConfig.native.ts
+++ b/clients/client-directory-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DirectoryServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-dlm/runtimeConfig.native.ts
+++ b/clients/client-dlm/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DLMClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-docdb/runtimeConfig.native.ts
+++ b/clients/client-docdb/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DocDBClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-dynamodb-streams/runtimeConfig.native.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DynamoDBStreamsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-dynamodb/runtimeConfig.native.ts
+++ b/clients/client-dynamodb/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DynamoDBClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ebs/runtimeConfig.native.ts
+++ b/clients/client-ebs/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EBSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ec2-instance-connect/runtimeConfig.native.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2InstanceConnectClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ec2/runtimeConfig.native.ts
+++ b/clients/client-ec2/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ecr/runtimeConfig.native.ts
+++ b/clients/client-ecr/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ECRClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ecs/runtimeConfig.native.ts
+++ b/clients/client-ecs/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ECSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-efs/runtimeConfig.native.ts
+++ b/clients/client-efs/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EFSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-eks/runtimeConfig.native.ts
+++ b/clients/client-eks/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EKSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-elastic-beanstalk/runtimeConfig.native.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticBeanstalkClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-elastic-inference/runtimeConfig.native.ts
+++ b/clients/client-elastic-inference/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticInferenceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.native.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticLoadBalancingv2Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-elastic-load-balancing/runtimeConfig.native.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticLoadBalancingClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-elastic-transcoder/runtimeConfig.native.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticTranscoderClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-elasticache/runtimeConfig.native.ts
+++ b/clients/client-elasticache/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElastiCacheClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-elasticsearch-service/runtimeConfig.native.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticsearchServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-emr/runtimeConfig.native.ts
+++ b/clients/client-emr/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EMRClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-eventbridge/runtimeConfig.native.ts
+++ b/clients/client-eventbridge/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EventBridgeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-firehose/runtimeConfig.native.ts
+++ b/clients/client-firehose/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FirehoseClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-fms/runtimeConfig.native.ts
+++ b/clients/client-fms/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FMSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-forecast/runtimeConfig.native.ts
+++ b/clients/client-forecast/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./forecastClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-forecastquery/runtimeConfig.native.ts
+++ b/clients/client-forecastquery/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./forecastqueryClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-frauddetector/runtimeConfig.native.ts
+++ b/clients/client-frauddetector/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FraudDetectorClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-fsx/runtimeConfig.native.ts
+++ b/clients/client-fsx/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FSxClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-gamelift/runtimeConfig.native.ts
+++ b/clients/client-gamelift/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GameLiftClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-glacier/runtimeConfig.native.ts
+++ b/clients/client-glacier/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlacierClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-global-accelerator/runtimeConfig.native.ts
+++ b/clients/client-global-accelerator/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlobalAcceleratorClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-glue/runtimeConfig.native.ts
+++ b/clients/client-glue/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlueClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-greengrass/runtimeConfig.native.ts
+++ b/clients/client-greengrass/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GreengrassClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-groundstation/runtimeConfig.native.ts
+++ b/clients/client-groundstation/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GroundStationClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-guardduty/runtimeConfig.native.ts
+++ b/clients/client-guardduty/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GuardDutyClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-health/runtimeConfig.native.ts
+++ b/clients/client-health/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./HealthClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iam/runtimeConfig.native.ts
+++ b/clients/client-iam/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IAMClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-imagebuilder/runtimeConfig.native.ts
+++ b/clients/client-imagebuilder/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./imagebuilderClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-inspector/runtimeConfig.native.ts
+++ b/clients/client-inspector/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./InspectorClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iot-1click-devices-service/runtimeConfig.native.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoT1ClickDevicesServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iot-1click-projects/runtimeConfig.native.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoT1ClickProjectsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iot-data-plane/runtimeConfig.native.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTDataPlaneClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iot-events-data/runtimeConfig.native.ts
+++ b/clients/client-iot-events-data/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTEventsDataClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iot-events/runtimeConfig.native.ts
+++ b/clients/client-iot-events/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTEventsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.native.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTJobsDataPlaneClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iot/runtimeConfig.native.ts
+++ b/clients/client-iot/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iotanalytics/runtimeConfig.native.ts
+++ b/clients/client-iotanalytics/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTAnalyticsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iotsecuretunneling/runtimeConfig.native.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTSecureTunnelingClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-iotthingsgraph/runtimeConfig.native.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTThingsGraphClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kafka/runtimeConfig.native.ts
+++ b/clients/client-kafka/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KafkaClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kendra/runtimeConfig.native.ts
+++ b/clients/client-kendra/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./kendraClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.native.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisAnalyticsV2Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kinesis-analytics/runtimeConfig.native.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisAnalyticsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoArchivedMediaClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kinesis-video-media/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoMediaClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kinesis-video-signaling/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoSignalingClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kinesis-video/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kinesis/runtimeConfig.native.ts
+++ b/clients/client-kinesis/runtimeConfig.native.ts
@@ -3,7 +3,7 @@ import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-kms/runtimeConfig.native.ts
+++ b/clients/client-kms/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KMSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-lakeformation/runtimeConfig.native.ts
+++ b/clients/client-lakeformation/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LakeFormationClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-lambda/runtimeConfig.native.ts
+++ b/clients/client-lambda/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LambdaClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-lex-model-building-service/runtimeConfig.native.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LexModelBuildingServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-lex-runtime-service/runtimeConfig.native.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LexRuntimeServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-license-manager/runtimeConfig.native.ts
+++ b/clients/client-license-manager/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LicenseManagerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-lightsail/runtimeConfig.native.ts
+++ b/clients/client-lightsail/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LightsailClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-machine-learning/runtimeConfig.native.ts
+++ b/clients/client-machine-learning/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MachineLearningClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-macie/runtimeConfig.native.ts
+++ b/clients/client-macie/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MacieClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-managedblockchain/runtimeConfig.native.ts
+++ b/clients/client-managedblockchain/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ManagedBlockchainClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-marketplace-catalog/runtimeConfig.native.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceCatalogClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.native.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceCommerceAnalyticsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.native.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceEntitlementServiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-marketplace-metering/runtimeConfig.native.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceMeteringClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mediaconnect/runtimeConfig.native.ts
+++ b/clients/client-mediaconnect/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaConnectClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mediaconvert/runtimeConfig.native.ts
+++ b/clients/client-mediaconvert/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaConvertClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-medialive/runtimeConfig.native.ts
+++ b/clients/client-medialive/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaLiveClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mediapackage-vod/runtimeConfig.native.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaPackageVodClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mediapackage/runtimeConfig.native.ts
+++ b/clients/client-mediapackage/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaPackageClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mediastore-data/runtimeConfig.native.ts
+++ b/clients/client-mediastore-data/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaStoreDataClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mediastore/runtimeConfig.native.ts
+++ b/clients/client-mediastore/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaStoreClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mediatailor/runtimeConfig.native.ts
+++ b/clients/client-mediatailor/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaTailorClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-migration-hub/runtimeConfig.native.ts
+++ b/clients/client-migration-hub/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MigrationHubClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-migrationhub-config/runtimeConfig.native.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MigrationHubConfigClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mobile/runtimeConfig.native.ts
+++ b/clients/client-mobile/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MobileClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mq/runtimeConfig.native.ts
+++ b/clients/client-mq/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./mqClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-mturk/runtimeConfig.native.ts
+++ b/clients/client-mturk/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MTurkClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-neptune/runtimeConfig.native.ts
+++ b/clients/client-neptune/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./NeptuneClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-networkmanager/runtimeConfig.native.ts
+++ b/clients/client-networkmanager/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./NetworkManagerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-opsworks/runtimeConfig.native.ts
+++ b/clients/client-opsworks/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OpsWorksClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-opsworkscm/runtimeConfig.native.ts
+++ b/clients/client-opsworkscm/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OpsWorksCMClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-organizations/runtimeConfig.native.ts
+++ b/clients/client-organizations/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OrganizationsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-outposts/runtimeConfig.native.ts
+++ b/clients/client-outposts/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OutpostsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-personalize-events/runtimeConfig.native.ts
+++ b/clients/client-personalize-events/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeEventsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-personalize-runtime/runtimeConfig.native.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeRuntimeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-personalize/runtimeConfig.native.ts
+++ b/clients/client-personalize/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-pi/runtimeConfig.native.ts
+++ b/clients/client-pi/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PIClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-pinpoint-email/runtimeConfig.native.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointEmailClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.native.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointSMSVoiceClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-pinpoint/runtimeConfig.native.ts
+++ b/clients/client-pinpoint/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-polly/runtimeConfig.native.ts
+++ b/clients/client-polly/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PollyClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-pricing/runtimeConfig.native.ts
+++ b/clients/client-pricing/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PricingClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-qldb-session/runtimeConfig.native.ts
+++ b/clients/client-qldb-session/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QLDBSessionClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-qldb/runtimeConfig.native.ts
+++ b/clients/client-qldb/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QLDBClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-quicksight/runtimeConfig.native.ts
+++ b/clients/client-quicksight/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QuickSightClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ram/runtimeConfig.native.ts
+++ b/clients/client-ram/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RAMClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-rds-data/runtimeConfig.native.ts
+++ b/clients/client-rds-data/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RDSDataClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-rds/runtimeConfig.native.ts
+++ b/clients/client-rds/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RDSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-redshift/runtimeConfig.native.ts
+++ b/clients/client-redshift/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RedshiftClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-rekognition/runtimeConfig.native.ts
+++ b/clients/client-rekognition/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RekognitionClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.native.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ResourceGroupsTaggingAPIClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-resource-groups/runtimeConfig.native.ts
+++ b/clients/client-resource-groups/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ResourceGroupsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-robomaker/runtimeConfig.native.ts
+++ b/clients/client-robomaker/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RoboMakerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-route-53-domains/runtimeConfig.native.ts
+++ b/clients/client-route-53-domains/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53DomainsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-route-53/runtimeConfig.native.ts
+++ b/clients/client-route-53/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-route53resolver/runtimeConfig.native.ts
+++ b/clients/client-route53resolver/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53ResolverClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-s3-control/runtimeConfig.native.ts
+++ b/clients/client-s3-control/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./S3ControlClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-s3/runtimeConfig.native.ts
+++ b/clients/client-s3/runtimeConfig.native.ts
@@ -3,7 +3,7 @@ import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./S3Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.native.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerA2IRuntimeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sagemaker-runtime/runtimeConfig.native.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerRuntimeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sagemaker/runtimeConfig.native.ts
+++ b/clients/client-sagemaker/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-savingsplans/runtimeConfig.native.ts
+++ b/clients/client-savingsplans/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./savingsplansClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-schemas/runtimeConfig.native.ts
+++ b/clients/client-schemas/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./schemasClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-secrets-manager/runtimeConfig.native.ts
+++ b/clients/client-secrets-manager/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SecretsManagerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-securityhub/runtimeConfig.native.ts
+++ b/clients/client-securityhub/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SecurityHubClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.native.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServerlessApplicationRepositoryClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-service-catalog/runtimeConfig.native.ts
+++ b/clients/client-service-catalog/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceCatalogClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-service-quotas/runtimeConfig.native.ts
+++ b/clients/client-service-quotas/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceQuotasClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-servicediscovery/runtimeConfig.native.ts
+++ b/clients/client-servicediscovery/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceDiscoveryClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ses/runtimeConfig.native.ts
+++ b/clients/client-ses/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SESClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sesv2/runtimeConfig.native.ts
+++ b/clients/client-sesv2/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SESv2Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sfn/runtimeConfig.native.ts
+++ b/clients/client-sfn/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SFNClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-shield/runtimeConfig.native.ts
+++ b/clients/client-shield/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ShieldClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-signer/runtimeConfig.native.ts
+++ b/clients/client-signer/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./signerClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sms/runtimeConfig.native.ts
+++ b/clients/client-sms/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SMSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-snowball/runtimeConfig.native.ts
+++ b/clients/client-snowball/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SnowballClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sns/runtimeConfig.native.ts
+++ b/clients/client-sns/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SNSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sqs/runtimeConfig.native.ts
+++ b/clients/client-sqs/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SQSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-ssm/runtimeConfig.native.ts
+++ b/clients/client-ssm/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSMClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sso-oidc/runtimeConfig.native.ts
+++ b/clients/client-sso-oidc/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSOOIDCClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sso/runtimeConfig.native.ts
+++ b/clients/client-sso/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSOClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-storage-gateway/runtimeConfig.native.ts
+++ b/clients/client-storage-gateway/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./StorageGatewayClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-sts/runtimeConfig.native.ts
+++ b/clients/client-sts/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./STSClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-support/runtimeConfig.native.ts
+++ b/clients/client-support/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SupportClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-swf/runtimeConfig.native.ts
+++ b/clients/client-swf/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SWFClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-textract/runtimeConfig.native.ts
+++ b/clients/client-textract/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TextractClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-transcribe-streaming/runtimeConfig.native.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.native.ts
@@ -3,7 +3,7 @@ import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TranscribeStreamingClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-transcribe/runtimeConfig.native.ts
+++ b/clients/client-transcribe/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TranscribeClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-transfer/runtimeConfig.native.ts
+++ b/clients/client-transfer/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TransferClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-translate/runtimeConfig.native.ts
+++ b/clients/client-translate/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TranslateClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-waf-regional/runtimeConfig.native.ts
+++ b/clients/client-waf-regional/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFRegionalClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-waf/runtimeConfig.native.ts
+++ b/clients/client-waf/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-wafv2/runtimeConfig.native.ts
+++ b/clients/client-wafv2/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFV2Client";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-workdocs/runtimeConfig.native.ts
+++ b/clients/client-workdocs/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkDocsClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-worklink/runtimeConfig.native.ts
+++ b/clients/client-worklink/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkLinkClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-workmail/runtimeConfig.native.ts
+++ b/clients/client-workmail/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkMailClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-workmailmessageflow/runtimeConfig.native.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkMailMessageFlowClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-workspaces/runtimeConfig.native.ts
+++ b/clients/client-workspaces/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkSpacesClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 

--- a/clients/client-xray/runtimeConfig.native.ts
+++ b/clients/client-xray/runtimeConfig.native.ts
@@ -2,7 +2,7 @@ import { name, version } from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
+import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./XRayClient";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 


### PR DESCRIPTION
*Description of changes:*
Fix a regression introduced in release beta.4. Use the right URL parser in react native.

Paired with https://github.com/awslabs/smithy-typescript/pull/169

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
