### PR TITLE
feat: use google-java-format for formatting Java code on build

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -19,3 +19,13 @@ allprojects {
         mavenCentral()
     }
 }
+
+plugins {
+  id("com.github.sherter.google-java-format") version "0.8"
+}
+
+buildscript {
+    dependencies {
+        classpath("gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8")
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBodyChecksumGeneratorDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBodyChecksumGeneratorDependency.java
@@ -27,68 +27,73 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
-
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SetUtils;
 
-/**
- * Adds blobReader dependency if needed.
- */
+/** Adds blobReader dependency if needed. */
 public class AddBodyChecksumGeneratorDependency implements TypeScriptIntegration {
-    private static final Set<String> SERVICE_IDS = SetUtils.of("Glacier");
+  private static final Set<String> SERVICE_IDS = SetUtils.of("Glacier");
 
-    private static final Logger LOGGER = Logger.getLogger(AddBodyChecksumGeneratorDependency.class.getName());
+  private static final Logger LOGGER =
+      Logger.getLogger(AddBodyChecksumGeneratorDependency.class.getName());
 
-    @Override
-    public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
-    ) {
-        if (!needsBodyChecksumGeneratorDep(settings.getService(model))) {
-            return;
-        }
-        writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/types");
-        writer.writeDocs("Function that returns body checksums.");
-        writer.write("bodyChecksumGenerator?: (request: __HttpRequest, options: { sha256: __HashConstructor; "
-                + "utf8Decoder: __Decoder }) => Promise<[string, string]>;\n");
-}
+  @Override
+  public void addConfigInterfaceFields(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      TypeScriptWriter writer) {
+    if (!needsBodyChecksumGeneratorDep(settings.getService(model))) {
+      return;
+    }
+    writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/types");
+    writer.writeDocs("Function that returns body checksums.");
+    writer.write(
+        "bodyChecksumGenerator?: (request: __HttpRequest, options: { sha256: __HashConstructor; "
+            + "utf8Decoder: __Decoder }) => Promise<[string, string]>;\n");
+  }
 
-    @Override
-    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
-    ) {
-        if (!needsBodyChecksumGeneratorDep(settings.getService(model))) {
-            return Collections.emptyMap();
-        }
-
-        switch (target) {
-            case NODE:
-                return MapUtils.of("bodyChecksumGenerator", writer -> {
-                    writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_NODE);
-                    writer.addImport("bodyChecksumGenerator", "bodyChecksumGenerator",
-                            AwsDependency.BODY_CHECKSUM_GENERATOR_NODE.packageName);
-                    writer.write("bodyChecksumGenerator,");
-                });
-            case BROWSER:
-                return MapUtils.of("bodyChecksumGenerator", writer -> {
-                    writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER);
-                    writer.addImport("bodyChecksumGenerator", "bodyChecksumGenerator",
-                            AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER.packageName);
-                    writer.write("bodyChecksumGenerator,");
-                });
-            default:
-                return Collections.emptyMap();
-        }
+  @Override
+  public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      LanguageTarget target) {
+    if (!needsBodyChecksumGeneratorDep(settings.getService(model))) {
+      return Collections.emptyMap();
     }
 
-    private static boolean needsBodyChecksumGeneratorDep(ServiceShape service) {
-        String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
-        return SERVICE_IDS.contains(serviceId);
+    switch (target) {
+      case NODE:
+        return MapUtils.of(
+            "bodyChecksumGenerator",
+            writer -> {
+              writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_NODE);
+              writer.addImport(
+                  "bodyChecksumGenerator",
+                  "bodyChecksumGenerator",
+                  AwsDependency.BODY_CHECKSUM_GENERATOR_NODE.packageName);
+              writer.write("bodyChecksumGenerator,");
+            });
+      case BROWSER:
+        return MapUtils.of(
+            "bodyChecksumGenerator",
+            writer -> {
+              writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER);
+              writer.addImport(
+                  "bodyChecksumGenerator",
+                  "bodyChecksumGenerator",
+                  AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER.packageName);
+              writer.write("bodyChecksumGenerator,");
+            });
+      default:
+        return Collections.emptyMap();
     }
