### PR TITLE
chore: make generateIdempotencyToken calls before consuming

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
@@ -114,6 +114,9 @@ export const serializeAws_restJson1_1CreateAnalyzerCommand = async (
   };
   let resolvedPath = "/analyzer";
   let body: any;
+  if (input.clientToken === undefined) {
+    input.clientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.analyzerName !== undefined) {
     bodyParams["analyzerName"] = input.analyzerName;
@@ -123,9 +126,6 @@ export const serializeAws_restJson1_1CreateAnalyzerCommand = async (
       input.archiveRules,
       context
     );
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
   }
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
@@ -172,10 +172,10 @@ export const serializeAws_restJson1_1CreateArchiveRuleCommand = async (
     throw new Error("No value provided for input HTTP label: analyzerName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -766,10 +766,10 @@ export const serializeAws_restJson1_1UpdateArchiveRuleCommand = async (
     throw new Error("No value provided for input HTTP label: ruleName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -801,12 +801,12 @@ export const serializeAws_restJson1_1UpdateFindingsCommand = async (
   };
   let resolvedPath = "/finding";
   let body: any;
+  if (input.clientToken === undefined) {
+    input.clientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.analyzerArn !== undefined) {
     bodyParams["analyzerArn"] = input.analyzerArn;
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
   }
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -8782,10 +8782,10 @@ const serializeAws_json1_1SendAnnouncementRequest = (
   input: SendAnnouncementRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9008,10 +9008,10 @@ const serializeAws_json1_1CreateAddressBookRequest = (
   input: CreateAddressBookRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9028,10 +9028,10 @@ const serializeAws_json1_1CreateBusinessReportScheduleRequest = (
   input: CreateBusinessReportScheduleRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9066,10 +9066,10 @@ const serializeAws_json1_1CreateConferenceProviderRequest = (
   input: CreateConferenceProviderRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9104,10 +9104,10 @@ const serializeAws_json1_1CreateContactRequest = (
   input: CreateContactRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9164,10 +9164,10 @@ const serializeAws_json1_1CreateGatewayGroupRequest = (
   input: CreateGatewayGroupRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9230,12 +9230,12 @@ const serializeAws_json1_1CreateNetworkProfileRequest = (
   input: CreateNetworkProfileRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.CertificateAuthorityArn !== undefined) {
     bodyParams["CertificateAuthorityArn"] = input.CertificateAuthorityArn;
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
   }
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
@@ -9274,12 +9274,12 @@ const serializeAws_json1_1CreateProfileRequest = (
   input: CreateProfileRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Address !== undefined) {
     bodyParams["Address"] = input.Address;
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
   }
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
@@ -9340,10 +9340,10 @@ const serializeAws_json1_1CreateRoomRequest = (
   input: CreateRoomRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9369,10 +9369,10 @@ const serializeAws_json1_1CreateSkillGroupRequest = (
   input: CreateSkillGroupRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -9389,10 +9389,10 @@ const serializeAws_json1_1CreateUserRequest = (
   input: CreateUserRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
@@ -205,10 +205,10 @@ export const serializeAws_restJson1_1CreateMeshCommand = async (
   };
   let resolvedPath = "/v20190125/meshes";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -272,10 +272,10 @@ export const serializeAws_restJson1_1CreateRouteCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -322,10 +322,10 @@ export const serializeAws_restJson1_1CreateVirtualNodeCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -375,10 +375,10 @@ export const serializeAws_restJson1_1CreateVirtualRouterCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -428,10 +428,10 @@ export const serializeAws_restJson1_1CreateVirtualServiceCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1252,10 +1252,10 @@ export const serializeAws_restJson1_1UpdateMeshCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1325,10 +1325,10 @@ export const serializeAws_restJson1_1UpdateRouteCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1384,10 +1384,10 @@ export const serializeAws_restJson1_1UpdateVirtualNodeCommand = async (
     throw new Error("No value provided for input HTTP label: virtualNodeName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1448,10 +1448,10 @@ export const serializeAws_restJson1_1UpdateVirtualRouterCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1512,10 +1512,10 @@ export const serializeAws_restJson1_1UpdateVirtualServiceCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -4148,10 +4148,10 @@ const serializeAws_json1_1StartImportTaskRequest = (
   input: StartImportTaskRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }

--- a/clients/client-athena/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/protocols/Aws_json1_1.ts
@@ -1944,10 +1944,10 @@ const serializeAws_json1_1CreateNamedQueryInput = (
   input: CreateNamedQueryInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -1996,10 +1996,10 @@ const serializeAws_json1_1DeleteNamedQueryInput = (
   input: DeleteNamedQueryInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.NamedQueryId === undefined) {
     input.NamedQueryId = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.NamedQueryId !== undefined) {
     bodyParams["NamedQueryId"] = input.NamedQueryId;
   }
@@ -2231,10 +2231,10 @@ const serializeAws_json1_1StartQueryExecutionInput = (
   input: StartQueryExecutionInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2265,10 +2265,10 @@ const serializeAws_json1_1StopQueryExecutionInput = (
   input: StopQueryExecutionInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.QueryExecutionId === undefined) {
     input.QueryExecutionId = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.QueryExecutionId !== undefined) {
     bodyParams["QueryExecutionId"] = input.QueryExecutionId;
   }

--- a/clients/client-chime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1_1.ts
@@ -1076,10 +1076,10 @@ export const serializeAws_restJson1_1CreateMeetingCommand = async (
   };
   let resolvedPath = "/meetings";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -1165,10 +1165,10 @@ export const serializeAws_restJson1_1CreateRoomCommand = async (
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -6676,6 +6676,9 @@ const serializeAws_queryCreateStackInstancesInput = (
   input: CreateStackInstancesInput,
   context: __SerdeContext
 ): any => {
+  if (input.OperationId === undefined) {
+    input.OperationId = generateIdempotencyToken();
+  }
   const entries: any = {};
   if (input.Accounts !== undefined) {
     const memberEntries = serializeAws_queryAccountList(
@@ -6686,9 +6689,6 @@ const serializeAws_queryCreateStackInstancesInput = (
       const loc = `Accounts.${key}`;
       entries[loc] = memberEntries[key];
     });
-  }
-  if (input.OperationId === undefined) {
-    input.OperationId = generateIdempotencyToken();
   }
   if (input.OperationId !== undefined) {
     entries["OperationId"] = input.OperationId;
@@ -6730,6 +6730,9 @@ const serializeAws_queryCreateStackSetInput = (
   input: CreateStackSetInput,
   context: __SerdeContext
 ): any => {
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   const entries: any = {};
   if (input.AdministrationRoleARN !== undefined) {
     entries["AdministrationRoleARN"] = input.AdministrationRoleARN;
@@ -6743,9 +6746,6 @@ const serializeAws_queryCreateStackSetInput = (
       const loc = `Capabilities.${key}`;
       entries[loc] = memberEntries[key];
     });
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
   }
   if (input.ClientRequestToken !== undefined) {
     entries["ClientRequestToken"] = input.ClientRequestToken;
@@ -6789,6 +6789,9 @@ const serializeAws_queryDeleteStackInstancesInput = (
   input: DeleteStackInstancesInput,
   context: __SerdeContext
 ): any => {
+  if (input.OperationId === undefined) {
+    input.OperationId = generateIdempotencyToken();
+  }
   const entries: any = {};
   if (input.Accounts !== undefined) {
     const memberEntries = serializeAws_queryAccountList(
@@ -6799,9 +6802,6 @@ const serializeAws_queryDeleteStackInstancesInput = (
       const loc = `Accounts.${key}`;
       entries[loc] = memberEntries[key];
     });
-  }
-  if (input.OperationId === undefined) {
-    input.OperationId = generateIdempotencyToken();
   }
   if (input.OperationId !== undefined) {
     entries["OperationId"] = input.OperationId;
@@ -6889,10 +6889,10 @@ const serializeAws_queryDetectStackSetDriftInput = (
   input: DetectStackSetDriftInput,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.OperationId === undefined) {
     input.OperationId = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.OperationId !== undefined) {
     entries["OperationId"] = input.OperationId;
   }
@@ -7050,6 +7050,9 @@ const serializeAws_queryUpdateStackInstancesInput = (
   input: UpdateStackInstancesInput,
   context: __SerdeContext
 ): any => {
+  if (input.OperationId === undefined) {
+    input.OperationId = generateIdempotencyToken();
+  }
   const entries: any = {};
   if (input.Accounts !== undefined) {
     const memberEntries = serializeAws_queryAccountList(
@@ -7060,9 +7063,6 @@ const serializeAws_queryUpdateStackInstancesInput = (
       const loc = `Accounts.${key}`;
       entries[loc] = memberEntries[key];
     });
-  }
-  if (input.OperationId === undefined) {
-    input.OperationId = generateIdempotencyToken();
   }
   if (input.OperationId !== undefined) {
     entries["OperationId"] = input.OperationId;
@@ -7104,6 +7104,9 @@ const serializeAws_queryUpdateStackSetInput = (
   input: UpdateStackSetInput,
   context: __SerdeContext
 ): any => {
+  if (input.OperationId === undefined) {
+    input.OperationId = generateIdempotencyToken();
+  }
   const entries: any = {};
   if (input.Accounts !== undefined) {
     const memberEntries = serializeAws_queryAccountList(
@@ -7133,9 +7136,6 @@ const serializeAws_queryUpdateStackSetInput = (
   }
   if (input.ExecutionRoleName !== undefined) {
     entries["ExecutionRoleName"] = input.ExecutionRoleName;
-  }
-  if (input.OperationId === undefined) {
-    input.OperationId = generateIdempotencyToken();
   }
   if (input.OperationId !== undefined) {
     entries["OperationId"] = input.OperationId;

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -2448,7 +2448,9 @@ const deserializeAws_json1_1BatchDescribeMergeConflictsCommandError = async (
 export const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput> => {
+): Promise<
+  BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandError(
       output,
@@ -2472,7 +2474,9 @@ export const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepo
 const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput> => {
+): Promise<
+  BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)
@@ -20765,10 +20769,10 @@ const serializeAws_json1_1CreatePullRequestInput = (
   input: CreatePullRequestInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -21736,15 +21740,15 @@ const serializeAws_json1_1PostCommentForComparedCommitInput = (
   input: PostCommentForComparedCommitInput,
   context: __SerdeContext
 ): any => {
+  if (input.clientRequestToken === undefined) {
+    input.clientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.afterCommitId !== undefined) {
     bodyParams["afterCommitId"] = input.afterCommitId;
   }
   if (input.beforeCommitId !== undefined) {
     bodyParams["beforeCommitId"] = input.beforeCommitId;
-  }
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
   }
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
@@ -21768,15 +21772,15 @@ const serializeAws_json1_1PostCommentForPullRequestInput = (
   input: PostCommentForPullRequestInput,
   context: __SerdeContext
 ): any => {
+  if (input.clientRequestToken === undefined) {
+    input.clientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.afterCommitId !== undefined) {
     bodyParams["afterCommitId"] = input.afterCommitId;
   }
   if (input.beforeCommitId !== undefined) {
     bodyParams["beforeCommitId"] = input.beforeCommitId;
-  }
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
   }
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
@@ -21803,10 +21807,10 @@ const serializeAws_json1_1PostCommentReplyInput = (
   input: PostCommentReplyInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
@@ -51,10 +51,10 @@ export const serializeAws_restJson1_1AssociateRepositoryCommand = async (
   };
   let resolvedPath = "/associations";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -5717,10 +5717,10 @@ const serializeAws_json1_1StartPipelineExecutionInput = (
   input: StartPipelineExecutionInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
@@ -89,10 +89,10 @@ export const serializeAws_restJson1_1CreateNotificationRuleCommand = async (
   };
   let resolvedPath = "/createNotificationRule";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-comprehend/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/protocols/Aws_json1_1.ts
@@ -6748,10 +6748,10 @@ const serializeAws_json1_1CreateDocumentClassifierRequest = (
   input: CreateDocumentClassifierRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -6802,10 +6802,10 @@ const serializeAws_json1_1CreateEndpointRequest = (
   input: CreateEndpointRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -6828,10 +6828,10 @@ const serializeAws_json1_1CreateEntityRecognizerRequest = (
   input: CreateEntityRecognizerRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -7603,10 +7603,10 @@ const serializeAws_json1_1StartDocumentClassificationJobRequest = (
   input: StartDocumentClassificationJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -7647,10 +7647,10 @@ const serializeAws_json1_1StartDominantLanguageDetectionJobRequest = (
   input: StartDominantLanguageDetectionJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -7688,10 +7688,10 @@ const serializeAws_json1_1StartEntitiesDetectionJobRequest = (
   input: StartEntitiesDetectionJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -7735,10 +7735,10 @@ const serializeAws_json1_1StartKeyPhrasesDetectionJobRequest = (
   input: StartKeyPhrasesDetectionJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -7779,10 +7779,10 @@ const serializeAws_json1_1StartSentimentDetectionJobRequest = (
   input: StartSentimentDetectionJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -7823,10 +7823,10 @@ const serializeAws_json1_1StartTopicsDetectionJobRequest = (
   input: StartTopicsDetectionJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
@@ -1960,10 +1960,10 @@ const serializeAws_json1_1StartEntitiesDetectionV2JobRequest = (
   input: StartEntitiesDetectionV2JobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -1998,10 +1998,10 @@ const serializeAws_json1_1StartPHIDetectionJobRequest = (
   input: StartPHIDetectionJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-connect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1_1.ts
@@ -1002,15 +1002,15 @@ export const serializeAws_restJson1_1StartChatContactCommand = async (
   };
   let resolvedPath = "/contact/chat";
   let body: any;
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Attributes !== undefined) {
     bodyParams["Attributes"] = serializeAws_restJson1_1Attributes(
       input.Attributes,
       context
     );
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
@@ -1057,15 +1057,15 @@ export const serializeAws_restJson1_1StartOutboundVoiceContactCommand = async (
   };
   let resolvedPath = "/contact/outbound-voice";
   let body: any;
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Attributes !== undefined) {
     bodyParams["Attributes"] = serializeAws_restJson1_1Attributes(
       input.Attributes,
       context
     );
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;

--- a/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
@@ -86,10 +86,10 @@ export const serializeAws_restJson1_1DisconnectParticipantCommand = async (
   };
   let resolvedPath = "/participant/disconnect";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }
@@ -165,10 +165,10 @@ export const serializeAws_restJson1_1SendEventCommand = async (
   };
   let resolvedPath = "/participant/event";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }
@@ -203,10 +203,10 @@ export const serializeAws_restJson1_1SendMessageCommand = async (
   };
   let resolvedPath = "/participant/message";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -7658,10 +7658,10 @@ const serializeAws_json1_0TransactWriteItemsInput = (
   input: TransactWriteItemsInput,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -20868,7 +20868,9 @@ const deserializeAws_ec2DescribeLaunchTemplatesCommandError = async (
 export const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput> => {
+): Promise<
+  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandError(
       output,
@@ -20893,7 +20895,9 @@ export const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGro
 const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput> => {
+): Promise<
+  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)
@@ -32570,10 +32574,10 @@ const serializeAws_ec2AssociateClientVpnTargetNetworkRequest = (
   input: AssociateClientVpnTargetNetworkRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -32873,15 +32877,15 @@ const serializeAws_ec2AuthorizeClientVpnIngressRequest = (
   input: AuthorizeClientVpnIngressRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const entries: any = {};
   if (input.AccessGroupId !== undefined) {
     entries["AccessGroupId"] = input.AccessGroupId;
   }
   if (input.AuthorizeAllGroups !== undefined) {
     entries["AuthorizeAllGroups"] = input.AuthorizeAllGroups;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
@@ -33693,6 +33697,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
   input: CreateClientVpnEndpointRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const entries: any = {};
   if (input.AuthenticationOptions !== undefined) {
     const memberEntries = serializeAws_ec2ClientVpnAuthenticationRequestList(
@@ -33706,9 +33713,6 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
   }
   if (input.ClientCidrBlock !== undefined) {
     entries["ClientCidrBlock"] = input.ClientCidrBlock;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
@@ -33768,10 +33772,10 @@ const serializeAws_ec2CreateClientVpnRouteRequest = (
   input: CreateClientVpnRouteRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -34692,10 +34696,10 @@ const serializeAws_ec2CreateTrafficMirrorFilterRequest = (
   input: CreateTrafficMirrorFilterRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -34722,10 +34726,10 @@ const serializeAws_ec2CreateTrafficMirrorFilterRuleRequest = (
   input: CreateTrafficMirrorFilterRuleRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -34783,10 +34787,10 @@ const serializeAws_ec2CreateTrafficMirrorSessionRequest = (
   input: CreateTrafficMirrorSessionRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -34831,10 +34835,10 @@ const serializeAws_ec2CreateTrafficMirrorTargetRequest = (
   input: CreateTrafficMirrorTargetRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -40539,10 +40543,10 @@ const serializeAws_ec2ExportImageRequest = (
   input: ExportImageRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -45241,10 +45245,10 @@ const serializeAws_ec2PurchaseScheduledInstancesRequest = (
   input: PurchaseScheduledInstancesRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }
@@ -46809,10 +46813,10 @@ const serializeAws_ec2RunScheduledInstancesRequest = (
   input: RunScheduledInstancesRequest,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.ClientToken !== undefined) {
     entries["ClientToken"] = input.ClientToken;
   }

--- a/clients/client-efs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1_1.ts
@@ -152,10 +152,10 @@ export const serializeAws_restJson1_1CreateAccessPointCommand = async (
   };
   let resolvedPath = "/2015-02-01/access-points";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }
@@ -199,10 +199,10 @@ export const serializeAws_restJson1_1CreateFileSystemCommand = async (
   };
   let resolvedPath = "/2015-02-01/file-systems";
   let body: any;
-  const bodyParams: any = {};
   if (input.CreationToken === undefined) {
     input.CreationToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.CreationToken !== undefined) {
     bodyParams["CreationToken"] = input.CreationToken;
   }

--- a/clients/client-eks/protocols/Aws_restJson1_1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1_1.ts
@@ -142,10 +142,10 @@ export const serializeAws_restJson1_1CreateClusterCommand = async (
   };
   let resolvedPath = "/clusters";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -209,10 +209,10 @@ export const serializeAws_restJson1_1CreateFargateProfileCommand = async (
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -273,12 +273,12 @@ export const serializeAws_restJson1_1CreateNodegroupCommand = async (
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   let body: any;
+  if (input.clientRequestToken === undefined) {
+    input.clientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.amiType !== undefined) {
     bodyParams["amiType"] = input.amiType;
-  }
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
   }
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
@@ -957,10 +957,10 @@ export const serializeAws_restJson1_1UpdateClusterConfigCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -1010,10 +1010,10 @@ export const serializeAws_restJson1_1UpdateClusterVersionCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -1071,10 +1071,10 @@ export const serializeAws_restJson1_1UpdateNodegroupConfigCommand = async (
     throw new Error("No value provided for input HTTP label: nodegroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -1143,10 +1143,10 @@ export const serializeAws_restJson1_1UpdateNodegroupVersionCommand = async (
     throw new Error("No value provided for input HTTP label: nodegroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }

--- a/clients/client-fsx/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/protocols/Aws_json1_1.ts
@@ -2336,10 +2336,10 @@ const serializeAws_json1_1CreateBackupRequest = (
   input: CreateBackupRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2356,10 +2356,10 @@ const serializeAws_json1_1CreateDataRepositoryTaskRequest = (
   input: CreateDataRepositoryTaskRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2391,12 +2391,12 @@ const serializeAws_json1_1CreateFileSystemFromBackupRequest = (
   input: CreateFileSystemFromBackupRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.BackupId !== undefined) {
     bodyParams["BackupId"] = input.BackupId;
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
   }
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
@@ -2451,10 +2451,10 @@ const serializeAws_json1_1CreateFileSystemRequest = (
   input: CreateFileSystemRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2597,12 +2597,12 @@ const serializeAws_json1_1DeleteBackupRequest = (
   input: DeleteBackupRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.BackupId !== undefined) {
     bodyParams["BackupId"] = input.BackupId;
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
   }
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
@@ -2614,10 +2614,10 @@ const serializeAws_json1_1DeleteFileSystemRequest = (
   input: DeleteFileSystemRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2950,10 +2950,10 @@ const serializeAws_json1_1UpdateFileSystemRequest = (
   input: UpdateFileSystemRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-guardduty/protocols/Aws_restJson1_1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1_1.ts
@@ -348,10 +348,10 @@ export const serializeAws_restJson1_1CreateDetectorCommand = async (
   };
   let resolvedPath = "/detector";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["clientToken"] = input.ClientToken;
   }
@@ -398,12 +398,12 @@ export const serializeAws_restJson1_1CreateFilterCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Action !== undefined) {
     bodyParams["action"] = input.Action;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     bodyParams["clientToken"] = input.ClientToken;
@@ -460,12 +460,12 @@ export const serializeAws_restJson1_1CreateIPSetCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Activate !== undefined) {
     bodyParams["activate"] = input.Activate;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     bodyParams["clientToken"] = input.ClientToken;
@@ -557,10 +557,10 @@ export const serializeAws_restJson1_1CreatePublishingDestinationCommand = async 
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["clientToken"] = input.ClientToken;
   }
@@ -650,12 +650,12 @@ export const serializeAws_restJson1_1CreateThreatIntelSetCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Activate !== undefined) {
     bodyParams["activate"] = input.Activate;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     bodyParams["clientToken"] = input.ClientToken;

--- a/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
@@ -265,12 +265,12 @@ export const serializeAws_restJson1_1CreateComponentCommand = async (
   };
   let resolvedPath = "/CreateComponent";
   let body: any;
+  if (input.clientToken === undefined) {
+    input.clientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.changeDescription !== undefined) {
     bodyParams["changeDescription"] = input.changeDescription;
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
   }
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
@@ -321,10 +321,10 @@ export const serializeAws_restJson1_1CreateDistributionConfigurationCommand = as
   };
   let resolvedPath = "/CreateDistributionConfiguration";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -365,10 +365,10 @@ export const serializeAws_restJson1_1CreateImageCommand = async (
   };
   let resolvedPath = "/CreateImage";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -416,10 +416,10 @@ export const serializeAws_restJson1_1CreateImagePipelineCommand = async (
   };
   let resolvedPath = "/CreateImagePipeline";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -482,6 +482,9 @@ export const serializeAws_restJson1_1CreateImageRecipeCommand = async (
   };
   let resolvedPath = "/CreateImageRecipe";
   let body: any;
+  if (input.clientToken === undefined) {
+    input.clientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.blockDeviceMappings !== undefined) {
     bodyParams[
@@ -490,9 +493,6 @@ export const serializeAws_restJson1_1CreateImageRecipeCommand = async (
       input.blockDeviceMappings,
       context
     );
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
   }
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
@@ -542,10 +542,10 @@ export const serializeAws_restJson1_1CreateInfrastructureConfigurationCommand = 
   };
   let resolvedPath = "/CreateInfrastructureConfiguration";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1016,12 +1016,12 @@ export const serializeAws_restJson1_1ImportComponentCommand = async (
   };
   let resolvedPath = "/ImportComponent";
   let body: any;
+  if (input.clientToken === undefined) {
+    input.clientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.changeDescription !== undefined) {
     bodyParams["changeDescription"] = input.changeDescription;
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
   }
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
@@ -1527,10 +1527,10 @@ export const serializeAws_restJson1_1StartImagePipelineExecutionCommand = async 
   };
   let resolvedPath = "/StartImagePipelineExecution";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1640,10 +1640,10 @@ export const serializeAws_restJson1_1UpdateDistributionConfigurationCommand = as
   };
   let resolvedPath = "/UpdateDistributionConfiguration";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1682,10 +1682,10 @@ export const serializeAws_restJson1_1UpdateImagePipelineCommand = async (
   };
   let resolvedPath = "/UpdateImagePipeline";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }
@@ -1745,10 +1745,10 @@ export const serializeAws_restJson1_1UpdateInfrastructureConfigurationCommand = 
   };
   let resolvedPath = "/UpdateInfrastructureConfiguration";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }

--- a/clients/client-iot/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1_1.ts
@@ -8242,6 +8242,9 @@ export const serializeAws_restJson1_1StartAuditMitigationActionsTaskCommand = as
     throw new Error("No value provided for input HTTP label: taskId.");
   }
   let body: any;
+  if (input.clientRequestToken === undefined) {
+    input.clientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.auditCheckToActionsMapping !== undefined) {
     bodyParams[
@@ -8250,9 +8253,6 @@ export const serializeAws_restJson1_1StartAuditMitigationActionsTaskCommand = as
       input.auditCheckToActionsMapping,
       context
     );
-  }
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
   }
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;

--- a/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
@@ -145,10 +145,10 @@ export const serializeAws_restJson1_1CreateMemberCommand = async (
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -185,10 +185,10 @@ export const serializeAws_restJson1_1CreateNetworkCommand = async (
   };
   let resolvedPath = "/networks";
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -272,10 +272,10 @@ export const serializeAws_restJson1_1CreateNodeCommand = async (
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -319,15 +319,15 @@ export const serializeAws_restJson1_1CreateProposalCommand = async (
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   let body: any;
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Actions !== undefined) {
     bodyParams["Actions"] = serializeAws_restJson1_1ProposalActions(
       input.Actions,
       context
     );
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
   }
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;

--- a/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
@@ -320,6 +320,9 @@ export const serializeAws_restJson1_1CreateJobCommand = async (
   };
   let resolvedPath = "/2017-08-29/jobs";
   let body: any;
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AccelerationSettings !== undefined) {
     bodyParams[
@@ -331,9 +334,6 @@ export const serializeAws_restJson1_1CreateJobCommand = async (
   }
   if (input.BillingTagsSource !== undefined) {
     bodyParams["billingTagsSource"] = input.BillingTagsSource;
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
   }
   if (input.ClientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.ClientRequestToken;

--- a/clients/client-medialive/protocols/Aws_restJson1_1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1_1.ts
@@ -432,6 +432,9 @@ export const serializeAws_restJson1_1CreateChannelCommand = async (
   };
   let resolvedPath = "/prod/channels";
   let body: any;
+  if (input.RequestId === undefined) {
+    input.RequestId = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.ChannelClass !== undefined) {
     bodyParams["channelClass"] = input.ChannelClass;
@@ -472,9 +475,6 @@ export const serializeAws_restJson1_1CreateChannelCommand = async (
   if (input.Name !== undefined) {
     bodyParams["name"] = input.Name;
   }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
-  }
   if (input.RequestId !== undefined) {
     bodyParams["requestId"] = input.RequestId;
   }
@@ -509,6 +509,9 @@ export const serializeAws_restJson1_1CreateInputCommand = async (
   };
   let resolvedPath = "/prod/inputs";
   let body: any;
+  if (input.RequestId === undefined) {
+    input.RequestId = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Destinations !== undefined) {
     bodyParams[
@@ -536,9 +539,6 @@ export const serializeAws_restJson1_1CreateInputCommand = async (
   }
   if (input.Name !== undefined) {
     bodyParams["name"] = input.Name;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
   }
   if (input.RequestId !== undefined) {
     bodyParams["requestId"] = input.RequestId;
@@ -620,6 +620,9 @@ export const serializeAws_restJson1_1CreateMultiplexCommand = async (
   };
   let resolvedPath = "/prod/multiplexes";
   let body: any;
+  if (input.RequestId === undefined) {
+    input.RequestId = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AvailabilityZones !== undefined) {
     bodyParams["availabilityZones"] = serializeAws_restJson1_1__listOf__string(
@@ -635,9 +638,6 @@ export const serializeAws_restJson1_1CreateMultiplexCommand = async (
   }
   if (input.Name !== undefined) {
     bodyParams["name"] = input.Name;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
   }
   if (input.RequestId !== undefined) {
     bodyParams["requestId"] = input.RequestId;
@@ -681,6 +681,9 @@ export const serializeAws_restJson1_1CreateMultiplexProgramCommand = async (
     throw new Error("No value provided for input HTTP label: MultiplexId.");
   }
   let body: any;
+  if (input.RequestId === undefined) {
+    input.RequestId = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.MultiplexProgramSettings !== undefined) {
     bodyParams[
@@ -692,9 +695,6 @@ export const serializeAws_restJson1_1CreateMultiplexProgramCommand = async (
   }
   if (input.ProgramName !== undefined) {
     bodyParams["programName"] = input.ProgramName;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
   }
   if (input.RequestId !== undefined) {
     bodyParams["requestId"] = input.RequestId;
@@ -1653,15 +1653,15 @@ export const serializeAws_restJson1_1PurchaseOfferingCommand = async (
     throw new Error("No value provided for input HTTP label: OfferingId.");
   }
   let body: any;
+  if (input.RequestId === undefined) {
+    input.RequestId = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Count !== undefined) {
     bodyParams["count"] = input.Count;
   }
   if (input.Name !== undefined) {
     bodyParams["name"] = input.Name;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
   }
   if (input.RequestId !== undefined) {
     bodyParams["requestId"] = input.RequestId;

--- a/clients/client-mq/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1_1.ts
@@ -139,6 +139,9 @@ export const serializeAws_restJson1_1CreateBrokerCommand = async (
   };
   let resolvedPath = "/v1/brokers";
   let body: any;
+  if (input.CreatorRequestId === undefined) {
+    input.CreatorRequestId = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AutoMinorVersionUpgrade !== undefined) {
     bodyParams["autoMinorVersionUpgrade"] = input.AutoMinorVersionUpgrade;
@@ -151,9 +154,6 @@ export const serializeAws_restJson1_1CreateBrokerCommand = async (
       input.Configuration,
       context
     );
-  }
-  if (input.CreatorRequestId === undefined) {
-    input.CreatorRequestId = generateIdempotencyToken();
   }
   if (input.CreatorRequestId !== undefined) {
     bodyParams["creatorRequestId"] = input.CreatorRequestId;

--- a/clients/client-robomaker/protocols/Aws_restJson1_1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1_1.ts
@@ -288,10 +288,10 @@ export const serializeAws_restJson1_1CreateDeploymentJobCommand = async (
   };
   let resolvedPath = "/createDeploymentJob";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -559,10 +559,10 @@ export const serializeAws_restJson1_1CreateSimulationJobCommand = async (
   };
   let resolvedPath = "/createSimulationJob";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }
@@ -1247,10 +1247,10 @@ export const serializeAws_restJson1_1SyncDeploymentJobCommand = async (
   };
   let resolvedPath = "/syncDeploymentJob";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -197,15 +197,15 @@ export const serializeAws_restXmlCreateJobCommand = async (
   };
   let resolvedPath = "/v20180820/jobs";
   let body: any;
+  if (input.ClientRequestToken === undefined) {
+    input.ClientRequestToken = generateIdempotencyToken();
+  }
   body = '<?xml version="1.0" encoding="UTF-8"?>';
   const bodyNode = new __XmlNode("CreateJobRequest");
   bodyNode.addAttribute(
     "xmlns",
     "http://awss3control.amazonaws.com/doc/2018-08-20/"
   );
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
   if (input.ClientRequestToken !== undefined) {
     const node = new __XmlNode("NonEmptyMaxLength64String")
       .addChildNode(new __XmlText(input.ClientRequestToken))

--- a/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
@@ -265,10 +265,10 @@ export const serializeAws_restJson1_1CreateSavingsPlanCommand = async (
   };
   let resolvedPath = "/CreateSavingsPlan";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientToken === undefined) {
     input.clientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientToken !== undefined) {
     bodyParams["clientToken"] = input.clientToken;
   }

--- a/clients/client-schemas/protocols/Aws_restJson1_1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1_1.ts
@@ -1376,10 +1376,10 @@ export const serializeAws_restJson1_1UpdateSchemaCommand = async (
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   let body: any;
-  const bodyParams: any = {};
   if (input.ClientTokenId === undefined) {
     input.ClientTokenId = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientTokenId !== undefined) {
     bodyParams["ClientTokenId"] = input.ClientTokenId;
   }

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -2394,10 +2394,10 @@ const serializeAws_json1_1CreateSecretRequest = (
   input: CreateSecretRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2573,10 +2573,10 @@ const serializeAws_json1_1PutSecretValueRequest = (
   input: PutSecretValueRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2613,10 +2613,10 @@ const serializeAws_json1_1RotateSecretRequest = (
   input: RotateSecretRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }
@@ -2725,10 +2725,10 @@ const serializeAws_json1_1UpdateSecretRequest = (
   input: UpdateSecretRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientRequestToken === undefined) {
     input.ClientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientRequestToken !== undefined) {
     bodyParams["ClientRequestToken"] = input.ClientRequestToken;
   }

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -2424,7 +2424,9 @@ const deserializeAws_json1_1AssociateTagOptionWithResourceCommandError = async (
 export const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchAssociateServiceActionWithProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchAssociateServiceActionWithProvisioningArtifactCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactCommandError(
       output,
@@ -2448,7 +2450,9 @@ export const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningAr
 const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchAssociateServiceActionWithProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchAssociateServiceActionWithProvisioningArtifactCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)
@@ -2490,7 +2494,9 @@ const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactC
 export const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifactCommandError(
       output,
@@ -2514,7 +2520,9 @@ export const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisionin
 const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifactCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)
@@ -8750,6 +8758,9 @@ const serializeAws_json1_1CopyProductInput = (
   input: CopyProductInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
@@ -8759,9 +8770,6 @@ const serializeAws_json1_1CopyProductInput = (
       input.CopyOptions,
       context
     );
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -8790,15 +8798,15 @@ const serializeAws_json1_1CreateConstraintInput = (
   input: CreateConstraintInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
   }
   if (input.Description !== undefined) {
     bodyParams["Description"] = input.Description;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -8822,6 +8830,9 @@ const serializeAws_json1_1CreatePortfolioInput = (
   input: CreatePortfolioInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
@@ -8831,9 +8842,6 @@ const serializeAws_json1_1CreatePortfolioInput = (
   }
   if (input.DisplayName !== undefined) {
     bodyParams["DisplayName"] = input.DisplayName;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -8874,6 +8882,9 @@ const serializeAws_json1_1CreateProductInput = (
   input: CreateProductInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
@@ -8883,9 +8894,6 @@ const serializeAws_json1_1CreateProductInput = (
   }
   if (input.Distributor !== undefined) {
     bodyParams["Distributor"] = input.Distributor;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -8926,12 +8934,12 @@ const serializeAws_json1_1CreateProvisionedProductPlanInput = (
   input: CreateProvisionedProductPlanInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -8978,12 +8986,12 @@ const serializeAws_json1_1CreateProvisioningArtifactInput = (
   input: CreateProvisioningArtifactInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -9006,6 +9014,9 @@ const serializeAws_json1_1CreateServiceActionInput = (
   input: CreateServiceActionInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
@@ -9021,9 +9032,6 @@ const serializeAws_json1_1CreateServiceActionInput = (
   }
   if (input.Description !== undefined) {
     bodyParams["Description"] = input.Description;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -9455,12 +9463,12 @@ const serializeAws_json1_1ExecuteProvisionedProductPlanInput = (
   input: ExecuteProvisionedProductPlanInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;
@@ -9475,12 +9483,12 @@ const serializeAws_json1_1ExecuteProvisionedProductServiceActionInput = (
   input: ExecuteProvisionedProductServiceActionInput,
   context: __SerdeContext
 ): any => {
+  if (input.ExecuteToken === undefined) {
+    input.ExecuteToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
-  }
-  if (input.ExecuteToken === undefined) {
-    input.ExecuteToken = generateIdempotencyToken();
   }
   if (input.ExecuteToken !== undefined) {
     bodyParams["ExecuteToken"] = input.ExecuteToken;
@@ -9924,6 +9932,9 @@ const serializeAws_json1_1ProvisionProductInput = (
   input: ProvisionProductInput,
   context: __SerdeContext
 ): any => {
+  if (input.ProvisionToken === undefined) {
+    input.ProvisionToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
@@ -9939,9 +9950,6 @@ const serializeAws_json1_1ProvisionProductInput = (
   }
   if (input.ProductId !== undefined) {
     bodyParams["ProductId"] = input.ProductId;
-  }
-  if (input.ProvisionToken === undefined) {
-    input.ProvisionToken = generateIdempotencyToken();
   }
   if (input.ProvisionToken !== undefined) {
     bodyParams["ProvisionToken"] = input.ProvisionToken;
@@ -10367,6 +10375,9 @@ const serializeAws_json1_1TerminateProvisionedProductInput = (
   input: TerminateProvisionedProductInput,
   context: __SerdeContext
 ): any => {
+  if (input.TerminateToken === undefined) {
+    input.TerminateToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
@@ -10379,9 +10390,6 @@ const serializeAws_json1_1TerminateProvisionedProductInput = (
   }
   if (input.ProvisionedProductName !== undefined) {
     bodyParams["ProvisionedProductName"] = input.ProvisionedProductName;
-  }
-  if (input.TerminateToken === undefined) {
-    input.TerminateToken = generateIdempotencyToken();
   }
   if (input.TerminateToken !== undefined) {
     bodyParams["TerminateToken"] = input.TerminateToken;
@@ -10489,6 +10497,9 @@ const serializeAws_json1_1UpdateProvisionedProductInput = (
   input: UpdateProvisionedProductInput,
   context: __SerdeContext
 ): any => {
+  if (input.UpdateToken === undefined) {
+    input.UpdateToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
@@ -10527,9 +10538,6 @@ const serializeAws_json1_1UpdateProvisionedProductInput = (
   if (input.Tags !== undefined) {
     bodyParams["Tags"] = serializeAws_json1_1Tags(input.Tags, context);
   }
-  if (input.UpdateToken === undefined) {
-    input.UpdateToken = generateIdempotencyToken();
-  }
   if (input.UpdateToken !== undefined) {
     bodyParams["UpdateToken"] = input.UpdateToken;
   }
@@ -10540,12 +10548,12 @@ const serializeAws_json1_1UpdateProvisionedProductPropertiesInput = (
   input: UpdateProvisionedProductPropertiesInput,
   context: __SerdeContext
 ): any => {
+  if (input.IdempotencyToken === undefined) {
+    input.IdempotencyToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AcceptLanguage !== undefined) {
     bodyParams["AcceptLanguage"] = input.AcceptLanguage;
-  }
-  if (input.IdempotencyToken === undefined) {
-    input.IdempotencyToken = generateIdempotencyToken();
   }
   if (input.IdempotencyToken !== undefined) {
     bodyParams["IdempotencyToken"] = input.IdempotencyToken;

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -2342,10 +2342,10 @@ const serializeAws_json1_1CreateHttpNamespaceRequest = (
   input: CreateHttpNamespaceRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.CreatorRequestId === undefined) {
     input.CreatorRequestId = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.CreatorRequestId !== undefined) {
     bodyParams["CreatorRequestId"] = input.CreatorRequestId;
   }
@@ -2362,10 +2362,10 @@ const serializeAws_json1_1CreatePrivateDnsNamespaceRequest = (
   input: CreatePrivateDnsNamespaceRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.CreatorRequestId === undefined) {
     input.CreatorRequestId = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.CreatorRequestId !== undefined) {
     bodyParams["CreatorRequestId"] = input.CreatorRequestId;
   }
@@ -2385,10 +2385,10 @@ const serializeAws_json1_1CreatePublicDnsNamespaceRequest = (
   input: CreatePublicDnsNamespaceRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.CreatorRequestId === undefined) {
     input.CreatorRequestId = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.CreatorRequestId !== undefined) {
     bodyParams["CreatorRequestId"] = input.CreatorRequestId;
   }
@@ -2405,10 +2405,10 @@ const serializeAws_json1_1CreateServiceRequest = (
   input: CreateServiceRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.CreatorRequestId === undefined) {
     input.CreatorRequestId = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.CreatorRequestId !== undefined) {
     bodyParams["CreatorRequestId"] = input.CreatorRequestId;
   }
@@ -2828,15 +2828,15 @@ const serializeAws_json1_1RegisterInstanceRequest = (
   input: RegisterInstanceRequest,
   context: __SerdeContext
 ): any => {
+  if (input.CreatorRequestId === undefined) {
+    input.CreatorRequestId = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.Attributes !== undefined) {
     bodyParams["Attributes"] = serializeAws_json1_1Attributes(
       input.Attributes,
       context
     );
-  }
-  if (input.CreatorRequestId === undefined) {
-    input.CreatorRequestId = generateIdempotencyToken();
   }
   if (input.CreatorRequestId !== undefined) {
     bodyParams["CreatorRequestId"] = input.CreatorRequestId;

--- a/clients/client-signer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1_1.ts
@@ -424,10 +424,10 @@ export const serializeAws_restJson1_1StartSigningJobCommand = async (
   };
   let resolvedPath = "/signing-jobs";
   let body: any;
-  const bodyParams: any = {};
   if (input.clientRequestToken === undefined) {
     input.clientRequestToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.clientRequestToken !== undefined) {
     bodyParams["clientRequestToken"] = input.clientRequestToken;
   }

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -16797,12 +16797,12 @@ const serializeAws_json1_1CreateMaintenanceWindowRequest = (
   input: CreateMaintenanceWindowRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.AllowUnassociatedTargets !== undefined) {
     bodyParams["AllowUnassociatedTargets"] = input.AllowUnassociatedTargets;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
@@ -16888,6 +16888,9 @@ const serializeAws_json1_1CreatePatchBaselineRequest = (
   input: CreatePatchBaselineRequest,
   context: __SerdeContext
 ): any => {
+  if (input.ClientToken === undefined) {
+    input.ClientToken = generateIdempotencyToken();
+  }
   const bodyParams: any = {};
   if (input.ApprovalRules !== undefined) {
     bodyParams["ApprovalRules"] = serializeAws_json1_1PatchRuleGroup(
@@ -16908,9 +16911,6 @@ const serializeAws_json1_1CreatePatchBaselineRequest = (
   if (input.ApprovedPatchesEnableNonSecurity !== undefined) {
     bodyParams["ApprovedPatchesEnableNonSecurity"] =
       input.ApprovedPatchesEnableNonSecurity;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
   }
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
@@ -17031,10 +17031,10 @@ const serializeAws_json1_1DeleteInventoryRequest = (
   input: DeleteInventoryRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }
@@ -19941,10 +19941,10 @@ const serializeAws_json1_1RegisterTargetWithMaintenanceWindowRequest = (
   input: RegisterTargetWithMaintenanceWindowRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }
@@ -19973,10 +19973,10 @@ const serializeAws_json1_1RegisterTaskWithMaintenanceWindowRequest = (
   input: RegisterTaskWithMaintenanceWindowRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -1444,10 +1444,10 @@ const serializeAws_json1_1StartTextTranslationJobRequest = (
   input: StartTextTranslationJobRequest,
   context: __SerdeContext
 ): any => {
-  const bodyParams: any = {};
   if (input.ClientToken === undefined) {
     input.ClientToken = generateIdempotencyToken();
   }
+  const bodyParams: any = {};
   if (input.ClientToken !== undefined) {
     bodyParams["ClientToken"] = input.ClientToken;
   }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -150,6 +150,17 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         }
 
         SymbolProvider symbolProvider = context.getSymbolProvider();
+
+        for (HttpBinding binding : documentBindings) {
+            MemberShape memberShape = binding.getMember();
+            // The name of the member to get from the input shape.
+            String memberName = symbolProvider.toMemberName(memberShape);
+            String inputLocation = "input." + memberName;
+
+            // Handle if the member is an idempotency token that should be auto-filled.
+            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+        }
+
         ShapeId inputShapeId = documentBindings.get(0).getMember().getContainer();
 
         // Start with the XML declaration.
@@ -173,9 +184,6 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             // The name of the member to get from the input shape.
             String memberName = symbolProvider.toMemberName(memberShape);
             String inputLocation = "input." + memberName;
-
-            // Handle if the member is an idempotency token that should be auto-filled.
-            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
 
             writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
                 shapeSerVisitor.serializeNamedMember(context, memberName, memberShape, () -> inputLocation);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -143,16 +143,18 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
     protected void serializeStructure(GenerationContext context, StructureShape shape) {
         TypeScriptWriter writer = context.getWriter();
 
+        shape.getAllMembers().forEach((memberName, memberShape) -> {
+            String inputLocation = "input." + memberName;
+            // Handle if the member is an idempotency token that should be auto-filled.
+            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+        });
+
         // Set up a location to store all of the entry pairs.
         writer.write("const entries: any = {};");
 
         // Serialize every member of the structure if present.
         shape.getAllMembers().forEach((memberName, memberShape) -> {
             String inputLocation = "input." + memberName;
-
-            // Handle if the member is an idempotency token that should be auto-filled.
-            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
-
             writer.openBlock("if ($L !== undefined) {", "}", inputLocation,
                     () -> serializeNamedMember(context, memberName, memberShape, inputLocation));
         });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeSerVisitor.java
@@ -168,22 +168,23 @@ final class XmlShapeSerVisitor extends DocumentShapeSerVisitor {
                 .map(XmlNameTrait::getValue)
                 .orElse(shape.getId().getName());
 
-        // Create the structure's node.
-        writer.write("const bodyNode = new __XmlNode($S);", nodeName);
-
         // Serialize every member of the structure if present.
         Map<String, MemberShape> members = shape.getAllMembers();
+
         members.forEach((memberName, memberShape) -> {
             String inputLocation = "input." + memberName;
-
             // Handle if the member is an idempotency token that should be auto-filled.
             AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+        });
 
+        // Create the structure's node.
+        writer.write("const bodyNode = new __XmlNode($S);", nodeName);
+        members.forEach((memberName, memberShape) -> {
+            String inputLocation = "input." + memberName;
             writer.openBlock("if ($L !== undefined) {", "}", inputLocation, () -> {
                 serializeNamedMember(context, memberName, memberShape, () -> inputLocation);
             });
         });
-
         writer.write("return bodyNode;");
     }
 

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -1294,10 +1294,10 @@ const serializeAws_ec2QueryIdempotencyTokenAutoFillInput = (
   input: QueryIdempotencyTokenAutoFillInput,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.token === undefined) {
     input.token = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.token !== undefined) {
     entries["Token"] = input.token;
   }

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -1701,10 +1701,10 @@ const serializeAws_queryQueryIdempotencyTokenAutoFillInput = (
   input: QueryIdempotencyTokenAutoFillInput,
   context: __SerdeContext
 ): any => {
-  const entries: any = {};
   if (input.token === undefined) {
     input.token = generateIdempotencyToken();
   }
+  const entries: any = {};
   if (input.token !== undefined) {
     entries["token"] = input.token;
   }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* make generateIdempotencyToken calls before consuming
* precursor to:
  * defining `body` and `bodyParams` objects while declaring (similar to https://github.com/aws/aws-sdk-js-v3/pull/1134)
  * populate values in new variable instead of modifying `input`

Before, the input is modified while populating body/bodyParams:
```typescript
const serializeAws_json1_1CreateProfileRequest = (
  input: CreateProfileRequest,
  context: __SerdeContext
): any => {
  const bodyParams: any = {};
  if (input.Address !== undefined) {
    bodyParams["Address"] = input.Address;
  }
  if (input.ClientRequestToken === undefined) {
    input.ClientRequestToken = generateIdempotencyToken();
  }
  if (input.ClientRequestToken !== undefined) {
    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
  }
```

After, the input is modified prior to populating body/bodyParams:
```typescript
const serializeAws_json1_1CreateProfileRequest = (
  input: CreateProfileRequest,
  context: __SerdeContext
): any => {
  if (input.ClientRequestToken === undefined) {
    input.ClientRequestToken = generateIdempotencyToken();
  }
  const bodyParams: any = {};
  if (input.Address !== undefined) {
    bodyParams["Address"] = input.Address;
  }
  if (input.ClientRequestToken !== undefined) {
    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
  }
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