+  }
+
+  private static boolean needsBodyChecksumGeneratorDep(ServiceShape service) {
+    String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
+    return SERVICE_IDS.contains(serviceId);
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -20,7 +20,6 @@ import static software.amazon.smithy.typescript.codegen.integration.RuntimeClien
 
 import java.util.List;
 import java.util.Set;
-
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
@@ -33,204 +32,224 @@ import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegrati
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SetUtils;
 
-/**
- * Adds all built-in runtime client plugins to clients.
- */
+/** Adds all built-in runtime client plugins to clients. */
 public class AddBuiltinPlugins implements TypeScriptIntegration {
 
-    private static final Set<String> SSEC_OPERATIONS = SetUtils.of("SSECustomerKey", "CopySourceSSECustomerKey");
+  private static final Set<String> SSEC_OPERATIONS =
+      SetUtils.of("SSECustomerKey", "CopySourceSSECustomerKey");
 
-    private static final Set<String> ROUTE_53_ID_MEMBERS = SetUtils.of("DelegationSetId", "HostedZoneId", "Id");
+  private static final Set<String> ROUTE_53_ID_MEMBERS =
+      SetUtils.of("DelegationSetId", "HostedZoneId", "Id");
 
-    private static final Set<String> RDS_PRESIGNED_URL_OPERATIONS = SetUtils.of(
-        "CopyDBSnapshot",
-        "CreateDBInstanceReadReplica",
-        "CreateDBCluster",
-        "CopyDBClusterSnapshot"
-    );
+  private static final Set<String> RDS_PRESIGNED_URL_OPERATIONS =
+      SetUtils.of(
+          "CopyDBSnapshot",
+          "CreateDBInstanceReadReplica",
+          "CreateDBCluster",
+          "CopyDBClusterSnapshot");
 
-    private static final Set<String> S3_MD5_OPERATIONS = SetUtils.of(
-            "DeleteObjects",
-            "PutBucketCors",
-            "PutBucketLifecycle",
-            "PutBucketLifecycleConfiguration",
-            "PutBucketPolicy",
-            "PutBucketTagging",
-            "PutBucketReplication"
-    );
+  private static final Set<String> S3_MD5_OPERATIONS =
+      SetUtils.of(
+          "DeleteObjects",
+          "PutBucketCors",
+          "PutBucketLifecycle",
+          "PutBucketLifecycleConfiguration",
+          "PutBucketPolicy",
+          "PutBucketTagging",
+          "PutBucketReplication");
 
-    private static final Set<String> NON_BUCKET_ENDPOINT_OPERATIONS = SetUtils.of(
-            "CreateBucket",
-            "DeleteBucket",
-            "ListBuckets"
-    );
+  private static final Set<String> NON_BUCKET_ENDPOINT_OPERATIONS =
+      SetUtils.of("CreateBucket", "DeleteBucket", "ListBuckets");
 
-    @Override
-    public List<RuntimeClientPlugin> getClientPlugins() {
-        // Note that order is significant because configurations might
-        // rely on previously resolved values.
-        return ListUtils.of(
-                RuntimeClientPlugin.builder()
-                        .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Endpoints", HAS_CONFIG)
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_CONFIG)
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
-                        // See operationUsesAwsAuth() below for AwsAuth Middleware customizations.
-                        .servicePredicate((m, s) -> !testServiceId(s, "Cognito Identity"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "Retry")
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(TypeScriptDependency.MIDDLEWARE_USER_AGENT.dependency, "UserAgent")
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(TypeScriptDependency.MIDDLEWARE_CONTENT_LENGTH.dependency, "ContentLength",
-                                         HAS_MIDDLEWARE)
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.ACCEPT_HEADER.dependency, "AcceptHeader",
-                                         HAS_MIDDLEWARE)
-                        .servicePredicate((m, s) -> testServiceId(s, "API Gateway"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.VALIDATE_BUCKET_NAME.dependency, "ValidateBucketName",
-                                         HAS_MIDDLEWARE)
-                        .servicePredicate((m, s) -> testServiceId(s, "S3"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.ADD_EXPECT_CONTINUE.dependency, "AddExpectContinue",
-                                         HAS_MIDDLEWARE)
-                        .servicePredicate((m, s) -> testServiceId(s, "S3"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.GLACIER_MIDDLEWARE.dependency,
-                                         "Glacier", HAS_MIDDLEWARE)
-                        .servicePredicate((m, s) -> testServiceId(s, "Glacier"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.EC2_MIDDLEWARE.dependency,
-                                         "CopySnapshotPresignedUrl", HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("CopySnapshot")
-                                            && testServiceId(s, "EC2"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.SSEC_MIDDLEWARE.dependency, "Ssec", HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> testInputContainsMember(m, o, SSEC_OPERATIONS)
-                                            && testServiceId(s, "S3"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.LOCATION_CONSTRAINT.dependency, "LocationConstraint",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("CreateBucket")
-                                            && testServiceId(s, "S3"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MACHINELEARNING_MIDDLEWARE.dependency, "PredictEndpoint",
-                                HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("Predict")
-                                            && testServiceId(s, "Machine Learning"))
-                        .build(),
-                /**
-                 * BUCKET_ENDPOINT_MIDDLEWARE needs two separate plugins. The first resolves the config in the client.
-                 * The second applies the middleware to bucket endpoint operations.
-                 */
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint",
-                                         HAS_CONFIG)
-                        .servicePredicate((m, s) -> testServiceId(s, "S3"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> !NON_BUCKET_ENDPOINT_OPERATIONS.contains(o.getId().getName())
-                                            && testServiceId(s, "S3"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.BODY_CHECKSUM.dependency, "ApplyMd5BodyChecksum",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> S3_MD5_OPERATIONS.contains(o.getId().getName())
-                                            && testServiceId(s, "S3"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.ROUTE53_MIDDLEWARE.dependency,
-                                         "ChangeResourceRecordSets", HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("ChangeResourceRecordSets")
-                                            && testServiceId(s, "Route 53"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> RDS_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
-                                            && testServiceId(s, "RDS"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.ROUTE53_MIDDLEWARE.dependency, "IdNormalizer",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> testInputContainsMember(m, o, ROUTE_53_ID_MEMBERS)
-                                            && testServiceId(s, "Route 53"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.S3_CONTROL_MIDDLEWARE.dependency, "PrependAccountId",
-                                         HAS_MIDDLEWARE)
-                        .servicePredicate((m, s) -> testServiceId(s, "S3 Control"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessage",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("SendMessage")
-                                            && testServiceId(s, "SQS"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessageBatch",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("SendMessageBatch")
-                                            && testServiceId(s, "SQS"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "ReceiveMessage",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("ReceiveMessage")
-                                            && testServiceId(s, "SQS"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_HOST_HEADER.dependency, "HostHeader")
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
-                        .operationPredicate(AddBuiltinPlugins::operationUsesAwsAuth)
-                        .build()
-        );
+  @Override
+  public List<RuntimeClientPlugin> getClientPlugins() {
+    // Note that order is significant because configurations might
+    // rely on previously resolved values.
+    return ListUtils.of(
+        RuntimeClientPlugin.builder()
+            .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                TypeScriptDependency.CONFIG_RESOLVER.dependency, "Endpoints", HAS_CONFIG)
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_CONFIG)
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
+            // See operationUsesAwsAuth() below for AwsAuth Middleware customizations.
+            .servicePredicate((m, s) -> !testServiceId(s, "Cognito Identity"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "Retry")
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(TypeScriptDependency.MIDDLEWARE_USER_AGENT.dependency, "UserAgent")
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                TypeScriptDependency.MIDDLEWARE_CONTENT_LENGTH.dependency,
+                "ContentLength",
+                HAS_MIDDLEWARE)
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.ACCEPT_HEADER.dependency, "AcceptHeader", HAS_MIDDLEWARE)
+            .servicePredicate((m, s) -> testServiceId(s, "API Gateway"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.VALIDATE_BUCKET_NAME.dependency, "ValidateBucketName", HAS_MIDDLEWARE)
+            .servicePredicate((m, s) -> testServiceId(s, "S3"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.ADD_EXPECT_CONTINUE.dependency, "AddExpectContinue", HAS_MIDDLEWARE)
+            .servicePredicate((m, s) -> testServiceId(s, "S3"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.GLACIER_MIDDLEWARE.dependency, "Glacier", HAS_MIDDLEWARE)
+            .servicePredicate((m, s) -> testServiceId(s, "Glacier"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.EC2_MIDDLEWARE.dependency, "CopySnapshotPresignedUrl", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) -> o.getId().getName().equals("CopySnapshot") && testServiceId(s, "EC2"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.SSEC_MIDDLEWARE.dependency, "Ssec", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    testInputContainsMember(m, o, SSEC_OPERATIONS) && testServiceId(s, "S3"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.LOCATION_CONSTRAINT.dependency, "LocationConstraint", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) -> o.getId().getName().equals("CreateBucket") && testServiceId(s, "S3"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.MACHINELEARNING_MIDDLEWARE.dependency,
+                "PredictEndpoint",
+                HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    o.getId().getName().equals("Predict") && testServiceId(s, "Machine Learning"))
+            .build(),
+        /**
+         * BUCKET_ENDPOINT_MIDDLEWARE needs two separate plugins. The first resolves the config in
+         * the client. The second applies the middleware to bucket endpoint operations.
+         */
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint", HAS_CONFIG)
+            .servicePredicate((m, s) -> testServiceId(s, "S3"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency,
+                "BucketEndpoint",
+                HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    !NON_BUCKET_ENDPOINT_OPERATIONS.contains(o.getId().getName())
+                        && testServiceId(s, "S3"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.BODY_CHECKSUM.dependency, "ApplyMd5BodyChecksum", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    S3_MD5_OPERATIONS.contains(o.getId().getName()) && testServiceId(s, "S3"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.ROUTE53_MIDDLEWARE.dependency,
+                "ChangeResourceRecordSets",
+                HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    o.getId().getName().equals("ChangeResourceRecordSets")
+                        && testServiceId(s, "Route 53"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    RDS_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
+                        && testServiceId(s, "RDS"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.ROUTE53_MIDDLEWARE.dependency, "IdNormalizer", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    testInputContainsMember(m, o, ROUTE_53_ID_MEMBERS)
+                        && testServiceId(s, "Route 53"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.S3_CONTROL_MIDDLEWARE.dependency, "PrependAccountId", HAS_MIDDLEWARE)
+            .servicePredicate((m, s) -> testServiceId(s, "S3 Control"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessage", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) -> o.getId().getName().equals("SendMessage") && testServiceId(s, "SQS"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessageBatch", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    o.getId().getName().equals("SendMessageBatch") && testServiceId(s, "SQS"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(
+                AwsDependency.SQS_MIDDLEWARE.dependency, "ReceiveMessage", HAS_MIDDLEWARE)
+            .operationPredicate(
+                (m, s, o) ->
+                    o.getId().getName().equals("ReceiveMessage") && testServiceId(s, "SQS"))
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.MIDDLEWARE_HOST_HEADER.dependency, "HostHeader")
+            .build(),
+        RuntimeClientPlugin.builder()
+            .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
+            .operationPredicate(AddBuiltinPlugins::operationUsesAwsAuth)
+            .build());
+  }
+
+  private static boolean testInputContainsMember(
+      Model model, OperationShape operationShape, Set<String> expectedMemberNames) {
+    OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+    return operationIndex
+        .getInput(operationShape)
+        .filter(input -> input.getMemberNames().stream().anyMatch(expectedMemberNames::contains))
+        .isPresent();
+  }
+
+  private static boolean testServiceId(Shape serviceShape, String expectedId) {
+    return serviceShape
+        .getTrait(ServiceTrait.class)
+        .map(ServiceTrait::getSdkId)
+        .orElse("")
+        .equals(expectedId);
+  }
+
+  private static boolean operationUsesAwsAuth(
+      Model model, ServiceShape service, OperationShape operation) {
+    // Cognito Identity service doesn't need auth for GetId, GetOpenIdToken,
+    // GetCredentialsForIdentity.
+    if (testServiceId(service, "Cognito Identity")) {
+      Boolean isUnsignedCommand =
+          SetUtils.of("GetId", "GetOpenIdToken", "GetCredentialsForIdentity")
+              .contains(operation.getId().getName());
+      return !isUnsignedCommand;
     }
-
-    private static boolean testInputContainsMember(
-            Model model,
-            OperationShape operationShape,
-            Set<String> expectedMemberNames
-    ) {
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
-        return operationIndex.getInput(operationShape)
-                .filter(input -> input.getMemberNames().stream().anyMatch(expectedMemberNames::contains))
-                .isPresent();
-    }
-
-    private static boolean testServiceId(Shape serviceShape, String expectedId) {
-        return serviceShape.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("").equals(expectedId);
-    }
-
-    private static boolean operationUsesAwsAuth(Model model, ServiceShape service, OperationShape operation) {
-        // Cognito Identity service doesn't need auth for GetId, GetOpenIdToken, GetCredentialsForIdentity.
-        if (testServiceId(service, "Cognito Identity")) {
-            Boolean isUnsignedCommand = SetUtils.of("GetId", "GetOpenIdToken", "GetCredentialsForIdentity")
-                    .contains(operation.getId().getName());
-            return !isUnsignedCommand;
-        }
-        return false;
-    }
+    return false;
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
@@ -20,14 +20,17 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.ListUtils;
 
-/**
- * Adds all built-in AWS protocols.
- */
+/** Adds all built-in AWS protocols. */
 public class AddProtocols implements TypeScriptIntegration {
 
-    @Override
-    public List<ProtocolGenerator> getProtocolGenerators() {
-        return ListUtils.of(new AwsRestJson1_1(), new AwsJsonRpc1_0(), new AwsJsonRpc1_1(),
-                new AwsRestXml(), new AwsQuery(), new AwsEc2());
-    }
+  @Override
+  public List<ProtocolGenerator> getProtocolGenerators() {
+    return ListUtils.of(
+        new AwsRestJson1_1(),
+        new AwsJsonRpc1_0(),
+        new AwsJsonRpc1_1(),
+        new AwsRestXml(),
+        new AwsQuery(),
+        new AwsEc2());
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.aws.typescript.codegen;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
-
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -29,47 +28,46 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.MapUtils;
 
-/**
- * AWS S3 client configuration.
- */
+/** AWS S3 client configuration. */
 public final class AddS3Config implements TypeScriptIntegration {
 
-    @Override
-    public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
-    ) {
-        if (!needsS3Config(settings.getService(model))) {
-            return;
-        }
-        writer.writeDocs("Whether to escape request path when signing the request.")
-                .write("signingEscapePath?: boolean;\n");
+  @Override
+  public void addConfigInterfaceFields(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      TypeScriptWriter writer) {
+    if (!needsS3Config(settings.getService(model))) {
+      return;
     }
+    writer
+        .writeDocs("Whether to escape request path when signing the request.")
+        .write("signingEscapePath?: boolean;\n");
+  }
 
-    @Override
-    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
-    ) {
-        if (!needsS3Config(settings.getService(model))) {
-            return Collections.emptyMap();
-        }
-        switch (target) {
-            case SHARED:
-                return MapUtils.of("signingEscapePath", writer -> {
-                    writer.write("signingEscapePath: false,");
-                });
-            default:
-                return Collections.emptyMap();
-        }
+  @Override
+  public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      LanguageTarget target) {
+    if (!needsS3Config(settings.getService(model))) {
+      return Collections.emptyMap();
     }
+    switch (target) {
+      case SHARED:
+        return MapUtils.of(
+            "signingEscapePath",
+            writer -> {
+              writer.write("signingEscapePath: false,");
+            });
+      default:
+        return Collections.emptyMap();
+    }
+  }
 
-    private static boolean needsS3Config(ServiceShape service) {
-        String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
-        return serviceId.equals("S3");
-    }
+  private static boolean needsS3Config(ServiceShape service) {
+    String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
+    return serviceId.equals("S3");
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -23,52 +23,53 @@ import java.util.List;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 
-/**
- * This enum should define all TypeScript dependencies that are introduced by
- * this package.
- */
+/** This enum should define all TypeScript dependencies that are introduced by this package. */
 public enum AwsDependency implements SymbolDependencyContainer {
+  MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing", "^1.0.0-beta.1"),
+  CREDENTIAL_PROVIDER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/credential-provider-node", "^1.0.0-beta.1"),
+  REGION_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/region-provider", "^1.0.0-beta.1"),
+  ACCEPT_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-api-gateway", "^1.0.0-beta.1"),
+  VALIDATE_BUCKET_NAME(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-s3", "^1.0.0-beta.1"),
+  ADD_EXPECT_CONTINUE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-expect-continue", "^1.0.0-beta.1"),
+  GLACIER_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-glacier", "^1.0.0-beta.1"),
+  MACHINELEARNING_MIDDLEWARE(
+      NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-machinelearning", "^1.0.0-beta.1"),
+  S3_CONTROL_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-s3-control", "^1.0.0-beta.1"),
+  SSEC_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-ssec", "^1.0.0-beta.1"),
+  RDS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-rds", "^1.0.0-beta.1"),
+  LOCATION_CONSTRAINT(
+      NORMAL_DEPENDENCY, "@aws-sdk/middleware-location-constraint", "^1.0.0-beta.1"),
+  MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js", "^1.0.0-beta.1"),
+  STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node", "^1.0.0-beta.1"),
+  STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser", "^1.0.0-beta.1"),
+  ROUTE53_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-route53", "^1.0.0-beta.1"),
+  EC2_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-ec2", "^1.0.0-beta.0"),
+  BUCKET_ENDPOINT_MIDDLEWARE(
+      NORMAL_DEPENDENCY, "@aws-sdk/middleware-bucket-endpoint", "^1.0.0-beta.1"),
+  BODY_CHECKSUM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-apply-body-checksum", "^1.0.0-beta.1"),
+  MIDDLEWARE_HOST_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-host-header", "^1.0.0-beta.1"),
+  SQS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-sqs", "^1.0.0-beta.0"),
+  BODY_CHECKSUM_GENERATOR_BROWSER(
+      NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser", "^1.0.0-beta.0"),
+  BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node", "^1.0.0-beta.0"),
+  XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder", "^1.0.0-beta.1"),
+  XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "^3.16.0"),
+  UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^7.0.0"),
+  UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^7.0.0");
 
-    MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing", "^1.0.0-beta.1"),
-    CREDENTIAL_PROVIDER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/credential-provider-node", "^1.0.0-beta.1"),
-    REGION_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/region-provider", "^1.0.0-beta.1"),
-    ACCEPT_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-api-gateway", "^1.0.0-beta.1"),
-    VALIDATE_BUCKET_NAME(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-s3", "^1.0.0-beta.1"),
-    ADD_EXPECT_CONTINUE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-expect-continue", "^1.0.0-beta.1"),
-    GLACIER_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-glacier", "^1.0.0-beta.1"),
-    MACHINELEARNING_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-machinelearning", "^1.0.0-beta.1"),
-    S3_CONTROL_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-s3-control", "^1.0.0-beta.1"),
-    SSEC_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-ssec", "^1.0.0-beta.1"),
-    RDS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-rds", "^1.0.0-beta.1"),
-    LOCATION_CONSTRAINT(NORMAL_DEPENDENCY, "@aws-sdk/middleware-location-constraint", "^1.0.0-beta.1"),
-    MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js", "^1.0.0-beta.1"),
-    STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node", "^1.0.0-beta.1"),
-    STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser", "^1.0.0-beta.1"),
-    ROUTE53_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-route53", "^1.0.0-beta.1"),
-    EC2_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-ec2", "^1.0.0-beta.0"),
-    BUCKET_ENDPOINT_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-bucket-endpoint", "^1.0.0-beta.1"),
-    BODY_CHECKSUM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-apply-body-checksum", "^1.0.0-beta.1"),
-    MIDDLEWARE_HOST_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-host-header", "^1.0.0-beta.1"),
-    SQS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-sqs", "^1.0.0-beta.0"),
-    BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser", "^1.0.0-beta.0"),
-    BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node", "^1.0.0-beta.0"),
-    XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder", "^1.0.0-beta.1"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "^3.16.0"),
-    UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^7.0.0"),
-    UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^7.0.0");
+  public final String packageName;
+  public final String version;
+  public final SymbolDependency dependency;
 
-    public final String packageName;
-    public final String version;
-    public final SymbolDependency dependency;
+  AwsDependency(String type, String name, String version) {
+    this.dependency =
+        SymbolDependency.builder().dependencyType(type).packageName(name).version(version).build();
+    this.packageName = name;
+    this.version = version;
+  }
 
-    AwsDependency(String type, String name, String version) {
-        this.dependency = SymbolDependency.builder().dependencyType(type).packageName(name).version(version).build();
-        this.packageName = name;
-        this.version = version;
-    }
-
-    @Override
-    public List<SymbolDependency> getDependencies() {
-        return Collections.singletonList(dependency);
-    }
+  @Override
+  public List<SymbolDependency> getDependencies() {
+    return Collections.singletonList(dependency);
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -25,12 +25,11 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
 
 /**
- * Handles generating the aws.ec2 protocol for services. It handles reading and
- * writing from document bodies, including generating any functions needed for
- * performing serde.
+ * Handles generating the aws.ec2 protocol for services. It handles reading and writing from
+ * document bodies, including generating any functions needed for performing serde.
  *
- * This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle
- * standard components of the HTTP requests and responses.
+ * <p>This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle standard
+ * components of the HTTP requests and responses.
  *
  * @see Ec2ShapeSerVisitor
  * @see XmlShapeDeserVisitor
@@ -38,124 +37,134 @@ import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGene
  * @see XmlMemberDeserVisitor
  * @see AwsProtocolUtils
  * @see <a href="https://awslabs.github.io/smithy/spec/xml.html">Smithy XML traits.</a>
- * @see <a href="https://awslabs.github.io/smithy/spec/aws-core.html#ec2QueryName-trait">Smithy EC2 Query Name trait.</a>
+ * @see <a href="https://awslabs.github.io/smithy/spec/aws-core.html#ec2QueryName-trait">Smithy EC2
+ *     Query Name trait.</a>
  */
 final class AwsEc2 extends HttpRpcProtocolGenerator {
 
-    AwsEc2() {
-        super(true);
-    }
+  AwsEc2() {
+    super(true);
+  }
 
-    @Override
-    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
-        return "/";
-    }
+  @Override
+  protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
+    return "/";
+  }
 
-    @Override
-    public String getName() {
-        return "aws.ec2";
-    }
+  @Override
+  public String getName() {
+    return "aws.ec2";
+  }
 
-    @Override
-    protected String getDocumentContentType() {
-        return "application/x-www-form-urlencoded";
-    }
+  @Override
+  protected String getDocumentContentType() {
+    return "application/x-www-form-urlencoded";
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new Ec2ShapeSerVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeSerializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new Ec2ShapeSerVisitor(context));
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new XmlShapeDeserVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeDeserializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new XmlShapeDeserVisitor(context));
+  }
 
-    @Override
-    public void generateSharedComponents(GenerationContext context) {
-        super.generateSharedComponents(context);
-        AwsProtocolUtils.generateXmlParseBody(context);
-        AwsProtocolUtils.generateBuildFormUrlencodedString(context);
-        AwsProtocolUtils.addItempotencyAutofillImport(context);
+  @Override
+  public void generateSharedComponents(GenerationContext context) {
+    super.generateSharedComponents(context);
+    AwsProtocolUtils.generateXmlParseBody(context);
+    AwsProtocolUtils.generateBuildFormUrlencodedString(context);
+    AwsProtocolUtils.addItempotencyAutofillImport(context);
 
-        TypeScriptWriter writer = context.getWriter();
+    TypeScriptWriter writer = context.getWriter();
 
-        // Generate a function that handles the complex rules around deserializing
-        // an error code from an xml error body.
-        SymbolReference responseType = getApplicationProtocol().getResponseType();
-        writer.openBlock("const loadEc2ErrorCode = (\n"
-                       + "  output: $T,\n"
-                       + "  data: any\n"
-                       + "): string => {", "};", responseType, () -> {
-            // Attempt to fetch the error code from the specific location.
-            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
-            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+    // Generate a function that handles the complex rules around deserializing
+    // an error code from an xml error body.
+    SymbolReference responseType = getApplicationProtocol().getResponseType();
+    writer.openBlock(
+        "const loadEc2ErrorCode = (\n" + "  output: $T,\n" + "  data: any\n" + "): string => {",
+        "};",
+        responseType,
+        () -> {
+          // Attempt to fetch the error code from the specific location.
+          String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
+          writer.openBlock(
+              "if ($L !== undefined) {",
+              "}",
+              errorCodeLocation,
+              () -> {
                 writer.write("return $L;", errorCodeLocation);
-            });
+              });
 
-            // Default a 404 status code to the NotFound code.
-            writer.openBlock("if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
+          // Default a 404 status code to the NotFound code.
+          writer.openBlock(
+              "if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
 
-            // Default to an empty error code so an unmodeled exception is built.
-            writer.write("return '';");
+          // Default to an empty error code so an unmodeled exception is built.
+          writer.write("return '';");
         });
-        writer.write("");
-    }
+    writer.write("");
+  }
 
-    @Override
-    protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
-        return outputLocation + ".Errors.Error";
-    }
+  @Override
+  protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
+    return outputLocation + ".Errors.Error";
+  }
 
-    @Override
-    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
-        super.writeDefaultHeaders(context, operation);
-        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
-    }
+  @Override
+  protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
+    super.writeDefaultHeaders(context, operation);
+    AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+  }
 
-    @Override
-    protected void serializeInputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape inputStructure
-    ) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void serializeInputDocument(
+      GenerationContext context, OperationShape operation, StructureShape inputStructure) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Gather all the explicit input entries.
-        writer.write("const entries = $L;",
-                inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
+    // Gather all the explicit input entries.
+    writer.write(
+        "const entries = $L;",
+        inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
 
-        // Set the form encoded string.
-        writer.openBlock("body = buildFormUrlencodedString({", "});", () -> {
-            writer.write("...entries,");
-            // Set the protocol required values.
-            writer.write("Action: $S,", operation.getId().getName());
-            writer.write("Version: $S,", context.getService().getVersion());
+    // Set the form encoded string.
+    writer.openBlock(
+        "body = buildFormUrlencodedString({",
+        "});",
+        () -> {
+          writer.write("...entries,");
+          // Set the protocol required values.
+          writer.write("Action: $S,", operation.getId().getName());
+          writer.write("Version: $S,", context.getService().getVersion());
         });
-    }
+  }
 
-    @Override
-    protected boolean writeUndefinedInputBody(GenerationContext context, OperationShape operation) {
-        return AwsProtocolUtils.generateUndefinedQueryInputBody(context, operation);
-    }
+  @Override
+  protected boolean writeUndefinedInputBody(GenerationContext context, OperationShape operation) {
+    return AwsProtocolUtils.generateUndefinedQueryInputBody(context, operation);
+  }
 
-    @Override
-    protected void writeErrorCodeParser(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void writeErrorCodeParser(GenerationContext context) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Outsource error code parsing since it's complex for this protocol.
-        writer.write("errorCode = loadEc2ErrorCode(output, parsedOutput.body);");
-    }
+    // Outsource error code parsing since it's complex for this protocol.
+    writer.write("errorCode = loadEc2ErrorCode(output, parsedOutput.body);");
+  }
 
-    @Override
-    protected void deserializeOutputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape outputStructure
-    ) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void deserializeOutputDocument(
+      GenerationContext context, OperationShape operation, StructureShape outputStructure) {
+    TypeScriptWriter writer = context.getWriter();
 
-        writer.write("contents = $L;",
-                outputStructure.accept(new XmlMemberDeserVisitor(context, "data", Format.DATE_TIME)));
-    }
+    writer.write(
+        "contents = $L;",
+        outputStructure.accept(new XmlMemberDeserVisitor(context, "data", Format.DATE_TIME)));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -28,49 +28,50 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.MapUtils;
 
-/**
- * Generates an endpoint resolver from endpoints.json.
- */
+/** Generates an endpoint resolver from endpoints.json. */
 public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegration {
-    @Override
-    public void writeAdditionalFiles(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory
-    ) {
-        writerFactory.accept("endpoints.ts", writer -> {
-            new EndpointGenerator(settings.getService(model), writer).run();
+  @Override
+  public void writeAdditionalFiles(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory) {
+    writerFactory.accept(
+        "endpoints.ts",
+        writer -> {
+          new EndpointGenerator(settings.getService(model), writer).run();
         });
-    }
+  }
 
-    @Override
-    public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
-    ) {
-        writer.addImport("RegionInfoProvider", "RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.writeDocs("Fetch related hostname, signing name or signing region with given region.");
-        writer.write("regionInfoProvider?: RegionInfoProvider;\n");
-    }
+  @Override
+  public void addConfigInterfaceFields(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      TypeScriptWriter writer) {
+    writer.addImport(
+        "RegionInfoProvider", "RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+    writer.writeDocs("Fetch related hostname, signing name or signing region with given region.");
+    writer.write("regionInfoProvider?: RegionInfoProvider;\n");
+  }
 
-    @Override
-    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
-    ) {
-        switch (target) {
-            case SHARED:
-                return MapUtils.of("regionInfoProvider", writer -> {
-                    writer.addImport("defaultRegionInfoProvider", "defaultRegionInfoProvider", "./endpoints");
-                    writer.write("regionInfoProvider: defaultRegionInfoProvider,");
-                });
-            default:
-                return Collections.emptyMap();
-        }
+  @Override
+  public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      LanguageTarget target) {
+    switch (target) {
+      case SHARED:
+        return MapUtils.of(
+            "regionInfoProvider",
+            writer -> {
+              writer.addImport(
+                  "defaultRegionInfoProvider", "defaultRegionInfoProvider", "./endpoints");
+              writer.write("regionInfoProvider: defaultRegionInfoProvider,");
+            });
+      default:
+        return Collections.emptyMap();
     }
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_0.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_0.java
@@ -19,18 +19,17 @@ package software.amazon.smithy.aws.typescript.codegen;
  * Handles generating the aws.json-1.0 protocol for services.
  *
  * @inheritDoc
- *
  * @see JsonRpcProtocolGenerator
  */
 final class AwsJsonRpc1_0 extends JsonRpcProtocolGenerator {
 
-    @Override
-    protected String getDocumentContentType() {
-        return "application/x-amz-json-1.0";
-    }
+  @Override
+  protected String getDocumentContentType() {
+    return "application/x-amz-json-1.0";
+  }
 
-    @Override
-    public String getName() {
-        return "aws.json-1.0";
-    }
+  @Override
+  public String getName() {
+    return "aws.json-1.0";
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
@@ -19,18 +19,17 @@ package software.amazon.smithy.aws.typescript.codegen;
  * Handles generating the aws.json-1.1 protocol for services.
  *
  * @inheritDoc
- *
  * @see JsonRpcProtocolGenerator
  */
 final class AwsJsonRpc1_1 extends JsonRpcProtocolGenerator {
 
-    @Override
-    protected String getDocumentContentType() {
-        return "application/x-amz-json-1.1";
-    }
+  @Override
+  protected String getDocumentContentType() {
+    return "application/x-amz-json-1.1";
+  }
 
-    @Override
-    public String getName() {
-        return "aws.json-1.1";
-    }
+  @Override
+  public String getName() {
+    return "aws.json-1.1";
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -19,7 +19,6 @@ import java.util.Calendar;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
-
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -28,30 +27,40 @@ import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegrati
 import software.amazon.smithy.utils.IoUtils;
 
 public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptIntegration {
-    @Override
-    public void writeAdditionalFiles(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory
-    ) {
-        writerFactory.accept(".gitignore", writer -> {
-            String resource =  IoUtils.readUtf8Resource(getClass(), "gitignore");
-            writer.write(resource);
+  @Override
+  public void writeAdditionalFiles(
+      TypeScriptSettings settings,
+      Model model,
+      SymbolProvider symbolProvider,
+      BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory) {
+    writerFactory.accept(
+        ".gitignore",
+        writer -> {
+          String resource = IoUtils.readUtf8Resource(getClass(), "gitignore");
+          writer.write(resource);
         });
-        writerFactory.accept(".npmignore", writer -> {
-            String resource =  IoUtils.readUtf8Resource(getClass(), "npmignore");
-            writer.write(resource);
+    writerFactory.accept(
+        ".npmignore",
+        writer -> {
+          String resource = IoUtils.readUtf8Resource(getClass(), "npmignore");
+          writer.write(resource);
         });
-        writerFactory.accept("LICENSE", writer -> {
-            String resource =  IoUtils.readUtf8Resource(getClass(), "LICENSE.template");
-            resource = resource.replace("${year}", Integer.toString(Calendar.getInstance().get(Calendar.YEAR)));
-            writer.write(resource);
+    writerFactory.accept(
+        "LICENSE",
+        writer -> {
+          String resource = IoUtils.readUtf8Resource(getClass(), "LICENSE.template");
+          resource =
+              resource.replace(
+                  "${year}", Integer.toString(Calendar.getInstance().get(Calendar.YEAR)));
+          writer.write(resource);
         });
-        writerFactory.accept("README.md", writer -> {
-            String resource =  IoUtils.readUtf8Resource(getClass(), "README.md.template");
-            resource = resource.replaceAll(Pattern.quote("${packageName}"), settings.getPackageName());
-            writer.write(resource);
+    writerFactory.accept(
+        "README.md",
+        writer -> {
+          String resource = IoUtils.readUtf8Resource(getClass(), "README.md.template");
+          resource =
+              resource.replaceAll(Pattern.quote("${packageName}"), settings.getPackageName());
+          writer.write(resource);
         });
-    }
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -37,238 +37,278 @@ import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGenerat
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.IoUtils;
 
-/**
- * Utility methods for generating AWS protocols.
- */
+/** Utility methods for generating AWS protocols. */
 final class AwsProtocolUtils {
 
-    private AwsProtocolUtils() {}
+  private AwsProtocolUtils() {}
 
-    /**
-     * Writes an {@code 'x-amz-content-sha256' = 'UNSIGNED_PAYLOAD'} header for an
-     * {@code @aws.api#unsignedPayload} trait that specifies the {@code "aws.v4"} auth scheme.
-     *
-     * @see <a href=https://awslabs.github.io/smithy/spec/aws-core.html#aws-api-unsignedpayload-trait>@aws.api#unsignedPayload trait</a>
-     *
-     * @param context The generation context.
-     * @param operation The operation being generated.
-     */
-    static void generateUnsignedPayloadSigV4Header(GenerationContext context, OperationShape operation) {
-        TypeScriptWriter writer = context.getWriter();
+  /**
+   * Writes an {@code 'x-amz-content-sha256' = 'UNSIGNED_PAYLOAD'} header for an
+   * {@code @aws.api#unsignedPayload} trait that specifies the {@code "aws.v4"} auth scheme.
+   *
+   * @see <a
+   *     href=https://awslabs.github.io/smithy/spec/aws-core.html#aws-api-unsignedpayload-trait>@aws.api#unsignedPayload
+   *     trait</a>
+   * @param context The generation context.
+   * @param operation The operation being generated.
+   */
+  static void generateUnsignedPayloadSigV4Header(
+      GenerationContext context, OperationShape operation) {
+    TypeScriptWriter writer = context.getWriter();
 
-        operation.getTrait(UnsignedPayloadTrait.class)
-                .filter(trait -> trait.getValues().contains("aws.v4"))
-                .ifPresent(trait -> {
-                    writer.write("headers['x-amz-content-sha256'] = 'UNSIGNED_PAYLOAD';");
-                });
-    }
-
-    /**
-     * Writes a serde function for a set of shapes using the passed visitor.
-     * This will walk the input set of shapes and invoke the visitor for any
-     * members of aggregate shapes in the set.
-     *
-     * @see software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVisitor
-     * @see software.amazon.smithy.typescript.codegen.integration.DocumentShapeDeserVisitor
-     *
-     * @param context The generation context.
-     * @param shapes A list of shapes to generate serde for, including their members.
-     * @param visitor A ShapeVisitor that generates a serde function for shapes.
-     */
-    static void generateDocumentBodyShapeSerde(
-            GenerationContext context,
-            Set<Shape> shapes,
-            ShapeVisitor<Void> visitor
-    ) {
-        // Walk all the shapes within those in the document and generate for them as well.
-        Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
-        Set<Shape> shapesToGenerate = new TreeSet<>(shapes);
-        shapes.forEach(shape -> shapesToGenerate.addAll(shapeWalker.walkShapes(shape)));
-        shapesToGenerate.forEach(shape -> shape.accept(visitor));
-    }
-
-    /**
-     * Writes a response body parser function for JSON protocols. This
-     * will parse a present body after converting it to utf-8.
-     *
-     * @param context The generation context.
-     */
-    static void generateJsonParseBody(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Include a JSON body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
-        writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): any => {", "};", () -> {
-            writer.openBlock("return collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
-                writer.openBlock("if (encoded.length) {", "}", () -> {
-                    writer.write("return JSON.parse(encoded);");
-                });
-                writer.write("return {};");
+    operation
+        .getTrait(UnsignedPayloadTrait.class)
+        .filter(trait -> trait.getValues().contains("aws.v4"))
+        .ifPresent(
+            trait -> {
+              writer.write("headers['x-amz-content-sha256'] = 'UNSIGNED_PAYLOAD';");
             });
-        });
+  }
 
-        writer.write("");
-    }
+  /**
+   * Writes a serde function for a set of shapes using the passed visitor. This will walk the input
+   * set of shapes and invoke the visitor for any members of aggregate shapes in the set.
+   *
+   * @see software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVisitor
+   * @see software.amazon.smithy.typescript.codegen.integration.DocumentShapeDeserVisitor
+   * @param context The generation context.
+   * @param shapes A list of shapes to generate serde for, including their members.
+   * @param visitor A ShapeVisitor that generates a serde function for shapes.
+   */
+  static void generateDocumentBodyShapeSerde(
+      GenerationContext context, Set<Shape> shapes, ShapeVisitor<Void> visitor) {
+    // Walk all the shapes within those in the document and generate for them as well.
+    Walker shapeWalker =
+        new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
+    Set<Shape> shapesToGenerate = new TreeSet<>(shapes);
+    shapes.forEach(shape -> shapesToGenerate.addAll(shapeWalker.walkShapes(shape)));
+    shapesToGenerate.forEach(shape -> shape.accept(visitor));
+  }
 
-    /**
-     * Writes a response body parser function for XML protocols. This
-     * will parse a present body after converting it to utf-8.
-     *
-     * @param context The generation context.
-     */
-    static void generateXmlParseBody(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
+  /**
+   * Writes a response body parser function for JSON protocols. This will parse a present body after
+   * converting it to utf-8.
+   *
+   * @param context The generation context.
+   */
+  static void generateJsonParseBody(GenerationContext context) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Include function that decodes XML escape characters.
-        writer.write(IoUtils.readUtf8Resource(AwsProtocolUtils.class, "decodeEscapedXML.ts"));
-
-        // Include an XML body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
-        writer.addDependency(AwsDependency.XML_PARSER);
-        writer.addImport("parse", "xmlParse", "fast-xml-parser");
-        writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): any => {", "};", () -> {
-            writer.openBlock("return collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
-                writer.openBlock("if (encoded.length) {", "}", () -> {
-                    writer.write("const parsedObj = xmlParse(encoded, { attributeNamePrefix: '', "
-                            + "ignoreAttributes: false, parseNodeValue: false, tagValueProcessor: (val, tagName) "
-                            + "=> decodeEscapedXML(val) });");
-                    writer.write("const textNodeName = '#text';");
-                    writer.write("const key = Object.keys(parsedObj)[0];");
-                    writer.write("const parsedObjToReturn = parsedObj[key];");
-                    writer.openBlock("if (parsedObjToReturn[textNodeName]) {", "}", () -> {
-                        writer.write("parsedObjToReturn[key] = parsedObjToReturn[textNodeName];");
-                        writer.write("delete parsedObjToReturn[textNodeName];");
+    // Include a JSON body parser used to deserialize documents from HTTP responses.
+    writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+    writer.openBlock(
+        "const parseBody = (streamBody: any, context: __SerdeContext): any => {",
+        "};",
+        () -> {
+          writer.openBlock(
+              "return collectBodyString(streamBody, context).then(encoded => {",
+              "});",
+              () -> {
+                writer.openBlock(
+                    "if (encoded.length) {",
+                    "}",
+                    () -> {
+                      writer.write("return JSON.parse(encoded);");
                     });
-                    writer.write("return parsedObjToReturn;");
-                });
                 writer.write("return {};");
+              });
+        });
+
+    writer.write("");
+  }
+
+  /**
+   * Writes a response body parser function for XML protocols. This will parse a present body after
+   * converting it to utf-8.
+   *
+   * @param context The generation context.
+   */
+  static void generateXmlParseBody(GenerationContext context) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Include function that decodes XML escape characters.
+    writer.write(IoUtils.readUtf8Resource(AwsProtocolUtils.class, "decodeEscapedXML.ts"));
+
+    // Include an XML body parser used to deserialize documents from HTTP responses.
+    writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+    writer.addDependency(AwsDependency.XML_PARSER);
+    writer.addImport("parse", "xmlParse", "fast-xml-parser");
+    writer.openBlock(
+        "const parseBody = (streamBody: any, context: __SerdeContext): any => {",
+        "};",
+        () -> {
+          writer.openBlock(
+              "return collectBodyString(streamBody, context).then(encoded => {",
+              "});",
+              () -> {
+                writer.openBlock(
+                    "if (encoded.length) {",
+                    "}",
+                    () -> {
+                      writer.write(
+                          "const parsedObj = xmlParse(encoded, { attributeNamePrefix: '', "
+                              + "ignoreAttributes: false, parseNodeValue: false, tagValueProcessor: (val, tagName) "
+                              + "=> decodeEscapedXML(val) });");
+                      writer.write("const textNodeName = '#text';");
+                      writer.write("const key = Object.keys(parsedObj)[0];");
+                      writer.write("const parsedObjToReturn = parsedObj[key];");
+                      writer.openBlock(
+                          "if (parsedObjToReturn[textNodeName]) {",
+                          "}",
+                          () -> {
+                            writer.write(
+                                "parsedObjToReturn[key] = parsedObjToReturn[textNodeName];");
+                            writer.write("delete parsedObjToReturn[textNodeName];");
+                          });
+                      writer.write("return parsedObjToReturn;");
+                    });
+                writer.write("return {};");
+              });
+        });
+    writer.write("");
+  }
+
+  /**
+   * Writes a form urlencoded string builder function for query based protocols. This will escape
+   * the keys and values, combine those with an '=', and combine those strings with an '&'.
+   *
+   * @param context The generation context.
+   */
+  static void generateBuildFormUrlencodedString(GenerationContext context) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Write a single function to handle combining a map in to a valid query string.
+    writer.addImport(
+        "extendedEncodeURIComponent", "__extendedEncodeURIComponent", "@aws-sdk/smithy-client");
+    writer.openBlock(
+        "const buildFormUrlencodedString = (entries: any): string => {",
+        "}",
+        () -> {
+          writer.openBlock(
+              "return Object.keys(entries).map(",
+              ").join(\"&\");",
+              () ->
+                  writer.write(
+                      "key => __extendedEncodeURIComponent(key) + '=' + "
+                          + "__extendedEncodeURIComponent(entries[key])"));
+        });
+    writer.write("");
+  }
+
+  /**
+   * Writes a default body for query-based operations when the operation doesn't have an input
+   * defined.
+   *
+   * @param context The generation context.
+   * @param operation The operation being generated for.
+   * @return That a body variable was generated and should be set on the request.
+   */
+  static boolean generateUndefinedQueryInputBody(
+      GenerationContext context, OperationShape operation) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Set the form encoded string.
+    writer.openBlock(
+        "const body = buildFormUrlencodedString({",
+        "});",
+        () -> {
+          // Set the protocol required values.
+          writer.write("Action: $S,", operation.getId().getName());
+          writer.write("Version: $S,", context.getService().getVersion());
+        });
+
+    return true;
+  }
+
+  /**
+   * Writes an attribute containing information about a Shape's optionally specified XML namespace
+   * configuration to an attribute of the passed node name.
+   *
+   * @param context The generation context.
+   * @param shape The shape to apply the namespace attribute to, if present on it.
+   * @param nodeName The node to apply the namespace attribute to.
+   * @return Returns if an XML namespace attribute was written.
+   */
+  static boolean writeXmlNamespace(GenerationContext context, Shape shape, String nodeName) {
+    Optional<XmlNamespaceTrait> traitOptional = shape.getTrait(XmlNamespaceTrait.class);
+
+    if (!traitOptional.isPresent()) {
+      return false;
+    }
+
+    XmlNamespaceTrait trait = traitOptional.get();
+    TypeScriptWriter writer = context.getWriter();
+    String xmlns = "xmlns";
+    Optional<String> prefix = trait.getPrefix();
+    if (prefix.isPresent()) {
+      xmlns += ":" + prefix.get();
+    }
+    writer.write("$L.addAttribute($S, $S);", nodeName, xmlns, trait.getUri());
+    return true;
+  }
+
+  /**
+   * Imports a UUID v4 generating function used for auto-filling idempotency tokens.
+   *
+   * @param context The generation context.
+   */
+  static void addItempotencyAutofillImport(GenerationContext context) {
+    context
+        .getModel()
+        .shapes(MemberShape.class)
+        .filter(memberShape -> memberShape.hasTrait(IdempotencyTokenTrait.class))
+        .findFirst()
+        .ifPresent(
+            memberShape -> {
+              TypeScriptWriter writer = context.getWriter();
+
+              // Include the uuid package and import the v4 function as our more clearly named
+              // alias.
+              writer.addDependency(AwsDependency.UUID_GENERATOR);
+              writer.addDependency(AwsDependency.UUID_GENERATOR_TYPES);
+              writer.addImport("v4", "generateIdempotencyToken", "uuid");
             });
-        });
-        writer.write("");
+  }
+
+  /**
+   * Writes a statement that auto-fills the value of a member that is an idempotency token if it is
+   * undefined at the time of serialization.
+   *
+   * @param context The generation context.
+   * @param memberShape The member that may be an idempotency token.
+   * @param inputLocation The location of input data for the member.
+   */
+  static void writeIdempotencyAutofill(
+      GenerationContext context, MemberShape memberShape, String inputLocation) {
+    if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
+      TypeScriptWriter writer = context.getWriter();
+
+      writer.openBlock(
+          "if ($L === undefined) {",
+          "}",
+          inputLocation,
+          () -> writer.write("$L = generateIdempotencyToken();", inputLocation));
     }
+  }
 
-    /**
-     * Writes a form urlencoded string builder function for query based protocols.
-     * This will escape the keys and values, combine those with an '=', and combine
-     * those strings with an '&'.
-     *
-     * @param context The generation context.
-     */
-    static void generateBuildFormUrlencodedString(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Write a single function to handle combining a map in to a valid query string.
-        writer.addImport("extendedEncodeURIComponent", "__extendedEncodeURIComponent", "@aws-sdk/smithy-client");
-        writer.openBlock("const buildFormUrlencodedString = (entries: any): string => {", "}", () -> {
-            writer.openBlock("return Object.keys(entries).map(", ").join(\"&\");", () ->
-                    writer.write("key => __extendedEncodeURIComponent(key) + '=' + "
-                            + "__extendedEncodeURIComponent(entries[key])"));
-        });
-        writer.write("");
-    }
-
-    /**
-     * Writes a default body for query-based operations when the operation doesn't
-     * have an input defined.
-     *
-     * @param context The generation context.
-     * @param operation The operation being generated for.
-     * @return That a body variable was generated and should be set on the request.
-     */
-    static boolean generateUndefinedQueryInputBody(GenerationContext context, OperationShape operation) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Set the form encoded string.
-        writer.openBlock("const body = buildFormUrlencodedString({", "});", () -> {
-            // Set the protocol required values.
-            writer.write("Action: $S,", operation.getId().getName());
-            writer.write("Version: $S,", context.getService().getVersion());
-        });
-
-        return true;
-    }
-
-    /**
-     * Writes an attribute containing information about a Shape's optionally specified
-     * XML namespace configuration to an attribute of the passed node name.
-     *
-     * @param context The generation context.
-     * @param shape The shape to apply the namespace attribute to, if present on it.
-     * @param nodeName The node to apply the namespace attribute to.
-     * @return Returns if an XML namespace attribute was written.
-     */
-    static boolean writeXmlNamespace(GenerationContext context, Shape shape, String nodeName) {
-        Optional<XmlNamespaceTrait> traitOptional = shape.getTrait(XmlNamespaceTrait.class);
-
-        if (!traitOptional.isPresent()) {
-            return false;
-        }
-
-        XmlNamespaceTrait trait = traitOptional.get();
-        TypeScriptWriter writer = context.getWriter();
-        String xmlns = "xmlns";
-        Optional<String> prefix = trait.getPrefix();
-        if (prefix.isPresent()) {
-            xmlns += ":" + prefix.get();
-        }
-        writer.write("$L.addAttribute($S, $S);", nodeName, xmlns, trait.getUri());
-        return true;
-    }
-
-    /**
-     * Imports a UUID v4 generating function used for auto-filling idempotency tokens.
-     *
-     * @param context The generation context.
-     */
-    static void addItempotencyAutofillImport(GenerationContext context) {
-        context.getModel().shapes(MemberShape.class)
-                .filter(memberShape -> memberShape.hasTrait(IdempotencyTokenTrait.class))
-                .findFirst()
-                .ifPresent(memberShape -> {
-                    TypeScriptWriter writer = context.getWriter();
-
-                    // Include the uuid package and import the v4 function as our more clearly named alias.
-                    writer.addDependency(AwsDependency.UUID_GENERATOR);
-                    writer.addDependency(AwsDependency.UUID_GENERATOR_TYPES);
-                    writer.addImport("v4", "generateIdempotencyToken", "uuid");
-                });
-    }
-
-    /**
-     * Writes a statement that auto-fills the value of a member that is an idempotency
-     * token if it is undefined at the time of serialization.
-     *
-     * @param context The generation context.
-     * @param memberShape The member that may be an idempotency token.
-     * @param inputLocation The location of input data for the member.
-     */
-    static void writeIdempotencyAutofill(GenerationContext context, MemberShape memberShape, String inputLocation) {
-        if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
-            TypeScriptWriter writer = context.getWriter();
-
-            writer.openBlock("if ($L === undefined) {", "}", inputLocation, () ->
-                    writer.write("$L = generateIdempotencyToken();", inputLocation));
-        }
-    }
-
-    /**
-     * Gets a value provider for the timestamp member handling proper serialization
-     * formatting.
-     *
-     * @param context The generation context.
-     * @param memberShape The member that needs timestamp serialization.
-     * @param defaultFormat The timestamp format to default to.
-     * @param inputLocation The location of input data for the member.
-     * @return A string representing the proper value provider for this timestamp.
-     */
-    static String getInputTimestampValueProvider(
-            GenerationContext context,
-            MemberShape memberShape,
-            Format defaultFormat,
-            String inputLocation
-    ) {
-        HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
-        TimestampFormatTrait.Format format = httpIndex.determineTimestampFormat(memberShape, DOCUMENT, defaultFormat);
-        return HttpProtocolGeneratorUtils.getTimestampInputParam(context, inputLocation, memberShape, format);
-    }
+  /**
+   * Gets a value provider for the timestamp member handling proper serialization formatting.
+   *
+   * @param context The generation context.
+   * @param memberShape The member that needs timestamp serialization.
+   * @param defaultFormat The timestamp format to default to.
+   * @param inputLocation The location of input data for the member.
+   * @return A string representing the proper value provider for this timestamp.
+   */
+  static String getInputTimestampValueProvider(
+      GenerationContext context,
+      MemberShape memberShape,
+      Format defaultFormat,
+      String inputLocation) {
+    HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
+    TimestampFormatTrait.Format format =
+        httpIndex.determineTimestampFormat(memberShape, DOCUMENT, defaultFormat);
+    return HttpProtocolGeneratorUtils.getTimestampInputParam(
+        context, inputLocation, memberShape, format);
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -25,12 +25,11 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
 
 /**
- * Handles generating the aws.query protocol for services. It handles reading and
- * writing from document bodies, including generating any functions needed for
- * performing serde.
+ * Handles generating the aws.query protocol for services. It handles reading and writing from
+ * document bodies, including generating any functions needed for performing serde.
  *
- * This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle
- * standard components of the HTTP requests and responses.
+ * <p>This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle standard
+ * components of the HTTP requests and responses.
  *
  * @see QueryShapeSerVisitor
  * @see XmlShapeDeserVisitor
@@ -41,122 +40,131 @@ import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGene
  */
 final class AwsQuery extends HttpRpcProtocolGenerator {
 
-    AwsQuery() {
-        // AWS Query protocols will attempt to parse error codes from response bodies.
-        super(true);
-    }
+  AwsQuery() {
+    // AWS Query protocols will attempt to parse error codes from response bodies.
+    super(true);
+  }
 
-    @Override
-    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
-        return "/";
-    }
+  @Override
+  protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
+    return "/";
+  }
 
-    @Override
-    public String getName() {
-        return "aws.query";
-    }
+  @Override
+  public String getName() {
+    return "aws.query";
+  }
 
-    @Override
-    protected String getDocumentContentType() {
-        return "application/x-www-form-urlencoded";
-    }
+  @Override
+  protected String getDocumentContentType() {
+    return "application/x-www-form-urlencoded";
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new QueryShapeSerVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeSerializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new QueryShapeSerVisitor(context));
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new XmlShapeDeserVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeDeserializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new XmlShapeDeserVisitor(context));
+  }
 
-    @Override
-    public void generateSharedComponents(GenerationContext context) {
-        super.generateSharedComponents(context);
-        AwsProtocolUtils.generateXmlParseBody(context);
-        AwsProtocolUtils.generateBuildFormUrlencodedString(context);
-        AwsProtocolUtils.addItempotencyAutofillImport(context);
+  @Override
+  public void generateSharedComponents(GenerationContext context) {
+    super.generateSharedComponents(context);
+    AwsProtocolUtils.generateXmlParseBody(context);
+    AwsProtocolUtils.generateBuildFormUrlencodedString(context);
+    AwsProtocolUtils.addItempotencyAutofillImport(context);
 
-        TypeScriptWriter writer = context.getWriter();
+    TypeScriptWriter writer = context.getWriter();
 
-        // Generate a function that handles the complex rules around deserializing
-        // an error code from an xml error body.
-        SymbolReference responseType = getApplicationProtocol().getResponseType();
-        writer.openBlock("const loadQueryErrorCode = (\n"
-                       + "  output: $T,\n"
-                       + "  data: any\n"
-                       + "): string => {", "};", responseType, () -> {
-            // Attempt to fetch the error code from the specific location.
-            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
-            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+    // Generate a function that handles the complex rules around deserializing
+    // an error code from an xml error body.
+    SymbolReference responseType = getApplicationProtocol().getResponseType();
+    writer.openBlock(
+        "const loadQueryErrorCode = (\n" + "  output: $T,\n" + "  data: any\n" + "): string => {",
+        "};",
+        responseType,
+        () -> {
+          // Attempt to fetch the error code from the specific location.
+          String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
+          writer.openBlock(
+              "if ($L !== undefined) {",
+              "}",
+              errorCodeLocation,
+              () -> {
                 writer.write("return $L;", errorCodeLocation);
-            });
+              });
 
-            // Default a 404 status code to the NotFound code.
-            writer.openBlock("if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
+          // Default a 404 status code to the NotFound code.
+          writer.openBlock(
+              "if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
 
-            // Default to an empty error code so an unmodeled exception is built.
-            writer.write("return '';");
+          // Default to an empty error code so an unmodeled exception is built.
+          writer.write("return '';");
         });
-        writer.write("");
-    }
+    writer.write("");
+  }
 
-    @Override
-    protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
-        return outputLocation + ".Error";
-    }
+  @Override
+  protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
+    return outputLocation + ".Error";
+  }
 
-    @Override
-    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
-        super.writeDefaultHeaders(context, operation);
-        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
-    }
+  @Override
+  protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
+    super.writeDefaultHeaders(context, operation);
+    AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+  }
 
-    @Override
-    protected void serializeInputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape inputStructure
-    ) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void serializeInputDocument(
+      GenerationContext context, OperationShape operation, StructureShape inputStructure) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Gather all the explicit input entries.
-        writer.write("const entries = $L;",
-                inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
+    // Gather all the explicit input entries.
+    writer.write(
+        "const entries = $L;",
+        inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
 
-        // Set the form encoded string.
-        writer.openBlock("body = buildFormUrlencodedString({", "});", () -> {
-            writer.write("...entries,");
-            // Set the protocol required values.
-            writer.write("Action: $S,", operation.getId().getName());
-            writer.write("Version: $S,", context.getService().getVersion());
+    // Set the form encoded string.
+    writer.openBlock(
+        "body = buildFormUrlencodedString({",
+        "});",
+        () -> {
+          writer.write("...entries,");
+          // Set the protocol required values.
+          writer.write("Action: $S,", operation.getId().getName());
+          writer.write("Version: $S,", context.getService().getVersion());
         });
-    }
+  }
 
-    @Override
-    protected boolean writeUndefinedInputBody(GenerationContext context, OperationShape operation) {
-        return AwsProtocolUtils.generateUndefinedQueryInputBody(context, operation);
-    }
+  @Override
+  protected boolean writeUndefinedInputBody(GenerationContext context, OperationShape operation) {
+    return AwsProtocolUtils.generateUndefinedQueryInputBody(context, operation);
+  }
 
-    @Override
-    protected void writeErrorCodeParser(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void writeErrorCodeParser(GenerationContext context) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Outsource error code parsing since it's complex for this protocol.
-        writer.write("errorCode = loadQueryErrorCode(output, parsedOutput.body);");
-    }
+    // Outsource error code parsing since it's complex for this protocol.
+    writer.write("errorCode = loadQueryErrorCode(output, parsedOutput.body);");
+  }
 
-    @Override
-    protected void deserializeOutputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape outputStructure
-    ) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void deserializeOutputDocument(
+      GenerationContext context, OperationShape operation, StructureShape outputStructure) {
+    TypeScriptWriter writer = context.getWriter();
 
-        String dataSource = "data." + operation.getId().getName() + "Result";
-        writer.write("contents = $L;",
-                outputStructure.accept(new XmlMemberDeserVisitor(context, dataSource, Format.DATE_TIME)));
-    }
+    String dataSource = "data." + operation.getId().getName() + "Result";
+    writer.write(
+        "contents = $L;",
+        outputStructure.accept(new XmlMemberDeserVisitor(context, dataSource, Format.DATE_TIME)));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_1.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1_1.java
@@ -19,18 +19,17 @@ package software.amazon.smithy.aws.typescript.codegen;
  * Handles generating the aws.rest-json protocol for services.
  *
  * @inheritDoc
- *
  * @see RestJsonProtocolGenerator
  */
 public final class AwsRestJson1_1 extends RestJsonProtocolGenerator {
 
-    @Override
-    protected String getDocumentContentType() {
-        return "application/json";
-    }
+  @Override
+  protected String getDocumentContentType() {
+    return "application/json";
+  }
 
-    @Override
-    public String getName() {
-        return "aws.rest-json-1.1";
-    }
+  @Override
+  public String getName() {
+    return "aws.rest-json-1.1";
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -33,17 +33,17 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
 
 /**
- * Handles generating the aws.rest-xml protocol for services. It handles reading and
- * writing from document bodies, including generating any functions needed for
- * performing serde.
+ * Handles generating the aws.rest-xml protocol for services. It handles reading and writing from
+ * document bodies, including generating any functions needed for performing serde.
  *
- * This builds on the foundations of the {@link HttpBindingProtocolGenerator} to handle
+ * <p>This builds on the foundations of the {@link HttpBindingProtocolGenerator} to handle
  * components of binding to HTTP requests and responses.
  *
- * A service-specific customization exists for Amazon S3, which doesn't wrap the Error
- * object in the response.
+ * <p>A service-specific customization exists for Amazon S3, which doesn't wrap the Error object in
+ * the response.
  *
- * TODO: Build an XmlIndex to handle pre-computing resolved values for names, namespaces, and more.
+ * <p>TODO: Build an XmlIndex to handle pre-computing resolved values for names, namespaces, and
+ * more.
  *
  * @see XmlShapeSerVisitor
  * @see XmlShapeDeserVisitor
@@ -55,206 +55,227 @@ import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocol
  */
 final class AwsRestXml extends HttpBindingProtocolGenerator {
 
-    AwsRestXml() {
-        super(true);
-    }
+  AwsRestXml() {
+    super(true);
+  }
 
-    @Override
-    protected String getDocumentContentType() {
-        return "application/xml";
-    }
+  @Override
+  protected String getDocumentContentType() {
+    return "application/xml";
+  }
 
-    @Override
-    protected Format getDocumentTimestampFormat() {
-        return Format.DATE_TIME;
-    }
+  @Override
+  protected Format getDocumentTimestampFormat() {
+    return Format.DATE_TIME;
+  }
 
-    @Override
-    public String getName() {
-        return "aws.rest-xml";
-    }
+  @Override
+  public String getName() {
+    return "aws.rest-xml";
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new XmlShapeSerVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeSerializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new XmlShapeSerVisitor(context));
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new XmlShapeDeserVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeDeserializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new XmlShapeDeserVisitor(context));
+  }
 
-    @Override
-    public void generateSharedComponents(GenerationContext context) {
-        super.generateSharedComponents(context);
-        AwsProtocolUtils.generateXmlParseBody(context);
-        AwsProtocolUtils.addItempotencyAutofillImport(context);
+  @Override
+  public void generateSharedComponents(GenerationContext context) {
+    super.generateSharedComponents(context);
+    AwsProtocolUtils.generateXmlParseBody(context);
+    AwsProtocolUtils.addItempotencyAutofillImport(context);
 
-        TypeScriptWriter writer = context.getWriter();
-        writer.addDependency(AwsDependency.XML_BUILDER);
+    TypeScriptWriter writer = context.getWriter();
+    writer.addDependency(AwsDependency.XML_BUILDER);
 
-        // Generate a function that handles the complex rules around deserializing
-        // an error code from a rest-xml error.
-        SymbolReference responseType = getApplicationProtocol().getResponseType();
-        writer.openBlock("const loadRestXmlErrorCode = (\n"
-                       + "  output: $T,\n"
-                       + "  data: any\n"
-                       + "): string => {", "};", responseType, () -> {
-            // Attempt to fetch the error code from the specific location.
-            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
-            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+    // Generate a function that handles the complex rules around deserializing
+    // an error code from a rest-xml error.
+    SymbolReference responseType = getApplicationProtocol().getResponseType();
+    writer.openBlock(
+        "const loadRestXmlErrorCode = (\n" + "  output: $T,\n" + "  data: any\n" + "): string => {",
+        "};",
+        responseType,
+        () -> {
+          // Attempt to fetch the error code from the specific location.
+          String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
+          writer.openBlock(
+              "if ($L !== undefined) {",
+              "}",
+              errorCodeLocation,
+              () -> {
                 writer.write("return $L;", errorCodeLocation);
-            });
+              });
 
-            // Default a 404 status code to the NotFound code.
-            writer.openBlock("if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
+          // Default a 404 status code to the NotFound code.
+          writer.openBlock(
+              "if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
 
-            // Default to an empty error code so an unmodeled exception is built.
-            writer.write("return '';");
+          // Default to an empty error code so an unmodeled exception is built.
+          writer.write("return '';");
         });
-        writer.write("");
+    writer.write("");
+  }
+
+  @Override
+  protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
+    // Some services, S3 for example, don't wrap the Error object in the response.
+    if (usesWrappedErrorResponse(context)) {
+      return outputLocation + ".Error";
+    }
+    return outputLocation;
+  }
+
+  private boolean usesWrappedErrorResponse(GenerationContext context) {
+    return context
+        .getService()
+        .getTrait(ServiceTrait.class)
+        .map(trait -> !trait.getSdkId().equals("S3"))
+        .orElse(true);
+  }
+
+  @Override
+  protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
+    super.writeDefaultHeaders(context, operation);
+    AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+  }
+
+  @Override
+  protected void serializeInputDocument(
+      GenerationContext context, OperationShape operation, List<HttpBinding> documentBindings) {
+    // Short circuit when we have no bindings.
+    TypeScriptWriter writer = context.getWriter();
+    if (documentBindings.isEmpty()) {
+      writer.write("body = \"\";");
+      return;
     }
 
-    @Override
-    protected String getErrorBodyLocation(GenerationContext context, String outputLocation) {
-        // Some services, S3 for example, don't wrap the Error object in the response.
-        if (usesWrappedErrorResponse(context)) {
-            return outputLocation + ".Error";
-        }
-        return outputLocation;
+    SymbolProvider symbolProvider = context.getSymbolProvider();
+    ShapeId inputShapeId = documentBindings.get(0).getMember().getContainer();
+
+    // Start with the XML declaration.
+    writer.write("body = \"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\";");
+
+    writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
+    writer.write("const bodyNode = new __XmlNode($S);", inputShapeId.getName());
+
+    // Add @xmlNamespace value of the service to the root node,
+    // fall back to one from the input shape.
+    boolean serviceXmlns =
+        AwsProtocolUtils.writeXmlNamespace(context, context.getService(), "bodyNode");
+    if (!serviceXmlns) {
+      StructureShape inputShape =
+          context.getModel().expectShape(inputShapeId, StructureShape.class);
+      AwsProtocolUtils.writeXmlNamespace(context, inputShape, "bodyNode");
     }
 
-    private boolean usesWrappedErrorResponse(GenerationContext context) {
-        return context.getService().getTrait(ServiceTrait.class)
-                .map(trait -> !trait.getSdkId().equals("S3"))
-                .orElse(true);
+    XmlShapeSerVisitor shapeSerVisitor = new XmlShapeSerVisitor(context);
+
+    for (HttpBinding binding : documentBindings) {
+      MemberShape memberShape = binding.getMember();
+      // The name of the member to get from the input shape.
+      String memberName = symbolProvider.toMemberName(memberShape);
+      String inputLocation = "input." + memberName;
+
+      // Handle if the member is an idempotency token that should be auto-filled.
+      AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+
+      writer.openBlock(
+          "if ($L !== undefined) {",
+          "}",
+          inputLocation,
+          () -> {
+            shapeSerVisitor.serializeNamedMember(
+                context, memberName, memberShape, () -> inputLocation);
+          });
     }
 
-    @Override
-    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
-        super.writeDefaultHeaders(context, operation);
-        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
-    }
+    // Append the generated XML to the body.
+    writer.write("body += bodyNode.toString();");
+  }
 
-    @Override
-    protected void serializeInputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
-    ) {
-        // Short circuit when we have no bindings.
-        TypeScriptWriter writer = context.getWriter();
-        if (documentBindings.isEmpty()) {
-            writer.write("body = \"\";");
-            return;
-        }
+  @Override
+  protected void serializeInputPayload(
+      GenerationContext context, OperationShape operation, HttpBinding payloadBinding) {
+    SymbolProvider symbolProvider = context.getSymbolProvider();
+    TypeScriptWriter writer = context.getWriter();
 
-        SymbolProvider symbolProvider = context.getSymbolProvider();
-        ShapeId inputShapeId = documentBindings.get(0).getMember().getContainer();
+    MemberShape member = payloadBinding.getMember();
+    String memberName = symbolProvider.toMemberName(member);
 
-        // Start with the XML declaration.
-        writer.write("body = \"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\";");
+    writer.write("let contents: any;");
 
-        writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
-        writer.write("const bodyNode = new __XmlNode($S);", inputShapeId.getName());
+    // Generate an if statement to set the body node if the member is set.
+    writer.openBlock(
+        "if (input.$L !== undefined) {",
+        "}",
+        memberName,
+        () -> {
+          Shape target = context.getModel().expectShape(member.getTarget());
+          writer.write(
+              "contents = $L;",
+              getInputValue(context, Location.PAYLOAD, "input." + memberName, member, target));
 
-        // Add @xmlNamespace value of the service to the root node,
-        // fall back to one from the input shape.
-        boolean serviceXmlns = AwsProtocolUtils.writeXmlNamespace(context, context.getService(), "bodyNode");
-        if (!serviceXmlns) {
-            StructureShape inputShape = context.getModel().expectShape(inputShapeId, StructureShape.class);
-            AwsProtocolUtils.writeXmlNamespace(context, inputShape, "bodyNode");
-        }
+          // Structure and Union payloads will serialize as XML documents via XmlNode.
+          if (target instanceof StructureShape || target instanceof UnionShape) {
+            // Start with the XML declaration.
+            writer.write("body = \"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\";");
 
-        XmlShapeSerVisitor shapeSerVisitor = new XmlShapeSerVisitor(context);
-
-        for (HttpBinding binding : documentBindings) {
-            MemberShape memberShape = binding.getMember();
-            // The name of the member to get from the input shape.
-            String memberName = symbolProvider.toMemberName(memberShape);
-            String inputLocation = "input." + memberName;
-
-            // Handle if the member is an idempotency token that should be auto-filled.
-            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
-
-            writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
-                shapeSerVisitor.serializeNamedMember(context, memberName, memberShape, () -> inputLocation);
-            });
-        }
-
-        // Append the generated XML to the body.
-        writer.write("body += bodyNode.toString();");
-    }
-
-    @Override
-    protected void serializeInputPayload(
-            GenerationContext context,
-            OperationShape operation,
-            HttpBinding payloadBinding
-    ) {
-        SymbolProvider symbolProvider = context.getSymbolProvider();
-        TypeScriptWriter writer = context.getWriter();
-
-        MemberShape member = payloadBinding.getMember();
-        String memberName = symbolProvider.toMemberName(member);
-
-        writer.write("let contents: any;");
-
-        // Generate an if statement to set the body node if the member is set.
-        writer.openBlock("if (input.$L !== undefined) {", "}", memberName, () -> {
-            Shape target = context.getModel().expectShape(member.getTarget());
-            writer.write("contents = $L;",
-                    getInputValue(context, Location.PAYLOAD, "input." + memberName, member, target));
-
-            // Structure and Union payloads will serialize as XML documents via XmlNode.
-            if (target instanceof StructureShape || target instanceof UnionShape) {
-                // Start with the XML declaration.
-                writer.write("body = \"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\";");
-
-                // Add @xmlNamespace value of the service to the root node,
-                // fall back to one from the payload target.
-                boolean serviceXmlns = AwsProtocolUtils.writeXmlNamespace(context, context.getService(), "contents");
-                if (!serviceXmlns) {
-                    AwsProtocolUtils.writeXmlNamespace(context, target, "contents");
-                }
-
-                // Append the generated XML to the body.
-                writer.write("body += contents.toString();");
-            } else {
-                // Strings and blobs (streaming or not) will not need any modification.
-                writer.write("body = contents;");
+            // Add @xmlNamespace value of the service to the root node,
+            // fall back to one from the payload target.
+            boolean serviceXmlns =
+                AwsProtocolUtils.writeXmlNamespace(context, context.getService(), "contents");
+            if (!serviceXmlns) {
+              AwsProtocolUtils.writeXmlNamespace(context, target, "contents");
             }
+
+            // Append the generated XML to the body.
+            writer.write("body += contents.toString();");
+          } else {
+            // Strings and blobs (streaming or not) will not need any modification.
+            writer.write("body = contents;");
+          }
         });
+  }
+
+  @Override
+  protected void writeErrorCodeParser(GenerationContext context) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Outsource error code parsing since it's complex for this protocol.
+    writer.write("errorCode = loadRestXmlErrorCode(output, parsedOutput.body);");
+  }
+
+  @Override
+  protected void deserializeOutputDocument(
+      GenerationContext context, Shape operationOrError, List<HttpBinding> documentBindings) {
+    SymbolProvider symbolProvider = context.getSymbolProvider();
+    XmlShapeDeserVisitor shapeVisitor = new XmlShapeDeserVisitor(context);
+
+    for (HttpBinding binding : documentBindings) {
+      MemberShape memberShape = binding.getMember();
+      // Grab the target shape so we can use a member deserializer on it.
+      Shape target = context.getModel().expectShape(memberShape.getTarget());
+      // The name of the member to get from the output shape.
+      String memberName = symbolProvider.toMemberName(memberShape);
+
+      shapeVisitor.deserializeNamedMember(
+          context,
+          memberName,
+          memberShape,
+          "data",
+          (dataSource, visitor) -> {
+            TypeScriptWriter writer = context.getWriter();
+            writer.write("contents.$L = $L;", memberName, target.accept(visitor));
+          });
     }
-
-    @Override
-    protected void writeErrorCodeParser(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Outsource error code parsing since it's complex for this protocol.
-        writer.write("errorCode = loadRestXmlErrorCode(output, parsedOutput.body);");
-    }
-
-    @Override
-    protected void deserializeOutputDocument(
-            GenerationContext context,
-            Shape operationOrError,
-            List<HttpBinding> documentBindings
-    ) {
-        SymbolProvider symbolProvider = context.getSymbolProvider();
-        XmlShapeDeserVisitor shapeVisitor = new XmlShapeDeserVisitor(context);
-
-        for (HttpBinding binding : documentBindings) {
-            MemberShape memberShape = binding.getMember();
-            // Grab the target shape so we can use a member deserializer on it.
-            Shape target = context.getModel().expectShape(memberShape.getTarget());
-            // The name of the member to get from the output shape.
-            String memberName = symbolProvider.toMemberName(memberShape);
-
-            shapeVisitor.deserializeNamedMember(context, memberName, memberShape, "data", (dataSource, visitor) -> {
-                TypeScriptWriter writer = context.getWriter();
-                writer.write("contents.$L = $L;", memberName, target.accept(visitor));
-            });
-        }
-    }
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/Ec2ShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/Ec2ShapeSerVisitor.java
@@ -27,56 +27,61 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
 import software.amazon.smithy.utils.StringUtils;
 
 /**
- * Visitor to generate serialization functions for shapes in form-urlencoded
- * based document bodies specific to aws.ec2.
+ * Visitor to generate serialization functions for shapes in form-urlencoded based document bodies
+ * specific to aws.ec2.
  *
- * This class uses the implementations provided by {@code QueryShapeSerVisitor} but with
- * the following protocol specific customizations for aws.ec2:
+ * <p>This class uses the implementations provided by {@code QueryShapeSerVisitor} but with the
+ * following protocol specific customizations for aws.ec2:
  *
  * <ul>
- *   <li>aws.ec2 flattens all lists, sets, and maps regardless of the {@code @xmlFlattened} trait.</li>
- *   <li>aws.ec2 respects the {@code @ec2QueryName} trait, then the {@code xmlName}
- *     trait value with the first letter capitalized.</li>
+ *   <li>aws.ec2 flattens all lists, sets, and maps regardless of the {@code @xmlFlattened} trait.
+ *   <li>aws.ec2 respects the {@code @ec2QueryName} trait, then the {@code xmlName} trait value with
+ *       the first letter capitalized.
  * </ul>
  *
  * Timestamps are serialized to {@link Format}.DATE_TIME by default.
  *
  * @see AwsEc2
  * @see QueryShapeSerVisitor
- * @see <a href="https://awslabs.github.io/smithy/spec/aws-core.html#ec2QueryName-trait">Smithy EC2 Query Name trait.</a>
+ * @see <a href="https://awslabs.github.io/smithy/spec/aws-core.html#ec2QueryName-trait">Smithy EC2
+ *     Query Name trait.</a>
  */
 final class Ec2ShapeSerVisitor extends QueryShapeSerVisitor {
 
-    Ec2ShapeSerVisitor(GenerationContext context) {
-        super(context);
+  Ec2ShapeSerVisitor(GenerationContext context) {
+    super(context);
+  }
+
+  @Override
+  protected void serializeDocument(GenerationContext context, DocumentShape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot serialize Document types in the aws.ec2 protocol, shape: %s.", shape.getId()));
+  }
+
+  @Override
+  protected String getMemberSerializedLocationName(MemberShape memberShape, String defaultValue) {
+    // The serialization for aws.ec2 prioritizes the @ec2QueryName trait for serialization.
+    Optional<Ec2QueryNameTrait> trait = memberShape.getTrait(Ec2QueryNameTrait.class);
+    if (trait.isPresent()) {
+      return trait.get().getValue();
     }
 
-    @Override
-    protected void serializeDocument(GenerationContext context, DocumentShape shape) {
-        throw new CodegenException(String.format(
-                "Cannot serialize Document types in the aws.ec2 protocol, shape: %s.", shape.getId()));
-    }
+    // Fall back to the capitalized @xmlName trait if present on the member,
+    // otherwise use the capitalized default value.
+    return memberShape
+        .getTrait(XmlNameTrait.class)
+        .map(XmlNameTrait::getValue)
+        .map(StringUtils::capitalize)
+        .orElseGet(() -> StringUtils.capitalize(defaultValue));
+  }
 
-    @Override
-    protected String getMemberSerializedLocationName(MemberShape memberShape, String defaultValue) {
-        // The serialization for aws.ec2 prioritizes the @ec2QueryName trait for serialization.
-        Optional<Ec2QueryNameTrait> trait = memberShape.getTrait(Ec2QueryNameTrait.class);
-        if (trait.isPresent()) {
-            return trait.get().getValue();
-        }
-
-        // Fall back to the capitalized @xmlName trait if present on the member,
-        // otherwise use the capitalized default value.
-        return memberShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .map(StringUtils::capitalize)
-                .orElseGet(() -> StringUtils.capitalize(defaultValue));
-    }
-
-    @Override
-    protected boolean isFlattenedMember(GenerationContext context, MemberShape memberShape) {
-        // All lists, sets, and maps are flattened in aws.ec2.
-        ShapeType targetType = context.getModel().expectShape(memberShape.getTarget()).getType();
-        return targetType == ShapeType.LIST || targetType == ShapeType.SET || targetType == ShapeType.MAP;
-    }
+  @Override
+  protected boolean isFlattenedMember(GenerationContext context, MemberShape memberShape) {
+    // All lists, sets, and maps are flattened in aws.ec2.
+    ShapeType targetType = context.getModel().expectShape(memberShape.getTarget()).getType();
+    return targetType == ShapeType.LIST
+        || targetType == ShapeType.SET
+        || targetType == ShapeType.MAP;
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -34,215 +34,266 @@ import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
- * Writes out a file that resolves endpoints using endpoints.json, but the
- * created resolver resolves endpoints for a single service.
+ * Writes out a file that resolves endpoints using endpoints.json, but the created resolver resolves
+ * endpoints for a single service.
  */
 final class EndpointGenerator implements Runnable {
 
-    private static final int VERSION = 3;
+  private static final int VERSION = 3;
 
-    private final TypeScriptWriter writer;
-    private final ObjectNode endpointData;
-    private final String endpointPrefix;
-    private final Map<String, Partition> partitions = new TreeMap<>();
-    private final Map<String, ObjectNode> endpoints = new TreeMap<>();
+  private final TypeScriptWriter writer;
+  private final ObjectNode endpointData;
+  private final String endpointPrefix;
+  private final Map<String, Partition> partitions = new TreeMap<>();
+  private final Map<String, ObjectNode> endpoints = new TreeMap<>();
 
-    EndpointGenerator(ServiceShape service, TypeScriptWriter writer) {
-        this.writer = writer;
-        endpointPrefix = getEndpointPrefix(service);
-        endpointData = Node.parse(IoUtils.readUtf8Resource(getClass(), "endpoints.json")).expectObjectNode();
-        validateVersion();
-        loadPartitions();
-        loadServiceEndpoints();
+  EndpointGenerator(ServiceShape service, TypeScriptWriter writer) {
+    this.writer = writer;
+    endpointPrefix = getEndpointPrefix(service);
+    endpointData =
+        Node.parse(IoUtils.readUtf8Resource(getClass(), "endpoints.json")).expectObjectNode();
+    validateVersion();
+    loadPartitions();
+    loadServiceEndpoints();
+  }
+
+  private void validateVersion() {
+    int version = endpointData.expectNumberMember("version").getValue().intValue();
+    if (version != VERSION) {
+      throw new CodegenException(
+          "Invalid endpoints.json version. Expected version 3, found " + version);
     }
+  }
 
-    private void validateVersion() {
-        int version = endpointData.expectNumberMember("version").getValue().intValue();
-        if (version != VERSION) {
-            throw new CodegenException("Invalid endpoints.json version. Expected version 3, found " +  version);
-        }
+  // Get service's endpoint prefix from a known list. If not found, fallback to ArnNamespace
+  private String getEndpointPrefix(ServiceShape service) {
+    ObjectNode endpointPrefixData =
+        Node.parse(IoUtils.readUtf8Resource(getClass(), "endpoint-prefix.json")).expectObjectNode();
+    ServiceTrait serviceTrait =
+        service
+            .getTrait(ServiceTrait.class)
+            .orElseThrow(
+                () -> new CodegenException("No service trait found on " + service.getId()));
+    return endpointPrefixData.getStringMemberOrDefault(
+        serviceTrait.getSdkId(), serviceTrait.getArnNamespace());
+  }
+
+  private void loadPartitions() {
+    List<ObjectNode> partitionObjects =
+        endpointData.expectArrayMember("partitions").getElementsAs(Node::expectObjectNode);
+
+    for (ObjectNode partition : partitionObjects) {
+      String partitionName = partition.expectStringMember("partition").getValue();
+      partitions.put(partitionName, new Partition(partition, partitionName));
     }
+  }
 
-    // Get service's endpoint prefix from a known list. If not found, fallback to ArnNamespace
-    private String getEndpointPrefix(ServiceShape service) {
-        ObjectNode endpointPrefixData = Node.parse(IoUtils.readUtf8Resource(getClass(), "endpoint-prefix.json"))
-                .expectObjectNode();
-        ServiceTrait serviceTrait = service.getTrait(ServiceTrait.class)
-                .orElseThrow(() -> new CodegenException("No service trait found on " + service.getId()));
-        return endpointPrefixData.getStringMemberOrDefault(serviceTrait.getSdkId(), serviceTrait.getArnNamespace());
+  private void loadServiceEndpoints() {
+    for (Partition partition : partitions.values()) {
+      String dnsSuffix = partition.dnsSuffix;
+      ObjectNode serviceData = partition.getService();
+      ObjectNode endpointMap = serviceData.getObjectMember("endpoints").orElse(Node.objectNode());
+
+      for (Map.Entry<String, Node> entry : endpointMap.getStringMap().entrySet()) {
+        // Merge the endpoint settings into the resolved service settings.
+        ObjectNode config = partition.getDefaults().merge(entry.getValue().expectObjectNode());
+        // Resolve the hostname.
+        String hostName = config.expectStringMember("hostname").getValue();
+        hostName = hostName.replace("{dnsSuffix}", dnsSuffix);
+        hostName = hostName.replace("{service}", endpointPrefix);
+        hostName = hostName.replace("{region}", entry.getKey());
+        config = config.withMember("hostname", hostName);
+        endpoints.put(entry.getKey(), config);
+      }
     }
+  }
 
-    private void loadPartitions() {
-        List<ObjectNode> partitionObjects = endpointData
-                .expectArrayMember("partitions")
-                .getElementsAs(Node::expectObjectNode);
+  @Override
+  public void run() {
+    writePartitionTemplates();
+    writePartitionRegions();
+    writeEndpointProviderFunction();
+  }
 
-        for (ObjectNode partition : partitionObjects) {
-            String partitionName = partition.expectStringMember("partition").getValue();
-            partitions.put(partitionName, new Partition(partition, partitionName));
-        }
-    }
-
-    private void loadServiceEndpoints() {
-        for (Partition partition : partitions.values()) {
-            String dnsSuffix = partition.dnsSuffix;
-            ObjectNode serviceData = partition.getService();
-            ObjectNode endpointMap = serviceData.getObjectMember("endpoints").orElse(Node.objectNode());
-
-            for (Map.Entry<String, Node> entry : endpointMap.getStringMap().entrySet()) {
-                // Merge the endpoint settings into the resolved service settings.
-                ObjectNode config = partition.getDefaults().merge(entry.getValue().expectObjectNode());
-                // Resolve the hostname.
-                String hostName = config.expectStringMember("hostname").getValue();
-                hostName = hostName.replace("{dnsSuffix}", dnsSuffix);
-                hostName = hostName.replace("{service}", endpointPrefix);
-                hostName = hostName.replace("{region}", entry.getKey());
-                config = config.withMember("hostname", hostName);
-                endpoints.put(entry.getKey(), config);
-            }
-        }
-    }
-
-    @Override
-    public void run() {
-        writePartitionTemplates();
-        writePartitionRegions();
-        writeEndpointProviderFunction();
-    }
-
-    private void writePartitionTemplates() {
-        writer.write("// Partition default templates");
-        partitions.values().forEach(partition -> {
-            writer.write("const $L = $S;", partition.templateVariableName, partition.templateValue);
-        });
-        writer.write("");
-    }
-
-    private void writePartitionRegions() {
-        writer.write("// Partition regions");
-        partitions.values().forEach(partition -> {
-            writer.openBlock("const $L = new Set([", "]);", partition.regionVariableName, () -> {
-                for (String region : partition.getAllRegions()) {
-                    writer.write("$S,", region);
-                }
+  private void writePartitionTemplates() {
+    writer.write("// Partition default templates");
+    partitions
+        .values()
+        .forEach(
+            partition -> {
+              writer.write(
+                  "const $L = $S;", partition.templateVariableName, partition.templateValue);
             });
-        });
-        writer.write("");
-    }
+    writer.write("");
+  }
 
-    private void writeEndpointProviderFunction() {
-        writer.addImport("RegionInfoProvider", "RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.addImport("RegionInfo", "RegionInfo", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.openBlock("export const defaultRegionInfoProvider: RegionInfoProvider = (\n"
-                         + "  region: string,\n"
-                         + "  options?: any\n"
-                         + ") => {", "};", () -> {
-            writer.write("let regionInfo: RegionInfo | undefined = undefined;");
-            writer.openBlock("switch (region) {", "}", () -> {
+  private void writePartitionRegions() {
+    writer.write("// Partition regions");
+    partitions
+        .values()
+        .forEach(
+            partition -> {
+              writer.openBlock(
+                  "const $L = new Set([",
+                  "]);",
+                  partition.regionVariableName,
+                  () -> {
+                    for (String region : partition.getAllRegions()) {
+                      writer.write("$S,", region);
+                    }
+                  });
+            });
+    writer.write("");
+  }
+
+  private void writeEndpointProviderFunction() {
+    writer.addImport(
+        "RegionInfoProvider", "RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+    writer.addImport("RegionInfo", "RegionInfo", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+    writer.openBlock(
+        "export const defaultRegionInfoProvider: RegionInfoProvider = (\n"
+            + "  region: string,\n"
+            + "  options?: any\n"
+            + ") => {",
+        "};",
+        () -> {
+          writer.write("let regionInfo: RegionInfo | undefined = undefined;");
+          writer.openBlock(
+              "switch (region) {",
+              "}",
+              () -> {
                 writer.write("// First, try to match exact region names.");
                 for (Map.Entry<String, ObjectNode> entry : endpoints.entrySet()) {
-                    writer.write("case $S:", entry.getKey()).indent();
-                    writeEndpointSpecificResolver(entry.getValue());
-                    writer.write("break;");
-                    writer.dedent();
+                  writer.write("case $S:", entry.getKey()).indent();
+                  writeEndpointSpecificResolver(entry.getValue());
+                  writer.write("break;");
+                  writer.dedent();
                 }
                 writer.write("// Next, try to match partition endpoints.");
                 writer.write("default:").indent();
-                partitions.values().forEach(partition -> {
-                    writer.openBlock("if ($L.has(region)) {", "}", partition.regionVariableName, () -> {
-                        writePartitionEndpointResolver(partition); });
-                });
+                partitions
+                    .values()
+                    .forEach(
+                        partition -> {
+                          writer.openBlock(
+                              "if ($L.has(region)) {",
+                              "}",
+                              partition.regionVariableName,
+                              () -> {
+                                writePartitionEndpointResolver(partition);
+                              });
+                        });
                 // Default to using the AWS partition resolver.
                 writer.write("// Finally, assume it's an AWS partition endpoint.");
-                writer.openBlock("if (regionInfo === undefined) {", "}", () -> {
-                    writePartitionEndpointResolver(partitions.get("aws")); });
-                writer.dedent();
-            });
-            writer.write("return Promise.resolve(regionInfo);");
-        });
-    }
-
-    private void writePartitionEndpointResolver(Partition partition) {
-        OptionalUtils.ifPresentOrElse(
-                partition.getPartitionEndpoint(),
-                name -> writer.write("return defaultRegionInfoProvider($S);", name),
-                () -> {
-                    writer.openBlock("regionInfo = {", "};", () -> {
-                        String template = partition.templateVariableName;
-                        writer.write("hostname: $L.replace(\"{region}\", region),", template);
-                        writeAdditionalEndpointSettings(partition.getDefaults());
+                writer.openBlock(
+                    "if (regionInfo === undefined) {",
+                    "}",
+                    () -> {
+                      writePartitionEndpointResolver(partitions.get("aws"));
                     });
-                }
-        );
-    }
-
-    private void writeEndpointSpecificResolver(ObjectNode resolved) {
-        String hostname = resolved.expectStringMember("hostname").getValue();
-        writer.openBlock("regionInfo = {", "};", () -> {
-            writer.write("hostname: $S,", hostname);
-            writeAdditionalEndpointSettings(resolved);
+                writer.dedent();
+              });
+          writer.write("return Promise.resolve(regionInfo);");
         });
-    }
+  }
 
-    // Write credential scope settings into the resolved endpoint object.
-    private void writeAdditionalEndpointSettings(ObjectNode settings) {
-        settings.getObjectMember("credentialScope").ifPresent(scope -> {
-            scope.getStringMember("region").ifPresent(signingRegion -> {
-                writer.write("signingRegion: $S,", signingRegion);
-            });
-            scope.getStringMember("service").ifPresent(signingService -> {
-                writer.write("signingService: $S,", signingService);
-            });
+  private void writePartitionEndpointResolver(Partition partition) {
+    OptionalUtils.ifPresentOrElse(
+        partition.getPartitionEndpoint(),
+        name -> writer.write("return defaultRegionInfoProvider($S);", name),
+        () -> {
+          writer.openBlock(
+              "regionInfo = {",
+              "};",
+              () -> {
+                String template = partition.templateVariableName;
+                writer.write("hostname: $L.replace(\"{region}\", region),", template);
+                writeAdditionalEndpointSettings(partition.getDefaults());
+              });
         });
+  }
+
+  private void writeEndpointSpecificResolver(ObjectNode resolved) {
+    String hostname = resolved.expectStringMember("hostname").getValue();
+    writer.openBlock(
+        "regionInfo = {",
+        "};",
+        () -> {
+          writer.write("hostname: $S,", hostname);
+          writeAdditionalEndpointSettings(resolved);
+        });
+  }
+
+  // Write credential scope settings into the resolved endpoint object.
+  private void writeAdditionalEndpointSettings(ObjectNode settings) {
+    settings
+        .getObjectMember("credentialScope")
+        .ifPresent(
+            scope -> {
+              scope
+                  .getStringMember("region")
+                  .ifPresent(
+                      signingRegion -> {
+                        writer.write("signingRegion: $S,", signingRegion);
+                      });
+              scope
+                  .getStringMember("service")
+                  .ifPresent(
+                      signingService -> {
+                        writer.write("signingService: $S,", signingService);
+                      });
+            });
+  }
+
+  private final class Partition {
+    final ObjectNode defaults;
+    final String regionVariableName;
+    final String templateVariableName;
+    final String templateValue;
+    final String dnsSuffix;
+    private final ObjectNode config;
+
+    private Partition(ObjectNode config, String partition) {
+      this.config = config;
+      // Resolve the partition defaults + the service defaults.
+      ObjectNode partitionDefaults = config.expectObjectMember("defaults");
+      defaults =
+          partitionDefaults.merge(
+              getService().getObjectMember("defaults").orElse(Node.objectNode()));
+
+      // Resolve the template to use for this service in this partition.
+      String template = defaults.expectStringMember("hostname").getValue();
+      template = template.replace("{service}", endpointPrefix);
+      template = template.replace("{dnsSuffix}", config.expectStringMember("dnsSuffix").getValue());
+      templateValue = template;
+
+      // Compute the template and regions variable names.
+      String snakePartition = StringUtils.upperCase(CaseUtils.toSnakeCase(partition));
+      templateVariableName = snakePartition + "_TEMPLATE";
+      regionVariableName = snakePartition + "_REGIONS";
+
+      dnsSuffix = config.expectStringMember("dnsSuffix").getValue();
     }
 
-    private final class Partition {
-        final ObjectNode defaults;
-        final String regionVariableName;
-        final String templateVariableName;
-        final String templateValue;
-        final String dnsSuffix;
-        private final ObjectNode config;
-
-        private Partition(ObjectNode config, String partition) {
-            this.config = config;
-            // Resolve the partition defaults + the service defaults.
-            ObjectNode partitionDefaults = config.expectObjectMember("defaults");
-            defaults = partitionDefaults.merge(getService().getObjectMember("defaults").orElse(Node.objectNode()));
-
-            // Resolve the template to use for this service in this partition.
-            String template = defaults.expectStringMember("hostname").getValue();
-            template = template.replace("{service}", endpointPrefix);
-            template = template.replace("{dnsSuffix}", config.expectStringMember("dnsSuffix").getValue());
-            templateValue = template;
-
-            // Compute the template and regions variable names.
-            String snakePartition = StringUtils.upperCase(CaseUtils.toSnakeCase(partition));
-            templateVariableName = snakePartition + "_TEMPLATE";
-            regionVariableName = snakePartition + "_REGIONS";
-
-            dnsSuffix = config.expectStringMember("dnsSuffix").getValue();
-        }
-
-        ObjectNode getDefaults() {
-            return defaults;
-        }
-
-        ObjectNode getService() {
-            ObjectNode services = config.getObjectMember("services").orElse(Node.objectNode());
-            return services.getObjectMember(endpointPrefix).orElse(Node.objectNode());
-        }
-
-        Set<String> getAllRegions() {
-            return config.getObjectMember("regions").orElse(Node.objectNode()).getStringMap().keySet();
-        }
-
-        Optional<String> getPartitionEndpoint() {
-            ObjectNode service = getService();
-            // Note: regionalized services always use regionalized endpoints.
-            return service.getBooleanMemberOrDefault("isRegionalized", true)
-                   ? Optional.empty()
-                   : service.getStringMember("partitionEndpoint").map(StringNode::getValue);
-        }
+    ObjectNode getDefaults() {
+      return defaults;
     }
+
+    ObjectNode getService() {
+      ObjectNode services = config.getObjectMember("services").orElse(Node.objectNode());
+      return services.getObjectMember(endpointPrefix).orElse(Node.objectNode());
+    }
+
+    Set<String> getAllRegions() {
+      return config.getObjectMember("regions").orElse(Node.objectNode()).getStringMap().keySet();
+    }
+
+    Optional<String> getPartitionEndpoint() {
+      ObjectNode service = getService();
+      // Note: regionalized services always use regionalized endpoints.
+      return service.getBooleanMemberOrDefault("isRegionalized", true)
+          ? Optional.empty()
+          : service.getStringMember("partitionEndpoint").map(StringNode::getValue);
+    }
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -24,32 +24,33 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeser
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Overrides the default implementation of BigDecimal and BigInteger shape
- * deserialization to throw when encountered in AWS REST JSON based protocols.
+ * Overrides the default implementation of BigDecimal and BigInteger shape deserialization to throw
+ * when encountered in AWS REST JSON based protocols.
  */
 final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
 
-    /**
-     * @inheritDoc
-     */
-    JsonMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
-        super(context, dataSource, defaultTimestampFormat);
-    }
+  /** @inheritDoc */
+  JsonMemberDeserVisitor(
+      GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    super(context, dataSource, defaultTimestampFormat);
+  }
 
-    @Override
-    public String bigDecimalShape(BigDecimalShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigDecimalShape(BigDecimalShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    @Override
-    public String bigIntegerShape(BigIntegerShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigIntegerShape(BigIntegerShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
-    }
+  private String unsupportedShape(Shape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot deserialize shape type %s on protocol, shape: %s.",
+            shape.getType(), shape.getId()));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
@@ -24,34 +24,35 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVi
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Overrides the default implementation of BigDecimal and BigInteger shape
- * serialization to throw when encountered in AWS REST-JSON based protocols.
+ * Overrides the default implementation of BigDecimal and BigInteger shape serialization to throw
+ * when encountered in AWS REST-JSON based protocols.
  *
- * TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
+ * <p>TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
  */
 final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
 
-    /**
-     * @inheritDoc
-     */
-    JsonMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
-        super(context, dataSource, defaultTimestampFormat);
-    }
+  /** @inheritDoc */
+  JsonMemberSerVisitor(
+      GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    super(context, dataSource, defaultTimestampFormat);
+  }
 
-    @Override
-    public String bigDecimalShape(BigDecimalShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigDecimalShape(BigDecimalShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    @Override
-    public String bigIntegerShape(BigIntegerShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigIntegerShape(BigIntegerShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
-    }
+  private String unsupportedShape(Shape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot serialize shape type %s on protocol, shape: %s.",
+            shape.getType(), shape.getId()));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -26,12 +26,12 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVi
 import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
 
 /**
- * Handles general components across the AWS JSON protocols that have do not have
- * HTTP bindings. It handles reading and writing from document bodies, including
- * generating any functions needed for performing serde.
+ * Handles general components across the AWS JSON protocols that have do not have HTTP bindings. It
+ * handles reading and writing from document bodies, including generating any functions needed for
+ * performing serde.
  *
- * This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle
- * standard components of the HTTP requests and responses.
+ * <p>This builds on the foundations of the {@link HttpRpcProtocolGenerator} to handle standard
+ * components of the HTTP requests and responses.
  *
  * @see JsonShapeSerVisitor
  * @see JsonShapeDeserVisitor
@@ -41,87 +41,87 @@ import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGene
  */
 abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
-    /**
-     * Creates a AWS JSON RPC protocol generator.
-     */
-    JsonRpcProtocolGenerator() {
-        // AWS JSON RPC protocols will attempt to parse error codes from response bodies.
-        super(true);
-    }
+  /** Creates a AWS JSON RPC protocol generator. */
+  JsonRpcProtocolGenerator() {
+    // AWS JSON RPC protocols will attempt to parse error codes from response bodies.
+    super(true);
+  }
 
-    @Override
-    protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
-        return "/";
-    }
+  @Override
+  protected String getOperationPath(GenerationContext context, OperationShape operationShape) {
+    return "/";
+  }
 
-    protected Format getDocumentTimestampFormat() {
-        return Format.EPOCH_SECONDS;
-    }
+  protected Format getDocumentTimestampFormat() {
+    return Format.EPOCH_SECONDS;
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeSerVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeSerializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new JsonShapeSerVisitor(context));
+  }
 
-    @Override
-    protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new JsonShapeDeserVisitor(context));
-    }
+  @Override
+  protected void generateDocumentBodyShapeDeserializers(
+      GenerationContext context, Set<Shape> shapes) {
+    AwsProtocolUtils.generateDocumentBodyShapeSerde(
+        context, shapes, new JsonShapeDeserVisitor(context));
+  }
 
-    @Override
-    public void generateSharedComponents(GenerationContext context) {
-        super.generateSharedComponents(context);
-        AwsProtocolUtils.generateJsonParseBody(context);
-        AwsProtocolUtils.addItempotencyAutofillImport(context);
-    }
+  @Override
+  public void generateSharedComponents(GenerationContext context) {
+    super.generateSharedComponents(context);
+    AwsProtocolUtils.generateJsonParseBody(context);
+    AwsProtocolUtils.addItempotencyAutofillImport(context);
+  }
 
-    @Override
-    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
-        super.writeDefaultHeaders(context, operation);
-        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+  @Override
+  protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
+    super.writeDefaultHeaders(context, operation);
+    AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
 
-        // AWS JSON RPC protocols use a combination of the service and operation shape names,
-        // separated by a '.' character, for the target header.
-        TypeScriptWriter writer = context.getWriter();
-        String target = context.getService().getId().getName() + "." + operation.getId().getName();
-        writer.write("headers['X-Amz-Target'] = $S;", target);
-    }
+    // AWS JSON RPC protocols use a combination of the service and operation shape names,
+    // separated by a '.' character, for the target header.
+    TypeScriptWriter writer = context.getWriter();
+    String target = context.getService().getId().getName() + "." + operation.getId().getName();
+    writer.write("headers['X-Amz-Target'] = $S;", target);
+  }
 
-    @Override
-    protected void serializeInputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape inputStructure
-    ) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void serializeInputDocument(
+      GenerationContext context, OperationShape operation, StructureShape inputStructure) {
+    TypeScriptWriter writer = context.getWriter();
 
-        writer.write("body = JSON.stringify($L);", inputStructure.accept(getMemberSerVisitor(context, "input")));
-    }
+    writer.write(
+        "body = JSON.stringify($L);", inputStructure.accept(getMemberSerVisitor(context, "input")));
+  }
 
-    private DocumentMemberSerVisitor getMemberSerVisitor(GenerationContext context, String dataSource) {
-        return new JsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
-    }
+  private DocumentMemberSerVisitor getMemberSerVisitor(
+      GenerationContext context, String dataSource) {
+    return new JsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
+  }
 
-    @Override
-    protected void writeErrorCodeParser(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
-        // parsedOutput is in scope because HttpRpcProtocolGenerator.isErrorCodeInBody is true
-        writer.write("const errorTypeParts: String = parsedOutput.body[\"__type\"].split('#');");
-        writer.write("errorCode = (errorTypeParts[1] === undefined) ? errorTypeParts[0] : errorTypeParts[1];");
-    }
+  @Override
+  protected void writeErrorCodeParser(GenerationContext context) {
+    TypeScriptWriter writer = context.getWriter();
+    // parsedOutput is in scope because HttpRpcProtocolGenerator.isErrorCodeInBody is true
+    writer.write("const errorTypeParts: String = parsedOutput.body[\"__type\"].split('#');");
+    writer.write(
+        "errorCode = (errorTypeParts[1] === undefined) ? errorTypeParts[0] : errorTypeParts[1];");
+  }
 
-    @Override
-    protected void deserializeOutputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape outputStructure
-    ) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void deserializeOutputDocument(
+      GenerationContext context, OperationShape operation, StructureShape outputStructure) {
+    TypeScriptWriter writer = context.getWriter();
 
-        writer.write("contents = $L;", outputStructure.accept(getMemberDeserVisitor(context, "data")));
-    }
+    writer.write("contents = $L;", outputStructure.accept(getMemberDeserVisitor(context, "data")));
+  }
 
-    private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
-        return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
-    }
+  private DocumentMemberDeserVisitor getMemberDeserVisitor(
+      GenerationContext context, String dataSource) {
+    return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -33,111 +33,141 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentShapeDeserV
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Visitor to generate deserialization functions for shapes in AWS JSON protocol
- * document bodies.
+ * Visitor to generate deserialization functions for shapes in AWS JSON protocol document bodies.
  *
- * No standard visitation methods are overridden; function body generation for all
- * expected deserializers is handled by this class.
+ * <p>No standard visitation methods are overridden; function body generation for all expected
+ * deserializers is handled by this class.
  *
- * Timestamps are deserialized from {@link Format}.EPOCH_SECONDS by default.
+ * <p>Timestamps are deserialized from {@link Format}.EPOCH_SECONDS by default.
  */
 final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
 
-    JsonShapeDeserVisitor(GenerationContext context) {
-        super(context);
-    }
+  JsonShapeDeserVisitor(GenerationContext context) {
+    super(context);
+  }
 
-    private DocumentMemberDeserVisitor getMemberVisitor(String dataSource) {
-        return new JsonMemberDeserVisitor(getContext(), dataSource, Format.EPOCH_SECONDS);
-    }
+  private DocumentMemberDeserVisitor getMemberVisitor(String dataSource) {
+    return new JsonMemberDeserVisitor(getContext(), dataSource, Format.EPOCH_SECONDS);
+  }
 
-    @Override
-    protected void deserializeCollection(GenerationContext context, CollectionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        Shape target = context.getModel().expectShape(shape.getMember().getTarget());
+  @Override
+  protected void deserializeCollection(GenerationContext context, CollectionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    Shape target = context.getModel().expectShape(shape.getMember().getTarget());
 
-        // Dispatch to the output value provider for any additional handling.
-        writer.openBlock("return (output || []).map((entry: any) =>", ");", () -> {
-            writer.write(target.accept(getMemberVisitor("entry")));
+    // Dispatch to the output value provider for any additional handling.
+    writer.openBlock(
+        "return (output || []).map((entry: any) =>",
+        ");",
+        () -> {
+          writer.write(target.accept(getMemberVisitor("entry")));
         });
-    }
+  }
 
-    @Override
-    protected void deserializeDocument(GenerationContext context, DocumentShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        // Documents are JSON content, so don't modify.
-        writer.write("return output;");
-    }
+  @Override
+  protected void deserializeDocument(GenerationContext context, DocumentShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    // Documents are JSON content, so don't modify.
+    writer.write("return output;");
+  }
 
-    @Override
-    protected void deserializeMap(GenerationContext context, MapShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        Shape target = context.getModel().expectShape(shape.getValue().getTarget());
+  @Override
+  protected void deserializeMap(GenerationContext context, MapShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    Shape target = context.getModel().expectShape(shape.getValue().getTarget());
 
-        // Get the right serialization for each entry in the map. Undefined
-        // outputs won't have this deserializer invoked.
-        writer.write("const mapParams: any = {};");
-        writer.openBlock("Object.keys(output).forEach(key => {", "});", () -> {
-            // Dispatch to the output value provider for any additional handling.
-            writer.write("mapParams[key] = $L;", target.accept(getMemberVisitor("output[key]")));
+    // Get the right serialization for each entry in the map. Undefined
+    // outputs won't have this deserializer invoked.
+    writer.write("const mapParams: any = {};");
+    writer.openBlock(
+        "Object.keys(output).forEach(key => {",
+        "});",
+        () -> {
+          // Dispatch to the output value provider for any additional handling.
+          writer.write("mapParams[key] = $L;", target.accept(getMemberVisitor("output[key]")));
         });
-        writer.write("return mapParams;");
-    }
+    writer.write("return mapParams;");
+  }
 
-    @Override
-    protected void deserializeStructure(GenerationContext context, StructureShape shape) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void deserializeStructure(GenerationContext context, StructureShape shape) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Prepare the document contents structure.
-        // Use a TreeMap to sort the members.
-        Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
-        writer.openBlock("let contents: any = {", "};", () -> {
-            writer.write("__type: $S,", shape.getId().getName());
-            // Set all the members to undefined to meet type constraints.
-            members.forEach((memberName, memberShape) -> writer.write("$L: undefined,", memberName));
+    // Prepare the document contents structure.
+    // Use a TreeMap to sort the members.
+    Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
+    writer.openBlock(
+        "let contents: any = {",
+        "};",
+        () -> {
+          writer.write("__type: $S,", shape.getId().getName());
+          // Set all the members to undefined to meet type constraints.
+          members.forEach((memberName, memberShape) -> writer.write("$L: undefined,", memberName));
         });
-        members.forEach((memberName, memberShape) -> {
-            // Use the jsonName trait value if present, otherwise use the member name.
-            String locationName = memberShape.getTrait(JsonNameTrait.class)
-                    .map(JsonNameTrait::getValue)
-                    .orElse(memberName);
-            Shape target = context.getModel().expectShape(memberShape.getTarget());
+    members.forEach(
+        (memberName, memberShape) -> {
+          // Use the jsonName trait value if present, otherwise use the member name.
+          String locationName =
+              memberShape
+                  .getTrait(JsonNameTrait.class)
+                  .map(JsonNameTrait::getValue)
+                  .orElse(memberName);
+          Shape target = context.getModel().expectShape(memberShape.getTarget());
 
-            // Generate an if statement to set the bodyParam if the member is set.
-            writer.openBlock("if (output.$L !== undefined && output.$L !== null) {", "}", locationName, locationName,
-                    () -> {
-                writer.write("contents.$L = $L;", memberName,
-                        // Dispatch to the output value provider for any additional handling.
-                        target.accept(getMemberVisitor("output." + locationName)));
-            });
-        });
-
-        writer.write("return contents;");
-    }
-
-    @Override
-    protected void deserializeUnion(GenerationContext context, UnionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        Model model = context.getModel();
-
-        // Check for any known union members and return when we find one.
-        Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
-        members.forEach((memberName, memberShape) -> {
-            Shape target = model.expectShape(memberShape.getTarget());
-            // Use the jsonName trait value if present, otherwise use the member name.
-            String locationName = memberShape.getTrait(JsonNameTrait.class)
-                    .map(JsonNameTrait::getValue)
-                    .orElse(memberName);
-            writer.openBlock("if (output.$L !== undefined && output.$L !== null) {", "}", locationName, locationName,
-                    () -> {
-                writer.openBlock("return {", "};", () -> {
+          // Generate an if statement to set the bodyParam if the member is set.
+          writer.openBlock(
+              "if (output.$L !== undefined && output.$L !== null) {",
+              "}",
+              locationName,
+              locationName,
+              () -> {
+                writer.write(
+                    "contents.$L = $L;",
+                    memberName,
                     // Dispatch to the output value provider for any additional handling.
-                    writer.write("$L: $L", memberName, target.accept(getMemberVisitor("output." + locationName)));
-                });
-            });
+                    target.accept(getMemberVisitor("output." + locationName)));
+              });
         });
-        // Or write to the unknown member the element in the output.
-        writer.write("const key = Object.keys(output)[0];");
-        writer.write("return { $$unknown: [key, output[key]] };");
-    }
+
+    writer.write("return contents;");
+  }
+
+  @Override
+  protected void deserializeUnion(GenerationContext context, UnionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    Model model = context.getModel();
+
+    // Check for any known union members and return when we find one.
+    Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
+    members.forEach(
+        (memberName, memberShape) -> {
+          Shape target = model.expectShape(memberShape.getTarget());
+          // Use the jsonName trait value if present, otherwise use the member name.
+          String locationName =
+              memberShape
+                  .getTrait(JsonNameTrait.class)
+                  .map(JsonNameTrait::getValue)
+                  .orElse(memberName);
+          writer.openBlock(
+              "if (output.$L !== undefined && output.$L !== null) {",
+              "}",
+              locationName,
+              locationName,
+              () -> {
+                writer.openBlock(
+                    "return {",
+                    "};",
+                    () -> {
+                      // Dispatch to the output value provider for any additional handling.
+                      writer.write(
+                          "$L: $L",
+                          memberName,
+                          target.accept(getMemberVisitor("output." + locationName)));
+                    });
+              });
+        });
+    // Or write to the unknown member the element in the output.
+    writer.write("const key = Object.keys(output)[0];");
+    writer.write("return { $$unknown: [key, output[key]] };");
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryMemberSerVisitor.java
@@ -24,36 +24,42 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVi
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Overrides the default implementation of BigDecimal and BigInteger shape
- * serialization to throw when encountered in the aws.query protocol.
+ * Overrides the default implementation of BigDecimal and BigInteger shape serialization to throw
+ * when encountered in the aws.query protocol.
  *
- * TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
+ * <p>TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
  */
 final class QueryMemberSerVisitor extends DocumentMemberSerVisitor {
 
-    QueryMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
-        super(context, dataSource, defaultTimestampFormat);
-    }
+  QueryMemberSerVisitor(
+      GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    super(context, dataSource, defaultTimestampFormat);
+  }
 
-    boolean visitSuppliesEntryList(Shape shape) {
-        return shape.isStructureShape() || shape.isUnionShape()
-                || shape.isMapShape() || shape.isListShape() || shape.isSetShape();
-    }
+  boolean visitSuppliesEntryList(Shape shape) {
+    return shape.isStructureShape()
+        || shape.isUnionShape()
+        || shape.isMapShape()
+        || shape.isListShape()
+        || shape.isSetShape();
+  }
 
-    @Override
-    public String bigDecimalShape(BigDecimalShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigDecimalShape(BigDecimalShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    @Override
-    public String bigIntegerShape(BigIntegerShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigIntegerShape(BigIntegerShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
-    }
+  private String unsupportedShape(Shape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot serialize shape type %s on protocol, shape: %s.",
+            shape.getType(), shape.getId()));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -34,246 +34,272 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVis
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Visitor to generate serialization functions for shapes in form-urlencoded
- * based document bodies.
+ * Visitor to generate serialization functions for shapes in form-urlencoded based document bodies.
  *
- * This class handles function body generation for all types expected by the {@code
+ * <p>This class handles function body generation for all types expected by the {@code
  * DocumentShapeSerVisitor}. No other shape type serialization is overridden.
  *
- * Timestamps are serialized to {@link Format}.DATE_TIME by default.
+ * <p>Timestamps are serialized to {@link Format}.DATE_TIME by default.
  */
 class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
-    private static final Format TIMESTAMP_FORMAT = Format.DATE_TIME;
+  private static final Format TIMESTAMP_FORMAT = Format.DATE_TIME;
 
-    QueryShapeSerVisitor(GenerationContext context) {
-        super(context);
-    }
+  QueryShapeSerVisitor(GenerationContext context) {
+    super(context);
+  }
 
-    private QueryMemberSerVisitor getMemberVisitor(String dataSource) {
-        return new QueryMemberSerVisitor(getContext(), dataSource, TIMESTAMP_FORMAT);
-    }
+  private QueryMemberSerVisitor getMemberVisitor(String dataSource) {
+    return new QueryMemberSerVisitor(getContext(), dataSource, TIMESTAMP_FORMAT);
+  }
 
-    @Override
-    protected void serializeCollection(GenerationContext context, CollectionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        MemberShape memberShape = shape.getMember();
-        Shape target = context.getModel().expectShape(memberShape.getTarget());
+  @Override
+  protected void serializeCollection(GenerationContext context, CollectionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    MemberShape memberShape = shape.getMember();
+    Shape target = context.getModel().expectShape(memberShape.getTarget());
 
-        // Use the @xmlName trait if present on the member, otherwise use "member".
-        String locationName = getMemberSerializedLocationName(memberShape, "member");
+    // Use the @xmlName trait if present on the member, otherwise use "member".
+    String locationName = getMemberSerializedLocationName(memberShape, "member");
 
-        // Set up a location to store all of the entry pairs.
-        writer.write("const entries: any = {};");
-        // Set up a counter to increment the member entries.
-        writer.write("let counter = 1;");
-        writer.openBlock("for (let entry of input) {", "}", () -> {
-            QueryMemberSerVisitor inputVisitor = getMemberVisitor("entry");
-            if (inputVisitor.visitSuppliesEntryList(target)) {
-                // Dispatch to the input value provider for any additional handling.
-                serializeUnnamedMemberEntryList(context, target, "entry", locationName + ".${counter}");
-            } else {
-                writer.write("entries[`$L.$${counter}`] = $L;", locationName, target.accept(inputVisitor));
-            }
-            writer.write("counter++;");
+    // Set up a location to store all of the entry pairs.
+    writer.write("const entries: any = {};");
+    // Set up a counter to increment the member entries.
+    writer.write("let counter = 1;");
+    writer.openBlock(
+        "for (let entry of input) {",
+        "}",
+        () -> {
+          QueryMemberSerVisitor inputVisitor = getMemberVisitor("entry");
+          if (inputVisitor.visitSuppliesEntryList(target)) {
+            // Dispatch to the input value provider for any additional handling.
+            serializeUnnamedMemberEntryList(context, target, "entry", locationName + ".${counter}");
+          } else {
+            writer.write(
+                "entries[`$L.$${counter}`] = $L;", locationName, target.accept(inputVisitor));
+          }
+          writer.write("counter++;");
         });
 
-        writer.write("return entries;");
-    }
+    writer.write("return entries;");
+  }
 
-    @Override
-    protected void serializeDocument(GenerationContext context, DocumentShape shape) {
-        throw new CodegenException(String.format(
-                "Cannot serialize Document types in the aws.query protocol, shape: %s.", shape.getId()));
-    }
+  @Override
+  protected void serializeDocument(GenerationContext context, DocumentShape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot serialize Document types in the aws.query protocol, shape: %s.",
+            shape.getId()));
+  }
 
-    @Override
-    protected void serializeMap(GenerationContext context, MapShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        Model model = context.getModel();
+  @Override
+  protected void serializeMap(GenerationContext context, MapShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    Model model = context.getModel();
 
-        // Set up a location to store all of the entry pairs.
-        writer.write("const entries: any = {};");
-        // Set up a counter to increment the member entries.
-        writer.write("let counter = 1;");
-        // Use the keys as an iteration point to dispatch to the input value providers.
-        writer.openBlock("Object.keys(input).forEach(key => {", "});", () -> {
-            // Prepare the key's entry.
-            // Use the @xmlName trait if present on the member, otherwise use "key".
-            MemberShape keyMember = shape.getKey();
-            Shape keyTarget = model.expectShape(keyMember.getTarget());
-            String keyName = getMemberSerializedLocationName(keyMember, "key");
-            writer.write("entries[`entry.$${counter}.$L`] = $L;", keyName, keyTarget.accept(getMemberVisitor("key")));
+    // Set up a location to store all of the entry pairs.
+    writer.write("const entries: any = {};");
+    // Set up a counter to increment the member entries.
+    writer.write("let counter = 1;");
+    // Use the keys as an iteration point to dispatch to the input value providers.
+    writer.openBlock(
+        "Object.keys(input).forEach(key => {",
+        "});",
+        () -> {
+          // Prepare the key's entry.
+          // Use the @xmlName trait if present on the member, otherwise use "key".
+          MemberShape keyMember = shape.getKey();
+          Shape keyTarget = model.expectShape(keyMember.getTarget());
+          String keyName = getMemberSerializedLocationName(keyMember, "key");
+          writer.write(
+              "entries[`entry.$${counter}.$L`] = $L;",
+              keyName,
+              keyTarget.accept(getMemberVisitor("key")));
 
+          // Prepare the value's entry.
+          // Use the @xmlName trait if present on the member, otherwise use "value".
+          MemberShape valueMember = shape.getValue();
+          Shape valueTarget = model.expectShape(valueMember.getTarget());
+          String valueName = getMemberSerializedLocationName(valueMember, "value");
 
-            // Prepare the value's entry.
-            // Use the @xmlName trait if present on the member, otherwise use "value".
-            MemberShape valueMember = shape.getValue();
-            Shape valueTarget = model.expectShape(valueMember.getTarget());
-            String valueName = getMemberSerializedLocationName(valueMember, "value");
-
-            QueryMemberSerVisitor inputVisitor = getMemberVisitor("input[key]");
-            String valueLocation = "entry.${counter}." + valueName;
-            if (inputVisitor.visitSuppliesEntryList(valueTarget)) {
-                serializeUnnamedMemberEntryList(context, valueTarget, "input[key]", valueLocation);
-            } else {
-                writer.write("entries[`$L`] = $L;", valueLocation, valueTarget.accept(inputVisitor));
-            }
-            writer.write("counter++;");
+          QueryMemberSerVisitor inputVisitor = getMemberVisitor("input[key]");
+          String valueLocation = "entry.${counter}." + valueName;
+          if (inputVisitor.visitSuppliesEntryList(valueTarget)) {
+            serializeUnnamedMemberEntryList(context, valueTarget, "input[key]", valueLocation);
+          } else {
+            writer.write("entries[`$L`] = $L;", valueLocation, valueTarget.accept(inputVisitor));
+          }
+          writer.write("counter++;");
         });
 
-        writer.write("return entries;");
-    }
+    writer.write("return entries;");
+  }
 
-    private void serializeUnnamedMemberEntryList(
-            GenerationContext context,
-            Shape target,
-            String inputLocation,
-            String entryWrapper
-    ) {
-        TypeScriptWriter writer = context.getWriter();
+  private void serializeUnnamedMemberEntryList(
+      GenerationContext context, Shape target, String inputLocation, String entryWrapper) {
+    TypeScriptWriter writer = context.getWriter();
 
-        QueryMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation);
-        // Map entries that supply entry lists need to have them joined properly.
-        writer.write("const memberEntries = $L;", target.accept(inputVisitor));
-        writer.openBlock("Object.keys(memberEntries).forEach(key => {", "});",
-                () -> writer.write("entries[`$L.$${key}`] = memberEntries[key];", entryWrapper));
-    }
+    QueryMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation);
+    // Map entries that supply entry lists need to have them joined properly.
+    writer.write("const memberEntries = $L;", target.accept(inputVisitor));
+    writer.openBlock(
+        "Object.keys(memberEntries).forEach(key => {",
+        "});",
+        () -> writer.write("entries[`$L.$${key}`] = memberEntries[key];", entryWrapper));
+  }
 
-    @Override
-    protected void serializeStructure(GenerationContext context, StructureShape shape) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void serializeStructure(GenerationContext context, StructureShape shape) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Set up a location to store all of the entry pairs.
-        writer.write("const entries: any = {};");
+    // Set up a location to store all of the entry pairs.
+    writer.write("const entries: any = {};");
 
-        // Serialize every member of the structure if present.
-        shape.getAllMembers().forEach((memberName, memberShape) -> {
-            String inputLocation = "input." + memberName;
+    // Serialize every member of the structure if present.
+    shape
+        .getAllMembers()
+        .forEach(
+            (memberName, memberShape) -> {
+              String inputLocation = "input." + memberName;
 
-            // Handle if the member is an idempotency token that should be auto-filled.
-            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+              // Handle if the member is an idempotency token that should be auto-filled.
+              AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
 
-            writer.openBlock("if ($L !== undefined) {", "}", inputLocation,
-                    () -> serializeNamedMember(context, memberName, memberShape, inputLocation));
-        });
-
-        writer.write("return entries");
-    }
-
-    private void serializeNamedMember(
-            GenerationContext context,
-            String memberName,
-            MemberShape memberShape,
-            String inputLocation
-    ) {
-        // Grab the target shape so we can use a member serializer on it.
-        Shape target = context.getModel().expectShape(memberShape.getTarget());
-
-        String locationName = getMemberSerializedLocationName(memberShape, memberName);
-
-        QueryMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation);
-        if (inputVisitor.visitSuppliesEntryList(target)) {
-            serializeNamedMemberEntryList(context, locationName, memberShape, target, inputVisitor);
-        } else {
-            serializeNamedMemberValue(context, locationName, "input." + memberName, memberShape, target);
-        }
-    }
-
-    private void serializeNamedMemberValue(
-            GenerationContext context,
-            String locationName,
-            String dataSource,
-            MemberShape memberShape,
-            Shape target
-    ) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Handle @timestampFormat on members not just the targeted shape.
-        String valueProvider = memberShape.hasTrait(TimestampFormatTrait.class)
-                ? AwsProtocolUtils.getInputTimestampValueProvider(context, memberShape,
-                        TIMESTAMP_FORMAT, dataSource)
-                : target.accept(getMemberVisitor(dataSource));
-
-        writer.write("entries[$S] = $L;", locationName, valueProvider);
-    }
-
-    /**
-     * Retrieves the correct serialization location based on the member's
-     * xmlName trait or uses the default value.
-     *
-     * @param memberShape The member being serialized.
-     * @param defaultValue A default value for the location.
-     * @return The location where the member will be serialized.
-     */
-    protected String getMemberSerializedLocationName(MemberShape memberShape, String defaultValue) {
-        // Use the @xmlName trait if present on the member, otherwise use the member name.
-        return memberShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(defaultValue);
-    }
-
-    private void serializeNamedMemberEntryList(
-            GenerationContext context,
-            String locationName,
-            MemberShape memberShape,
-            Shape target,
-            DocumentMemberSerVisitor inputVisitor
-    ) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Handle flattening for collections and maps.
-        boolean isFlattened = isFlattenedMember(context, memberShape);
-
-        // Set up a location to store all of the entry pairs.
-        writer.write("const memberEntries = $L;", target.accept(inputVisitor));
-
-        // Consolidate every entry in the list.
-        writer.openBlock("Object.keys(memberEntries).forEach(key => {", "});", () -> {
-            // Remove the last segment for any flattened entities.
-            if (isFlattened) {
-                writer.write("const loc = `$L.$${key.substring(key.indexOf('.') + 1)}`;", locationName);
-            } else {
-                writer.write("const loc = `$L.$${key}`;", locationName);
-            }
-
-            writer.write("entries[loc] = memberEntries[key];");
-        });
-    }
-
-    /**
-     * Tells whether the contents of the member should be flattened
-     * when serialized.
-     *
-     * @param context The generation context.
-     * @param memberShape The member being serialized.
-     * @return If the member's contents should be flattened when serialized.
-     */
-    protected boolean isFlattenedMember(GenerationContext context, MemberShape memberShape) {
-        // The @xmlFlattened trait determines the flattening of members in aws.query.
-        return memberShape.hasTrait(XmlFlattenedTrait.class);
-    }
-
-    @Override
-    protected void serializeUnion(GenerationContext context, UnionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Set up a location to store the entry pair.
-        writer.write("const entries: any = {};");
-
-        // Visit over the union type, then get the right serialization for the member.
-        writer.openBlock("$L.visit(input, {", "});", shape.getId().getName(), () -> {
-            shape.getAllMembers().forEach((memberName, memberShape) -> {
-                writer.openBlock("$L: value => {", "},", memberName, () -> {
-                    serializeNamedMember(context, memberName, memberShape, "value");
-                });
+              writer.openBlock(
+                  "if ($L !== undefined) {",
+                  "}",
+                  inputLocation,
+                  () -> serializeNamedMember(context, memberName, memberShape, inputLocation));
             });
 
-            // Handle the unknown property.
-            writer.openBlock("_: (name: string, value: any) => {", "}", () -> {
+    writer.write("return entries");
+  }
+
+  private void serializeNamedMember(
+      GenerationContext context, String memberName, MemberShape memberShape, String inputLocation) {
+    // Grab the target shape so we can use a member serializer on it.
+    Shape target = context.getModel().expectShape(memberShape.getTarget());
+
+    String locationName = getMemberSerializedLocationName(memberShape, memberName);
+
+    QueryMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation);
+    if (inputVisitor.visitSuppliesEntryList(target)) {
+      serializeNamedMemberEntryList(context, locationName, memberShape, target, inputVisitor);
+    } else {
+      serializeNamedMemberValue(context, locationName, "input." + memberName, memberShape, target);
+    }
+  }
+
+  private void serializeNamedMemberValue(
+      GenerationContext context,
+      String locationName,
+      String dataSource,
+      MemberShape memberShape,
+      Shape target) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Handle @timestampFormat on members not just the targeted shape.
+    String valueProvider =
+        memberShape.hasTrait(TimestampFormatTrait.class)
+            ? AwsProtocolUtils.getInputTimestampValueProvider(
+                context, memberShape, TIMESTAMP_FORMAT, dataSource)
+            : target.accept(getMemberVisitor(dataSource));
+
+    writer.write("entries[$S] = $L;", locationName, valueProvider);
+  }
+
+  /**
+   * Retrieves the correct serialization location based on the member's xmlName trait or uses the
+   * default value.
+   *
+   * @param memberShape The member being serialized.
+   * @param defaultValue A default value for the location.
+   * @return The location where the member will be serialized.
+   */
+  protected String getMemberSerializedLocationName(MemberShape memberShape, String defaultValue) {
+    // Use the @xmlName trait if present on the member, otherwise use the member name.
+    return memberShape
+        .getTrait(XmlNameTrait.class)
+        .map(XmlNameTrait::getValue)
+        .orElse(defaultValue);
+  }
+
+  private void serializeNamedMemberEntryList(
+      GenerationContext context,
+      String locationName,
+      MemberShape memberShape,
+      Shape target,
+      DocumentMemberSerVisitor inputVisitor) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Handle flattening for collections and maps.
+    boolean isFlattened = isFlattenedMember(context, memberShape);
+
+    // Set up a location to store all of the entry pairs.
+    writer.write("const memberEntries = $L;", target.accept(inputVisitor));
+
+    // Consolidate every entry in the list.
+    writer.openBlock(
+        "Object.keys(memberEntries).forEach(key => {",
+        "});",
+        () -> {
+          // Remove the last segment for any flattened entities.
+          if (isFlattened) {
+            writer.write("const loc = `$L.$${key.substring(key.indexOf('.') + 1)}`;", locationName);
+          } else {
+            writer.write("const loc = `$L.$${key}`;", locationName);
+          }
+
+          writer.write("entries[loc] = memberEntries[key];");
+        });
+  }
+
+  /**
+   * Tells whether the contents of the member should be flattened when serialized.
+   *
+   * @param context The generation context.
+   * @param memberShape The member being serialized.
+   * @return If the member's contents should be flattened when serialized.
+   */
+  protected boolean isFlattenedMember(GenerationContext context, MemberShape memberShape) {
+    // The @xmlFlattened trait determines the flattening of members in aws.query.
+    return memberShape.hasTrait(XmlFlattenedTrait.class);
+  }
+
+  @Override
+  protected void serializeUnion(GenerationContext context, UnionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Set up a location to store the entry pair.
+    writer.write("const entries: any = {};");
+
+    // Visit over the union type, then get the right serialization for the member.
+    writer.openBlock(
+        "$L.visit(input, {",
+        "});",
+        shape.getId().getName(),
+        () -> {
+          shape
+              .getAllMembers()
+              .forEach(
+                  (memberName, memberShape) -> {
+                    writer.openBlock(
+                        "$L: value => {",
+                        "},",
+                        memberName,
+                        () -> {
+                          serializeNamedMember(context, memberName, memberShape, "value");
+                        });
+                  });
+
+          // Handle the unknown property.
+          writer.openBlock(
+              "_: (name: string, value: any) => {",
+              "}",
+              () -> {
                 writer.write("entries[name] = value;");
-            });
+              });
         });
 
-        writer.write("return entries;");
-    }
+    writer.write("return entries;");
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
@@ -33,103 +33,111 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeser
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Overrides several of the default implementations to handle XML document
- * contents deserializing to strings instead of typed components:
+ * Overrides several of the default implementations to handle XML document contents deserializing to
+ * strings instead of typed components:
  *
  * <ul>
- *   <li>Uses {@code parseFloat} on Float and Double shapes.</li>
- *   <li>Fails on BigDecimal and BigInteger shapes.</li>
- *   <li>Uses {@code parseInt} on other number shapes.</li>
- *   <li>Compares boolean shapes to the string {@code "true"} to generate a boolean.</li>
+ *   <li>Uses {@code parseFloat} on Float and Double shapes.
+ *   <li>Fails on BigDecimal and BigInteger shapes.
+ *   <li>Uses {@code parseInt} on other number shapes.
+ *   <li>Compares boolean shapes to the string {@code "true"} to generate a boolean.
  * </ul>
  *
  * @see <a href="https://awslabs.github.io/smithy/spec/xml.html">Smithy XML traits.</a>
  */
 final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
 
-    XmlMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
-        super(context, dataSource, defaultTimestampFormat);
-    }
+  XmlMemberDeserVisitor(
+      GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    super(context, dataSource, defaultTimestampFormat);
+  }
 
-    @Override
-    public String stringShape(StringShape shape) {
-        return getSafeDataSource();
-    }
+  @Override
+  public String stringShape(StringShape shape) {
+    return getSafeDataSource();
+  }
 
-    /**
-     * Provides a data source safety mechanism to handle nodes that are
-     * expected to have only a value but were loaded from a node with
-     * a namespace.
-     *
-     * @return The node's value having handled a potential namespace.
-     */
-    private String getSafeDataSource() {
-        String dataSource = getDataSource();
-        return "((" + dataSource + "['#text'] !== undefined) ? " + dataSource + "['#text'] : " + dataSource + ")";
-    }
+  /**
+   * Provides a data source safety mechanism to handle nodes that are expected to have only a value
+   * but were loaded from a node with a namespace.
+   *
+   * @return The node's value having handled a potential namespace.
+   */
+  private String getSafeDataSource() {
+    String dataSource = getDataSource();
+    return "(("
+        + dataSource
+        + "['#text'] !== undefined) ? "
+        + dataSource
+        + "['#text'] : "
+        + dataSource
+        + ")";
+  }
 
-    @Override
-    public String blobShape(BlobShape shape) {
-        return "context.base64Decoder(" + getSafeDataSource() + ")";
-    }
+  @Override
+  public String blobShape(BlobShape shape) {
+    return "context.base64Decoder(" + getSafeDataSource() + ")";
+  }
 
-    @Override
-    public String booleanShape(BooleanShape shape) {
-        return getSafeDataSource() + " == 'true'";
-    }
+  @Override
+  public String booleanShape(BooleanShape shape) {
+    return getSafeDataSource() + " == 'true'";
+  }
 
-    @Override
-    public String byteShape(ByteShape shape) {
-        return deserializeInt();
-    }
+  @Override
+  public String byteShape(ByteShape shape) {
+    return deserializeInt();
+  }
 
-    @Override
-    public String shortShape(ShortShape shape) {
-        return deserializeInt();
-    }
+  @Override
+  public String shortShape(ShortShape shape) {
+    return deserializeInt();
+  }
 
-    @Override
-    public String integerShape(IntegerShape shape) {
-        return deserializeInt();
-    }
+  @Override
+  public String integerShape(IntegerShape shape) {
+    return deserializeInt();
+  }
 
-    @Override
-    public String longShape(LongShape shape) {
-        return deserializeInt();
-    }
+  @Override
+  public String longShape(LongShape shape) {
+    return deserializeInt();
+  }
 
-    private String deserializeInt() {
-        return "parseInt(" + getSafeDataSource() + ")";
-    }
+  private String deserializeInt() {
+    return "parseInt(" + getSafeDataSource() + ")";
+  }
 
-    @Override
-    public String floatShape(FloatShape shape) {
-        return deserializeFloat();
-    }
+  @Override
+  public String floatShape(FloatShape shape) {
+    return deserializeFloat();
+  }
 
-    @Override
-    public String doubleShape(DoubleShape shape) {
-        return deserializeFloat();
-    }
+  @Override
+  public String doubleShape(DoubleShape shape) {
+    return deserializeFloat();
+  }
 
-    private String deserializeFloat() {
-        return "parseFloat(" + getSafeDataSource() + ")";
-    }
+  private String deserializeFloat() {
+    return "parseFloat(" + getSafeDataSource() + ")";
+  }
 
-    @Override
-    public String bigDecimalShape(BigDecimalShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigDecimalShape(BigDecimalShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    @Override
-    public String bigIntegerShape(BigIntegerShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigIntegerShape(BigIntegerShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
-    }
+  private String unsupportedShape(Shape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot deserialize shape type %s on protocol, shape: %s.",
+            shape.getType(), shape.getId()));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
@@ -36,12 +36,12 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVi
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Overrides several of the default implementations to handle XML document
- * contents serializing as XmlText entities instead of typed components:
+ * Overrides several of the default implementations to handle XML document contents serializing as
+ * XmlText entities instead of typed components:
  *
  * <ul>
- *   <li>All scalar types are set as contents of an XmlText inside an XmlNode.</li>
- *   <li>Fails on BigDecimal and BigInteger shapes.</li>
+ *   <li>All scalar types are set as contents of an XmlText inside an XmlNode.
+ *   <li>Fails on BigDecimal and BigInteger shapes.
  * </ul>
  *
  * TODO: Work out support for BigDecimal and BigInteger, natively or through a library.
@@ -50,90 +50,94 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  */
 final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
 
-    XmlMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
-        super(context, dataSource, defaultTimestampFormat);
-    }
+  XmlMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    super(context, dataSource, defaultTimestampFormat);
+  }
 
-    @Override
-    public String stringShape(StringShape shape) {
-        return getAsXmlText(shape, super.stringShape(shape));
-    }
+  @Override
+  public String stringShape(StringShape shape) {
+    return getAsXmlText(shape, super.stringShape(shape));
+  }
 
-    @Override
-    public String blobShape(BlobShape shape) {
-        return getAsXmlText(shape, super.blobShape(shape));
-    }
+  @Override
+  public String blobShape(BlobShape shape) {
+    return getAsXmlText(shape, super.blobShape(shape));
+  }
 
-    @Override
-    public String timestampShape(TimestampShape shape) {
-        return getAsXmlText(shape, super.timestampShape(shape));
-    }
+  @Override
+  public String timestampShape(TimestampShape shape) {
+    return getAsXmlText(shape, super.timestampShape(shape));
+  }
 
-    @Override
-    public String booleanShape(BooleanShape shape) {
-        return serializeSimpleScalar(shape);
-    }
+  @Override
+  public String booleanShape(BooleanShape shape) {
+    return serializeSimpleScalar(shape);
+  }
 
-    @Override
-    public String byteShape(ByteShape shape) {
-        return serializeSimpleScalar(shape);
-    }
+  @Override
+  public String byteShape(ByteShape shape) {
+    return serializeSimpleScalar(shape);
+  }
 
-    @Override
-    public String shortShape(ShortShape shape) {
-        return serializeSimpleScalar(shape);
-    }
+  @Override
+  public String shortShape(ShortShape shape) {
+    return serializeSimpleScalar(shape);
+  }
 
-    @Override
-    public String integerShape(IntegerShape shape) {
-        return serializeSimpleScalar(shape);
-    }
+  @Override
+  public String integerShape(IntegerShape shape) {
+    return serializeSimpleScalar(shape);
+  }
 
-    @Override
-    public String longShape(LongShape shape) {
-        return serializeSimpleScalar(shape);
-    }
+  @Override
+  public String longShape(LongShape shape) {
+    return serializeSimpleScalar(shape);
+  }
 
-    @Override
-    public String floatShape(FloatShape shape) {
-        return serializeSimpleScalar(shape);
-    }
+  @Override
+  public String floatShape(FloatShape shape) {
+    return serializeSimpleScalar(shape);
+  }
 
-    @Override
-    public String doubleShape(DoubleShape shape) {
-        return serializeSimpleScalar(shape);
-    }
+  @Override
+  public String doubleShape(DoubleShape shape) {
+    return serializeSimpleScalar(shape);
+  }
 
-    private String serializeSimpleScalar(Shape shape) {
-        return getAsXmlText(shape, "String(" + getDataSource() + ")");
-    }
+  private String serializeSimpleScalar(Shape shape) {
+    return getAsXmlText(shape, "String(" + getDataSource() + ")");
+  }
 
-    String getAsXmlText(Shape shape, String dataSource) {
-        // Handle the @xmlName trait for the shape itself.
-        String nodeName = shape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(shape.getId().getName());
+  String getAsXmlText(Shape shape, String dataSource) {
+    // Handle the @xmlName trait for the shape itself.
+    String nodeName =
+        shape
+            .getTrait(XmlNameTrait.class)
+            .map(XmlNameTrait::getValue)
+            .orElse(shape.getId().getName());
 
-        TypeScriptWriter writer = getContext().getWriter();
-        writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
-        writer.addImport("XmlText", "__XmlText", "@aws-sdk/xml-builder");
-        return "new __XmlNode(\"" + nodeName + "\").addChildNode(new __XmlText(" + dataSource + "))";
-    }
+    TypeScriptWriter writer = getContext().getWriter();
+    writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
+    writer.addImport("XmlText", "__XmlText", "@aws-sdk/xml-builder");
+    return "new __XmlNode(\"" + nodeName + "\").addChildNode(new __XmlText(" + dataSource + "))";
+  }
 
-    @Override
-    public String bigDecimalShape(BigDecimalShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigDecimalShape(BigDecimalShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    @Override
-    public String bigIntegerShape(BigIntegerShape shape) {
-        // Fail instead of losing precision through Number.
-        return unsupportedShape(shape);
-    }
+  @Override
+  public String bigIntegerShape(BigIntegerShape shape) {
+    // Fail instead of losing precision through Number.
+    return unsupportedShape(shape);
+  }
 
-    private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
-    }
+  private String unsupportedShape(Shape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot serialize shape type %s on protocol, shape: %s.",
+            shape.getType(), shape.getId()));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -40,225 +40,270 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentShapeDeserV
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Visitor to generate deserialization functions for shapes in XML-document
- * based document bodies.
+ * Visitor to generate deserialization functions for shapes in XML-document based document bodies.
  *
- * No standard visitation methods are overridden; function body generation for all
- * expected deserializers is handled by this class.
+ * <p>No standard visitation methods are overridden; function body generation for all expected
+ * deserializers is handled by this class.
  *
- * Timestamps are deserialized from {@link Format}.DATE_TIME by default.
+ * <p>Timestamps are deserialized from {@link Format}.DATE_TIME by default.
  *
  * @see <a href="https://awslabs.github.io/smithy/spec/xml.html">Smithy XML traits.</a>
  */
 final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
 
-    XmlShapeDeserVisitor(GenerationContext context) {
-        super(context);
-    }
+  XmlShapeDeserVisitor(GenerationContext context) {
+    super(context);
+  }
 
-    private DocumentMemberDeserVisitor getMemberVisitor(String dataSource) {
-        return new XmlMemberDeserVisitor(getContext(), dataSource, Format.DATE_TIME);
-    }
+  private DocumentMemberDeserVisitor getMemberVisitor(String dataSource) {
+    return new XmlMemberDeserVisitor(getContext(), dataSource, Format.DATE_TIME);
+  }
 
-    @Override
-    protected void deserializeCollection(GenerationContext context, CollectionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        Shape target = context.getModel().expectShape(shape.getMember().getTarget());
+  @Override
+  protected void deserializeCollection(GenerationContext context, CollectionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    Shape target = context.getModel().expectShape(shape.getMember().getTarget());
 
-        // Dispatch to the output value provider for any additional handling.
-        writer.write("const contents: any = [];");
-        writer.openBlock("(output || []).map((entry: any) => {", "});", () -> {
-            String dataSource = handleUnnamedTargetWrapping(context, target, "entry");
-            writer.write("contents.push($L);", target.accept(getMemberVisitor(dataSource)));
+    // Dispatch to the output value provider for any additional handling.
+    writer.write("const contents: any = [];");
+    writer.openBlock(
+        "(output || []).map((entry: any) => {",
+        "});",
+        () -> {
+          String dataSource = handleUnnamedTargetWrapping(context, target, "entry");
+          writer.write("contents.push($L);", target.accept(getMemberVisitor(dataSource)));
         });
-        writer.write("return contents;");
+    writer.write("return contents;");
+  }
+
+  private String handleUnnamedTargetWrapping(
+      GenerationContext context, Shape target, String dataSource) {
+    if (!deserializationReturnsArray(target)) {
+      return dataSource;
     }
 
-    private String handleUnnamedTargetWrapping(GenerationContext context, Shape target, String dataSource) {
-        if (!deserializationReturnsArray(target)) {
-            return dataSource;
-        }
+    TypeScriptWriter writer = context.getWriter();
+    // The XML parser will set one K:V for a member that could
+    // return multiple entries but only has one.
+    // Update the target element if we target another level of collection.
+    String targetLocation = getUnnamedAggregateTargetLocation(context.getModel(), target);
+    writer.write(
+        "const wrappedItem = ($1L[$2S] instanceof Array) ? $1L[$2S] : [$1L[$2S]];",
+        dataSource,
+        targetLocation);
+    return "wrappedItem";
+  }
 
-        TypeScriptWriter writer = context.getWriter();
-        // The XML parser will set one K:V for a member that could
-        // return multiple entries but only has one.
-        // Update the target element if we target another level of collection.
-        String targetLocation = getUnnamedAggregateTargetLocation(context.getModel(), target);
-        writer.write("const wrappedItem = ($1L[$2S] instanceof Array) ? $1L[$2S] : [$1L[$2S]];",
-                dataSource, targetLocation);
-        return "wrappedItem";
-    }
+  private boolean deserializationReturnsArray(Shape shape) {
+    return (shape instanceof CollectionShape) || (shape instanceof MapShape);
+  }
 
-    private boolean deserializationReturnsArray(Shape shape) {
-        return (shape instanceof CollectionShape) || (shape instanceof MapShape);
-    }
+  @Override
+  protected void deserializeDocument(GenerationContext context, DocumentShape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot deserialize Document types on AWS XML protocols, shape: %s.", shape.getId()));
+  }
 
-    @Override
-    protected void deserializeDocument(GenerationContext context, DocumentShape shape) {
-        throw new CodegenException(String.format("Cannot deserialize Document types on AWS XML protocols, shape: %s.",
-                shape.getId()));
-    }
+  @Override
+  protected void deserializeMap(GenerationContext context, MapShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    Shape target = context.getModel().expectShape(shape.getValue().getTarget());
+    String keyLocation =
+        shape.getKey().getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse("key");
+    String valueLocation =
+        shape.getValue().getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse("value");
 
-    @Override
-    protected void deserializeMap(GenerationContext context, MapShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        Shape target = context.getModel().expectShape(shape.getValue().getTarget());
-        String keyLocation = shape.getKey().getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse("key");
-        String valueLocation = shape.getValue().getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue)
-                .orElse("value");
-
-        // Get the right serialization for each entry in the map. Undefined
-        // outputs won't have this deserializer invoked.
-        writer.write("const mapParams: any = {};");
-        writer.openBlock("output.forEach((pair: any) => {", "});", () -> {
-            // Dispatch to the output value provider for any additional handling.
-            String dataSource = handleUnnamedTargetWrapping(context, target, "pair[\"" + valueLocation + "\"]");
-            writer.write("mapParams[pair[$S]] = $L;", keyLocation, target.accept(getMemberVisitor(dataSource)));
+    // Get the right serialization for each entry in the map. Undefined
+    // outputs won't have this deserializer invoked.
+    writer.write("const mapParams: any = {};");
+    writer.openBlock(
+        "output.forEach((pair: any) => {",
+        "});",
+        () -> {
+          // Dispatch to the output value provider for any additional handling.
+          String dataSource =
+              handleUnnamedTargetWrapping(context, target, "pair[\"" + valueLocation + "\"]");
+          writer.write(
+              "mapParams[pair[$S]] = $L;",
+              keyLocation,
+              target.accept(getMemberVisitor(dataSource)));
         });
-        writer.write("return mapParams;");
-    }
+    writer.write("return mapParams;");
+  }
 
-    @Override
-    protected void deserializeStructure(GenerationContext context, StructureShape shape) {
-        TypeScriptWriter writer = context.getWriter();
+  @Override
+  protected void deserializeStructure(GenerationContext context, StructureShape shape) {
+    TypeScriptWriter writer = context.getWriter();
 
-        // Prepare the document contents structure.
-        Map<String, MemberShape> members = shape.getAllMembers();
-        writer.openBlock("let contents: any = {", "};", () -> {
-            writer.write("__type: $S,", shape.getId().getName());
-            // Set all the members to undefined to meet type constraints.
-            members.forEach((memberName, memberShape) -> writer.write("$L: undefined,", memberName));
+    // Prepare the document contents structure.
+    Map<String, MemberShape> members = shape.getAllMembers();
+    writer.openBlock(
+        "let contents: any = {",
+        "};",
+        () -> {
+          writer.write("__type: $S,", shape.getId().getName());
+          // Set all the members to undefined to meet type constraints.
+          members.forEach((memberName, memberShape) -> writer.write("$L: undefined,", memberName));
         });
 
-        members.forEach((memberName, memberShape) -> {
-            // Grab the target shape so we can use a member deserializer on it.
-            Shape target = context.getModel().expectShape(memberShape.getTarget());
-            deserializeNamedMember(context, memberName, memberShape, "output", (dataSource, visitor) -> {
+    members.forEach(
+        (memberName, memberShape) -> {
+          // Grab the target shape so we can use a member deserializer on it.
+          Shape target = context.getModel().expectShape(memberShape.getTarget());
+          deserializeNamedMember(
+              context,
+              memberName,
+              memberShape,
+              "output",
+              (dataSource, visitor) -> {
                 writer.write("contents.$L = $L;", memberName, target.accept(visitor));
-            });
+              });
         });
 
-        writer.write("return contents;");
+    writer.write("return contents;");
+  }
+
+  /**
+   * Generates an if statement for deserializing an output member, validating its presence at the
+   * correct location, handling collections and flattening, and dispatching to the supplied function
+   * to generate the body of the if statement.
+   *
+   * @param context The generation context.
+   * @param memberName The name of the member being deserialized.
+   * @param memberShape The shape of the member being deserialized.
+   * @param inputLocation The parent input location of the member being deserialized.
+   * @param statementBodyGenerator A function that generates the proper deserialization after member
+   *     presence is validated.
+   */
+  void deserializeNamedMember(
+      GenerationContext context,
+      String memberName,
+      MemberShape memberShape,
+      String inputLocation,
+      BiConsumer<String, DocumentMemberDeserVisitor> statementBodyGenerator) {
+    TypeScriptWriter writer = context.getWriter();
+    Model model = context.getModel();
+
+    // Use the @xmlName trait if present on the member, otherwise use the member name.
+    String locationName =
+        memberShape.getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse(memberName);
+    // Grab the target shape so we can use a member deserializer on it.
+    Shape target = context.getModel().expectShape(memberShape.getTarget());
+    // Handle @xmlFlattened for collections and maps.
+    boolean isFlattened = memberShape.hasTrait(XmlFlattenedTrait.class);
+    // Handle targets that return multiple entities per member.
+    boolean deserializationReturnsArray = deserializationReturnsArray(target);
+
+    // Build a string based on the traits that represents the location.
+    // Note we don't need to handle @xmlAttribute here because the parser flattens
+    // attributes in to the main structure.
+    StringBuilder sourceBuilder =
+        new StringBuilder(inputLocation).append("['").append(locationName).append("']");
+    // Track any locations we need to validate on our way to the final element.
+    List<String> locationsToValidate = new ArrayList<>();
+
+    // Go in to a specialized element for unflattened aggregates.
+    if (deserializationReturnsArray && !isFlattened) {
+      // Make sure we validate the wrapping element is set.
+      locationsToValidate.add(sourceBuilder.toString());
+      // Update the target element.
+      String targetLocation = getUnnamedAggregateTargetLocation(model, target);
+      sourceBuilder.append("['").append(targetLocation).append("']");
     }
 
-    /**
-     * Generates an if statement for deserializing an output member, validating its
-     * presence at the correct location, handling collections and flattening, and
-     * dispatching to the supplied function to generate the body of the if statement.
-     *
-     * @param context The generation context.
-     * @param memberName The name of the member being deserialized.
-     * @param memberShape The shape of the member being deserialized.
-     * @param inputLocation The parent input location of the member being deserialized.
-     * @param statementBodyGenerator A function that generates the proper deserialization
-     *   after member presence is validated.
-     */
-    void deserializeNamedMember(
-            GenerationContext context,
-            String memberName,
-            MemberShape memberShape,
-            String inputLocation,
-            BiConsumer<String, DocumentMemberDeserVisitor> statementBodyGenerator
-    ) {
-        TypeScriptWriter writer = context.getWriter();
-        Model model = context.getModel();
+    // Handle self-closed xml parsed as an empty string.
+    if (deserializationReturnsArray) {
+      writer.openBlock(
+          "if ($L.$L === \"\") {",
+          "}",
+          inputLocation,
+          locationName,
+          () -> {
+            if (target instanceof MapShape) {
+              writer.write("contents.$L = {};", memberName);
+            } else if (target instanceof ListShape) {
+              writer.write("contents.$L = [];", memberName);
+            } else if (target instanceof SetShape) {
+              writer.write("contents.$L = new Set([]);", memberName);
+            }
+          });
+    }
 
-        // Use the @xmlName trait if present on the member, otherwise use the member name.
-        String locationName = memberShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(memberName);
-        // Grab the target shape so we can use a member deserializer on it.
-        Shape target = context.getModel().expectShape(memberShape.getTarget());
-        // Handle @xmlFlattened for collections and maps.
-        boolean isFlattened = memberShape.hasTrait(XmlFlattenedTrait.class);
-        // Handle targets that return multiple entities per member.
-        boolean deserializationReturnsArray = deserializationReturnsArray(target);
-
-        // Build a string based on the traits that represents the location.
-        // Note we don't need to handle @xmlAttribute here because the parser flattens
-        // attributes in to the main structure.
-        StringBuilder sourceBuilder = new StringBuilder(inputLocation).append("['").append(locationName).append("']");
-        // Track any locations we need to validate on our way to the final element.
-        List<String> locationsToValidate = new ArrayList<>();
-
-        // Go in to a specialized element for unflattened aggregates.
-        if (deserializationReturnsArray && !isFlattened) {
-            // Make sure we validate the wrapping element is set.
-            locationsToValidate.add(sourceBuilder.toString());
-            // Update the target element.
-            String targetLocation = getUnnamedAggregateTargetLocation(model, target);
-            sourceBuilder.append("['").append(targetLocation).append("']");
-        }
-
-        // Handle self-closed xml parsed as an empty string.
-        if (deserializationReturnsArray) {
-            writer.openBlock("if ($L.$L === \"\") {", "}", inputLocation, locationName, () -> {
-                if (target instanceof MapShape) {
-                    writer.write("contents.$L = {};", memberName);
-                } else if (target instanceof ListShape) {
-                    writer.write("contents.$L = [];", memberName);
-                } else if (target instanceof SetShape) {
-                    writer.write("contents.$L = new Set([]);", memberName);
-                }
-            });
-        }
-
-        // Handle the response property.
-        String source = sourceBuilder.toString();
-        // Validate the resulting target element is set.
-        locationsToValidate.add(source);
-        // Build a string of the elements to validate before deserializing.
-        String validationStatement = locationsToValidate.stream()
-                .map(location -> location + " !== undefined")
-                .collect(Collectors.joining(" && "));
-        writer.openBlock("if ($L) {", "}", validationStatement, () -> {
-            String dataSource = handleNamedTargetWrapping(context, target, source);
-            statementBodyGenerator.accept(dataSource, getMemberVisitor(dataSource));
+    // Handle the response property.
+    String source = sourceBuilder.toString();
+    // Validate the resulting target element is set.
+    locationsToValidate.add(source);
+    // Build a string of the elements to validate before deserializing.
+    String validationStatement =
+        locationsToValidate
+            .stream()
+            .map(location -> location + " !== undefined")
+            .collect(Collectors.joining(" && "));
+    writer.openBlock(
+        "if ($L) {",
+        "}",
+        validationStatement,
+        () -> {
+          String dataSource = handleNamedTargetWrapping(context, target, source);
+          statementBodyGenerator.accept(dataSource, getMemberVisitor(dataSource));
         });
+  }
+
+  private String handleNamedTargetWrapping(
+      GenerationContext context, Shape target, String dataSource) {
+    if (!deserializationReturnsArray(target)) {
+      return dataSource;
     }
 
-    private String handleNamedTargetWrapping(GenerationContext context, Shape target, String dataSource) {
-        if (!deserializationReturnsArray(target)) {
-            return dataSource;
-        }
+    TypeScriptWriter writer = context.getWriter();
+    // The XML parser will set one K:V for a member that could
+    // return multiple entries but only has one.
+    writer.write("const wrappedItem = ($1L instanceof Array) ? $1L : [$1L];", dataSource);
+    return "wrappedItem";
+  }
 
-        TypeScriptWriter writer = context.getWriter();
-        // The XML parser will set one K:V for a member that could
-        // return multiple entries but only has one.
-        writer.write("const wrappedItem = ($1L instanceof Array) ? $1L : [$1L];", dataSource);
-        return "wrappedItem";
+  private String getUnnamedAggregateTargetLocation(Model model, Shape shape) {
+    if (shape.isMapShape()) {
+      return "entry";
     }
 
-    private String getUnnamedAggregateTargetLocation(Model model, Shape shape) {
-        if (shape.isMapShape()) {
-            return "entry";
-        }
+    // Any other aggregate shape is an instance of a CollectionShape.
+    return ((CollectionShape) shape)
+        .getMember()
+        .getMemberTrait(model, XmlNameTrait.class)
+        .map(XmlNameTrait::getValue)
+        .orElse("member");
+  }
 
-        // Any other aggregate shape is an instance of a CollectionShape.
-        return ((CollectionShape) shape).getMember().getMemberTrait(model, XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse("member");
-    }
+  @Override
+  protected void deserializeUnion(GenerationContext context, UnionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
 
-    @Override
-    protected void deserializeUnion(GenerationContext context, UnionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Check for any known union members and return when we find one.
-        Map<String, MemberShape> members = shape.getAllMembers();
-        members.forEach((memberName, memberShape) -> {
-            // Grab the target shape so we can use a member deserializer on it.
-            Shape target = context.getModel().expectShape(memberShape.getTarget());
-            deserializeNamedMember(context, memberName, memberShape, "output", (dataSource, visitor) -> {
-                writer.openBlock("return {", "};", () -> {
-                    // Dispatch to the output value provider for any additional handling.
-                    writer.write("$L: $L", memberName, target.accept(visitor));
-                });
-            });
+    // Check for any known union members and return when we find one.
+    Map<String, MemberShape> members = shape.getAllMembers();
+    members.forEach(
+        (memberName, memberShape) -> {
+          // Grab the target shape so we can use a member deserializer on it.
+          Shape target = context.getModel().expectShape(memberShape.getTarget());
+          deserializeNamedMember(
+              context,
+              memberName,
+              memberShape,
+              "output",
+              (dataSource, visitor) -> {
+                writer.openBlock(
+                    "return {",
+                    "};",
+                    () -> {
+                      // Dispatch to the output value provider for any additional handling.
+                      writer.write("$L: $L", memberName, target.accept(visitor));
+                    });
+              });
         });
 
-        // Or write output element to the unknown member.
-        writer.write("const key = Object.keys(output)[0];");
-        writer.write("return { $$unknown: [key, output[key]] };");
-    }
+    // Or write output element to the unknown member.
+    writer.write("const key = Object.keys(output)[0];");
+    writer.write("return { $$unknown: [key, output[key]] };");
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
@@ -37,277 +37,318 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentShapeSerVis
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 
 /**
- * Visitor to generate serialization functions for shapes in XML-document
- * based document bodies.
+ * Visitor to generate serialization functions for shapes in XML-document based document bodies.
  *
- * This class handles function body generation for all types expected by the {@code
+ * <p>This class handles function body generation for all types expected by the {@code
  * DocumentShapeSerVisitor}. No other shape type serialization is overridden.
  *
- * Timestamps are serialized to {@link Format}.DATE_TIME by default.
+ * <p>Timestamps are serialized to {@link Format}.DATE_TIME by default.
  *
  * @see <a href="https://awslabs.github.io/smithy/spec/xml.html">Smithy XML traits.</a>
  */
 final class XmlShapeSerVisitor extends DocumentShapeSerVisitor {
-    private static final Format TIMESTAMP_FORMAT = Format.DATE_TIME;
+  private static final Format TIMESTAMP_FORMAT = Format.DATE_TIME;
 
-    XmlShapeSerVisitor(GenerationContext context) {
-        super(context);
-    }
+  XmlShapeSerVisitor(GenerationContext context) {
+    super(context);
+  }
 
-    private XmlMemberSerVisitor getMemberVisitor(String dataSource) {
-        return new XmlMemberSerVisitor(getContext(), dataSource, TIMESTAMP_FORMAT);
-    }
+  private XmlMemberSerVisitor getMemberVisitor(String dataSource) {
+    return new XmlMemberSerVisitor(getContext(), dataSource, TIMESTAMP_FORMAT);
+  }
 
-    @Override
-    protected void serializeCollection(GenerationContext context, CollectionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        MemberShape memberShape = shape.getMember();
-        Shape target = context.getModel().expectShape(memberShape.getTarget());
-        writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
+  @Override
+  protected void serializeCollection(GenerationContext context, CollectionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    MemberShape memberShape = shape.getMember();
+    Shape target = context.getModel().expectShape(memberShape.getTarget());
+    writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
 
-        // Use the @xmlName trait if present on the member, otherwise use "member".
-        String locationName = memberShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse("member");
+    // Use the @xmlName trait if present on the member, otherwise use "member".
+    String locationName =
+        memberShape.getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse("member");
 
-        // Set up a location to store all of the child node(s).
-        writer.write("const collectedNodes: any = [];");
-        writer.openBlock("for (let entry of input) {", "}", () -> {
-            // Dispatch to the input value provider for any additional handling.
-            writer.write("const node = $L;", target.accept(getMemberVisitor("entry")));
-            // Handle proper unwrapping of target nodes.
-            if (serializationReturnsArray(target)) {
-                writer.write("const container = new __XmlNode($S);", locationName);
-                writer.openBlock("for (let index in node) {", "}", () -> {
-                    writer.write("const workingNode = node[index];");
-                    // Add @xmlNamespace value of the target member.
-                    AwsProtocolUtils.writeXmlNamespace(context, memberShape, "workingNode");
-                    writer.write("container.addChildNode(workingNode);");
+    // Set up a location to store all of the child node(s).
+    writer.write("const collectedNodes: any = [];");
+    writer.openBlock(
+        "for (let entry of input) {",
+        "}",
+        () -> {
+          // Dispatch to the input value provider for any additional handling.
+          writer.write("const node = $L;", target.accept(getMemberVisitor("entry")));
+          // Handle proper unwrapping of target nodes.
+          if (serializationReturnsArray(target)) {
+            writer.write("const container = new __XmlNode($S);", locationName);
+            writer.openBlock(
+                "for (let index in node) {",
+                "}",
+                () -> {
+                  writer.write("const workingNode = node[index];");
+                  // Add @xmlNamespace value of the target member.
+                  AwsProtocolUtils.writeXmlNamespace(context, memberShape, "workingNode");
+                  writer.write("container.addChildNode(workingNode);");
                 });
-                writer.write("collectedNodes.push(container);");
-            } else {
-                // Add @xmlNamespace value of the target member.
-                AwsProtocolUtils.writeXmlNamespace(context, memberShape, "node");
-                writer.write("collectedNodes.push(node.withName($S));", locationName);
-            }
-        });
-
-        writer.write("return collectedNodes;");
-    }
-
-    @Override
-    protected void serializeDocument(GenerationContext context, DocumentShape shape) {
-        throw new CodegenException(String.format(
-                "Cannot serialize Document types on AWS XML protocols, shape: %s.", shape.getId()));
-    }
-
-    @Override
-    protected void serializeMap(GenerationContext context, MapShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        Model model = context.getModel();
-        writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
-
-        // Set up a location to store all of the child node(s).
-        writer.write("const collectedNodes: any = [];");
-        // Use the keys as an iteration point to dispatch to the input value providers.
-        writer.openBlock("Object.keys(input).forEach(key => {", "});", () -> {
-            // Prepare a containing node for each entry's k/v pair.
-            writer.write("const entryNode = new __XmlNode(\"entry\");");
-
-            // Prepare the key's node.
-            // Use the @xmlName trait if present on the member, otherwise use "key".
-            MemberShape keyMember = shape.getKey();
-            Shape keyTarget = model.expectShape(keyMember.getTarget());
-            String keyName = keyMember.getTrait(XmlNameTrait.class)
-                    .map(XmlNameTrait::getValue)
-                    .orElse("key");
-            writer.write("const keyNode = $L.withName($S);", keyTarget.accept(getMemberVisitor("key")), keyName);
-            // Add @xmlNamespace value of the key member.
-            AwsProtocolUtils.writeXmlNamespace(context, keyMember, "workingNode");
-            writer.write("entryNode.addChildNode(keyNode);");
-
-            // Prepare the value's node.
-            // Use the @xmlName trait if present on the member, otherwise use "value".
-            MemberShape valueMember = shape.getValue();
-            Shape valueTarget = model.expectShape(valueMember.getTarget());
-            String valueName = valueMember.getTrait(XmlNameTrait.class)
-                    .map(XmlNameTrait::getValue)
-                    .orElse("value");
-            // Dispatch to the input value provider for any additional handling.
-            writer.write("const node = $L;", valueTarget.accept(getMemberVisitor("input[key]")));
-            // Handle proper unwrapping of target nodes.
-            if (serializationReturnsArray(valueTarget)) {
-                writer.write("const container = new __XmlNode($S);", valueName);
-                writer.openBlock("for (let index in node) {", "}", () -> {
-                    writer.write("const workingNode = node[index];");
-                    // Add @xmlNamespace value of the value member.
-                    AwsProtocolUtils.writeXmlNamespace(context, valueMember, "workingNode");
-                    writer.write("container.addChildNode(workingNode);");
-                });
-                writer.write("entryNode.addChildNode(container);");
-            } else {
-                // Add @xmlNamespace value of the target member.
-                AwsProtocolUtils.writeXmlNamespace(context, valueMember, "node");
-                writer.write("entryNode.addChildNode(node.withName($S));", valueName);
-            }
-
-            // Add the entry to the collection.
-            writer.write("collectedNodes.push(entryNode);");
-        });
-
-        writer.write("return collectedNodes;");
-    }
-
-    @Override
-    protected void serializeStructure(GenerationContext context, StructureShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
-
-        // Handle the @xmlName trait for the structure itself.
-        String nodeName = shape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(shape.getId().getName());
-
-        // Create the structure's node.
-        writer.write("const bodyNode = new __XmlNode($S);", nodeName);
-
-        // Serialize every member of the structure if present.
-        Map<String, MemberShape> members = shape.getAllMembers();
-        members.forEach((memberName, memberShape) -> {
-            String inputLocation = "input." + memberName;
-
-            // Handle if the member is an idempotency token that should be auto-filled.
-            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
-
-            writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
-                serializeNamedMember(context, memberName, memberShape, () -> inputLocation);
-            });
-        });
-
-        writer.write("return bodyNode;");
-    }
-
-    void serializeNamedMember(
-            GenerationContext context,
-            String memberName,
-            MemberShape memberShape,
-            Supplier<String> inputLocation
-    ) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Use the @xmlName trait if present on the member, otherwise use the member name.
-        String locationName = memberShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(memberName);
-
-        // Handle @xmlAttribute simple members.
-        if (memberShape.hasTrait(XmlAttributeTrait.class)) {
-            writer.write("bodyNode.addAttribute($S, $L);", locationName, inputLocation.get());
-        } else {
-            // Grab the target shape so we can use a member serializer on it.
-            Shape target = context.getModel().expectShape(memberShape.getTarget());
-            XmlMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation.get());
-
-            // Collected members must be handled with flattening and renaming.
-            if (serializationReturnsArray(target)) {
-                serializeNamedMemberFromArray(context, locationName, memberShape, target, inputVisitor);
-            } else {
-                // Handle @timestampFormat on members not just the targeted shape.
-                String valueProvider;
-                if (memberShape.hasTrait(TimestampFormatTrait.class)) {
-                    valueProvider = inputVisitor.getAsXmlText(target,
-                            AwsProtocolUtils.getInputTimestampValueProvider(context, memberShape,
-                                    TIMESTAMP_FORMAT, inputLocation.get()) + ".toString()");
-                } else {
-                    valueProvider = target.accept(inputVisitor);
-                }
-
-                // Standard members are added as children after updating their names.
-                writer.write("const node = $L.withName($S);", valueProvider, locationName);
-                // Add @xmlNamespace value of the target member.
-                AwsProtocolUtils.writeXmlNamespace(context, memberShape, "node");
-                writer.write("bodyNode.addChildNode(node);");
-            }
-        }
-    }
-
-    private void serializeNamedMemberFromArray(
-            GenerationContext context,
-            String locationName,
-            MemberShape memberShape,
-            Shape target,
-            DocumentMemberSerVisitor inputVisitor
-    ) {
-        TypeScriptWriter writer = context.getWriter();
-
-        // Handle @xmlFlattened for collections and maps.
-        boolean isFlattened = memberShape.hasTrait(XmlFlattenedTrait.class);
-
-        // Get all the nodes that are going to be serialized.
-        writer.write("const nodes = $L;", target.accept(inputVisitor));
-
-        // Prepare a containing node to hold the nodes if not flattened.
-        if (!isFlattened) {
-            writer.write("const containerNode = new __XmlNode($S);", locationName);
+            writer.write("collectedNodes.push(container);");
+          } else {
             // Add @xmlNamespace value of the target member.
-            AwsProtocolUtils.writeXmlNamespace(context, memberShape, "containerNode");
-        }
-
-        // Add every node to the target node.
-        writer.openBlock("nodes.map((node: any) => {", "});", () -> {
-            // Adjust to add sub nodes to the right target based on flattening.
-            String targetNode = isFlattened ? "bodyNode" : "containerNode";
-            if (isFlattened) {
-                writer.write("node = node.withName($S);", locationName);
-            }
-            writer.write("$L.addChildNode(node);", targetNode);
+            AwsProtocolUtils.writeXmlNamespace(context, memberShape, "node");
+            writer.write("collectedNodes.push(node.withName($S));", locationName);
+          }
         });
 
-        // For non-flattened collected nodes, we have to add the containing node.
-        if (!isFlattened) {
-            writer.write("bodyNode.addChildNode(containerNode);");
+    writer.write("return collectedNodes;");
+  }
+
+  @Override
+  protected void serializeDocument(GenerationContext context, DocumentShape shape) {
+    throw new CodegenException(
+        String.format(
+            "Cannot serialize Document types on AWS XML protocols, shape: %s.", shape.getId()));
+  }
+
+  @Override
+  protected void serializeMap(GenerationContext context, MapShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    Model model = context.getModel();
+    writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
+
+    // Set up a location to store all of the child node(s).
+    writer.write("const collectedNodes: any = [];");
+    // Use the keys as an iteration point to dispatch to the input value providers.
+    writer.openBlock(
+        "Object.keys(input).forEach(key => {",
+        "});",
+        () -> {
+          // Prepare a containing node for each entry's k/v pair.
+          writer.write("const entryNode = new __XmlNode(\"entry\");");
+
+          // Prepare the key's node.
+          // Use the @xmlName trait if present on the member, otherwise use "key".
+          MemberShape keyMember = shape.getKey();
+          Shape keyTarget = model.expectShape(keyMember.getTarget());
+          String keyName =
+              keyMember.getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse("key");
+          writer.write(
+              "const keyNode = $L.withName($S);",
+              keyTarget.accept(getMemberVisitor("key")),
+              keyName);
+          // Add @xmlNamespace value of the key member.
+          AwsProtocolUtils.writeXmlNamespace(context, keyMember, "workingNode");
+          writer.write("entryNode.addChildNode(keyNode);");
+
+          // Prepare the value's node.
+          // Use the @xmlName trait if present on the member, otherwise use "value".
+          MemberShape valueMember = shape.getValue();
+          Shape valueTarget = model.expectShape(valueMember.getTarget());
+          String valueName =
+              valueMember.getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse("value");
+          // Dispatch to the input value provider for any additional handling.
+          writer.write("const node = $L;", valueTarget.accept(getMemberVisitor("input[key]")));
+          // Handle proper unwrapping of target nodes.
+          if (serializationReturnsArray(valueTarget)) {
+            writer.write("const container = new __XmlNode($S);", valueName);
+            writer.openBlock(
+                "for (let index in node) {",
+                "}",
+                () -> {
+                  writer.write("const workingNode = node[index];");
+                  // Add @xmlNamespace value of the value member.
+                  AwsProtocolUtils.writeXmlNamespace(context, valueMember, "workingNode");
+                  writer.write("container.addChildNode(workingNode);");
+                });
+            writer.write("entryNode.addChildNode(container);");
+          } else {
+            // Add @xmlNamespace value of the target member.
+            AwsProtocolUtils.writeXmlNamespace(context, valueMember, "node");
+            writer.write("entryNode.addChildNode(node.withName($S));", valueName);
+          }
+
+          // Add the entry to the collection.
+          writer.write("collectedNodes.push(entryNode);");
+        });
+
+    writer.write("return collectedNodes;");
+  }
+
+  @Override
+  protected void serializeStructure(GenerationContext context, StructureShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
+
+    // Handle the @xmlName trait for the structure itself.
+    String nodeName =
+        shape
+            .getTrait(XmlNameTrait.class)
+            .map(XmlNameTrait::getValue)
+            .orElse(shape.getId().getName());
+
+    // Create the structure's node.
+    writer.write("const bodyNode = new __XmlNode($S);", nodeName);
+
+    // Serialize every member of the structure if present.
+    Map<String, MemberShape> members = shape.getAllMembers();
+    members.forEach(
+        (memberName, memberShape) -> {
+          String inputLocation = "input." + memberName;
+
+          // Handle if the member is an idempotency token that should be auto-filled.
+          AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+
+          writer.openBlock(
+              "if ($L !== undefined) {",
+              "}",
+              inputLocation,
+              () -> {
+                serializeNamedMember(context, memberName, memberShape, () -> inputLocation);
+              });
+        });
+
+    writer.write("return bodyNode;");
+  }
+
+  void serializeNamedMember(
+      GenerationContext context,
+      String memberName,
+      MemberShape memberShape,
+      Supplier<String> inputLocation) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Use the @xmlName trait if present on the member, otherwise use the member name.
+    String locationName =
+        memberShape.getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse(memberName);
+
+    // Handle @xmlAttribute simple members.
+    if (memberShape.hasTrait(XmlAttributeTrait.class)) {
+      writer.write("bodyNode.addAttribute($S, $L);", locationName, inputLocation.get());
+    } else {
+      // Grab the target shape so we can use a member serializer on it.
+      Shape target = context.getModel().expectShape(memberShape.getTarget());
+      XmlMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation.get());
+
+      // Collected members must be handled with flattening and renaming.
+      if (serializationReturnsArray(target)) {
+        serializeNamedMemberFromArray(context, locationName, memberShape, target, inputVisitor);
+      } else {
+        // Handle @timestampFormat on members not just the targeted shape.
+        String valueProvider;
+        if (memberShape.hasTrait(TimestampFormatTrait.class)) {
+          valueProvider =
+              inputVisitor.getAsXmlText(
+                  target,
+                  AwsProtocolUtils.getInputTimestampValueProvider(
+                          context, memberShape, TIMESTAMP_FORMAT, inputLocation.get())
+                      + ".toString()");
+        } else {
+          valueProvider = target.accept(inputVisitor);
         }
+
+        // Standard members are added as children after updating their names.
+        writer.write("const node = $L.withName($S);", valueProvider, locationName);
+        // Add @xmlNamespace value of the target member.
+        AwsProtocolUtils.writeXmlNamespace(context, memberShape, "node");
+        writer.write("bodyNode.addChildNode(node);");
+      }
+    }
+  }
+
+  private void serializeNamedMemberFromArray(
+      GenerationContext context,
+      String locationName,
+      MemberShape memberShape,
+      Shape target,
+      DocumentMemberSerVisitor inputVisitor) {
+    TypeScriptWriter writer = context.getWriter();
+
+    // Handle @xmlFlattened for collections and maps.
+    boolean isFlattened = memberShape.hasTrait(XmlFlattenedTrait.class);
+
+    // Get all the nodes that are going to be serialized.
+    writer.write("const nodes = $L;", target.accept(inputVisitor));
+
+    // Prepare a containing node to hold the nodes if not flattened.
+    if (!isFlattened) {
+      writer.write("const containerNode = new __XmlNode($S);", locationName);
+      // Add @xmlNamespace value of the target member.
+      AwsProtocolUtils.writeXmlNamespace(context, memberShape, "containerNode");
     }
 
-    private boolean serializationReturnsArray(Shape shape) {
-        return (shape instanceof CollectionShape) || (shape instanceof MapShape);
+    // Add every node to the target node.
+    writer.openBlock(
+        "nodes.map((node: any) => {",
+        "});",
+        () -> {
+          // Adjust to add sub nodes to the right target based on flattening.
+          String targetNode = isFlattened ? "bodyNode" : "containerNode";
+          if (isFlattened) {
+            writer.write("node = node.withName($S);", locationName);
+          }
+          writer.write("$L.addChildNode(node);", targetNode);
+        });
+
+    // For non-flattened collected nodes, we have to add the containing node.
+    if (!isFlattened) {
+      writer.write("bodyNode.addChildNode(containerNode);");
     }
+  }
 
-    @Override
-    protected void serializeUnion(GenerationContext context, UnionShape shape) {
-        TypeScriptWriter writer = context.getWriter();
-        writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
-        writer.addImport("XmlText", "__XmlText", "@aws-sdk/xml-builder");
+  private boolean serializationReturnsArray(Shape shape) {
+    return (shape instanceof CollectionShape) || (shape instanceof MapShape);
+  }
 
-        // Handle the @xmlName trait for the union itself.
-        String nodeName = shape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(shape.getId().getName());
+  @Override
+  protected void serializeUnion(GenerationContext context, UnionShape shape) {
+    TypeScriptWriter writer = context.getWriter();
+    writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
+    writer.addImport("XmlText", "__XmlText", "@aws-sdk/xml-builder");
 
-        // Create the union's node.
-        writer.write("const bodyNode = new __XmlNode($S);", nodeName);
+    // Handle the @xmlName trait for the union itself.
+    String nodeName =
+        shape
+            .getTrait(XmlNameTrait.class)
+            .map(XmlNameTrait::getValue)
+            .orElse(shape.getId().getName());
 
-        // Visit over the union type, then get the right serialization for the member.
-        writer.openBlock("$L.visit(input, {", "});", shape.getId().getName(), () -> {
-            Map<String, MemberShape> members = shape.getAllMembers();
-            members.forEach((memberName, memberShape) -> {
-                writer.openBlock("$L: value => {", "},", memberName, () -> {
-                    serializeNamedMember(context, memberName, memberShape, () -> "value");
-                });
-            });
+    // Create the union's node.
+    writer.write("const bodyNode = new __XmlNode($S);", nodeName);
 
-            // Handle the unknown property.
-            writer.openBlock("_: (name: string, value: any) => {", "}", () -> {
-                // Throw an exception if we're trying to serialize something that we wouldn't know how to.
-                writer.openBlock("if (!(value instanceof __XmlNode || value instanceof __XmlText)) {", "}", () -> {
-                    writer.write("throw new Error(\"Unable to serialize unknown union members in XML.\");");
-                });
+    // Visit over the union type, then get the right serialization for the member.
+    writer.openBlock(
+        "$L.visit(input, {",
+        "});",
+        shape.getId().getName(),
+        () -> {
+          Map<String, MemberShape> members = shape.getAllMembers();
+          members.forEach(
+              (memberName, memberShape) -> {
+                writer.openBlock(
+                    "$L: value => {",
+                    "},",
+                    memberName,
+                    () -> {
+                      serializeNamedMember(context, memberName, memberShape, () -> "value");
+                    });
+              });
+
+          // Handle the unknown property.
+          writer.openBlock(
+              "_: (name: string, value: any) => {",
+              "}",
+              () -> {
+                // Throw an exception if we're trying to serialize something that we wouldn't know
+                // how to.
+                writer.openBlock(
+                    "if (!(value instanceof __XmlNode || value instanceof __XmlText)) {",
+                    "}",
+                    () -> {
+                      writer.write(
+                          "throw new Error(\"Unable to serialize unknown union members in XML.\");");
+                    });
 
                 // Set the node explicitly for potentially correct cases.
                 writer.write("bodyNode.addChildNode(new __XmlNode(value).addChildNode(value));");
-            });
+              });
         });
 
-        writer.write("return bodyNode;");
-    }
+    writer.write("return bodyNode;");
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
@@ -11,35 +11,45 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
 public class AddAwsRuntimeConfigTest {
-    @Test
-    public void addsAwsRuntimeConfigSettings() {
-        Model model = Model.assembler()
-                .addImport(getClass().getResource("serviceid.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
-        MockManifest manifest = new MockManifest();
-        PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                                  .withMember("service", Node.from("smithy.example#OriginalName"))
-                                  .withMember("package", Node.from("example"))
-                                  .withMember("packageVersion", Node.from("1.0.0"))
-                                  .build())
-                .build();
-        new TypeScriptCodegenPlugin().execute(context);
+  @Test
+  public void addsAwsRuntimeConfigSettings() {
+    Model model =
+        Model.assembler()
+            .addImport(getClass().getResource("serviceid.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
+    MockManifest manifest = new MockManifest();
+    PluginContext context =
+        PluginContext.builder()
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build())
+            .build();
+    new TypeScriptCodegenPlugin().execute(context);
 
-        // Check that one of the many dependencies was added.
-        assertThat(manifest.getFileString("package.json").get(),
-                   containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
+    // Check that one of the many dependencies was added.
+    assertThat(
+        manifest.getFileString("package.json").get(),
+        containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
 
-        // Check that both the config files were updated.
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("credentialDefaultProvider"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("invalidFunction"));
+    // Check that both the config files were updated.
+    assertThat(
+        manifest.getFileString("runtimeConfig.ts").get(),
+        containsString("credentialDefaultProvider"));
+    assertThat(
+        manifest.getFileString("runtimeConfig.browser.ts").get(),
+        containsString("invalidFunction"));
 
-        // Check that the dependency interface was updated.
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("credentialDefaultProvider?"));
-    }
+    // Check that the dependency interface was updated.
+    assertThat(
+        manifest.getFileString("NotSameClient.ts").get(),
+        containsString("credentialDefaultProvider?"));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegrationTest.java
@@ -9,29 +9,32 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
 public class AwsPackageFixturesGeneratorIntegrationTest {
-    @Test
-    public void expandsPackageFixtureFiles() {
-        Model model = Model.assembler()
-                .addImport(getClass().getResource("serviceid.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
-        MockManifest manifest = new MockManifest();
-        PluginContext context = PluginContext.builder()
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#OriginalName"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+  @Test
+  public void expandsPackageFixtureFiles() {
+    Model model =
+        Model.assembler()
+            .addImport(getClass().getResource("serviceid.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
+    MockManifest manifest = new MockManifest();
+    PluginContext context =
+        PluginContext.builder()
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build())
+            .build();
 
-        new TypeScriptCodegenPlugin().execute(context);
+    new TypeScriptCodegenPlugin().execute(context);
 
-        Assertions.assertTrue(manifest.hasFile("LICENSE"));
-        Assertions.assertTrue(manifest.hasFile(".gitignore"));
-        Assertions.assertTrue(manifest.hasFile(".npmignore"));
-        Assertions.assertTrue(manifest.hasFile("README.md"));
-    }
+    Assertions.assertTrue(manifest.hasFile("LICENSE"));
+    Assertions.assertTrue(manifest.hasFile(".gitignore"));
+    Assertions.assertTrue(manifest.hasFile(".npmignore"));
+    Assertions.assertTrue(manifest.hasFile("README.md"));
+  }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -16,22 +16,23 @@ import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 
 public class AwsServiceIdIntegrationTest {
-    @Test
-    public void testSomeLibraryMethod() {
-        Model model = Model.assembler()
-                .addImport(getClass().getResource("serviceid.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
-        Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
-        AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
-        SymbolProvider decorated = integration.decorateSymbolProvider(
-                new TypeScriptSettings(), model, provider);
-        Symbol symbol = decorated.toSymbol(service);
+  @Test
+  public void testSomeLibraryMethod() {
+    Model model =
+        Model.assembler()
+            .addImport(getClass().getResource("serviceid.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
+    Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
+    AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
+    SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+    SymbolProvider decorated =
+        integration.decorateSymbolProvider(new TypeScriptSettings(), model, provider);
+    Symbol symbol = decorated.toSymbol(service);
 
-        assertThat(symbol.getName(), equalTo("NotSameClient"));
-        assertThat(symbol.getNamespace(), equalTo("./NotSameClient"));
-        assertThat(symbol.getDefinitionFile(), equalTo("NotSameClient.ts"));
-    }
+    assertThat(symbol.getName(), equalTo("NotSameClient"));
+    assertThat(symbol.getNamespace(), equalTo("./NotSameClient"));
+    assertThat(symbol.getDefinitionFile(), equalTo("NotSameClient.ts"));
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1147

*Description of changes:*
use google-java-format for formatting Java code on build

Example code before formatting: https://github.com/aws/aws-sdk-js-v3/blob/4b16f7c3ee15b90f02c4087650357c4964980f64/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBodyChecksumGeneratorDependency.java#L43-L57

After formatting:
```java
  @Override
  public void addConfigInterfaceFields(
      TypeScriptSettings settings,
      Model model,
      SymbolProvider symbolProvider,
      TypeScriptWriter writer) {
    if (!needsBodyChecksumGeneratorDep(settings.getService(model))) {
      return;
    }
    writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/types");
    writer.writeDocs("Function that returns body checksums.");
    writer.write(
        "bodyChecksumGenerator?: (request: __HttpRequest, options: { sha256: __HashConstructor; "
            + "utf8Decoder: __Decoder }) => Promise<[string, string]>;\n");
  }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
