### PR TITLE
chore: remove contents from JsonShape serializeCollection

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
@@ -2941,11 +2941,7 @@ const serializeAws_restJson1_1FindingIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1InlineArchiveRule = (
@@ -2969,11 +2965,9 @@ const serializeAws_restJson1_1InlineArchiveRulesList = (
   input: InlineArchiveRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InlineArchiveRule(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InlineArchiveRule(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SortCriteria = (
@@ -3004,11 +2998,7 @@ const serializeAws_restJson1_1ValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1ActionList = (

--- a/clients/client-acm-pca/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/protocols/Aws_json1_1.ts
@@ -2866,11 +2866,7 @@ const serializeAws_json1_1ActionList = (
   input: (ActionType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CertificateAuthorityConfiguration = (
@@ -3246,11 +3242,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1UntagCertificateAuthorityRequest = (

--- a/clients/client-acm/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/protocols/Aws_json1_1.ts
@@ -1718,11 +1718,7 @@ const serializeAws_json1_1CertificateStatuses = (
   input: (CertificateStatus | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeleteCertificateRequest = (
@@ -1751,11 +1747,7 @@ const serializeAws_json1_1DomainList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DomainValidationOption = (
@@ -1776,11 +1768,9 @@ const serializeAws_json1_1DomainValidationOptionList = (
   input: DomainValidationOption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DomainValidationOption(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DomainValidationOption(entry, context)
+  );
 };
 
 const serializeAws_json1_1ExportCertificateRequest = (
@@ -1801,11 +1791,7 @@ const serializeAws_json1_1ExtendedKeyUsageFilterList = (
   input: (ExtendedKeyUsageName | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filters = (
@@ -1876,22 +1862,14 @@ const serializeAws_json1_1KeyAlgorithmList = (
   input: (KeyAlgorithm | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1KeyUsageFilterList = (
   input: (KeyUsageName | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListCertificatesRequest = (
@@ -2031,11 +2009,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1UpdateCertificateOptionsRequest = (

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -8664,22 +8664,14 @@ const serializeAws_json1_1FilterList = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1FilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IPDialIn = (
@@ -8745,11 +8737,7 @@ const serializeAws_json1_1AudioList = (
   input: Audio[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Audio(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Audio(entry, context));
 };
 
 const serializeAws_json1_1Content = (
@@ -8822,11 +8810,7 @@ const serializeAws_json1_1SsmlList = (
   input: Ssml[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Ssml(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Ssml(entry, context));
 };
 
 const serializeAws_json1_1Text = (
@@ -8847,11 +8831,7 @@ const serializeAws_json1_1TextList = (
   input: Text[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Text(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Text(entry, context));
 };
 
 const serializeAws_json1_1DeleteDeviceUsageDataRequest = (
@@ -9637,22 +9617,14 @@ const serializeAws_json1_1EndOfMeetingReminderMinutesList = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Features = (
   input: (Feature | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ForgetSmartHomeAppliancesRequest = (
@@ -9994,11 +9966,7 @@ const serializeAws_json1_1PhoneNumberList = (
   input: PhoneNumber[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PhoneNumber(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PhoneNumber(entry, context));
 };
 
 const serializeAws_json1_1PutConferencePreferenceRequest = (
@@ -10376,11 +10344,7 @@ const serializeAws_json1_1ShortSkillIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SipAddress = (
@@ -10401,11 +10365,7 @@ const serializeAws_json1_1SipAddressList = (
   input: SipAddress[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SipAddress(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1SipAddress(entry, context));
 };
 
 const serializeAws_json1_1Sort = (
@@ -10426,11 +10386,7 @@ const serializeAws_json1_1SortList = (
   input: Sort[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Sort(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Sort(entry, context));
 };
 
 const serializeAws_json1_1StartDeviceSyncRequest = (
@@ -10479,22 +10435,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -10515,11 +10463,7 @@ const serializeAws_json1_1TrustAnchorList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UntagResourceRequest = (

--- a/clients/client-amplify/protocols/Aws_restJson1_1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1_1.ts
@@ -5929,11 +5929,7 @@ const serializeAws_restJson1_1AutoBranchCreationPatterns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CustomRule = (
@@ -5960,11 +5956,7 @@ const serializeAws_restJson1_1CustomRules = (
   input: CustomRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CustomRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1CustomRule(entry, context));
 };
 
 const serializeAws_restJson1_1EnvironmentVariables = (
@@ -6005,11 +5997,9 @@ const serializeAws_restJson1_1SubDomainSettings = (
   input: SubDomainSetting[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SubDomainSetting(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SubDomainSetting(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TagMap = (

--- a/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
@@ -22762,44 +22762,28 @@ const serializeAws_restJson1_1ListOfARNs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ListOfApiStage = (
   input: ApiStage[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ApiStage(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1ApiStage(entry, context));
 };
 
 const serializeAws_restJson1_1ListOfEndpointType = (
   input: (EndpointType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ListOfStageKeys = (
   input: StageKey[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1StageKey(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1StageKey(entry, context));
 };
 
 const serializeAws_restJson1_1MapOfApiStageThrottleSettings = (
@@ -22891,22 +22875,16 @@ const serializeAws_restJson1_1ListOfPatchOperation = (
   input: PatchOperation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1PatchOperation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1PatchOperation(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfString = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1PatchOperation = (

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
@@ -10515,11 +10515,7 @@ const serializeAws_restJson1_1AuthorizationScopes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Cors = (
@@ -10564,33 +10560,21 @@ const serializeAws_restJson1_1CorsHeaderList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CorsMethodList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CorsOriginList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DomainNameConfiguration = (
@@ -10633,24 +10617,16 @@ const serializeAws_restJson1_1DomainNameConfigurations = (
   input: DomainNameConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1DomainNameConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DomainNameConfiguration(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1IdentitySourceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1IntegrationParameters = (
@@ -10781,11 +10757,7 @@ const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1AccessLogSettings = (

--- a/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
@@ -5261,13 +5261,9 @@ const serializeAws_restJson1_1AwsCloudMapInstanceAttributes = (
   input: AwsCloudMapInstanceAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1AwsCloudMapInstanceAttribute(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AwsCloudMapInstanceAttribute(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AwsCloudMapServiceDiscovery = (
@@ -5307,11 +5303,7 @@ const serializeAws_restJson1_1Backends = (
   input: Backend[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Backend(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Backend(entry, context));
 };
 
 const serializeAws_restJson1_1DnsServiceDiscovery = (
@@ -5404,11 +5396,7 @@ const serializeAws_restJson1_1GrpcRetryPolicyEvents = (
   input: (GrpcRetryPolicyEvent | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1GrpcRoute = (
@@ -5495,11 +5483,9 @@ const serializeAws_restJson1_1GrpcRouteMetadataList = (
   input: GrpcRouteMetadata[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1GrpcRouteMetadata(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1GrpcRouteMetadata(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1GrpcRouteMetadataMatchMethod = (
@@ -5594,11 +5580,7 @@ const serializeAws_restJson1_1HttpRetryPolicyEvents = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1HttpRoute = (
@@ -5665,11 +5647,9 @@ const serializeAws_restJson1_1HttpRouteHeaders = (
   input: HttpRouteHeader[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1HttpRouteHeader(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1HttpRouteHeader(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1HttpRouteMatch = (
@@ -5719,11 +5699,7 @@ const serializeAws_restJson1_1Listeners = (
   input: Listener[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Listener(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Listener(entry, context));
 };
 
 const serializeAws_restJson1_1Logging = (
@@ -5833,22 +5809,14 @@ const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagList = (
   input: TagRef[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1TagRef(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1TagRef(entry, context));
 };
 
 const serializeAws_restJson1_1TagRef = (
@@ -5869,11 +5837,7 @@ const serializeAws_restJson1_1TcpRetryPolicyEvents = (
   input: (TcpRetryPolicyEvent | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TcpRoute = (
@@ -5965,13 +5929,9 @@ const serializeAws_restJson1_1VirtualRouterListeners = (
   input: VirtualRouterListener[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1VirtualRouterListener(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1VirtualRouterListener(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1VirtualRouterServiceProvider = (
@@ -6055,11 +6015,9 @@ const serializeAws_restJson1_1WeightedTargets = (
   input: WeightedTarget[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1WeightedTarget(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1WeightedTarget(entry, context)
+  );
 };
 
 const deserializeAws_restJson1_1AccessLog = (

--- a/clients/client-appconfig/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1_1.ts
@@ -4596,11 +4596,7 @@ const serializeAws_restJson1_1MonitorList = (
   input: Monitor[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Monitor(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Monitor(entry, context));
 };
 
 const serializeAws_restJson1_1TagMap = (
@@ -4631,11 +4627,7 @@ const serializeAws_restJson1_1ValidatorList = (
   input: Validator[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Validator(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Validator(entry, context));
 };
 
 const deserializeAws_restJson1_1Application = (

--- a/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
@@ -1598,11 +1598,9 @@ const serializeAws_json1_1MetricDimensions = (
   input: MetricDimension[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MetricDimension(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MetricDimension(entry, context)
+  );
 };
 
 const serializeAws_json1_1PredefinedMetricSpecification = (
@@ -1731,11 +1729,7 @@ const serializeAws_json1_1ResourceIdsMaxLen1600 = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ScalableTargetAction = (
@@ -1773,11 +1767,7 @@ const serializeAws_json1_1StepAdjustments = (
   input: StepAdjustment[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1StepAdjustment(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1StepAdjustment(entry, context));
 };
 
 const serializeAws_json1_1StepScalingPolicyConfiguration = (

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -3582,22 +3582,14 @@ const serializeAws_json1_1AgentIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ApplicationIdsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AssociateConfigurationItemsToApplicationRequest = (
@@ -3635,22 +3627,14 @@ const serializeAws_json1_1ConfigurationIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContinuousExportIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateApplicationRequest = (
@@ -3822,11 +3806,9 @@ const serializeAws_json1_1DescribeImportTasksFilterList = (
   input: ImportTaskFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ImportTaskFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ImportTaskFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1DescribeImportTasksRequest = (
@@ -3890,11 +3872,7 @@ const serializeAws_json1_1ExportDataFormats = (
   input: (ExportDataFormat | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ExportFilter = (
@@ -3921,22 +3899,14 @@ const serializeAws_json1_1ExportFilters = (
   input: ExportFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ExportFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ExportFilter(entry, context));
 };
 
 const serializeAws_json1_1ExportIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filter = (
@@ -3963,22 +3933,14 @@ const serializeAws_json1_1FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1GetDiscoverySummaryRequest = (
@@ -4010,11 +3972,7 @@ const serializeAws_json1_1ImportTaskFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListConfigurationsRequest = (
@@ -4089,11 +4047,7 @@ const serializeAws_json1_1OrderByList = (
   input: OrderByElement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OrderByElement(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1OrderByElement(entry, context));
 };
 
 const serializeAws_json1_1StartContinuousExportRequest = (
@@ -4221,33 +4175,21 @@ const serializeAws_json1_1TagFilters = (
   input: TagFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TagFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TagFilter(entry, context));
 };
 
 const serializeAws_json1_1TagSet = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1ToDeleteIdentifierList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UpdateApplicationRequest = (

--- a/clients/client-application-insights/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/protocols/Aws_json1_1.ts
@@ -3381,11 +3381,7 @@ const serializeAws_json1_1ResourceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -3403,22 +3399,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-appstream/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/protocols/Aws_json1_1.ts
@@ -5192,11 +5192,7 @@ const serializeAws_json1_1AccessEndpointList = (
   input: AccessEndpoint[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AccessEndpoint(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1AccessEndpoint(entry, context));
 };
 
 const serializeAws_json1_1ApplicationSettings = (
@@ -5217,11 +5213,7 @@ const serializeAws_json1_1ArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AssociateFleetRequest = (
@@ -5242,11 +5234,7 @@ const serializeAws_json1_1AwsAccountIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchAssociateUserStackRequest = (
@@ -5877,11 +5865,7 @@ const serializeAws_json1_1DirectoryNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DisableUserRequest = (
@@ -5931,22 +5915,14 @@ const serializeAws_json1_1DomainList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EmbedHostDomains = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EnableUserRequest = (
@@ -5978,11 +5954,7 @@ const serializeAws_json1_1FleetAttributes = (
   input: (FleetAttribute | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ImagePermissions = (
@@ -6042,22 +6014,14 @@ const serializeAws_json1_1OrganizationalUnitDistinguishedNamesList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SecurityGroupIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ServiceAccountCredentials = (
@@ -6078,11 +6042,7 @@ const serializeAws_json1_1StackAttributes = (
   input: (StackAttribute | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartFleetRequest = (
@@ -6156,44 +6116,30 @@ const serializeAws_json1_1StorageConnectorList = (
   input: StorageConnector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1StorageConnector(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1StorageConnector(entry, context)
+  );
 };
 
 const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SubnetIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -6434,11 +6380,7 @@ const serializeAws_json1_1UserSettingList = (
   input: UserSetting[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1UserSetting(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1UserSetting(entry, context));
 };
 
 const serializeAws_json1_1UserStackAssociation = (
@@ -6465,11 +6407,9 @@ const serializeAws_json1_1UserStackAssociationList = (
   input: UserStackAssociation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1UserStackAssociation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1UserStackAssociation(entry, context)
+  );
 };
 
 const serializeAws_json1_1VpcConfig = (

--- a/clients/client-appsync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1_1.ts
@@ -6651,13 +6651,9 @@ const serializeAws_restJson1_1AdditionalAuthenticationProviders = (
   input: AdditionalAuthenticationProvider[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1AdditionalAuthenticationProvider(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AdditionalAuthenticationProvider(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AuthorizationConfig = (
@@ -6712,11 +6708,7 @@ const serializeAws_restJson1_1CachingKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CognitoUserPoolConfig = (
@@ -6797,11 +6789,7 @@ const serializeAws_restJson1_1FunctionsIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1HttpDataSourceConfig = (

--- a/clients/client-athena/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/protocols/Aws_json1_1.ts
@@ -2153,11 +2153,7 @@ const serializeAws_json1_1NamedQueryIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1QueryExecutionContext = (
@@ -2175,11 +2171,7 @@ const serializeAws_json1_1QueryExecutionIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResultConfiguration = (
@@ -2290,22 +2282,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceInput = (

--- a/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
@@ -843,11 +843,9 @@ const serializeAws_json1_1ApplicationSources = (
   input: ApplicationSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ApplicationSource(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ApplicationSource(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateScalingPlanRequest = (
@@ -1038,11 +1036,9 @@ const serializeAws_json1_1MetricDimensions = (
   input: MetricDimension[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MetricDimension(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MetricDimension(entry, context)
+  );
 };
 
 const serializeAws_json1_1PredefinedLoadMetricSpecification = (
@@ -1146,22 +1142,16 @@ const serializeAws_json1_1ScalingInstructions = (
   input: ScalingInstruction[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ScalingInstruction(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ScalingInstruction(entry, context)
+  );
 };
 
 const serializeAws_json1_1ScalingPlanNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagFilter = (
@@ -1182,22 +1172,14 @@ const serializeAws_json1_1TagFilters = (
   input: TagFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TagFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TagFilter(entry, context));
 };
 
 const serializeAws_json1_1TagValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TargetTrackingConfiguration = (
@@ -1243,13 +1225,9 @@ const serializeAws_json1_1TargetTrackingConfigurations = (
   input: TargetTrackingConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1TargetTrackingConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1TargetTrackingConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1UpdateScalingPlanRequest = (

--- a/clients/client-backup/protocols/Aws_restJson1_1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1_1.ts
@@ -7232,11 +7232,9 @@ const serializeAws_restJson1_1BackupRulesInput = (
   input: BackupRuleInput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1BackupRuleInput(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1BackupRuleInput(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1BackupSelection = (
@@ -7269,11 +7267,7 @@ const serializeAws_restJson1_1BackupVaultEvents = (
   input: (BackupVaultEvent | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Condition = (
@@ -7314,11 +7308,7 @@ const serializeAws_restJson1_1CopyActions = (
   input: CopyAction[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CopyAction(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1CopyAction(entry, context));
 };
 
 const serializeAws_restJson1_1Lifecycle = (
@@ -7339,11 +7329,7 @@ const serializeAws_restJson1_1ListOfTags = (
   input: Condition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Condition(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Condition(entry, context));
 };
 
 const serializeAws_restJson1_1Metadata = (
@@ -7360,22 +7346,14 @@ const serializeAws_restJson1_1ResourceArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tags = (

--- a/clients/client-batch/protocols/Aws_restJson1_1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1_1.ts
@@ -1997,13 +1997,9 @@ const serializeAws_restJson1_1ComputeEnvironmentOrders = (
   input: ComputeEnvironmentOrder[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1ComputeEnvironmentOrder(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ComputeEnvironmentOrder(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ComputeResource = (
@@ -2230,33 +2226,23 @@ const serializeAws_restJson1_1DeviceCgroupPermissions = (
   input: (DeviceCgroupPermission | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DevicesList = (
   input: Device[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Device(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Device(entry, context));
 };
 
 const serializeAws_restJson1_1EnvironmentVariables = (
   input: KeyValuePair[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1KeyValuePair(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1KeyValuePair(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Host = (
@@ -2288,11 +2274,9 @@ const serializeAws_restJson1_1JobDependencyList = (
   input: JobDependency[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1JobDependency(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1JobDependency(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1JobTimeout = (
@@ -2372,11 +2356,7 @@ const serializeAws_restJson1_1MountPoints = (
   input: MountPoint[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1MountPoint(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1MountPoint(entry, context));
 };
 
 const serializeAws_restJson1_1NodeOverrides = (
@@ -2443,22 +2423,18 @@ const serializeAws_restJson1_1NodePropertyOverrides = (
   input: NodePropertyOverride[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1NodePropertyOverride(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1NodePropertyOverride(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1NodeRangeProperties = (
   input: NodeRangeProperty[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1NodeRangeProperty(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1NodeRangeProperty(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1NodeRangeProperty = (
@@ -2506,11 +2482,9 @@ const serializeAws_restJson1_1ResourceRequirements = (
   input: ResourceRequirement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ResourceRequirement(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ResourceRequirement(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1RetryStrategy = (
@@ -2528,11 +2502,7 @@ const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagsMap = (
@@ -2566,11 +2536,7 @@ const serializeAws_restJson1_1Ulimits = (
   input: Ulimit[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Ulimit(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Ulimit(entry, context));
 };
 
 const serializeAws_restJson1_1Volume = (
@@ -2591,11 +2557,7 @@ const serializeAws_restJson1_1Volumes = (
   input: Volume[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Volume(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Volume(entry, context));
 };
 
 const deserializeAws_restJson1_1ArrayJobStatusSummary = (

--- a/clients/client-budgets/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/protocols/Aws_json1_1.ts
@@ -2336,11 +2336,7 @@ const serializeAws_json1_1DimensionValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Notification = (
@@ -2390,13 +2386,9 @@ const serializeAws_json1_1NotificationWithSubscribersList = (
   input: NotificationWithSubscribers[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1NotificationWithSubscribers(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1NotificationWithSubscribers(entry, context)
+  );
 };
 
 const serializeAws_json1_1PlannedBudgetLimits = (
@@ -2441,11 +2433,7 @@ const serializeAws_json1_1Subscribers = (
   input: Subscriber[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Subscriber(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Subscriber(entry, context));
 };
 
 const serializeAws_json1_1TimePeriod = (

--- a/clients/client-chime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1_1.ts
@@ -16857,11 +16857,7 @@ const serializeAws_restJson1_1CallingRegionList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CreateAttendeeRequestItem = (
@@ -16879,13 +16875,9 @@ const serializeAws_restJson1_1CreateAttendeeRequestItemList = (
   input: CreateAttendeeRequestItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1CreateAttendeeRequestItem(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CreateAttendeeRequestItem(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Credential = (
@@ -16906,22 +16898,14 @@ const serializeAws_restJson1_1CredentialList = (
   input: Credential[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Credential(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Credential(entry, context));
 };
 
 const serializeAws_restJson1_1E164PhoneNumberList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1LoggingConfiguration = (
@@ -16967,22 +16951,16 @@ const serializeAws_restJson1_1MembershipItemList = (
   input: MembershipItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1MembershipItem(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1MembershipItem(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1NonEmptyStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Origination = (
@@ -17029,22 +17007,16 @@ const serializeAws_restJson1_1OriginationRouteList = (
   input: OriginationRoute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1OriginationRoute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1OriginationRoute(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SensitiveStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SigninDelegateGroup = (
@@ -17062,11 +17034,9 @@ const serializeAws_restJson1_1SigninDelegateGroupList = (
   input: SigninDelegateGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SigninDelegateGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SigninDelegateGroup(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StreamingConfiguration = (
@@ -17087,11 +17057,7 @@ const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TelephonySettings = (
@@ -17161,13 +17127,9 @@ const serializeAws_restJson1_1UpdatePhoneNumberRequestItemList = (
   input: UpdatePhoneNumberRequestItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1UpdatePhoneNumberRequestItem(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1UpdatePhoneNumberRequestItem(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1UpdateUserRequestItem = (
@@ -17199,35 +17161,23 @@ const serializeAws_restJson1_1UpdateUserRequestItemList = (
   input: UpdateUserRequestItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1UpdateUserRequestItem(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1UpdateUserRequestItem(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1UserEmailList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1UserIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1UserSettings = (
@@ -17262,11 +17212,9 @@ const serializeAws_restJson1_1VoiceConnectorItemList = (
   input: VoiceConnectorItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1VoiceConnectorItem(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1VoiceConnectorItem(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1VoiceConnectorSettings = (

--- a/clients/client-cloud9/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/protocols/Aws_json1_1.ts
@@ -1665,11 +1665,7 @@ const serializeAws_json1_1BoundedEnvironmentIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateEnvironmentEC2Request = (
@@ -1812,11 +1808,7 @@ const serializeAws_json1_1PermissionsList = (
   input: (Permissions | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UpdateEnvironmentMembershipRequest = (

--- a/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
@@ -13304,22 +13304,18 @@ const serializeAws_restJson1_1AttributeKeyAndValueList = (
   input: AttributeKeyAndValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AttributeKeyAndValue(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AttributeKeyAndValue(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AttributeKeyList = (
   input: AttributeKey[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AttributeKey(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AttributeKey(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AttributeNameAndValue = (
@@ -13343,24 +13339,16 @@ const serializeAws_restJson1_1AttributeNameAndValueList = (
   input: AttributeNameAndValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1AttributeNameAndValue(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AttributeNameAndValue(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AttributeNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1BatchAddFacetToObject = (
@@ -14097,11 +14085,9 @@ const serializeAws_restJson1_1BatchReadOperationList = (
   input: BatchReadOperation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1BatchReadOperation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1BatchReadOperation(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1BatchRemoveFacetFromObject = (
@@ -14286,11 +14272,9 @@ const serializeAws_restJson1_1BatchWriteOperationList = (
   input: BatchWriteOperation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1BatchWriteOperation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1BatchWriteOperation(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1FacetAttribute = (
@@ -14350,11 +14334,9 @@ const serializeAws_restJson1_1FacetAttributeList = (
   input: FacetAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1FacetAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1FacetAttribute(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1FacetAttributeReference = (
@@ -14392,11 +14374,9 @@ const serializeAws_restJson1_1FacetAttributeUpdateList = (
   input: FacetAttributeUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1FacetAttributeUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1FacetAttributeUpdate(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1LinkAttributeAction = (
@@ -14442,11 +14422,9 @@ const serializeAws_restJson1_1LinkAttributeUpdateList = (
   input: LinkAttributeUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1LinkAttributeUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1LinkAttributeUpdate(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ObjectAttributeAction = (
@@ -14492,11 +14470,9 @@ const serializeAws_restJson1_1ObjectAttributeRangeList = (
   input: ObjectAttributeRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ObjectAttributeRange(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ObjectAttributeRange(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ObjectAttributeUpdate = (
@@ -14525,13 +14501,9 @@ const serializeAws_restJson1_1ObjectAttributeUpdateList = (
   input: ObjectAttributeUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1ObjectAttributeUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ObjectAttributeUpdate(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ObjectReference = (
@@ -14600,11 +14572,9 @@ const serializeAws_restJson1_1SchemaFacetList = (
   input: SchemaFacet[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SchemaFacet(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SchemaFacet(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -14625,22 +14595,14 @@ const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TypedAttributeValue = (
@@ -14727,13 +14689,9 @@ const serializeAws_restJson1_1TypedLinkAttributeDefinitionList = (
   input: TypedLinkAttributeDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1TypedLinkAttributeDefinition(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1TypedLinkAttributeDefinition(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TypedLinkAttributeRange = (
@@ -14757,13 +14715,9 @@ const serializeAws_restJson1_1TypedLinkAttributeRangeList = (
   input: TypedLinkAttributeRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1TypedLinkAttributeRange(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1TypedLinkAttributeRange(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TypedLinkFacet = (
@@ -14816,13 +14770,9 @@ const serializeAws_restJson1_1TypedLinkFacetAttributeUpdateList = (
   input: TypedLinkFacetAttributeUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1TypedLinkFacetAttributeUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1TypedLinkFacetAttributeUpdate(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TypedLinkSchemaAndFacetName = (

--- a/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
@@ -2025,22 +2025,14 @@ const serializeAws_json1_1Strings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -2058,22 +2050,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-cloudhsm/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/protocols/Aws_json1_1.ts
@@ -2271,11 +2271,7 @@ const serializeAws_json1_1HapgList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListAvailableZonesRequest = (
@@ -2394,11 +2390,7 @@ const serializeAws_json1_1PartitionSerialList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RemoveTagsFromResourceRequest = (
@@ -2433,22 +2425,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const deserializeAws_json1_1AZList = (

--- a/clients/client-cloudtrail/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/protocols/Aws_json1_1.ts
@@ -3791,22 +3791,14 @@ const serializeAws_json1_1DataResourceValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DataResources = (
   input: DataResource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DataResource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DataResource(entry, context));
 };
 
 const serializeAws_json1_1DeleteTrailRequest = (
@@ -3869,22 +3861,14 @@ const serializeAws_json1_1EventSelectors = (
   input: EventSelector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EventSelector(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1EventSelector(entry, context));
 };
 
 const serializeAws_json1_1ExcludeManagementEventSources = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetEventSelectorsRequest = (
@@ -3946,11 +3930,9 @@ const serializeAws_json1_1InsightSelectors = (
   input: InsightSelector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InsightSelector(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InsightSelector(entry, context)
+  );
 };
 
 const serializeAws_json1_1ListPublicKeysRequest = (
@@ -4016,11 +3998,9 @@ const serializeAws_json1_1LookupAttributesList = (
   input: LookupAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1LookupAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1LookupAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1LookupEventsRequest = (
@@ -4107,11 +4087,7 @@ const serializeAws_json1_1ResourceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartLoggingRequest = (
@@ -4151,22 +4127,14 @@ const serializeAws_json1_1TagsList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TrailNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UpdateTrailRequest = (

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -3585,11 +3585,7 @@ const serializeAws_json1_1EventResourceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InputTransformer = (
@@ -3820,11 +3816,9 @@ const serializeAws_json1_1PutEventsRequestEntryList = (
   input: PutEventsRequestEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PutEventsRequestEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PutEventsRequestEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1PutPartnerEventsRequest = (
@@ -3873,13 +3867,9 @@ const serializeAws_json1_1PutPartnerEventsRequestEntryList = (
   input: PutPartnerEventsRequestEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1PutPartnerEventsRequestEntry(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PutPartnerEventsRequestEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1PutPermissionRequest = (
@@ -4029,22 +4019,16 @@ const serializeAws_json1_1RunCommandTargetValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RunCommandTargets = (
   input: RunCommandTarget[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RunCommandTarget(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RunCommandTarget(entry, context)
+  );
 };
 
 const serializeAws_json1_1SqsParameters = (
@@ -4062,11 +4046,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -4084,22 +4064,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -4181,22 +4153,14 @@ const serializeAws_json1_1TargetIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TargetList = (
   input: Target[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Target(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Target(entry, context));
 };
 
 const serializeAws_json1_1TestEventPatternRequest = (

--- a/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
@@ -4874,22 +4874,14 @@ const serializeAws_json1_1InputLogEvents = (
   input: InputLogEvent[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InputLogEvent(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1InputLogEvent(entry, context));
 };
 
 const serializeAws_json1_1InputLogStreamNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListTagsLogGroupRequest = (
@@ -4907,11 +4899,7 @@ const serializeAws_json1_1LogGroupNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MetricTransformation = (
@@ -4938,11 +4926,9 @@ const serializeAws_json1_1MetricTransformations = (
   input: MetricTransformation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MetricTransformation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MetricTransformation(entry, context)
+  );
 };
 
 const serializeAws_json1_1PutDestinationPolicyRequest = (
@@ -5122,11 +5108,7 @@ const serializeAws_json1_1TagList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagLogGroupRequest = (
@@ -5157,11 +5139,7 @@ const serializeAws_json1_1TestEventMessages = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TestMetricFilterRequest = (

--- a/clients/client-codebuild/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/protocols/Aws_json1_1.ts
@@ -3237,11 +3237,7 @@ const serializeAws_json1_1BuildIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CloudWatchLogsConfig = (
@@ -3502,33 +3498,23 @@ const serializeAws_json1_1EnvironmentVariables = (
   input: EnvironmentVariable[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EnvironmentVariable(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EnvironmentVariable(entry, context)
+  );
 };
 
 const serializeAws_json1_1FilterGroup = (
   input: WebhookFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1WebhookFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1WebhookFilter(entry, context));
 };
 
 const serializeAws_json1_1FilterGroups = (
   input: WebhookFilter[][],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FilterGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1FilterGroup(entry, context));
 };
 
 const serializeAws_json1_1GetResourcePolicyInput = (
@@ -3819,11 +3805,9 @@ const serializeAws_json1_1ProjectArtifactsList = (
   input: ProjectArtifacts[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProjectArtifacts(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProjectArtifacts(entry, context)
+  );
 };
 
 const serializeAws_json1_1ProjectCache = (
@@ -3850,11 +3834,7 @@ const serializeAws_json1_1ProjectCacheModes = (
   input: (CacheMode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ProjectEnvironment = (
@@ -3901,22 +3881,16 @@ const serializeAws_json1_1ProjectNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ProjectSecondarySourceVersions = (
   input: ProjectSourceVersion[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProjectSourceVersion(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProjectSourceVersion(entry, context)
+  );
 };
 
 const serializeAws_json1_1ProjectSource = (
@@ -3975,11 +3949,7 @@ const serializeAws_json1_1ProjectSources = (
   input: ProjectSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProjectSource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ProjectSource(entry, context));
 };
 
 const serializeAws_json1_1PutResourcePolicyInput = (
@@ -4014,11 +3984,7 @@ const serializeAws_json1_1ReportArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ReportExportConfig = (
@@ -4053,11 +4019,7 @@ const serializeAws_json1_1ReportGroupArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1S3LogsConfig = (
@@ -4104,11 +4066,7 @@ const serializeAws_json1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SourceAuth = (
@@ -4277,11 +4235,7 @@ const serializeAws_json1_1Subnets = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -4299,11 +4253,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TestCaseFilter = (

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -2448,7 +2448,9 @@ const deserializeAws_json1_1BatchDescribeMergeConflictsCommandError = async (
 export const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput> => {
+): Promise<
+  BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandError(
       output,
@@ -2472,7 +2474,9 @@ export const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepo
 const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput> => {
+): Promise<
+  BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)
@@ -20617,22 +20621,14 @@ const serializeAws_json1_1BranchNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CommitIdsInputList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConflictResolution = (
@@ -20888,11 +20884,9 @@ const serializeAws_json1_1DeleteFileEntries = (
   input: DeleteFileEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DeleteFileEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DeleteFileEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1DeleteFileEntry = (
@@ -21053,11 +21047,7 @@ const serializeAws_json1_1FilePaths = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetApprovalRuleTemplateInput = (
@@ -21823,11 +21813,7 @@ const serializeAws_json1_1PutFileEntries = (
   input: PutFileEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PutFileEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PutFileEntry(entry, context));
 };
 
 const serializeAws_json1_1PutFileEntry = (
@@ -21909,11 +21895,9 @@ const serializeAws_json1_1ReplaceContentEntries = (
   input: ReplaceContentEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ReplaceContentEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ReplaceContentEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1ReplaceContentEntry = (
@@ -21940,11 +21924,7 @@ const serializeAws_json1_1RepositoryNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RepositoryTrigger = (
@@ -21980,33 +21960,25 @@ const serializeAws_json1_1RepositoryTriggerEventList = (
   input: (RepositoryTriggerEventEnum | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RepositoryTriggersList = (
   input: RepositoryTrigger[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RepositoryTrigger(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RepositoryTrigger(entry, context)
+  );
 };
 
 const serializeAws_json1_1SetFileModeEntries = (
   input: SetFileModeEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SetFileModeEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SetFileModeEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1SetFileModeEntry = (
@@ -22041,11 +22013,7 @@ const serializeAws_json1_1TagKeysList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceInput = (
@@ -22093,11 +22061,7 @@ const serializeAws_json1_1TargetList = (
   input: Target[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Target(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Target(entry, context));
 };
 
 const serializeAws_json1_1TestRepositoryTriggersInput = (

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -9034,11 +9034,7 @@ const serializeAws_json1_1AlarmList = (
   input: Alarm[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Alarm(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Alarm(entry, context));
 };
 
 const serializeAws_json1_1AppSpecContent = (
@@ -9059,11 +9055,7 @@ const serializeAws_json1_1ApplicationsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AutoRollbackConfiguration = (
@@ -9087,22 +9079,14 @@ const serializeAws_json1_1AutoRollbackEventsList = (
   input: (AutoRollbackEvent | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AutoScalingGroupNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchGetApplicationRevisionsInput = (
@@ -9528,11 +9512,7 @@ const serializeAws_json1_1DeploymentGroupsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeploymentReadyOption = (
@@ -9553,11 +9533,7 @@ const serializeAws_json1_1DeploymentStatusList = (
   input: (DeploymentStatus | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeploymentStyle = (
@@ -9578,11 +9554,7 @@ const serializeAws_json1_1DeploymentsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeregisterOnPremisesInstanceInput = (
@@ -9617,11 +9589,7 @@ const serializeAws_json1_1EC2TagFilterList = (
   input: EC2TagFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EC2TagFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1EC2TagFilter(entry, context));
 };
 
 const serializeAws_json1_1EC2TagSet = (
@@ -9642,11 +9610,9 @@ const serializeAws_json1_1EC2TagSetList = (
   input: EC2TagFilter[][],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EC2TagFilterList(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EC2TagFilterList(entry, context)
+  );
 };
 
 const serializeAws_json1_1ECSService = (
@@ -9667,11 +9633,7 @@ const serializeAws_json1_1ECSServiceList = (
   input: ECSService[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ECSService(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ECSService(entry, context));
 };
 
 const serializeAws_json1_1ELBInfo = (
@@ -9689,22 +9651,14 @@ const serializeAws_json1_1ELBInfoList = (
   input: ELBInfo[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ELBInfo(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ELBInfo(entry, context));
 };
 
 const serializeAws_json1_1FilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetApplicationInput = (
@@ -9839,44 +9793,28 @@ const serializeAws_json1_1InstanceNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InstanceStatusList = (
   input: (InstanceStatus | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InstanceTypeList = (
   input: (_InstanceType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InstancesList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListApplicationRevisionsInput = (
@@ -10070,11 +10008,7 @@ const serializeAws_json1_1ListenerArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1LoadBalancerInfo = (
@@ -10139,11 +10073,7 @@ const serializeAws_json1_1OnPremisesTagSetList = (
   input: TagFilter[][],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TagFilterList(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TagFilterList(entry, context));
 };
 
 const serializeAws_json1_1PutLifecycleEventHookExecutionStatusInput = (
@@ -10268,11 +10198,9 @@ const serializeAws_json1_1RevisionLocationList = (
   input: RevisionLocation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RevisionLocation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RevisionLocation(entry, context)
+  );
 };
 
 const serializeAws_json1_1S3Location = (
@@ -10355,33 +10283,21 @@ const serializeAws_json1_1TagFilterList = (
   input: TagFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TagFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TagFilter(entry, context));
 };
 
 const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceInput = (
@@ -10423,11 +10339,9 @@ const serializeAws_json1_1TargetGroupInfoList = (
   input: TargetGroupInfo[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TargetGroupInfo(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1TargetGroupInfo(entry, context)
+  );
 };
 
 const serializeAws_json1_1TargetGroupPairInfo = (
@@ -10460,22 +10374,16 @@ const serializeAws_json1_1TargetGroupPairInfoList = (
   input: TargetGroupPairInfo[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TargetGroupPairInfo(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1TargetGroupPairInfo(entry, context)
+  );
 };
 
 const serializeAws_json1_1TargetIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TargetInstances = (
@@ -10609,22 +10517,14 @@ const serializeAws_json1_1TriggerConfigList = (
   input: TriggerConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TriggerConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TriggerConfig(entry, context));
 };
 
 const serializeAws_json1_1TriggerEventTypeList = (
   input: (TriggerEventType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UntagResourceInput = (

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -4857,13 +4857,9 @@ const serializeAws_json1_1ActionConfigurationPropertyList = (
   input: ActionConfigurationProperty[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ActionConfigurationProperty(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ActionConfigurationProperty(entry, context)
+  );
 };
 
 const serializeAws_json1_1ActionDeclaration = (
@@ -5262,11 +5258,7 @@ const serializeAws_json1_1InputArtifactList = (
   input: InputArtifact[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InputArtifact(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1InputArtifact(entry, context));
 };
 
 const serializeAws_json1_1ListActionExecutionsInput = (
@@ -5380,11 +5372,7 @@ const serializeAws_json1_1OutputArtifactList = (
   input: OutputArtifact[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OutputArtifact(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1OutputArtifact(entry, context));
 };
 
 const serializeAws_json1_1PipelineDeclaration = (
@@ -5426,11 +5414,9 @@ const serializeAws_json1_1PipelineStageDeclarationList = (
   input: StageDeclaration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1StageDeclaration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1StageDeclaration(entry, context)
+  );
 };
 
 const serializeAws_json1_1PollForJobsInput = (
@@ -5672,22 +5658,18 @@ const serializeAws_json1_1StageActionDeclarationList = (
   input: ActionDeclaration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ActionDeclaration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ActionDeclaration(entry, context)
+  );
 };
 
 const serializeAws_json1_1StageBlockerDeclarationList = (
   input: BlockerDeclaration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1BlockerDeclaration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1BlockerDeclaration(entry, context)
+  );
 };
 
 const serializeAws_json1_1StageDeclaration = (
@@ -5765,22 +5747,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceInput = (
@@ -5894,11 +5868,9 @@ const serializeAws_json1_1WebhookFilters = (
   input: WebhookFilterRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1WebhookFilterRule(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1WebhookFilterRule(entry, context)
+  );
 };
 
 const serializeAws_json1_1ActionConfigurationMap = (

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
@@ -1710,11 +1710,7 @@ const serializeAws_restJson1_1EventTypeIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ListEventTypesFilter = (
@@ -1735,11 +1731,9 @@ const serializeAws_restJson1_1ListEventTypesFilters = (
   input: ListEventTypesFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ListEventTypesFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ListEventTypesFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListNotificationRulesFilter = (
@@ -1760,13 +1754,9 @@ const serializeAws_restJson1_1ListNotificationRulesFilters = (
   input: ListNotificationRulesFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1ListNotificationRulesFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ListNotificationRulesFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListTargetsFilter = (
@@ -1787,22 +1777,16 @@ const serializeAws_restJson1_1ListTargetsFilters = (
   input: ListTargetsFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ListTargetsFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ListTargetsFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tags = (
@@ -1833,11 +1817,7 @@ const serializeAws_restJson1_1Targets = (
   input: Target[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Target(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Target(entry, context));
 };
 
 const deserializeAws_restJson1_1EventTypeBatch = (

--- a/clients/client-codestar/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/protocols/Aws_json1_1.ts
@@ -2566,22 +2566,14 @@ const serializeAws_json1_1SourceCode = (
   input: Code[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Code(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Code(entry, context));
 };
 
 const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagProjectRequest = (

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -17128,11 +17128,7 @@ const serializeAws_json1_1AliasAttributesListType = (
   input: (AliasAttributeType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AnalyticsConfigurationType = (
@@ -17184,11 +17180,7 @@ const serializeAws_json1_1AttributeListType = (
   input: AttributeType[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AttributeType(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1AttributeType(entry, context));
 };
 
 const serializeAws_json1_1AttributeMappingType = (
@@ -17205,11 +17197,7 @@ const serializeAws_json1_1AttributeNameListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AttributeType = (
@@ -17240,22 +17228,14 @@ const serializeAws_json1_1BlockedIPRangeListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CallbackURLsListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ChallengeResponsesType = (
@@ -17299,11 +17279,7 @@ const serializeAws_json1_1ClientPermissionListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CompromisedCredentialsActionsType = (
@@ -17812,11 +17788,9 @@ const serializeAws_json1_1CustomAttributesListType = (
   input: SchemaAttributeType[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SchemaAttributeType(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SchemaAttributeType(entry, context)
+  );
 };
 
 const serializeAws_json1_1CustomDomainConfigType = (
@@ -17945,11 +17919,7 @@ const serializeAws_json1_1DeliveryMediumListType = (
   input: (DeliveryMediumType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DescribeIdentityProviderRequest = (
@@ -18101,22 +18071,14 @@ const serializeAws_json1_1EventFiltersType = (
   input: (EventFilterType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ExplicitAuthFlowsListType = (
   input: (ExplicitAuthFlowsType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ForgetDeviceRequest = (
@@ -18317,22 +18279,14 @@ const serializeAws_json1_1HttpHeaderList = (
   input: HttpHeader[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1HttpHeader(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1HttpHeader(entry, context));
 };
 
 const serializeAws_json1_1IdpIdentifiersListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InitiateAuthRequest = (
@@ -18591,22 +18545,14 @@ const serializeAws_json1_1LogoutURLsListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MFAOptionListType = (
   input: MFAOptionType[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MFAOptionType(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1MFAOptionType(entry, context));
 };
 
 const serializeAws_json1_1MFAOptionType = (
@@ -18710,11 +18656,7 @@ const serializeAws_json1_1OAuthFlowsType = (
   input: (OAuthFlowType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PasswordPolicyType = (
@@ -18775,11 +18717,9 @@ const serializeAws_json1_1RecoveryMechanismsType = (
   input: RecoveryOptionType[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RecoveryOptionType(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RecoveryOptionType(entry, context)
+  );
 };
 
 const serializeAws_json1_1RecoveryOptionType = (
@@ -18835,11 +18775,9 @@ const serializeAws_json1_1ResourceServerScopeListType = (
   input: ResourceServerScopeType[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResourceServerScopeType(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ResourceServerScopeType(entry, context)
+  );
 };
 
 const serializeAws_json1_1ResourceServerScopeType = (
@@ -18980,33 +18918,23 @@ const serializeAws_json1_1SchemaAttributesListType = (
   input: SchemaAttributeType[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SchemaAttributeType(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SchemaAttributeType(entry, context)
+  );
 };
 
 const serializeAws_json1_1ScopeListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SearchedAttributeNamesListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SetRiskConfigurationRequest = (
@@ -19191,11 +19119,7 @@ const serializeAws_json1_1SkippedIPRangeListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SmsConfigurationType = (
@@ -19300,11 +19224,7 @@ const serializeAws_json1_1SupportedIdentityProvidersListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -19740,11 +19660,7 @@ const serializeAws_json1_1UserPoolTagsListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UserPoolTagsType = (
@@ -19761,11 +19677,7 @@ const serializeAws_json1_1UsernameAttributesListType = (
   input: (UsernameAttributeType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1VerificationMessageTemplateType = (
@@ -19798,11 +19710,7 @@ const serializeAws_json1_1VerifiedAttributesListType = (
   input: (VerifiedAttributeType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1VerifySoftwareTokenRequest = (

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -3113,11 +3113,9 @@ const serializeAws_json1_1CognitoIdentityProviderList = (
   input: CognitoIdentityProvider[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CognitoIdentityProvider(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CognitoIdentityProvider(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateIdentityPoolInput = (
@@ -3307,11 +3305,7 @@ const serializeAws_json1_1IdentityIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IdentityPool = (
@@ -3378,11 +3372,7 @@ const serializeAws_json1_1IdentityPoolTagsListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IdentityPoolTagsType = (
@@ -3454,11 +3444,7 @@ const serializeAws_json1_1LoginsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1LoginsMap = (
@@ -3518,11 +3504,7 @@ const serializeAws_json1_1MappingRulesList = (
   input: MappingRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MappingRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1MappingRule(entry, context));
 };
 
 const serializeAws_json1_1MergeDeveloperIdentitiesInput = (
@@ -3549,11 +3531,7 @@ const serializeAws_json1_1OIDCProviderList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RoleMapping = (
@@ -3616,11 +3594,7 @@ const serializeAws_json1_1SAMLProviderList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SetIdentityPoolRolesInput = (

--- a/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
@@ -3211,11 +3211,7 @@ const serializeAws_restJson1_1ApplicationArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CognitoStreams = (
@@ -3294,11 +3290,9 @@ const serializeAws_restJson1_1RecordPatchList = (
   input: RecordPatch[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1RecordPatch(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1RecordPatch(entry, context)
+  );
 };
 
 const deserializeAws_restJson1_1ApplicationArnList = (

--- a/clients/client-comprehend/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/protocols/Aws_json1_1.ts
@@ -7301,11 +7301,9 @@ const serializeAws_json1_1EntityTypesList = (
   input: EntityTypesListItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EntityTypesListItem(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EntityTypesListItem(entry, context)
+  );
 };
 
 const serializeAws_json1_1EntityTypesListItem = (
@@ -7568,11 +7566,7 @@ const serializeAws_json1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SentimentDetectionJobFilter = (
@@ -7933,22 +7927,14 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Subnets = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -7966,22 +7952,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
@@ -1115,22 +1115,14 @@ const serializeAws_json1_0AccountIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0AutoScalingGroupArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0Filter = (
@@ -1154,22 +1146,14 @@ const serializeAws_json1_0FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0Filter(entry, context));
 };
 
 const serializeAws_json1_0GetAutoScalingGroupRecommendationsRequest = (
@@ -1287,11 +1271,7 @@ const serializeAws_json1_0InstanceArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0UpdateEnrollmentStatusRequest = (

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -9404,22 +9404,16 @@ const serializeAws_json1_1AccountAggregationSourceAccountList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AccountAggregationSourceList = (
   input: AccountAggregationSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AccountAggregationSource(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AccountAggregationSource(entry, context)
+  );
 };
 
 const serializeAws_json1_1AggregateResourceIdentifier = (
@@ -9449,22 +9443,14 @@ const serializeAws_json1_1AggregatedSourceStatusTypeList = (
   input: (AggregatedSourceStatusType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AggregatorRegionList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchGetAggregateResourceConfigRequest = (
@@ -9505,22 +9491,14 @@ const serializeAws_json1_1ComplianceResourceTypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ComplianceTypes = (
   input: (ComplianceType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConfigRule = (
@@ -9599,11 +9577,7 @@ const serializeAws_json1_1ConfigRuleNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConfigSnapshotDeliveryProperties = (
@@ -9621,11 +9595,7 @@ const serializeAws_json1_1ConfigurationAggregatorNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConfigurationRecorder = (
@@ -9652,11 +9622,7 @@ const serializeAws_json1_1ConfigurationRecorderNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConformancePackComplianceFilters = (
@@ -9682,22 +9648,14 @@ const serializeAws_json1_1ConformancePackComplianceResourceIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConformancePackConfigRuleNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConformancePackEvaluationFilters = (
@@ -9748,35 +9706,23 @@ const serializeAws_json1_1ConformancePackInputParameters = (
   input: ConformancePackInputParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ConformancePackInputParameter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ConformancePackInputParameter(entry, context)
+  );
 };
 
 const serializeAws_json1_1ConformancePackNamesList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConformancePackNamesToSummarizeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeleteAggregationAuthorizationRequest = (
@@ -9998,11 +9944,7 @@ const serializeAws_json1_1DeliveryChannelNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DescribeAggregateComplianceByConfigRulesRequest = (
@@ -10522,22 +10464,14 @@ const serializeAws_json1_1Evaluations = (
   input: Evaluation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Evaluation(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Evaluation(entry, context));
 };
 
 const serializeAws_json1_1ExcludedAccounts = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ExecutionControls = (
@@ -10962,33 +10896,21 @@ const serializeAws_json1_1OrganizationConfigRuleNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OrganizationConfigRuleTriggerTypes = (
   input: (OrganizationConfigRuleTriggerType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OrganizationConformancePackNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OrganizationCustomRuleMetadata = (
@@ -11404,11 +11326,7 @@ const serializeAws_json1_1ReevaluateConfigRuleNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RemediationConfiguration = (
@@ -11465,11 +11383,9 @@ const serializeAws_json1_1RemediationConfigurations = (
   input: RemediationConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RemediationConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RemediationConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1RemediationExceptionResourceKey = (
@@ -11490,13 +11406,9 @@ const serializeAws_json1_1RemediationExceptionResourceKeys = (
   input: RemediationExceptionResourceKey[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1RemediationExceptionResourceKey(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RemediationExceptionResourceKey(entry, context)
+  );
 };
 
 const serializeAws_json1_1RemediationParameterValue = (
@@ -11573,24 +11485,16 @@ const serializeAws_json1_1ResourceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResourceIdentifiersList = (
   input: AggregateResourceIdentifier[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1AggregateResourceIdentifier(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AggregateResourceIdentifier(entry, context)
+  );
 };
 
 const serializeAws_json1_1ResourceKey = (
@@ -11611,44 +11515,28 @@ const serializeAws_json1_1ResourceKeys = (
   input: ResourceKey[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResourceKey(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ResourceKey(entry, context));
 };
 
 const serializeAws_json1_1ResourceTypeList = (
   input: (ResourceType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResourceTypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResourceTypesScope = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResourceValue = (
@@ -11666,11 +11554,7 @@ const serializeAws_json1_1RetentionConfigurationNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Scope = (
@@ -11756,11 +11640,7 @@ const serializeAws_json1_1SourceDetails = (
   input: SourceDetail[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SourceDetail(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1SourceDetail(entry, context));
 };
 
 const serializeAws_json1_1SsmControls = (
@@ -11826,11 +11706,7 @@ const serializeAws_json1_1StaticParameterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StaticValue = (
@@ -11887,22 +11763,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -11933,11 +11801,7 @@ const serializeAws_json1_1TagsList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1UntagResourceRequest = (

--- a/clients/client-connect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1_1.ts
@@ -4872,11 +4872,7 @@ const serializeAws_restJson1_1Channels = (
   input: (Channel | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CurrentMetric = (
@@ -4897,11 +4893,9 @@ const serializeAws_restJson1_1CurrentMetrics = (
   input: CurrentMetric[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CurrentMetric(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CurrentMetric(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Filters = (
@@ -4928,11 +4922,7 @@ const serializeAws_restJson1_1Groupings = (
   input: (Grouping | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1HistoricalMetric = (
@@ -4962,22 +4952,16 @@ const serializeAws_restJson1_1HistoricalMetrics = (
   input: HistoricalMetric[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1HistoricalMetric(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1HistoricalMetric(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Queues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Threshold = (
@@ -4998,11 +4982,7 @@ const serializeAws_restJson1_1SecurityProfileIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagMap = (

--- a/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
@@ -795,11 +795,7 @@ const serializeAws_restJson1_1ConnectionTypeList = (
   input: (ConnectionType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1StartPosition = (

--- a/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
@@ -496,11 +496,7 @@ const serializeAws_json1_1AdditionalArtifactList = (
   input: (AdditionalArtifact | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeleteReportDefinitionRequest = (
@@ -614,11 +610,7 @@ const serializeAws_json1_1SchemaElementList = (
   input: (SchemaElement | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1AdditionalArtifactList = (

--- a/clients/client-cost-explorer/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/protocols/Aws_json1_1.ts
@@ -2281,11 +2281,9 @@ const serializeAws_json1_1CostCategoryRulesList = (
   input: CostCategoryRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CostCategoryRule(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CostCategoryRule(entry, context)
+  );
 };
 
 const serializeAws_json1_1CostCategoryValues = (
@@ -2422,11 +2420,7 @@ const serializeAws_json1_1Expressions = (
   input: Expression[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Expression(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Expression(entry, context));
 };
 
 const serializeAws_json1_1GetCostAndUsageRequest = (
@@ -2879,11 +2873,9 @@ const serializeAws_json1_1GroupDefinitions = (
   input: GroupDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1GroupDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1GroupDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1ListCostCategoryDefinitionsRequest = (
@@ -2904,11 +2896,7 @@ const serializeAws_json1_1MetricNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ServiceSpecification = (
@@ -2963,11 +2951,7 @@ const serializeAws_json1_1Values = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1Attributes = (

--- a/clients/client-data-pipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/protocols/Aws_json1_1.ts
@@ -2463,11 +2463,9 @@ const serializeAws_json1_1ParameterAttributeList = (
   input: ParameterAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ParameterAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ParameterAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1ParameterObject = (
@@ -2491,11 +2489,9 @@ const serializeAws_json1_1ParameterObjectList = (
   input: ParameterObject[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ParameterObject(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ParameterObject(entry, context)
+  );
 };
 
 const serializeAws_json1_1ParameterValue = (
@@ -2516,11 +2512,7 @@ const serializeAws_json1_1ParameterValueList = (
   input: ParameterValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ParameterValue(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ParameterValue(entry, context));
 };
 
 const serializeAws_json1_1PipelineObject = (
@@ -2544,11 +2536,7 @@ const serializeAws_json1_1PipelineObjectList = (
   input: PipelineObject[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PipelineObject(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PipelineObject(entry, context));
 };
 
 const serializeAws_json1_1PollForTaskInput = (
@@ -2706,11 +2694,7 @@ const serializeAws_json1_1SelectorList = (
   input: Selector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Selector(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Selector(entry, context));
 };
 
 const serializeAws_json1_1SetStatusInput = (
@@ -2800,44 +2784,28 @@ const serializeAws_json1_1fieldList = (
   input: Field[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Field(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Field(entry, context));
 };
 
 const serializeAws_json1_1idList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1stringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1tagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const deserializeAws_json1_1ActivatePipelineOutput = (

--- a/clients/client-database-migration-service/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/protocols/Aws_json1_1.ts
@@ -6069,11 +6069,7 @@ const serializeAws_json1_1EventCategoriesList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filter = (
@@ -6097,22 +6093,14 @@ const serializeAws_json1_1FilterList = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1FilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ImportCertificateMessage = (
@@ -6141,11 +6129,7 @@ const serializeAws_json1_1KeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1KinesisSettings = (
@@ -6663,11 +6647,7 @@ const serializeAws_json1_1SourceIdsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartReplicationTaskAssessmentMessage = (
@@ -6721,22 +6701,14 @@ const serializeAws_json1_1SubnetIdentifierList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TableListToReload = (
   input: TableToReload[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TableToReload(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TableToReload(entry, context));
 };
 
 const serializeAws_json1_1TableToReload = (
@@ -6768,11 +6740,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TestConnectionMessage = (
@@ -6793,11 +6761,7 @@ const serializeAws_json1_1VpcSecurityGroupIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1AccessDeniedFault = (

--- a/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
@@ -3755,24 +3755,18 @@ const serializeAws_restJson1_1ListOfAssetDestinationEntry = (
   input: AssetDestinationEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1AssetDestinationEntry(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AssetDestinationEntry(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfAssetSourceEntry = (
   input: AssetSourceEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AssetSourceEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AssetSourceEntry(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1MapOf__string = (

--- a/clients/client-datasync/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/protocols/Aws_json1_1.ts
@@ -2563,11 +2563,7 @@ const serializeAws_json1_1AgentArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CancelTaskExecutionRequest = (
@@ -2902,22 +2898,14 @@ const serializeAws_json1_1Ec2SecurityGroupArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FilterList = (
   input: FilterRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FilterRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1FilterRule(entry, context));
 };
 
 const serializeAws_json1_1FilterRule = (
@@ -3080,22 +3068,14 @@ const serializeAws_json1_1PLSecurityGroupArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PLSubnetArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1S3Config = (
@@ -3147,22 +3127,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: TagListEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TagListEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TagListEntry(entry, context));
 };
 
 const serializeAws_json1_1TagListEntry = (

--- a/clients/client-dax/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/protocols/Aws_json1_1.ts
@@ -3300,22 +3300,14 @@ const serializeAws_json1_1AvailabilityZoneList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ClusterNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateClusterRequest = (
@@ -3618,11 +3610,7 @@ const serializeAws_json1_1KeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListTagsRequest = (
@@ -3643,22 +3631,14 @@ const serializeAws_json1_1NodeIdentifierList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ParameterGroupNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ParameterNameValue = (
@@ -3679,11 +3659,9 @@ const serializeAws_json1_1ParameterNameValueList = (
   input: ParameterNameValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ParameterNameValue(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ParameterNameValue(entry, context)
+  );
 };
 
 const serializeAws_json1_1RebootNodeRequest = (
@@ -3715,33 +3693,21 @@ const serializeAws_json1_1SecurityGroupIdentifierList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SubnetGroupNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SubnetIdentifierList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -3759,11 +3725,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-detective/protocols/Aws_restJson1_1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1_1.ts
@@ -1448,22 +1448,14 @@ const serializeAws_restJson1_1AccountIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1AccountList = (
   input: Account[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Account(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Account(entry, context));
 };
 
 const deserializeAws_restJson1_1AccountIdList = (

--- a/clients/client-device-farm/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/protocols/Aws_json1_1.ts
@@ -9069,22 +9069,14 @@ const serializeAws_json1_1AmazonResourceNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AndroidPaths = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateDevicePoolRequest = (
@@ -9482,33 +9474,21 @@ const serializeAws_json1_1DeviceFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeviceFilters = (
   input: DeviceFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DeviceFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DeviceFilter(entry, context));
 };
 
 const serializeAws_json1_1DeviceHostPaths = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeviceSelectionConfiguration = (
@@ -9788,22 +9768,14 @@ const serializeAws_json1_1InstanceLabels = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IosPaths = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListArtifactsRequest = (
@@ -10201,11 +10173,7 @@ const serializeAws_json1_1PackageIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PurchaseOfferingRequest = (
@@ -10280,11 +10248,7 @@ const serializeAws_json1_1Rules = (
   input: Rule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Rule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Rule(entry, context));
 };
 
 const serializeAws_json1_1ScheduleRunConfiguration = (
@@ -10460,22 +10424,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-direct-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/protocols/Aws_json1_1.ts
@@ -6458,11 +6458,7 @@ const serializeAws_json1_1ResourceArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RouteFilterPrefix = (
@@ -6480,11 +6476,9 @@ const serializeAws_json1_1RouteFilterPrefixList = (
   input: RouteFilterPrefix[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RouteFilterPrefix(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RouteFilterPrefix(entry, context)
+  );
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -6502,22 +6496,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-directory-service/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/protocols/Aws_json1_1.ts
@@ -8089,11 +8089,7 @@ const serializeAws_json1_1Attributes = (
   input: Attribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Attribute(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Attribute(entry, context));
 };
 
 const serializeAws_json1_1CancelSchemaExtensionRequest = (
@@ -8114,11 +8110,7 @@ const serializeAws_json1_1CidrIps = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConnectDirectoryRequest = (
@@ -8640,11 +8632,7 @@ const serializeAws_json1_1DirectoryIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DirectoryVpcSettings = (
@@ -8710,22 +8698,14 @@ const serializeAws_json1_1DnsIpAddrs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DomainControllerIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EnableLDAPSRequest = (
@@ -8813,11 +8793,7 @@ const serializeAws_json1_1IpRoutes = (
   input: IpRoute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IpRoute(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1IpRoute(entry, context));
 };
 
 const serializeAws_json1_1ListCertificatesRequest = (
@@ -8983,11 +8959,7 @@ const serializeAws_json1_1RemoteDomainNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RemoveIpRoutesRequest = (
@@ -9050,11 +9022,7 @@ const serializeAws_json1_1Servers = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ShareDirectoryRequest = (
@@ -9098,11 +9066,7 @@ const serializeAws_json1_1SnapshotIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartSchemaExtensionRequest = (
@@ -9130,11 +9094,7 @@ const serializeAws_json1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -9152,44 +9112,28 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TopicNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TrustIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UnshareDirectoryRequest = (

--- a/clients/client-dlm/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1_1.ts
@@ -1174,11 +1174,7 @@ const serializeAws_restJson1_1AvailabilityZoneList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1CreateRule = (
@@ -1247,11 +1243,9 @@ const serializeAws_restJson1_1CrossRegionCopyRules = (
   input: CrossRegionCopyRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CrossRegionCopyRule(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CrossRegionCopyRule(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1FastRestoreRule = (
@@ -1331,11 +1325,7 @@ const serializeAws_restJson1_1ResourceTypeValuesList = (
   input: (ResourceTypeValues | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1RetainRule = (
@@ -1411,11 +1401,7 @@ const serializeAws_restJson1_1ScheduleList = (
   input: Schedule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Schedule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Schedule(entry, context));
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -1446,44 +1432,28 @@ const serializeAws_restJson1_1TagsToAddList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TargetTagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TimesList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1VariableTagsList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const deserializeAws_restJson1_1AvailabilityZoneList = (

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -5526,22 +5526,16 @@ const serializeAws_json1_0AttributeDefinitions = (
   input: AttributeDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0AttributeDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0AttributeDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_0AttributeNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0AttributeUpdates = (
@@ -5605,11 +5599,7 @@ const serializeAws_json1_0AttributeValueList = (
   input: AttributeValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0AttributeValue(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0AttributeValue(entry, context));
 };
 
 const serializeAws_json1_0AttributeValueUpdate = (
@@ -5758,11 +5748,7 @@ const serializeAws_json1_0BinarySetAttributeValue = (
   input: Uint8Array[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(context.base64Encoder(entry));
-  }
-  return contents;
+  return input.map(entry => context.base64Encoder(entry));
 };
 
 const serializeAws_json1_0Condition = (
@@ -6422,24 +6408,18 @@ const serializeAws_json1_0GlobalSecondaryIndexAutoScalingUpdateList = (
   input: GlobalSecondaryIndexAutoScalingUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_0GlobalSecondaryIndexAutoScalingUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0GlobalSecondaryIndexAutoScalingUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_0GlobalSecondaryIndexList = (
   input: GlobalSecondaryIndex[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0GlobalSecondaryIndex(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0GlobalSecondaryIndex(entry, context)
+  );
 };
 
 const serializeAws_json1_0GlobalSecondaryIndexUpdate = (
@@ -6472,13 +6452,9 @@ const serializeAws_json1_0GlobalSecondaryIndexUpdateList = (
   input: GlobalSecondaryIndexUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_0GlobalSecondaryIndexUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0GlobalSecondaryIndexUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_0GlobalTableGlobalSecondaryIndexSettingsUpdate = (
@@ -6508,16 +6484,12 @@ const serializeAws_json1_0GlobalTableGlobalSecondaryIndexSettingsUpdateList = (
   input: GlobalTableGlobalSecondaryIndexSettingsUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_0GlobalTableGlobalSecondaryIndexSettingsUpdate(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0GlobalTableGlobalSecondaryIndexSettingsUpdate(
+      entry,
+      context
+    )
+  );
 };
 
 const serializeAws_json1_0Key = (
@@ -6544,22 +6516,16 @@ const serializeAws_json1_0KeyList = (
   input: { [key: string]: AttributeValue }[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0Key(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0Key(entry, context));
 };
 
 const serializeAws_json1_0KeySchema = (
   input: KeySchemaElement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0KeySchemaElement(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0KeySchemaElement(entry, context)
+  );
 };
 
 const serializeAws_json1_0KeySchemaElement = (
@@ -6611,11 +6577,7 @@ const serializeAws_json1_0ListAttributeValue = (
   input: AttributeValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0AttributeValue(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0AttributeValue(entry, context));
 };
 
 const serializeAws_json1_0ListBackupsInput = (
@@ -6738,11 +6700,9 @@ const serializeAws_json1_0LocalSecondaryIndexList = (
   input: LocalSecondaryIndex[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0LocalSecondaryIndex(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0LocalSecondaryIndex(entry, context)
+  );
 };
 
 const serializeAws_json1_0MapAttributeValue = (
@@ -6759,22 +6719,14 @@ const serializeAws_json1_0NonKeyAttributeNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0NumberSetAttributeValue = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0PointInTimeRecoverySpecification = (
@@ -7071,11 +7023,9 @@ const serializeAws_json1_0ReplicaAutoScalingUpdateList = (
   input: ReplicaAutoScalingUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0ReplicaAutoScalingUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0ReplicaAutoScalingUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_0ReplicaGlobalSecondaryIndex = (
@@ -7120,29 +7070,21 @@ const serializeAws_json1_0ReplicaGlobalSecondaryIndexAutoScalingUpdateList = (
   input: ReplicaGlobalSecondaryIndexAutoScalingUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_0ReplicaGlobalSecondaryIndexAutoScalingUpdate(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0ReplicaGlobalSecondaryIndexAutoScalingUpdate(
+      entry,
+      context
+    )
+  );
 };
 
 const serializeAws_json1_0ReplicaGlobalSecondaryIndexList = (
   input: ReplicaGlobalSecondaryIndex[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_0ReplicaGlobalSecondaryIndex(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0ReplicaGlobalSecondaryIndex(entry, context)
+  );
 };
 
 const serializeAws_json1_0ReplicaGlobalSecondaryIndexSettingsUpdate = (
@@ -7172,27 +7114,19 @@ const serializeAws_json1_0ReplicaGlobalSecondaryIndexSettingsUpdateList = (
   input: ReplicaGlobalSecondaryIndexSettingsUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_0ReplicaGlobalSecondaryIndexSettingsUpdate(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0ReplicaGlobalSecondaryIndexSettingsUpdate(
+      entry,
+      context
+    )
+  );
 };
 
 const serializeAws_json1_0ReplicaList = (
   input: Replica[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0Replica(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0Replica(entry, context));
 };
 
 const serializeAws_json1_0ReplicaSettingsUpdate = (
@@ -7232,11 +7166,9 @@ const serializeAws_json1_0ReplicaSettingsUpdateList = (
   input: ReplicaSettingsUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0ReplicaSettingsUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0ReplicaSettingsUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_0ReplicaUpdate = (
@@ -7263,11 +7195,7 @@ const serializeAws_json1_0ReplicaUpdateList = (
   input: ReplicaUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0ReplicaUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0ReplicaUpdate(entry, context));
 };
 
 const serializeAws_json1_0ReplicationGroupUpdate = (
@@ -7306,11 +7234,9 @@ const serializeAws_json1_0ReplicationGroupUpdateList = (
   input: ReplicationGroupUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0ReplicationGroupUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0ReplicationGroupUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_0RestoreTableFromBackupInput = (
@@ -7513,11 +7439,7 @@ const serializeAws_json1_0StringSetAttributeValue = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0Tag = (input: Tag, context: __SerdeContext): any => {
@@ -7535,22 +7457,14 @@ const serializeAws_json1_0TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0Tag(entry, context));
 };
 
 const serializeAws_json1_0TagResourceInput = (
@@ -7596,11 +7510,9 @@ const serializeAws_json1_0TransactGetItemList = (
   input: TransactGetItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0TransactGetItem(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0TransactGetItem(entry, context)
+  );
 };
 
 const serializeAws_json1_0TransactGetItemsInput = (
@@ -7647,11 +7559,9 @@ const serializeAws_json1_0TransactWriteItemList = (
   input: TransactWriteItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0TransactWriteItem(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_0TransactWriteItem(entry, context)
+  );
 };
 
 const serializeAws_json1_0TransactWriteItemsInput = (
@@ -8082,11 +7992,7 @@ const serializeAws_json1_0WriteRequests = (
   input: WriteRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0WriteRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0WriteRequest(entry, context));
 };
 
 const deserializeAws_json1_0DescribeEndpointsResponse = (

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -20868,7 +20868,9 @@ const deserializeAws_ec2DescribeLaunchTemplatesCommandError = async (
 export const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput> => {
+): Promise<
+  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandError(
       output,
@@ -20893,7 +20895,9 @@ export const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGro
 const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput> => {
+): Promise<
+  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)

--- a/clients/client-ecr/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/protocols/Aws_json1_1.ts
@@ -3977,11 +3977,7 @@ const serializeAws_json1_1BatchedOperationLayerDigestList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CompleteLayerUploadRequest = (
@@ -4173,11 +4169,7 @@ const serializeAws_json1_1GetAuthorizationTokenRegistryIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetAuthorizationTokenRequest = (
@@ -4291,11 +4283,9 @@ const serializeAws_json1_1ImageIdentifierList = (
   input: ImageIdentifier[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ImageIdentifier(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ImageIdentifier(entry, context)
+  );
 };
 
 const serializeAws_json1_1ImageScanningConfiguration = (
@@ -4327,11 +4317,7 @@ const serializeAws_json1_1LayerDigestList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1LifecyclePolicyPreviewFilter = (
@@ -4397,11 +4383,7 @@ const serializeAws_json1_1MediaTypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PutImageRequest = (
@@ -4484,11 +4466,7 @@ const serializeAws_json1_1RepositoryNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SetRepositoryPolicyRequest = (
@@ -4563,22 +4541,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-ecs/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/protocols/Aws_json1_1.ts
@@ -6486,11 +6486,9 @@ const serializeAws_json1_1AttachmentStateChanges = (
   input: AttachmentStateChange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AttachmentStateChange(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AttachmentStateChange(entry, context)
+  );
 };
 
 const serializeAws_json1_1Attribute = (
@@ -6517,11 +6515,7 @@ const serializeAws_json1_1Attributes = (
   input: Attribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Attribute(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Attribute(entry, context));
 };
 
 const serializeAws_json1_1AutoScalingGroupProvider = (
@@ -6572,24 +6566,16 @@ const serializeAws_json1_1CapacityProviderFieldList = (
   input: (CapacityProviderField | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CapacityProviderStrategy = (
   input: CapacityProviderStrategyItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1CapacityProviderStrategyItem(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CapacityProviderStrategyItem(entry, context)
+  );
 };
 
 const serializeAws_json1_1CapacityProviderStrategyItem = (
@@ -6613,11 +6599,7 @@ const serializeAws_json1_1ClusterFieldList = (
   input: (ClusterField | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ClusterSetting = (
@@ -6638,22 +6620,14 @@ const serializeAws_json1_1ClusterSettings = (
   input: ClusterSetting[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ClusterSetting(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ClusterSetting(entry, context));
 };
 
 const serializeAws_json1_1CompatibilityList = (
   input: (Compatibility | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContainerDefinition = (
@@ -6851,22 +6825,18 @@ const serializeAws_json1_1ContainerDefinitions = (
   input: ContainerDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ContainerDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContainerDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1ContainerDependencies = (
   input: ContainerDependency[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ContainerDependency(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContainerDependency(entry, context)
+  );
 };
 
 const serializeAws_json1_1ContainerDependency = (
@@ -6887,11 +6857,7 @@ const serializeAws_json1_1ContainerInstanceFieldList = (
   input: (ContainerInstanceField | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContainerOverride = (
@@ -6938,11 +6904,9 @@ const serializeAws_json1_1ContainerOverrides = (
   input: ContainerOverride[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ContainerOverride(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContainerOverride(entry, context)
+  );
 };
 
 const serializeAws_json1_1ContainerStateChange = (
@@ -6981,11 +6945,9 @@ const serializeAws_json1_1ContainerStateChanges = (
   input: ContainerStateChange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ContainerStateChange(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContainerStateChange(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateCapacityProviderRequest = (
@@ -7515,22 +7477,14 @@ const serializeAws_json1_1DeviceCgroupPermissions = (
   input: (DeviceCgroupPermission | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DevicesList = (
   input: Device[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Device(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Device(entry, context));
 };
 
 const serializeAws_json1_1DiscoverPollEndpointRequest = (
@@ -7601,11 +7555,7 @@ const serializeAws_json1_1EnvironmentVariables = (
   input: KeyValuePair[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1KeyValuePair(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1KeyValuePair(entry, context));
 };
 
 const serializeAws_json1_1FirelensConfiguration = (
@@ -7679,11 +7629,7 @@ const serializeAws_json1_1HostEntryList = (
   input: HostEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1HostEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1HostEntry(entry, context));
 };
 
 const serializeAws_json1_1HostVolumeProperties = (
@@ -7729,24 +7675,18 @@ const serializeAws_json1_1InferenceAcceleratorOverrides = (
   input: InferenceAcceleratorOverride[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1InferenceAcceleratorOverride(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InferenceAcceleratorOverride(entry, context)
+  );
 };
 
 const serializeAws_json1_1InferenceAccelerators = (
   input: InferenceAccelerator[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InferenceAccelerator(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InferenceAccelerator(entry, context)
+  );
 };
 
 const serializeAws_json1_1KernelCapabilities = (
@@ -8037,11 +7977,7 @@ const serializeAws_json1_1LoadBalancers = (
   input: LoadBalancer[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1LoadBalancer(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1LoadBalancer(entry, context));
 };
 
 const serializeAws_json1_1LogConfiguration = (
@@ -8118,11 +8054,7 @@ const serializeAws_json1_1MountPointList = (
   input: MountPoint[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MountPoint(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1MountPoint(entry, context));
 };
 
 const serializeAws_json1_1NetworkBinding = (
@@ -8149,11 +8081,7 @@ const serializeAws_json1_1NetworkBindings = (
   input: NetworkBinding[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1NetworkBinding(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1NetworkBinding(entry, context));
 };
 
 const serializeAws_json1_1NetworkConfiguration = (
@@ -8188,22 +8116,18 @@ const serializeAws_json1_1PlacementConstraints = (
   input: PlacementConstraint[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PlacementConstraint(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PlacementConstraint(entry, context)
+  );
 };
 
 const serializeAws_json1_1PlacementStrategies = (
   input: PlacementStrategy[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PlacementStrategy(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PlacementStrategy(entry, context)
+  );
 };
 
 const serializeAws_json1_1PlacementStrategy = (
@@ -8238,11 +8162,7 @@ const serializeAws_json1_1PlatformDevices = (
   input: PlatformDevice[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PlatformDevice(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PlatformDevice(entry, context));
 };
 
 const serializeAws_json1_1PortMapping = (
@@ -8266,11 +8186,7 @@ const serializeAws_json1_1PortMappingList = (
   input: PortMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PortMapping(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PortMapping(entry, context));
 };
 
 const serializeAws_json1_1ProxyConfiguration = (
@@ -8297,11 +8213,7 @@ const serializeAws_json1_1ProxyConfigurationProperties = (
   input: KeyValuePair[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1KeyValuePair(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1KeyValuePair(entry, context));
 };
 
 const serializeAws_json1_1PutAccountSettingDefaultRequest = (
@@ -8562,22 +8474,16 @@ const serializeAws_json1_1ResourceRequirements = (
   input: ResourceRequirement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResourceRequirement(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ResourceRequirement(entry, context)
+  );
 };
 
 const serializeAws_json1_1Resources = (
   input: Resource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Resource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Resource(entry, context));
 };
 
 const serializeAws_json1_1RunTaskRequest = (
@@ -8689,33 +8595,23 @@ const serializeAws_json1_1SecretList = (
   input: Secret[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Secret(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Secret(entry, context));
 };
 
 const serializeAws_json1_1ServiceFieldList = (
   input: (ServiceField | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ServiceRegistries = (
   input: ServiceRegistry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ServiceRegistry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ServiceRegistry(entry, context)
+  );
 };
 
 const serializeAws_json1_1ServiceRegistry = (
@@ -8811,11 +8707,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StringMap = (
@@ -8945,11 +8837,7 @@ const serializeAws_json1_1SystemControls = (
   input: SystemControl[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SystemControl(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1SystemControl(entry, context));
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -8967,11 +8855,7 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -8992,22 +8876,14 @@ const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TaskDefinitionFieldList = (
   input: (TaskDefinitionField | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TaskDefinitionPlacementConstraint = (
@@ -9028,24 +8904,16 @@ const serializeAws_json1_1TaskDefinitionPlacementConstraints = (
   input: TaskDefinitionPlacementConstraint[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1TaskDefinitionPlacementConstraint(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1TaskDefinitionPlacementConstraint(entry, context)
+  );
 };
 
 const serializeAws_json1_1TaskFieldList = (
   input: (TaskField | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TaskOverride = (
@@ -9106,11 +8974,7 @@ const serializeAws_json1_1TmpfsList = (
   input: Tmpfs[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tmpfs(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tmpfs(entry, context));
 };
 
 const serializeAws_json1_1Ulimit = (
@@ -9134,11 +8998,7 @@ const serializeAws_json1_1UlimitList = (
   input: Ulimit[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Ulimit(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Ulimit(entry, context));
 };
 
 const serializeAws_json1_1UntagResourceRequest = (
@@ -9365,22 +9225,14 @@ const serializeAws_json1_1VolumeFromList = (
   input: VolumeFrom[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1VolumeFrom(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1VolumeFrom(entry, context));
 };
 
 const serializeAws_json1_1VolumeList = (
   input: Volume[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Volume(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Volume(entry, context));
 };
 
 const deserializeAws_json1_1AccessDeniedException = (

--- a/clients/client-efs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1_1.ts
@@ -4106,11 +4106,9 @@ const serializeAws_restJson1_1LifecyclePolicies = (
   input: LifecyclePolicy[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1LifecyclePolicy(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1LifecyclePolicy(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1LifecyclePolicy = (
@@ -4165,22 +4163,14 @@ const serializeAws_restJson1_1SecondaryGids = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SecurityGroups = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -4201,22 +4191,14 @@ const serializeAws_restJson1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const deserializeAws_restJson1_1AccessPointDescription = (

--- a/clients/client-eks/protocols/Aws_restJson1_1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1_1.ts
@@ -3658,13 +3658,9 @@ const serializeAws_restJson1_1FargateProfileSelectors = (
   input: FargateProfileSelector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1FargateProfileSelector(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1FargateProfileSelector(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1LogSetup = (
@@ -3688,22 +3684,14 @@ const serializeAws_restJson1_1LogSetups = (
   input: LogSetup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1LogSetup(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1LogSetup(entry, context));
 };
 
 const serializeAws_restJson1_1LogTypes = (
   input: (LogType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Logging = (
@@ -3758,11 +3746,7 @@ const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagMap = (
@@ -3831,11 +3815,7 @@ const serializeAws_restJson1_1labelsKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1labelsMap = (

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
@@ -2808,11 +2808,7 @@ const serializeAws_restJson1_1AccessControls = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Artwork = (
@@ -2851,11 +2847,7 @@ const serializeAws_restJson1_1Artworks = (
   input: Artwork[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Artwork(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Artwork(entry, context));
 };
 
 const serializeAws_restJson1_1AudioCodecOptions = (
@@ -2931,11 +2923,9 @@ const serializeAws_restJson1_1CaptionFormats = (
   input: CaptionFormat[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CaptionFormat(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CaptionFormat(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1CaptionSource = (
@@ -2968,11 +2958,9 @@ const serializeAws_restJson1_1CaptionSources = (
   input: CaptionSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CaptionSource(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CaptionSource(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Captions = (
@@ -3026,11 +3014,7 @@ const serializeAws_restJson1_1Composition = (
   input: Clip[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Clip(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Clip(entry, context));
 };
 
 const serializeAws_restJson1_1CreateJobOutput = (
@@ -3096,11 +3080,9 @@ const serializeAws_restJson1_1CreateJobOutputs = (
   input: CreateJobOutput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CreateJobOutput(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CreateJobOutput(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1CreateJobPlaylist = (
@@ -3141,11 +3123,9 @@ const serializeAws_restJson1_1CreateJobPlaylists = (
   input: CreateJobPlaylist[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CreateJobPlaylist(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CreateJobPlaylist(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DetectedProperties = (
@@ -3307,11 +3287,7 @@ const serializeAws_restJson1_1JobInputs = (
   input: JobInput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1JobInput(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1JobInput(entry, context));
 };
 
 const serializeAws_restJson1_1JobWatermark = (
@@ -3338,11 +3314,9 @@ const serializeAws_restJson1_1JobWatermarks = (
   input: JobWatermark[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1JobWatermark(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1JobWatermark(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Notifications = (
@@ -3369,11 +3343,7 @@ const serializeAws_restJson1_1OutputKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Permission = (
@@ -3400,11 +3370,7 @@ const serializeAws_restJson1_1Permissions = (
   input: Permission[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Permission(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Permission(entry, context));
 };
 
 const serializeAws_restJson1_1PipelineOutputConfig = (
@@ -3495,22 +3461,16 @@ const serializeAws_restJson1_1PresetWatermarks = (
   input: PresetWatermark[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1PresetWatermark(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1PresetWatermark(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SnsTopics = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Thumbnails = (

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
@@ -3575,11 +3575,7 @@ const serializeAws_restJson1_1DomainNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1EBSOptions = (
@@ -3709,11 +3705,7 @@ const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -3734,11 +3726,7 @@ const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1VPCOptions = (

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -2891,11 +2891,7 @@ const serializeAws_json1_1ApplicationList = (
   input: Application[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Application(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Application(entry, context));
 };
 
 const serializeAws_json1_1AutoScalingPolicy = (
@@ -2976,11 +2972,9 @@ const serializeAws_json1_1BootstrapActionConfigList = (
   input: BootstrapActionConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1BootstrapActionConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1BootstrapActionConfig(entry, context)
+  );
 };
 
 const serializeAws_json1_1CancelStepsInput = (
@@ -3045,11 +3039,7 @@ const serializeAws_json1_1ClusterStateList = (
   input: (ClusterState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Configuration = (
@@ -3079,11 +3069,7 @@ const serializeAws_json1_1ConfigurationList = (
   input: Configuration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Configuration(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Configuration(entry, context));
 };
 
 const serializeAws_json1_1CreateSecurityConfigurationInput = (
@@ -3181,22 +3167,14 @@ const serializeAws_json1_1EC2InstanceIdsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EC2InstanceIdsToTerminateList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EbsBlockDeviceConfig = (
@@ -3220,11 +3198,9 @@ const serializeAws_json1_1EbsBlockDeviceConfigList = (
   input: EbsBlockDeviceConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EbsBlockDeviceConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EbsBlockDeviceConfig(entry, context)
+  );
 };
 
 const serializeAws_json1_1EbsConfiguration = (
@@ -3317,11 +3293,9 @@ const serializeAws_json1_1InstanceFleetConfigList = (
   input: InstanceFleetConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InstanceFleetConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InstanceFleetConfig(entry, context)
+  );
 };
 
 const serializeAws_json1_1InstanceFleetModifyConfig = (
@@ -3405,11 +3379,9 @@ const serializeAws_json1_1InstanceGroupConfigList = (
   input: InstanceGroupConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InstanceGroupConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InstanceGroupConfig(entry, context)
+  );
 };
 
 const serializeAws_json1_1InstanceGroupModifyConfig = (
@@ -3450,24 +3422,16 @@ const serializeAws_json1_1InstanceGroupModifyConfigList = (
   input: InstanceGroupModifyConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1InstanceGroupModifyConfig(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InstanceGroupModifyConfig(entry, context)
+  );
 };
 
 const serializeAws_json1_1InstanceGroupTypeList = (
   input: (InstanceGroupType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InstanceResizePolicy = (
@@ -3497,11 +3461,7 @@ const serializeAws_json1_1InstanceStateList = (
   input: (InstanceState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InstanceTypeConfig = (
@@ -3541,22 +3501,16 @@ const serializeAws_json1_1InstanceTypeConfigList = (
   input: InstanceTypeConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InstanceTypeConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InstanceTypeConfig(entry, context)
+  );
 };
 
 const serializeAws_json1_1JobFlowExecutionStateList = (
   input: (JobFlowExecutionState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1JobFlowInstancesConfig = (
@@ -3685,11 +3639,7 @@ const serializeAws_json1_1KeyValueList = (
   input: KeyValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1KeyValue(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1KeyValue(entry, context));
 };
 
 const serializeAws_json1_1ListBootstrapActionsInput = (
@@ -3853,11 +3803,9 @@ const serializeAws_json1_1MetricDimensionList = (
   input: MetricDimension[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MetricDimension(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MetricDimension(entry, context)
+  );
 };
 
 const serializeAws_json1_1ModifyClusterInput = (
@@ -3914,11 +3862,9 @@ const serializeAws_json1_1NewSupportedProductsList = (
   input: SupportedProductConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SupportedProductConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SupportedProductConfig(entry, context)
+  );
 };
 
 const serializeAws_json1_1PlacementType = (
@@ -3958,11 +3904,7 @@ const serializeAws_json1_1PortRanges = (
   input: PortRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PortRange(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PortRange(entry, context));
 };
 
 const serializeAws_json1_1PutAutoScalingPolicyInput = (
@@ -4203,11 +4145,7 @@ const serializeAws_json1_1ScalingRuleList = (
   input: ScalingRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ScalingRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ScalingRule(entry, context));
 };
 
 const serializeAws_json1_1ScalingTrigger = (
@@ -4244,11 +4182,7 @@ const serializeAws_json1_1SecurityGroupsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SetTerminationProtectionInput = (
@@ -4362,44 +4296,28 @@ const serializeAws_json1_1StepConfigList = (
   input: StepConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1StepConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1StepConfig(entry, context));
 };
 
 const serializeAws_json1_1StepIdsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StepStateList = (
   input: (StepState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StringMap = (
@@ -4430,11 +4348,7 @@ const serializeAws_json1_1SupportedProductsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -4452,11 +4366,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TerminateJobFlowsInput = (
@@ -4494,22 +4404,14 @@ const serializeAws_json1_1XmlStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1XmlStringMaxLen256List = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1AddInstanceFleetOutput = (

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -3585,11 +3585,7 @@ const serializeAws_json1_1EventResourceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InputTransformer = (
@@ -3820,11 +3816,9 @@ const serializeAws_json1_1PutEventsRequestEntryList = (
   input: PutEventsRequestEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PutEventsRequestEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PutEventsRequestEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1PutPartnerEventsRequest = (
@@ -3873,13 +3867,9 @@ const serializeAws_json1_1PutPartnerEventsRequestEntryList = (
   input: PutPartnerEventsRequestEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1PutPartnerEventsRequestEntry(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PutPartnerEventsRequestEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1PutPermissionRequest = (
@@ -4029,22 +4019,16 @@ const serializeAws_json1_1RunCommandTargetValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RunCommandTargets = (
   input: RunCommandTarget[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RunCommandTarget(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RunCommandTarget(entry, context)
+  );
 };
 
 const serializeAws_json1_1SqsParameters = (
@@ -4062,11 +4046,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -4084,22 +4064,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -4181,22 +4153,14 @@ const serializeAws_json1_1TargetIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TargetList = (
   input: Target[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Target(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Target(entry, context));
 };
 
 const serializeAws_json1_1TestEventPatternRequest = (

--- a/clients/client-firehose/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/protocols/Aws_json1_1.ts
@@ -2115,22 +2115,14 @@ const serializeAws_json1_1ListOfNonEmptyStrings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListOfNonEmptyStringsWithoutWhitespace = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListTagsForDeliveryStreamInput = (
@@ -2296,11 +2288,7 @@ const serializeAws_json1_1ProcessorList = (
   input: Processor[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Processor(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Processor(entry, context));
 };
 
 const serializeAws_json1_1ProcessorParameter = (
@@ -2321,11 +2309,9 @@ const serializeAws_json1_1ProcessorParameterList = (
   input: ProcessorParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProcessorParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProcessorParameter(entry, context)
+  );
 };
 
 const serializeAws_json1_1PutRecordBatchInput = (
@@ -2349,11 +2335,7 @@ const serializeAws_json1_1PutRecordBatchRequestEntryList = (
   input: _Record[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1_Record(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1_Record(entry, context));
 };
 
 const serializeAws_json1_1PutRecordInput = (
@@ -2837,22 +2819,14 @@ const serializeAws_json1_1TagDeliveryStreamInputTagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UntagDeliveryStreamInput = (

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -1981,11 +1981,7 @@ const serializeAws_json1_1CustomerPolicyScopeIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CustomerPolicyScopeMap = (
@@ -2258,22 +2254,14 @@ const serializeAws_json1_1ResourceTags = (
   input: ResourceTag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResourceTag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ResourceTag(entry, context));
 };
 
 const serializeAws_json1_1ResourceTypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SecurityServicePolicyData = (
@@ -2305,22 +2293,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -2821,11 +2821,7 @@ const serializeAws_json1_1ArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CategoricalParameterRange = (
@@ -2846,13 +2842,9 @@ const serializeAws_json1_1CategoricalParameterRanges = (
   input: CategoricalParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1CategoricalParameterRange(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CategoricalParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1ContinuousParameterRange = (
@@ -2879,11 +2871,9 @@ const serializeAws_json1_1ContinuousParameterRanges = (
   input: ContinuousParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ContinuousParameterRange(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContinuousParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateDatasetGroupRequest = (
@@ -3322,22 +3312,16 @@ const serializeAws_json1_1FeaturizationPipeline = (
   input: FeaturizationMethod[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FeaturizationMethod(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1FeaturizationMethod(entry, context)
+  );
 };
 
 const serializeAws_json1_1Featurizations = (
   input: Featurization[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Featurization(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Featurization(entry, context));
 };
 
 const serializeAws_json1_1Filter = (
@@ -3361,33 +3345,21 @@ const serializeAws_json1_1Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1ForecastDimensions = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ForecastTypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetAccuracyMetricsRequest = (
@@ -3458,11 +3430,9 @@ const serializeAws_json1_1IntegerParameterRanges = (
   input: IntegerParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IntegerParameterRange(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1IntegerParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1ListDatasetGroupsRequest = (
@@ -3642,11 +3612,9 @@ const serializeAws_json1_1SchemaAttributes = (
   input: SchemaAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SchemaAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SchemaAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1SupplementaryFeature = (
@@ -3667,11 +3635,9 @@ const serializeAws_json1_1SupplementaryFeatures = (
   input: SupplementaryFeature[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SupplementaryFeature(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SupplementaryFeature(entry, context)
+  );
 };
 
 const serializeAws_json1_1TrainingParameters = (
@@ -3705,11 +3671,7 @@ const serializeAws_json1_1Values = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1ArnList = (

--- a/clients/client-frauddetector/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/protocols/Aws_json1_1.ts
@@ -3856,22 +3856,14 @@ const serializeAws_json1_1ListOfModelVersions = (
   input: ModelVersion[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ModelVersion(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ModelVersion(entry, context));
 };
 
 const serializeAws_json1_1ListOfStrings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ModelEndpointDataBlob = (
@@ -3953,11 +3945,7 @@ const serializeAws_json1_1ModelVariablesList = (
   input: ModelVariable[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ModelVariable(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ModelVariable(entry, context));
 };
 
 const serializeAws_json1_1ModelVersion = (
@@ -3981,22 +3969,14 @@ const serializeAws_json1_1NameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1NonEmptyListOfStrings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PutDetectorRequest = (
@@ -4133,11 +4113,7 @@ const serializeAws_json1_1RuleList = (
   input: Rule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Rule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Rule(entry, context));
 };
 
 const serializeAws_json1_1TrainingDataSource = (
@@ -4333,11 +4309,7 @@ const serializeAws_json1_1VariableEntryList = (
   input: VariableEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1VariableEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1VariableEntry(entry, context));
 };
 
 const deserializeAws_json1_1BatchCreateVariableError = (

--- a/clients/client-fsx/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/protocols/Aws_json1_1.ts
@@ -2294,11 +2294,7 @@ const serializeAws_json1_1BackupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CancelDataRepositoryTaskRequest = (
@@ -2564,33 +2560,23 @@ const serializeAws_json1_1DataRepositoryTaskFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DataRepositoryTaskFilters = (
   input: DataRepositoryTaskFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DataRepositoryTaskFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DataRepositoryTaskFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1DataRepositoryTaskPaths = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeleteBackupRequest = (
@@ -2722,22 +2708,14 @@ const serializeAws_json1_1DnsIps = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FileSystemIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filter = (
@@ -2761,22 +2739,14 @@ const serializeAws_json1_1FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1ListTagsForResourceRequest = (
@@ -2800,11 +2770,7 @@ const serializeAws_json1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SelfManagedActiveDirectoryConfiguration = (
@@ -2856,11 +2822,7 @@ const serializeAws_json1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -2878,11 +2840,7 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -2903,22 +2861,14 @@ const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TaskIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UntagResourceRequest = (

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -10493,33 +10493,23 @@ const serializeAws_json1_1DesiredPlayerSessionList = (
   input: DesiredPlayerSession[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DesiredPlayerSession(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DesiredPlayerSession(entry, context)
+  );
 };
 
 const serializeAws_json1_1FleetActionList = (
   input: (FleetAction | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FleetIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GameProperty = (
@@ -10540,11 +10530,7 @@ const serializeAws_json1_1GamePropertyList = (
   input: GameProperty[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1GameProperty(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1GameProperty(entry, context));
 };
 
 const serializeAws_json1_1GameSessionQueueDestination = (
@@ -10562,24 +10548,16 @@ const serializeAws_json1_1GameSessionQueueDestinationList = (
   input: GameSessionQueueDestination[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1GameSessionQueueDestination(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1GameSessionQueueDestination(entry, context)
+  );
 };
 
 const serializeAws_json1_1GameSessionQueueNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetGameSessionLogUrlInput = (
@@ -10631,11 +10609,7 @@ const serializeAws_json1_1IpPermissionsList = (
   input: IpPermission[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IpPermission(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1IpPermission(entry, context));
 };
 
 const serializeAws_json1_1LatencyMap = (
@@ -10734,44 +10708,28 @@ const serializeAws_json1_1MatchmakingConfigurationNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MatchmakingIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MatchmakingRuleSetNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MetricGroupList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Player = (
@@ -10824,11 +10782,7 @@ const serializeAws_json1_1PlayerIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PlayerLatency = (
@@ -10852,11 +10806,7 @@ const serializeAws_json1_1PlayerLatencyList = (
   input: PlayerLatency[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PlayerLatency(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PlayerLatency(entry, context));
 };
 
 const serializeAws_json1_1PlayerLatencyPolicy = (
@@ -10878,22 +10828,16 @@ const serializeAws_json1_1PlayerLatencyPolicyList = (
   input: PlayerLatencyPolicy[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PlayerLatencyPolicy(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PlayerLatencyPolicy(entry, context)
+  );
 };
 
 const serializeAws_json1_1PlayerList = (
   input: Player[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Player(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Player(entry, context));
 };
 
 const serializeAws_json1_1PutScalingPolicyInput = (
@@ -10941,11 +10885,7 @@ const serializeAws_json1_1QueueArnsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RequestUploadCredentialsInput = (
@@ -11090,11 +11030,7 @@ const serializeAws_json1_1ServerProcessList = (
   input: ServerProcess[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ServerProcess(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ServerProcess(entry, context));
 };
 
 const serializeAws_json1_1StartFleetActionsInput = (
@@ -11253,11 +11189,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -11275,22 +11207,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-glacier/protocols/Aws_restJson1_1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1_1.ts
@@ -5319,11 +5319,7 @@ const serializeAws_restJson1_1AccessControlPolicyList = (
   input: Grant[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Grant(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Grant(entry, context));
 };
 
 const serializeAws_restJson1_1CSVInput = (
@@ -5583,11 +5579,9 @@ const serializeAws_restJson1_1DataRetrievalRulesList = (
   input: DataRetrievalRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DataRetrievalRule(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DataRetrievalRule(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1InventoryRetrievalJobInput = (
@@ -5663,22 +5657,14 @@ const serializeAws_restJson1_1NotificationEventList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagMap = (

--- a/clients/client-global-accelerator/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/protocols/Aws_json1_1.ts
@@ -2398,11 +2398,9 @@ const serializeAws_json1_1EndpointConfigurations = (
   input: EndpointConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EndpointConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EndpointConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1ListAcceleratorsRequest = (
@@ -2471,11 +2469,7 @@ const serializeAws_json1_1PortRanges = (
   input: PortRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PortRange(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PortRange(entry, context));
 };
 
 const serializeAws_json1_1UpdateAcceleratorAttributesRequest = (

--- a/clients/client-glue/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/protocols/Aws_json1_1.ts
@@ -15052,22 +15052,14 @@ const serializeAws_json1_1NameStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagKeysList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagsMap = (
@@ -15151,22 +15143,16 @@ const serializeAws_json1_1BatchDeletePartitionValueList = (
   input: PartitionValueList[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PartitionValueList(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PartitionValueList(entry, context)
+  );
 };
 
 const serializeAws_json1_1BatchDeleteTableNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchDeleteTableRequest = (
@@ -15193,11 +15179,7 @@ const serializeAws_json1_1BatchDeleteTableVersionList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchDeleteTableVersionRequest = (
@@ -15252,22 +15234,16 @@ const serializeAws_json1_1BatchGetPartitionValueList = (
   input: PartitionValueList[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PartitionValueList(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PartitionValueList(entry, context)
+  );
 };
 
 const serializeAws_json1_1BoundedPartitionValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Column = (
@@ -15297,22 +15273,14 @@ const serializeAws_json1_1ColumnList = (
   input: Column[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Column(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Column(entry, context));
 };
 
 const serializeAws_json1_1ColumnValueStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ConnectionInput = (
@@ -15545,11 +15513,7 @@ const serializeAws_json1_1DeleteConnectionNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeleteConnectionRequest = (
@@ -16003,11 +15967,7 @@ const serializeAws_json1_1MatchCriteria = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Order = (
@@ -16028,11 +15988,7 @@ const serializeAws_json1_1OrderList = (
   input: Order[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Order(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Order(entry, context));
 };
 
 const serializeAws_json1_1ParametersMap = (
@@ -16085,11 +16041,7 @@ const serializeAws_json1_1PartitionInputList = (
   input: PartitionInput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PartitionInput(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PartitionInput(entry, context));
 };
 
 const serializeAws_json1_1PartitionValueList = (
@@ -16110,11 +16062,7 @@ const serializeAws_json1_1PermissionList = (
   input: (Permission | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PhysicalConnectionRequirements = (
@@ -16161,11 +16109,9 @@ const serializeAws_json1_1PrincipalPermissionsList = (
   input: PrincipalPermissions[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PrincipalPermissions(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PrincipalPermissions(entry, context)
+  );
 };
 
 const serializeAws_json1_1PropertyPredicate = (
@@ -16239,22 +16185,16 @@ const serializeAws_json1_1ResourceUriList = (
   input: ResourceUri[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResourceUri(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ResourceUri(entry, context));
 };
 
 const serializeAws_json1_1SearchPropertyPredicates = (
   input: PropertyPredicate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PropertyPredicate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PropertyPredicate(entry, context)
+  );
 };
 
 const serializeAws_json1_1SearchTablesRequest = (
@@ -16293,11 +16233,7 @@ const serializeAws_json1_1SecurityGroupIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Segment = (
@@ -16368,11 +16304,7 @@ const serializeAws_json1_1SortCriteria = (
   input: SortCriterion[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SortCriterion(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1SortCriterion(entry, context));
 };
 
 const serializeAws_json1_1SortCriterion = (
@@ -16655,11 +16587,7 @@ const serializeAws_json1_1ValueStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchGetDevEndpointsRequest = (
@@ -16811,11 +16739,7 @@ const serializeAws_json1_1DevEndpointNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EncryptionConfiguration = (
@@ -16957,11 +16881,7 @@ const serializeAws_json1_1PublicKeysList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResetJobBookmarkRequest = (
@@ -16996,22 +16916,14 @@ const serializeAws_json1_1S3EncryptionList = (
   input: S3Encryption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1S3Encryption(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1S3Encryption(entry, context));
 };
 
 const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UpdateDevEndpointRequest = (
@@ -17259,11 +17171,7 @@ const serializeAws_json1_1GlueTables = (
   input: GlueTable[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1GlueTable(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1GlueTable(entry, context));
 };
 
 const serializeAws_json1_1SchemaColumn = (
@@ -17443,11 +17351,7 @@ const serializeAws_json1_1TransformSchema = (
   input: SchemaColumn[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SchemaColumn(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1SchemaColumn(entry, context));
 };
 
 const serializeAws_json1_1TransformSortCriteria = (
@@ -17546,11 +17450,7 @@ const serializeAws_json1_1ActionList = (
   input: Action[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Action(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Action(entry, context));
 };
 
 const serializeAws_json1_1BatchGetJobsRequest = (
@@ -17602,11 +17502,7 @@ const serializeAws_json1_1BatchStopJobRunJobRunIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchStopJobRunRequest = (
@@ -17653,11 +17549,7 @@ const serializeAws_json1_1ConditionList = (
   input: Condition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Condition(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Condition(entry, context));
 };
 
 const serializeAws_json1_1ConnectionsList = (
@@ -18046,11 +17938,7 @@ const serializeAws_json1_1JobNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1JobUpdate = (
@@ -18192,11 +18080,7 @@ const serializeAws_json1_1OrchestrationStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Predicate = (
@@ -18319,11 +18203,7 @@ const serializeAws_json1_1TriggerNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TriggerUpdate = (
@@ -18415,11 +18295,7 @@ const serializeAws_json1_1WorkflowNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1WorkflowRunProperties = (
@@ -18450,11 +18326,7 @@ const serializeAws_json1_1CatalogEntries = (
   input: CatalogEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CatalogEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CatalogEntry(entry, context));
 };
 
 const serializeAws_json1_1CatalogEntry = (
@@ -18475,11 +18347,7 @@ const serializeAws_json1_1CatalogTablesList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CatalogTarget = (
@@ -18503,22 +18371,14 @@ const serializeAws_json1_1CatalogTargetList = (
   input: CatalogTarget[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CatalogTarget(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CatalogTarget(entry, context));
 };
 
 const serializeAws_json1_1ClassifierNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CodeGenEdge = (
@@ -18582,22 +18442,14 @@ const serializeAws_json1_1CodeGenNodeArgs = (
   input: CodeGenNodeArg[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CodeGenNodeArg(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CodeGenNodeArg(entry, context));
 };
 
 const serializeAws_json1_1CrawlerNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CrawlerTargets = (
@@ -18833,33 +18685,21 @@ const serializeAws_json1_1CsvHeader = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DagEdges = (
   input: CodeGenEdge[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CodeGenEdge(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CodeGenEdge(entry, context));
 };
 
 const serializeAws_json1_1DagNodes = (
   input: CodeGenNode[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CodeGenNode(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CodeGenNode(entry, context));
 };
 
 const serializeAws_json1_1DeleteClassifierRequest = (
@@ -18899,11 +18739,7 @@ const serializeAws_json1_1DynamoDBTargetList = (
   input: DynamoDBTarget[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DynamoDBTarget(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DynamoDBTarget(entry, context));
 };
 
 const serializeAws_json1_1GetClassifierRequest = (
@@ -19072,11 +18908,7 @@ const serializeAws_json1_1JdbcTargetList = (
   input: JdbcTarget[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1JdbcTarget(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1JdbcTarget(entry, context));
 };
 
 const serializeAws_json1_1ListCrawlersRequest = (
@@ -19149,22 +18981,14 @@ const serializeAws_json1_1MappingList = (
   input: MappingEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MappingEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1MappingEntry(entry, context));
 };
 
 const serializeAws_json1_1PathList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1S3Target = (
@@ -19188,11 +19012,7 @@ const serializeAws_json1_1S3TargetList = (
   input: S3Target[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1S3Target(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1S3Target(entry, context));
 };
 
 const serializeAws_json1_1SchemaChangePolicy = (

--- a/clients/client-greengrass/protocols/Aws_restJson1_1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1_1.ts
@@ -11244,121 +11244,83 @@ const serializeAws_restJson1_1UpdateTargets = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOfConnectivityInfo = (
   input: ConnectivityInfo[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ConnectivityInfo(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ConnectivityInfo(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfConnector = (
   input: Connector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Connector(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Connector(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfCore = (
   input: Core[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Core(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Core(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfDevice = (
   input: Device[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Device(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Device(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfFunction = (
   input: Function[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Function(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Function(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfLogger = (
   input: Logger[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Logger(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Logger(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfResource = (
   input: Resource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Resource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Resource(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfResourceAccessPolicy = (
   input: ResourceAccessPolicy[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ResourceAccessPolicy(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ResourceAccessPolicy(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfSubscription = (
   input: Subscription[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Subscription(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1Subscription(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__mapOf__string = (

--- a/clients/client-groundstation/protocols/Aws_restJson1_1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1_1.ts
@@ -3577,22 +3577,16 @@ const serializeAws_restJson1_1DataflowEdge = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DataflowEdgeList = (
   input: string[][],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DataflowEdge(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DataflowEdge(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DataflowEndpoint = (
@@ -3672,22 +3666,16 @@ const serializeAws_restJson1_1EndpointDetailsList = (
   input: EndpointDetails[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1EndpointDetails(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1EndpointDetails(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StatusList = (
   input: (ContactStatus | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TrackingConfig = (
@@ -3786,11 +3774,7 @@ const serializeAws_restJson1_1SecurityGroupIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SocketAddress = (
@@ -3834,11 +3818,7 @@ const serializeAws_restJson1_1SubnetList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagsMap = (

--- a/clients/client-guardduty/protocols/Aws_restJson1_1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1_1.ts
@@ -6212,22 +6212,16 @@ const serializeAws_restJson1_1AccountDetails = (
   input: AccountDetail[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AccountDetail(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AccountDetail(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AccountIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Condition = (
@@ -6308,22 +6302,14 @@ const serializeAws_restJson1_1Eq = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Equals = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1FindingCriteria = (
@@ -6344,55 +6330,35 @@ const serializeAws_restJson1_1FindingIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1FindingStatisticTypes = (
   input: (FindingStatisticType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1FindingTypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Neq = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1NotEquals = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SortCriteria = (

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -1228,132 +1228,84 @@ const serializeAws_json1_1availabilityZones = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1awsAccountIdsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1entityArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1entityStatusCodeList = (
   input: (EntityStatusCode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1entityValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1eventArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1eventStatusCodeList = (
   input: (EventStatusCode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1eventTypeCategoryList = (
   input: (EventTypeCategory | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1eventTypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1regionList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1serviceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1tagFilter = (
   input: { [key: string]: string }[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1tagSet(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1tagSet(entry, context));
 };
 
 const serializeAws_json1_1tagSet = (
@@ -1577,33 +1529,25 @@ const serializeAws_json1_1EventArnsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OrganizationEntityFiltersList = (
   input: EventAccountFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EventAccountFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EventAccountFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1OrganizationEventDetailFiltersList = (
   input: EventAccountFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EventAccountFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EventAccountFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1DateTimeRange = (
@@ -1764,22 +1708,14 @@ const serializeAws_json1_1EventTypeCategoryList = (
   input: (EventTypeCategory | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EventTypeCodeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EventTypeFilter = (
@@ -1890,11 +1826,7 @@ const serializeAws_json1_1dateTimeRangeList = (
   input: DateTimeRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DateTimeRange(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DateTimeRange(entry, context));
 };
 
 const deserializeAws_json1_1eventMetadata = (

--- a/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
@@ -7850,11 +7850,7 @@ const serializeAws_restJson1_1AccountList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1AmiDistributionConfiguration = (
@@ -7889,11 +7885,7 @@ const serializeAws_restJson1_1ArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ComponentConfiguration = (
@@ -7911,13 +7903,9 @@ const serializeAws_restJson1_1ComponentConfigurationList = (
   input: ComponentConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1ComponentConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ComponentConfiguration(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Distribution = (
@@ -7949,11 +7937,9 @@ const serializeAws_restJson1_1DistributionList = (
   input: Distribution[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Distribution(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1Distribution(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1EbsInstanceBlockDeviceSpecification = (
@@ -8006,22 +7992,14 @@ const serializeAws_restJson1_1FilterList = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Filter(entry, context));
 };
 
 const serializeAws_restJson1_1FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ImageTestsConfiguration = (
@@ -8067,24 +8045,16 @@ const serializeAws_restJson1_1InstanceBlockDeviceMappings = (
   input: InstanceBlockDeviceMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1InstanceBlockDeviceMapping(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InstanceBlockDeviceMapping(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1InstanceTypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1LaunchPermissionConfiguration = (
@@ -8154,22 +8124,14 @@ const serializeAws_restJson1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagMap = (

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -4714,11 +4714,7 @@ const serializeAws_json1_1AddRemoveAttributesFindingArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AgentFilter = (
@@ -4745,33 +4741,21 @@ const serializeAws_json1_1AgentHealthCodeList = (
   input: (AgentHealthCode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AgentHealthList = (
   input: (AgentHealth | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AgentIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AssessmentRunFilter = (
@@ -4827,11 +4811,7 @@ const serializeAws_json1_1AssessmentRunStateList = (
   input: (AssessmentRunState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AssessmentTargetFilter = (
@@ -4875,11 +4855,7 @@ const serializeAws_json1_1AssessmentTemplateRulesPackageArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Attribute = (
@@ -4900,44 +4876,28 @@ const serializeAws_json1_1AttributeList = (
   input: Attribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Attribute(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Attribute(entry, context));
 };
 
 const serializeAws_json1_1AutoScalingGroupList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchDescribeArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1BatchDescribeExclusionsArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateAssessmentTargetRequest = (
@@ -5176,11 +5136,7 @@ const serializeAws_json1_1FilterRulesPackageArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FindingFilter = (
@@ -5453,11 +5409,7 @@ const serializeAws_json1_1ListParentArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListRulesPackagesRequest = (
@@ -5553,22 +5505,16 @@ const serializeAws_json1_1ResourceGroupTags = (
   input: ResourceGroupTag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResourceGroupTag(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ResourceGroupTag(entry, context)
+  );
 };
 
 const serializeAws_json1_1RuleNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SetTagsForResourceRequest = (
@@ -5589,11 +5535,7 @@ const serializeAws_json1_1SeverityList = (
   input: (Severity | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartAssessmentRunRequest = (
@@ -5656,11 +5598,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TimestampRange = (
@@ -5715,22 +5653,14 @@ const serializeAws_json1_1UserAttributeKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UserAttributeList = (
   input: Attribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Attribute(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Attribute(entry, context));
 };
 
 const deserializeAws_json1_1AccessDeniedException = (

--- a/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
@@ -743,11 +743,7 @@ const serializeAws_restJson1_1Messages = (
   input: Message[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Message(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Message(entry, context));
 };
 
 const serializeAws_restJson1_1TimerDefinition = (
@@ -768,11 +764,9 @@ const serializeAws_restJson1_1TimerDefinitions = (
   input: TimerDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1TimerDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1TimerDefinition(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1UpdateDetectorRequest = (
@@ -802,13 +796,9 @@ const serializeAws_restJson1_1UpdateDetectorRequests = (
   input: UpdateDetectorRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1UpdateDetectorRequest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1UpdateDetectorRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1VariableDefinition = (
@@ -829,11 +819,9 @@ const serializeAws_restJson1_1VariableDefinitions = (
   input: VariableDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1VariableDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1VariableDefinition(entry, context)
+  );
 };
 
 const deserializeAws_restJson1_1BatchPutMessageErrorEntries = (

--- a/clients/client-iot-events/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1_1.ts
@@ -2705,11 +2705,7 @@ const serializeAws_restJson1_1Actions = (
   input: Action[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Action(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Action(entry, context));
 };
 
 const serializeAws_restJson1_1Attribute = (
@@ -2727,11 +2723,7 @@ const serializeAws_restJson1_1Attributes = (
   input: Attribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Attribute(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Attribute(entry, context));
 };
 
 const serializeAws_restJson1_1ClearTimerAction = (
@@ -2763,11 +2755,9 @@ const serializeAws_restJson1_1DetectorDebugOptions = (
   input: DetectorDebugOption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DetectorDebugOption(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DetectorDebugOption(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DetectorModelDefinition = (
@@ -2811,11 +2801,7 @@ const serializeAws_restJson1_1Events = (
   input: Event[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Event(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Event(entry, context));
 };
 
 const serializeAws_restJson1_1FirehoseAction = (
@@ -3049,11 +3035,7 @@ const serializeAws_restJson1_1States = (
   input: State[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1State(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1State(entry, context));
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -3074,11 +3056,7 @@ const serializeAws_restJson1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TransitionEvent = (
@@ -3108,11 +3086,9 @@ const serializeAws_restJson1_1TransitionEvents = (
   input: TransitionEvent[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1TransitionEvent(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1TransitionEvent(entry, context)
+  );
 };
 
 const deserializeAws_restJson1_1Action = (

--- a/clients/client-iot/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1_1.ts
@@ -32039,11 +32039,7 @@ const serializeAws_restJson1_1PolicyNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -32064,22 +32060,14 @@ const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1Action = (
@@ -32197,11 +32185,7 @@ const serializeAws_restJson1_1ActionList = (
   input: Action[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Action(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Action(entry, context));
 };
 
 const serializeAws_restJson1_1AssetPropertyTimestamp = (
@@ -32245,11 +32229,9 @@ const serializeAws_restJson1_1AssetPropertyValueList = (
   input: AssetPropertyValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AssetPropertyValue(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AssetPropertyValue(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AssetPropertyVariant = (
@@ -32417,11 +32399,9 @@ const serializeAws_restJson1_1HeaderList = (
   input: HttpActionHeader[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1HttpActionHeader(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1HttpActionHeader(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1HttpAction = (
@@ -32630,13 +32610,9 @@ const serializeAws_restJson1_1PutAssetPropertyValueEntryList = (
   input: PutAssetPropertyValueEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1PutAssetPropertyValueEntry(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1PutAssetPropertyValueEntry(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1PutItemInput = (
@@ -32838,11 +32814,7 @@ const serializeAws_restJson1_1AuthInfos = (
   input: AuthInfo[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AuthInfo(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1AuthInfo(entry, context));
 };
 
 const serializeAws_restJson1_1AuthorizerConfig = (
@@ -32941,22 +32913,14 @@ const serializeAws_restJson1_1Resources = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ServerCertificateArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TlsContext = (
@@ -32988,22 +32952,14 @@ const serializeAws_restJson1_1Fields = (
   input: Field[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Field(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Field(entry, context));
 };
 
 const serializeAws_restJson1_1PercentList = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ThingGroupIndexingConfiguration = (
@@ -33094,11 +33050,9 @@ const serializeAws_restJson1_1AbortCriteriaList = (
   input: AbortCriteria[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AbortCriteria(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AbortCriteria(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ExponentialRolloutRate = (
@@ -33146,11 +33100,7 @@ const serializeAws_restJson1_1JobTargets = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1PresignedUrlConfig = (
@@ -33392,22 +33342,16 @@ const serializeAws_restJson1_1OTAUpdateFiles = (
   input: OTAUpdateFile[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1OTAUpdateFile(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1OTAUpdateFile(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Protocols = (
   input: (Protocol | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1S3Destination = (
@@ -33484,11 +33428,7 @@ const serializeAws_restJson1_1Targets = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1AttributePayload = (
@@ -33533,22 +33473,14 @@ const serializeAws_restJson1_1SearchableAttributes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ThingGroupList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ThingGroupProperties = (
@@ -33700,11 +33632,7 @@ const serializeAws_restJson1_1ThingGroupNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1UpdateCACertificateParams = (
@@ -33838,22 +33766,14 @@ const serializeAws_restJson1_1FindingIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1MitigationActionNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1PolicyVersionIdentifier = (
@@ -33874,11 +33794,7 @@ const serializeAws_restJson1_1ReasonForNonComplianceCodes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourceIdentifier = (
@@ -33922,22 +33838,14 @@ const serializeAws_restJson1_1TargetAuditCheckNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1AdditionalMetricsToRetainList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1AlertTarget = (
@@ -34024,22 +33932,14 @@ const serializeAws_restJson1_1Behaviors = (
   input: Behavior[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Behavior(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Behavior(entry, context));
 };
 
 const serializeAws_restJson1_1Cidrs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1MetricValue = (
@@ -34063,11 +33963,7 @@ const serializeAws_restJson1_1Ports = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1StatisticalThreshold = (
@@ -34102,11 +33998,7 @@ const serializeAws_restJson1_1StreamFiles = (
   input: StreamFile[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1StreamFile(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1StreamFile(entry, context));
 };
 
 const serializeAws_restJson1_1S3Location = (

--- a/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
@@ -5359,11 +5359,7 @@ const serializeAws_restJson1_1AttributeNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ChannelActivity = (
@@ -5498,11 +5494,9 @@ const serializeAws_restJson1_1DatasetActions = (
   input: DatasetAction[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DatasetAction(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DatasetAction(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DatasetContentDeliveryDestination = (
@@ -5552,13 +5546,9 @@ const serializeAws_restJson1_1DatasetContentDeliveryRules = (
   input: DatasetContentDeliveryRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1DatasetContentDeliveryRule(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DatasetContentDeliveryRule(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DatasetContentVersionValue = (
@@ -5596,11 +5586,9 @@ const serializeAws_restJson1_1DatasetTriggers = (
   input: DatasetTrigger[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DatasetTrigger(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DatasetTrigger(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DatastoreActivity = (
@@ -5807,11 +5795,7 @@ const serializeAws_restJson1_1MessagePayloads = (
   input: Uint8Array[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(context.base64Encoder(entry));
-  }
-  return contents;
+  return input.map(entry => context.base64Encoder(entry));
 };
 
 const serializeAws_restJson1_1OutputFileUriValue = (
@@ -5829,11 +5813,9 @@ const serializeAws_restJson1_1PipelineActivities = (
   input: PipelineActivity[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1PipelineActivity(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1PipelineActivity(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1PipelineActivity = (
@@ -5930,11 +5912,9 @@ const serializeAws_restJson1_1QueryFilters = (
   input: QueryFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1QueryFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1QueryFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1RemoveAttributesActivity = (
@@ -6090,11 +6070,7 @@ const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TriggeringDataset = (
@@ -6145,11 +6121,7 @@ const serializeAws_restJson1_1Variables = (
   input: Variable[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Variable(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Variable(entry, context));
 };
 
 const serializeAws_restJson1_1VersioningConfiguration = (
@@ -6184,11 +6156,7 @@ const serializeAws_restJson1_1Messages = (
   input: Message[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Message(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Message(entry, context));
 };
 
 const deserializeAws_restJson1_1AddAttributesActivity = (

--- a/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
@@ -708,11 +708,7 @@ const serializeAws_json1_1ServiceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -730,22 +726,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
@@ -4785,22 +4785,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1DefinitionDocument = (
@@ -4821,11 +4813,7 @@ const serializeAws_json1_1Urns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EntityFilter = (
@@ -4849,33 +4837,21 @@ const serializeAws_json1_1EntityFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1EntityFilters = (
   input: EntityFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EntityFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1EntityFilter(entry, context));
 };
 
 const serializeAws_json1_1EntityTypes = (
   input: (EntityType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FlowTemplateFilter = (
@@ -4899,22 +4875,16 @@ const serializeAws_json1_1FlowTemplateFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FlowTemplateFilters = (
   input: FlowTemplateFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FlowTemplateFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1FlowTemplateFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1MetricsConfiguration = (
@@ -4952,22 +4922,16 @@ const serializeAws_json1_1SystemInstanceFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SystemInstanceFilters = (
   input: SystemInstanceFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SystemInstanceFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SystemInstanceFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1SystemTemplateFilter = (
@@ -4991,22 +4955,16 @@ const serializeAws_json1_1SystemTemplateFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SystemTemplateFilters = (
   input: SystemTemplateFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SystemTemplateFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SystemTemplateFilter(entry, context)
+  );
 };
 
 const deserializeAws_json1_1AssociateEntityToThingResponse = (

--- a/clients/client-kafka/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1_1.ts
@@ -3556,22 +3556,16 @@ const serializeAws_restJson1_1__listOfBrokerEBSVolumeInfo = (
   input: BrokerEBSVolumeInfo[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1BrokerEBSVolumeInfo(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1BrokerEBSVolumeInfo(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__mapOf__string = (

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -2998,11 +2998,9 @@ const serializeAws_json1_1AttributeFilterList = (
   input: AttributeFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AttributeFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AttributeFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1BatchDeleteDocumentRequest = (
@@ -3046,11 +3044,7 @@ const serializeAws_json1_1ChangeDetectingColumns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ClickFeedback = (
@@ -3071,11 +3065,7 @@ const serializeAws_json1_1ClickFeedbackList = (
   input: ClickFeedback[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ClickFeedback(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ClickFeedback(entry, context));
 };
 
 const serializeAws_json1_1ColumnConfiguration = (
@@ -3250,11 +3240,7 @@ const serializeAws_json1_1DataSourceInclusionsExclusionsStrings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DataSourceToIndexFieldMapping = (
@@ -3278,13 +3264,9 @@ const serializeAws_json1_1DataSourceToIndexFieldMappingList = (
   input: DataSourceToIndexFieldMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1DataSourceToIndexFieldMapping(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DataSourceToIndexFieldMapping(entry, context)
+  );
 };
 
 const serializeAws_json1_1DataSourceVpcConfiguration = (
@@ -3466,33 +3448,23 @@ const serializeAws_json1_1DocumentAttributeKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DocumentAttributeList = (
   input: DocumentAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DocumentAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DocumentAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1DocumentAttributeStringListValue = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DocumentAttributeValue = (
@@ -3524,22 +3496,14 @@ const serializeAws_json1_1DocumentIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DocumentList = (
   input: Document[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Document(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Document(entry, context));
 };
 
 const serializeAws_json1_1DocumentMetadataConfiguration = (
@@ -3569,13 +3533,9 @@ const serializeAws_json1_1DocumentMetadataConfigurationList = (
   input: DocumentMetadataConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1DocumentMetadataConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DocumentMetadataConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1DocumentsMetadataConfiguration = (
@@ -3604,11 +3564,7 @@ const serializeAws_json1_1FacetList = (
   input: Facet[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Facet(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Facet(entry, context));
 };
 
 const serializeAws_json1_1ListDataSourceSyncJobsRequest = (
@@ -3709,11 +3665,7 @@ const serializeAws_json1_1PrincipalList = (
   input: Principal[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Principal(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Principal(entry, context));
 };
 
 const serializeAws_json1_1QueryRequest = (
@@ -3800,11 +3752,9 @@ const serializeAws_json1_1RelevanceFeedbackList = (
   input: RelevanceFeedback[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RelevanceFeedback(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RelevanceFeedback(entry, context)
+  );
 };
 
 const serializeAws_json1_1S3DataSourceConfiguration = (
@@ -3885,11 +3835,7 @@ const serializeAws_json1_1SecurityGroupIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ServerSideEncryptionConfiguration = (
@@ -3949,11 +3895,7 @@ const serializeAws_json1_1SharePointUrlList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartDataSourceSyncJobRequest = (
@@ -4016,11 +3958,7 @@ const serializeAws_json1_1SubnetIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TimeRange = (

--- a/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
@@ -4043,24 +4043,18 @@ const serializeAws_json1_1CloudWatchLoggingOptionUpdates = (
   input: CloudWatchLoggingOptionUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1CloudWatchLoggingOptionUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CloudWatchLoggingOptionUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1CloudWatchLoggingOptions = (
   input: CloudWatchLoggingOption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CloudWatchLoggingOption(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CloudWatchLoggingOption(entry, context)
+  );
 };
 
 const serializeAws_json1_1CodeContent = (
@@ -4674,22 +4668,14 @@ const serializeAws_json1_1InputUpdates = (
   input: InputUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InputUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1InputUpdate(entry, context));
 };
 
 const serializeAws_json1_1Inputs = (
   input: Input[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Input(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Input(entry, context));
 };
 
 const serializeAws_json1_1JSONMappingParameters = (
@@ -5000,22 +4986,14 @@ const serializeAws_json1_1OutputUpdates = (
   input: OutputUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OutputUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1OutputUpdate(entry, context));
 };
 
 const serializeAws_json1_1Outputs = (
   input: Output[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Output(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Output(entry, context));
 };
 
 const serializeAws_json1_1ParallelismConfiguration = (
@@ -5079,11 +5057,7 @@ const serializeAws_json1_1PropertyGroups = (
   input: PropertyGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PropertyGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PropertyGroup(entry, context));
 };
 
 const serializeAws_json1_1PropertyMap = (
@@ -5117,11 +5091,7 @@ const serializeAws_json1_1RecordColumns = (
   input: RecordColumn[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RecordColumn(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1RecordColumn(entry, context));
 };
 
 const serializeAws_json1_1RecordFormat = (
@@ -5198,24 +5168,18 @@ const serializeAws_json1_1ReferenceDataSourceUpdates = (
   input: ReferenceDataSourceUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ReferenceDataSourceUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ReferenceDataSourceUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1ReferenceDataSources = (
   input: ReferenceDataSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ReferenceDataSource(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ReferenceDataSource(entry, context)
+  );
 };
 
 const serializeAws_json1_1RunConfiguration = (
@@ -5354,11 +5318,7 @@ const serializeAws_json1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SourceSchema = (
@@ -5457,11 +5417,9 @@ const serializeAws_json1_1SqlRunConfigurations = (
   input: SqlRunConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SqlRunConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SqlRunConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1StartApplicationRequest = (
@@ -5496,11 +5454,7 @@ const serializeAws_json1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -5518,11 +5472,7 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -5543,11 +5493,7 @@ const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1UntagResourceRequest = (
@@ -5653,22 +5599,18 @@ const serializeAws_json1_1VpcConfigurationUpdates = (
   input: VpcConfigurationUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1VpcConfigurationUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1VpcConfigurationUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1VpcConfigurations = (
   input: VpcConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1VpcConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1VpcConfiguration(entry, context)
+  );
 };
 
 const deserializeAws_json1_1AddApplicationCloudWatchLoggingOptionResponse = (

--- a/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
@@ -2943,24 +2943,18 @@ const serializeAws_json1_1CloudWatchLoggingOptionUpdates = (
   input: CloudWatchLoggingOptionUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1CloudWatchLoggingOptionUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CloudWatchLoggingOptionUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1CloudWatchLoggingOptions = (
   input: CloudWatchLoggingOption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CloudWatchLoggingOption(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CloudWatchLoggingOption(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateApplicationRequest = (
@@ -3211,11 +3205,9 @@ const serializeAws_json1_1InputConfigurations = (
   input: InputConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InputConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InputConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1InputLambdaProcessor = (
@@ -3390,22 +3382,14 @@ const serializeAws_json1_1InputUpdates = (
   input: InputUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InputUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1InputUpdate(entry, context));
 };
 
 const serializeAws_json1_1Inputs = (
   input: Input[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Input(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Input(entry, context));
 };
 
 const serializeAws_json1_1JSONMappingParameters = (
@@ -3696,22 +3680,14 @@ const serializeAws_json1_1OutputUpdates = (
   input: OutputUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OutputUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1OutputUpdate(entry, context));
 };
 
 const serializeAws_json1_1Outputs = (
   input: Output[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Output(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Output(entry, context));
 };
 
 const serializeAws_json1_1RecordColumn = (
@@ -3735,11 +3711,7 @@ const serializeAws_json1_1RecordColumns = (
   input: RecordColumn[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RecordColumn(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1RecordColumn(entry, context));
 };
 
 const serializeAws_json1_1RecordFormat = (
@@ -3816,13 +3788,9 @@ const serializeAws_json1_1ReferenceDataSourceUpdates = (
   input: ReferenceDataSourceUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ReferenceDataSourceUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ReferenceDataSourceUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1S3Configuration = (
@@ -3942,11 +3910,7 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -3967,11 +3931,7 @@ const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1UntagResourceRequest = (

--- a/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1_1.ts
@@ -876,11 +876,7 @@ const serializeAws_restJson1_1FragmentNumberList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1FragmentSelector = (

--- a/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
@@ -2952,11 +2952,7 @@ const serializeAws_restJson1_1ListOfProtocols = (
   input: (ChannelProtocol | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourceTags = (
@@ -3029,33 +3025,21 @@ const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TagOnCreateList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const deserializeAws_restJson1_1ChannelInfo = (

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -3829,11 +3829,7 @@ const serializeAws_json1_1MetricsNameList = (
   input: (MetricsName | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PutRecordInput = (
@@ -3897,11 +3893,9 @@ const serializeAws_json1_1PutRecordsRequestEntryList = (
   input: PutRecordsRequestEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PutRecordsRequestEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PutRecordsRequestEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1RegisterStreamConsumerInput = (
@@ -4027,11 +4021,7 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagMap = (

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -7542,22 +7542,14 @@ const serializeAws_json1_1GrantOperationList = (
   input: (GrantOperation | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GrantTokenList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ImportKeyMaterialRequest = (
@@ -7837,22 +7829,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-lakeformation/protocols/Aws_json1_1.ts
+++ b/clients/client-lakeformation/protocols/Aws_json1_1.ts
@@ -1589,13 +1589,9 @@ const serializeAws_json1_1BatchPermissionsRequestEntryList = (
   input: BatchPermissionsRequestEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1BatchPermissionsRequestEntry(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1BatchPermissionsRequestEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1BatchRevokePermissionsRequest = (
@@ -1629,11 +1625,7 @@ const serializeAws_json1_1ColumnNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ColumnWildcard = (
@@ -1666,11 +1658,9 @@ const serializeAws_json1_1DataLakePrincipalList = (
   input: DataLakePrincipal[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DataLakePrincipal(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DataLakePrincipal(entry, context)
+  );
 };
 
 const serializeAws_json1_1DataLakeSettings = (
@@ -1871,11 +1861,7 @@ const serializeAws_json1_1PermissionList = (
   input: (Permission | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PrincipalPermissions = (
@@ -1902,11 +1888,9 @@ const serializeAws_json1_1PrincipalPermissionsList = (
   input: PrincipalPermissions[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PrincipalPermissions(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PrincipalPermissions(entry, context)
+  );
 };
 
 const serializeAws_json1_1PutDataLakeSettingsRequest = (
@@ -2098,22 +2082,16 @@ const serializeAws_json1_1FilterConditionList = (
   input: FilterCondition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FilterCondition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1FilterCondition(entry, context)
+  );
 };
 
 const serializeAws_json1_1StringValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1BatchGrantPermissionsResponse = (

--- a/clients/client-lambda/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1_1.ts
@@ -9569,11 +9569,7 @@ const serializeAws_restJson1_1CompatibleRuntimes = (
   input: (Runtime | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DeadLetterConfig = (
@@ -9655,11 +9651,7 @@ const serializeAws_restJson1_1LayerList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1LayerVersionContentInput = (
@@ -9708,22 +9700,14 @@ const serializeAws_restJson1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tags = (

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
@@ -6379,11 +6379,9 @@ const serializeAws_restJson1_1EnumerationValues = (
   input: EnumerationValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1EnumerationValue(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1EnumerationValue(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1FollowUpPrompt = (
@@ -6441,22 +6439,14 @@ const serializeAws_restJson1_1IntentList = (
   input: Intent[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Intent(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Intent(entry, context));
 };
 
 const serializeAws_restJson1_1IntentUtteranceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1LogSettingsRequest = (
@@ -6483,11 +6473,9 @@ const serializeAws_restJson1_1LogSettingsRequestList = (
   input: LogSettingsRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1LogSettingsRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1LogSettingsRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Message = (
@@ -6511,11 +6499,7 @@ const serializeAws_restJson1_1MessageList = (
   input: Message[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Message(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Message(entry, context));
 };
 
 const serializeAws_restJson1_1Prompt = (
@@ -6586,22 +6570,14 @@ const serializeAws_restJson1_1SlotList = (
   input: Slot[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Slot(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Slot(entry, context));
 };
 
 const serializeAws_restJson1_1SlotUtteranceList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Statement = (
@@ -6625,11 +6601,7 @@ const serializeAws_restJson1_1SynonymList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1BotAliasMetadata = (

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
@@ -1458,11 +1458,9 @@ const serializeAws_restJson1_1IntentSummaryList = (
   input: IntentSummary[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1IntentSummary(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1IntentSummary(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StringMap = (

--- a/clients/client-license-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/protocols/Aws_json1_1.ts
@@ -2451,22 +2451,14 @@ const serializeAws_json1_1FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1GetLicenseConfigurationRequest = (
@@ -2509,11 +2501,9 @@ const serializeAws_json1_1InventoryFilterList = (
   input: InventoryFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InventoryFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InventoryFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1LicenseSpecification = (
@@ -2531,11 +2521,9 @@ const serializeAws_json1_1LicenseSpecifications = (
   input: LicenseSpecification[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1LicenseSpecification(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1LicenseSpecification(entry, context)
+  );
 };
 
 const serializeAws_json1_1ListAssociationsForLicenseConfigurationRequest = (
@@ -2721,33 +2709,25 @@ const serializeAws_json1_1ProductInformationFilterList = (
   input: ProductInformationFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProductInformationFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProductInformationFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1ProductInformationList = (
   input: ProductInformation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProductInformation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProductInformation(entry, context)
+  );
 };
 
 const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -2765,22 +2745,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-lightsail/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/protocols/Aws_json1_1.ts
@@ -15850,11 +15850,7 @@ const serializeAws_json1_1AddOnRequestList = (
   input: AddOnRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AddOnRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1AddOnRequest(entry, context));
 };
 
 const serializeAws_json1_1AllocateStaticIpRequest = (
@@ -16653,11 +16649,7 @@ const serializeAws_json1_1DiskMapList = (
   input: DiskMap[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DiskMap(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DiskMap(entry, context));
 };
 
 const serializeAws_json1_1DomainEntry = (
@@ -16703,11 +16695,7 @@ const serializeAws_json1_1DomainNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DownloadDefaultKeyPairRequest = (
@@ -17378,11 +17366,7 @@ const serializeAws_json1_1InstanceEntryList = (
   input: InstanceEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InstanceEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1InstanceEntry(entry, context));
 };
 
 const serializeAws_json1_1IsVpcPeeredRequest = (
@@ -17397,11 +17381,7 @@ const serializeAws_json1_1MetricStatisticList = (
   input: (MetricStatistic | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OpenInstancePublicPortsRequest = (
@@ -17450,11 +17430,7 @@ const serializeAws_json1_1PortInfoList = (
   input: PortInfo[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PortInfo(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PortInfo(entry, context));
 };
 
 const serializeAws_json1_1PutInstancePublicPortsRequest = (
@@ -17532,13 +17508,9 @@ const serializeAws_json1_1RelationalDatabaseParameterList = (
   input: RelationalDatabaseParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1RelationalDatabaseParameter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RelationalDatabaseParameter(entry, context)
+  );
 };
 
 const serializeAws_json1_1ReleaseStaticIpRequest = (
@@ -17556,11 +17528,7 @@ const serializeAws_json1_1ResourceNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartInstanceRequest = (
@@ -17618,11 +17586,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -17640,22 +17604,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-machine-learning/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/protocols/Aws_json1_1.ts
@@ -3535,11 +3535,7 @@ const serializeAws_json1_1EDPSecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetBatchPredictionInput = (
@@ -3799,22 +3795,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TrainingParameters = (

--- a/clients/client-macie/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/protocols/Aws_json1_1.ts
@@ -986,35 +986,25 @@ const serializeAws_json1_1S3Resources = (
   input: S3Resource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1S3Resource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1S3Resource(entry, context));
 };
 
 const serializeAws_json1_1S3ResourcesClassification = (
   input: S3ResourceClassification[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1S3ResourceClassification(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1S3ResourceClassification(entry, context)
+  );
 };
 
 const serializeAws_json1_1S3ResourcesClassificationUpdate = (
   input: S3ResourceClassificationUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1S3ResourceClassificationUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1S3ResourceClassificationUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1UpdateS3ResourcesRequest = (

--- a/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
@@ -3142,11 +3142,9 @@ const serializeAws_restJson1_1InviteActionList = (
   input: InviteAction[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InviteAction(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InviteAction(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1MemberConfiguration = (
@@ -3273,11 +3271,9 @@ const serializeAws_restJson1_1RemoveActionList = (
   input: RemoveAction[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1RemoveAction(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1RemoveAction(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1VotingPolicy = (

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
@@ -1188,22 +1188,14 @@ const serializeAws_restJson1_1FilterList = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Filter(entry, context));
 };
 
 const serializeAws_restJson1_1RequestedChangeList = (
   input: Change[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Change(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Change(entry, context));
 };
 
 const serializeAws_restJson1_1Sort = (
@@ -1224,11 +1216,7 @@ const serializeAws_restJson1_1ValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1ChangeSetDescription = (

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -179,11 +179,7 @@ const serializeAws_json1_1FilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetEntitlementFilters = (

--- a/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
@@ -978,11 +978,7 @@ const serializeAws_json1_1UsageRecordList = (
   input: UsageRecord[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1UsageRecord(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1UsageRecord(entry, context));
 };
 
 const deserializeAws_json1_1BatchMeterUsageResult = (

--- a/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
@@ -3115,35 +3115,25 @@ const serializeAws_restJson1_1__listOfAddOutputRequest = (
   input: AddOutputRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AddOutputRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AddOutputRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfGrantEntitlementRequest = (
   input: GrantEntitlementRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1GrantEntitlementRequest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1GrantEntitlementRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__mapOf__string = (

--- a/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
@@ -7977,298 +7977,210 @@ const serializeAws_restJson1_1__listOfAudioDescription = (
   input: AudioDescription[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AudioDescription(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AudioDescription(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfCaptionDescription = (
   input: CaptionDescription[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CaptionDescription(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CaptionDescription(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfCaptionDescriptionPreset = (
   input: CaptionDescriptionPreset[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1CaptionDescriptionPreset(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CaptionDescriptionPreset(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfCmafAdditionalManifest = (
   input: CmafAdditionalManifest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1CmafAdditionalManifest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CmafAdditionalManifest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfDashAdditionalManifest = (
   input: DashAdditionalManifest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1DashAdditionalManifest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DashAdditionalManifest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfHlsAdMarkers = (
   input: (HlsAdMarkers | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOfHlsAdditionalManifest = (
   input: HlsAdditionalManifest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1HlsAdditionalManifest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1HlsAdditionalManifest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfHlsCaptionLanguageMapping = (
   input: HlsCaptionLanguageMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1HlsCaptionLanguageMapping(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1HlsCaptionLanguageMapping(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfId3Insertion = (
   input: Id3Insertion[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Id3Insertion(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1Id3Insertion(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfInput = (
   input: Input[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Input(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Input(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfInputClipping = (
   input: InputClipping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InputClipping(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputClipping(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfInputTemplate = (
   input: InputTemplate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InputTemplate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputTemplate(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfInsertableImage = (
   input: InsertableImage[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InsertableImage(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InsertableImage(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfMsSmoothAdditionalManifest = (
   input: MsSmoothAdditionalManifest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1MsSmoothAdditionalManifest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1MsSmoothAdditionalManifest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfOutput = (
   input: Output[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Output(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Output(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfOutputChannelMapping = (
   input: OutputChannelMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1OutputChannelMapping(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1OutputChannelMapping(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfOutputGroup = (
   input: OutputGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1OutputGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1OutputGroup(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfTeletextPageType = (
   input: (TeletextPageType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__integerMin1Max2147483647 = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__integerMin32Max8182 = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__integerMinNegative60Max6 = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__stringMin1 = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__stringMin36Max36Pattern09aFAF809aFAF409aFAF409aFAF409aFAF12 = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__stringPattern09aFAF809aFAF409aFAF409aFAF409aFAF12 = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__stringPatternS3ASSETMAPXml = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__mapOfAudioSelector = (

--- a/clients/client-medialive/protocols/Aws_restJson1_1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1_1.ts
@@ -12556,270 +12556,204 @@ const serializeAws_restJson1_1__listOfAudioChannelMapping = (
   input: AudioChannelMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AudioChannelMapping(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AudioChannelMapping(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfAudioDescription = (
   input: AudioDescription[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AudioDescription(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AudioDescription(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfAudioSelector = (
   input: AudioSelector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AudioSelector(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AudioSelector(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfCaptionDescription = (
   input: CaptionDescription[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CaptionDescription(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CaptionDescription(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfCaptionLanguageMapping = (
   input: CaptionLanguageMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1CaptionLanguageMapping(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CaptionLanguageMapping(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfCaptionSelector = (
   input: CaptionSelector[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CaptionSelector(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CaptionSelector(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfHlsAdMarkers = (
   input: (HlsAdMarkers | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOfInputAttachment = (
   input: InputAttachment[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InputAttachment(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputAttachment(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfInputChannelLevel = (
   input: InputChannelLevel[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InputChannelLevel(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputChannelLevel(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfInputDestinationRequest = (
   input: InputDestinationRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1InputDestinationRequest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputDestinationRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfInputSourceRequest = (
   input: InputSourceRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InputSourceRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputSourceRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfInputWhitelistRuleCidr = (
   input: InputWhitelistRuleCidr[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1InputWhitelistRuleCidr(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputWhitelistRuleCidr(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfMediaConnectFlowRequest = (
   input: MediaConnectFlowRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1MediaConnectFlowRequest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1MediaConnectFlowRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfMediaPackageOutputDestinationSettings = (
   input: MediaPackageOutputDestinationSettings[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1MediaPackageOutputDestinationSettings(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1MediaPackageOutputDestinationSettings(
+      entry,
+      context
+    )
+  );
 };
 
 const serializeAws_restJson1_1__listOfOutput = (
   input: Output[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Output(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Output(entry, context));
 };
 
 const serializeAws_restJson1_1__listOfOutputDestination = (
   input: OutputDestination[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1OutputDestination(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1OutputDestination(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfOutputDestinationSettings = (
   input: OutputDestinationSettings[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1OutputDestinationSettings(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1OutputDestinationSettings(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfOutputGroup = (
   input: OutputGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1OutputGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1OutputGroup(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfPipelinePauseStateSettings = (
   input: PipelinePauseStateSettings[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1PipelinePauseStateSettings(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1PipelinePauseStateSettings(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfScheduleAction = (
   input: ScheduleAction[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ScheduleAction(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ScheduleAction(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfScte35Descriptor = (
   input: Scte35Descriptor[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Scte35Descriptor(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1Scte35Descriptor(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfVideoDescription = (
   input: VideoDescription[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1VideoDescription(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1VideoDescription(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1AacSettings = (

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
@@ -2416,44 +2416,34 @@ const serializeAws_restJson1_1__listOfDashManifest = (
   input: DashManifest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DashManifest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DashManifest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfHlsManifest = (
   input: HlsManifest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1HlsManifest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1HlsManifest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfMssManifest = (
   input: MssManifest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1MssManifest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1MssManifest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1AssetShallow = (

--- a/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
@@ -3267,11 +3267,7 @@ const serializeAws_restJson1_1AdTriggers = (
   input: (__AdTriggersElement | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Authorization = (
@@ -3649,38 +3645,23 @@ const serializeAws_restJson1_1__listOfHlsManifestCreateOrUpdateParameters = (
   input: HlsManifestCreateOrUpdateParameters[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1HlsManifestCreateOrUpdateParameters(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1HlsManifestCreateOrUpdateParameters(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOf__PeriodTriggersElement = (
   input: (__PeriodTriggersElement | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__mapOf__string = (

--- a/clients/client-mediastore/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/protocols/Aws_json1_1.ts
@@ -2038,44 +2038,28 @@ const serializeAws_json1_1AllowedHeaders = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AllowedMethods = (
   input: (MethodName | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AllowedOrigins = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CorsPolicy = (
   input: CorsRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CorsRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CorsRule(entry, context));
 };
 
 const serializeAws_json1_1CorsRule = (
@@ -2186,11 +2170,7 @@ const serializeAws_json1_1ExposeHeaders = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetContainerPolicyInput = (
@@ -2333,22 +2313,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceInput = (

--- a/clients/client-migration-hub/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/protocols/Aws_json1_1.ts
@@ -2817,11 +2817,7 @@ const serializeAws_json1_1ApplicationIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AssociateCreatedArtifactRequest = (
@@ -3192,11 +3188,9 @@ const serializeAws_json1_1ResourceAttributeList = (
   input: ResourceAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResourceAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ResourceAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1Task = (

--- a/clients/client-mq/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1_1.ts
@@ -3698,22 +3698,14 @@ const serializeAws_restJson1_1__listOfUser = (
   input: User[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1User(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1User(entry, context));
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1__mapOf__string = (

--- a/clients/client-mturk/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/protocols/Aws_json1_1.ts
@@ -3805,11 +3805,7 @@ const serializeAws_json1_1AssignmentStatusList = (
   input: (AssignmentStatus | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AssociateQualificationWithWorkerRequest = (
@@ -4063,11 +4059,7 @@ const serializeAws_json1_1CustomerIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DeleteHITRequest = (
@@ -4127,11 +4119,7 @@ const serializeAws_json1_1EventTypeList = (
   input: (EventType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetAccountBalanceRequest = (
@@ -4221,22 +4209,16 @@ const serializeAws_json1_1HITLayoutParameterList = (
   input: HITLayoutParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1HITLayoutParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1HITLayoutParameter(entry, context)
+  );
 };
 
 const serializeAws_json1_1IntegerList = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListAssignmentsForHITRequest = (
@@ -4454,11 +4436,7 @@ const serializeAws_json1_1LocaleList = (
   input: Locale[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Locale(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Locale(entry, context));
 };
 
 const serializeAws_json1_1NotificationSpecification = (
@@ -4525,11 +4503,9 @@ const serializeAws_json1_1ParameterMapEntryList = (
   input: ParameterMapEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ParameterMapEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ParameterMapEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1PolicyParameter = (
@@ -4559,11 +4535,9 @@ const serializeAws_json1_1PolicyParameterList = (
   input: PolicyParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PolicyParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PolicyParameter(entry, context)
+  );
 };
 
 const serializeAws_json1_1QualificationRequirement = (
@@ -4602,11 +4576,9 @@ const serializeAws_json1_1QualificationRequirementList = (
   input: QualificationRequirement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1QualificationRequirement(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1QualificationRequirement(entry, context)
+  );
 };
 
 const serializeAws_json1_1RejectAssignmentRequest = (
@@ -4658,11 +4630,7 @@ const serializeAws_json1_1ReviewPolicyLevelList = (
   input: (ReviewPolicyLevel | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SendBonusRequest = (
@@ -4709,11 +4677,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UpdateExpirationForHITRequest = (

--- a/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
@@ -4992,11 +4992,7 @@ const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const deserializeAws_restJson1_1Bandwidth = (

--- a/clients/client-opsworks/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/protocols/Aws_json1_1.ts
@@ -6817,11 +6817,9 @@ const serializeAws_json1_1BlockDeviceMappings = (
   input: BlockDeviceMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1BlockDeviceMapping(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1BlockDeviceMapping(entry, context)
+  );
 };
 
 const serializeAws_json1_1ChefConfiguration = (
@@ -6991,11 +6989,9 @@ const serializeAws_json1_1CloudWatchLogsLogStreams = (
   input: CloudWatchLogsLogStream[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CloudWatchLogsLogStream(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CloudWatchLogsLogStream(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateAppRequest = (
@@ -7382,11 +7378,7 @@ const serializeAws_json1_1DataSources = (
   input: DataSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DataSource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DataSource(entry, context));
 };
 
 const serializeAws_json1_1DeleteAppRequest = (
@@ -7940,11 +7932,9 @@ const serializeAws_json1_1EnvironmentVariables = (
   input: EnvironmentVariable[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EnvironmentVariable(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EnvironmentVariable(entry, context)
+  );
 };
 
 const serializeAws_json1_1GetHostnameSuggestionRequest = (
@@ -8365,22 +8355,14 @@ const serializeAws_json1_1Strings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -8820,11 +8802,9 @@ const serializeAws_json1_1VolumeConfigurations = (
   input: VolumeConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1VolumeConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1VolumeConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1WeeklyAutoScalingSchedule = (

--- a/clients/client-opsworkscm/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/protocols/Aws_json1_1.ts
@@ -2335,11 +2335,9 @@ const serializeAws_json1_1EngineAttributes = (
   input: EngineAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EngineAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EngineAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1ExportServerEngineAttributeRequest = (
@@ -2420,11 +2418,7 @@ const serializeAws_json1_1Strings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -2442,22 +2436,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-organizations/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/protocols/Aws_json1_1.ts
@@ -8262,11 +8262,7 @@ const serializeAws_json1_1CreateAccountStates = (
   input: (CreateAccountState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateGovCloudAccountRequest = (
@@ -8837,11 +8833,7 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -8862,11 +8854,7 @@ const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1UntagResourceRequest = (

--- a/clients/client-personalize-events/protocols/Aws_restJson1_1.ts
+++ b/clients/client-personalize-events/protocols/Aws_restJson1_1.ts
@@ -151,11 +151,7 @@ const serializeAws_restJson1_1EventList = (
   input: Event[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Event(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Event(entry, context));
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-personalize-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-personalize-runtime/protocols/Aws_restJson1_1.ts
@@ -308,11 +308,7 @@ const serializeAws_restJson1_1InputList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1ItemList = (

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -4096,11 +4096,7 @@ const serializeAws_json1_1ArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AutoMLConfig = (
@@ -4169,24 +4165,16 @@ const serializeAws_json1_1CategoricalHyperParameterRanges = (
   input: CategoricalHyperParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1CategoricalHyperParameterRange(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CategoricalHyperParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1CategoricalValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContinuousHyperParameterRange = (
@@ -4210,13 +4198,9 @@ const serializeAws_json1_1ContinuousHyperParameterRanges = (
   input: ContinuousHyperParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ContinuousHyperParameterRange(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContinuousHyperParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateBatchInferenceJobRequest = (
@@ -4754,13 +4738,9 @@ const serializeAws_json1_1IntegerHyperParameterRanges = (
   input: IntegerHyperParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1IntegerHyperParameterRange(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1IntegerHyperParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1ListBatchInferenceJobsRequest = (

--- a/clients/client-pi/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/protocols/Aws_json1_1.ts
@@ -431,22 +431,14 @@ const serializeAws_json1_1MetricQueryList = (
   input: MetricQuery[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MetricQuery(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1MetricQuery(entry, context));
 };
 
 const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1InternalServiceError = (

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
@@ -5847,11 +5847,7 @@ const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1Body = (
@@ -5905,13 +5901,9 @@ const serializeAws_restJson1_1CloudWatchDimensionConfigurations = (
   input: CloudWatchDimensionConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1CloudWatchDimensionConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CloudWatchDimensionConfiguration(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Content = (
@@ -5996,24 +5988,16 @@ const serializeAws_restJson1_1DomainDeliverabilityTrackingOptions = (
   input: DomainDeliverabilityTrackingOption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1DomainDeliverabilityTrackingOption(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DomainDeliverabilityTrackingOption(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1EmailAddressList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1EmailContent = (
@@ -6090,11 +6074,7 @@ const serializeAws_restJson1_1EventTypes = (
   input: (EventType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1InboxPlacementTrackingOption = (
@@ -6118,11 +6098,7 @@ const serializeAws_restJson1_1IspNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1KinesisFirehoseDestination = (
@@ -6174,11 +6150,7 @@ const serializeAws_restJson1_1MessageTagList = (
   input: MessageTag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1MessageTag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1MessageTag(entry, context));
 };
 
 const serializeAws_restJson1_1PinpointDestination = (

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
@@ -1331,11 +1331,7 @@ const serializeAws_restJson1_1EventTypes = (
   input: (EventType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1KinesisFirehoseDestination = (

--- a/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
@@ -19203,103 +19203,79 @@ const serializeAws_restJson1_1ListOfEndpointBatchItem = (
   input: EndpointBatchItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1EndpointBatchItem(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1EndpointBatchItem(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfMultiConditionalBranch = (
   input: MultiConditionalBranch[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1MultiConditionalBranch(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1MultiConditionalBranch(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfRandomSplitEntry = (
   input: RandomSplitEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1RandomSplitEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1RandomSplitEntry(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfSegmentDimensions = (
   input: SegmentDimensions[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SegmentDimensions(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SegmentDimensions(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfSegmentGroup = (
   input: SegmentGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SegmentGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SegmentGroup(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfSegmentReference = (
   input: SegmentReference[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SegmentReference(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SegmentReference(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfSimpleCondition = (
   input: SimpleCondition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SimpleCondition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SimpleCondition(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOfWriteTreatmentResource = (
   input: WriteTreatmentResource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1WriteTreatmentResource(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1WriteTreatmentResource(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ListOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1MapOfActivity = (

--- a/clients/client-polly/protocols/Aws_restJson1_1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1_1.ts
@@ -1715,22 +1715,14 @@ const serializeAws_restJson1_1LexiconNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SpeechMarkTypeList = (
   input: (SpeechMarkType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1EngineList = (

--- a/clients/client-pricing/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/protocols/Aws_json1_1.ts
@@ -531,11 +531,7 @@ const serializeAws_json1_1Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1GetAttributeValuesRequest = (

--- a/clients/client-qldb-session/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/protocols/Aws_json1_0.ts
@@ -395,11 +395,7 @@ const serializeAws_json1_0StatementParameters = (
   input: ValueHolder[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0ValueHolder(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0ValueHolder(entry, context));
 };
 
 const serializeAws_json1_0ValueHolder = (

--- a/clients/client-quicksight/protocols/Aws_restJson1_1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1_1.ts
@@ -13199,11 +13199,9 @@ const serializeAws_restJson1_1CalculatedColumnList = (
   input: CalculatedColumn[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1CalculatedColumn(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CalculatedColumn(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1CastColumnTypeOperation = (
@@ -13243,22 +13241,16 @@ const serializeAws_restJson1_1ColumnGroupList = (
   input: ColumnGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ColumnGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ColumnGroup(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ColumnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ColumnTag = (
@@ -13276,11 +13268,7 @@ const serializeAws_restJson1_1ColumnTagList = (
   input: ColumnTag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ColumnTag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1ColumnTag(entry, context));
 };
 
 const serializeAws_restJson1_1CreateColumnsOperation = (
@@ -13417,11 +13405,9 @@ const serializeAws_restJson1_1DataSetReferenceList = (
   input: DataSetReference[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DataSetReference(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DataSetReference(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DataSourceCredentials = (
@@ -13599,11 +13585,9 @@ const serializeAws_restJson1_1DateTimeParameterList = (
   input: DateTimeParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DateTimeParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DateTimeParameter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DecimalParameter = (
@@ -13627,11 +13611,9 @@ const serializeAws_restJson1_1DecimalParameterList = (
   input: DecimalParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DecimalParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DecimalParameter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ExportToCSVOption = (
@@ -13690,11 +13672,7 @@ const serializeAws_restJson1_1IdentityNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1InputColumn = (
@@ -13715,11 +13693,9 @@ const serializeAws_restJson1_1InputColumnList = (
   input: InputColumn[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1InputColumn(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1InputColumn(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1IntegerParameter = (
@@ -13743,11 +13719,9 @@ const serializeAws_restJson1_1IntegerParameterList = (
   input: IntegerParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1IntegerParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1IntegerParameter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1JiraParameters = (
@@ -14011,11 +13985,7 @@ const serializeAws_restJson1_1ProjectedColumnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1RdsParameters = (
@@ -14244,11 +14214,9 @@ const serializeAws_restJson1_1StringParameterList = (
   input: StringParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1StringParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1StringParameter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TagColumnOperation = (
@@ -14395,11 +14363,9 @@ const serializeAws_restJson1_1TransformOperationList = (
   input: TransformOperation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1TransformOperation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1TransformOperation(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TwitterParameters = (
@@ -14420,11 +14386,9 @@ const serializeAws_restJson1_1UpdateResourcePermissionList = (
   input: ResourcePermission[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ResourcePermission(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ResourcePermission(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1UploadSettings = (
@@ -14465,33 +14429,21 @@ const serializeAws_restJson1_1ActionList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DoubleList = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1LongList = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourcePermission = (
@@ -14515,22 +14467,16 @@ const serializeAws_restJson1_1ResourcePermissionList = (
   input: ResourcePermission[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ResourcePermission(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ResourcePermission(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -14551,22 +14497,14 @@ const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TimestampList = (
   input: Date[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(Math.round(entry.getTime() / 1000));
-  }
-  return contents;
+  return input.map(entry => Math.round(entry.getTime() / 1000));
 };
 
 const deserializeAws_restJson1_1ActiveIAMPolicyAssignment = (

--- a/clients/client-ram/protocols/Aws_restJson1_1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1_1.ts
@@ -4472,55 +4472,35 @@ const serializeAws_restJson1_1PermissionArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1PrincipalArnOrIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourceArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourceShareArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourceShareInvitationArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tag = (
@@ -4558,44 +4538,28 @@ const serializeAws_restJson1_1TagFilters = (
   input: TagFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1TagFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1TagFilter(entry, context));
 };
 
 const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1TagValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1PolicyList = (

--- a/clients/client-rds-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1_1.ts
@@ -1047,11 +1047,7 @@ const serializeAws_restJson1_1ArrayOfArray = (
   input: ArrayValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ArrayValue(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1ArrayValue(entry, context));
 };
 
 const serializeAws_restJson1_1ArrayValue = (
@@ -1073,22 +1069,14 @@ const serializeAws_restJson1_1BooleanArray = (
   input: boolean[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DoubleArray = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Field = (
@@ -1111,11 +1099,7 @@ const serializeAws_restJson1_1LongArray = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SqlParameter = (
@@ -1136,33 +1120,25 @@ const serializeAws_restJson1_1SqlParameterSets = (
   input: SqlParameter[][],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SqlParametersList(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SqlParametersList(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SqlParametersList = (
   input: SqlParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SqlParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SqlParameter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StringArray = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1ArrayOfArray = (

--- a/clients/client-rekognition/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/protocols/Aws_json1_1.ts
@@ -6755,22 +6755,14 @@ const serializeAws_json1_1Assets = (
   input: Asset[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Asset(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Asset(entry, context));
 };
 
 const serializeAws_json1_1Attributes = (
   input: (Attribute | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CompareFacesRequest = (
@@ -6803,11 +6795,7 @@ const serializeAws_json1_1ContentClassifiers = (
   input: (ContentClassifier | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateCollectionRequest = (
@@ -7083,11 +7071,7 @@ const serializeAws_json1_1FaceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FaceSearchSettings = (
@@ -7763,11 +7747,7 @@ const serializeAws_json1_1VersionNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Video = (

--- a/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
@@ -1159,44 +1159,28 @@ const serializeAws_json1_1GroupBy = (
   input: (GroupByAttribute | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RegionFilterList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResourceARNList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResourceTypeFilterList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartReportCreationInput = (
@@ -1231,33 +1215,21 @@ const serializeAws_json1_1TagFilterList = (
   input: TagFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TagFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TagFilter(entry, context));
 };
 
 const serializeAws_json1_1TagKeyFilterList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagKeyListForUntag = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagMap = (
@@ -1291,22 +1263,14 @@ const serializeAws_json1_1TagValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TargetIdFilterList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UntagResourcesInput = (

--- a/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
@@ -2102,22 +2102,16 @@ const serializeAws_restJson1_1GroupFilterList = (
   input: GroupFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1GroupFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1GroupFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1GroupFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourceFilter = (
@@ -2141,22 +2135,16 @@ const serializeAws_restJson1_1ResourceFilterList = (
   input: ResourceFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ResourceFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ResourceFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ResourceFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ResourceQuery = (
@@ -2177,11 +2165,7 @@ const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Tags = (

--- a/clients/client-robomaker/protocols/Aws_restJson1_1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1_1.ts
@@ -5933,11 +5933,7 @@ const serializeAws_restJson1_1Arns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DataSourceConfig = (
@@ -5964,11 +5960,9 @@ const serializeAws_restJson1_1DataSourceConfigs = (
   input: DataSourceConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DataSourceConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DataSourceConfig(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DeploymentApplicationConfig = (
@@ -5995,13 +5989,9 @@ const serializeAws_restJson1_1DeploymentApplicationConfigs = (
   input: DeploymentApplicationConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1DeploymentApplicationConfig(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DeploymentApplicationConfig(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1DeploymentConfig = (
@@ -6088,22 +6078,14 @@ const serializeAws_restJson1_1FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Filter(entry, context));
 };
 
 const serializeAws_restJson1_1LaunchConfig = (
@@ -6196,11 +6178,9 @@ const serializeAws_restJson1_1PortMappingList = (
   input: PortMapping[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1PortMapping(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1PortMapping(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1RenderingEngine = (
@@ -6241,13 +6221,9 @@ const serializeAws_restJson1_1RobotApplicationConfigs = (
   input: RobotApplicationConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1RobotApplicationConfig(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1RobotApplicationConfig(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1RobotSoftwareSuite = (
@@ -6268,11 +6244,7 @@ const serializeAws_restJson1_1S3Keys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1S3Object = (
@@ -6296,11 +6268,7 @@ const serializeAws_restJson1_1SecurityGroups = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SimulationApplicationConfig = (
@@ -6327,13 +6295,9 @@ const serializeAws_restJson1_1SimulationApplicationConfigs = (
   input: SimulationApplicationConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1SimulationApplicationConfig(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SimulationApplicationConfig(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SimulationSoftwareSuite = (
@@ -6371,22 +6335,16 @@ const serializeAws_restJson1_1SourceConfigs = (
   input: SourceConfig[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SourceConfig(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SourceConfig(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Subnets = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagMap = (

--- a/clients/client-route-53-domains/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/protocols/Aws_json1_1.ts
@@ -2878,11 +2878,7 @@ const serializeAws_json1_1ExtraParamList = (
   input: ExtraParam[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ExtraParam(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ExtraParam(entry, context));
 };
 
 const serializeAws_json1_1GetContactReachabilityStatusRequest = (
@@ -2939,11 +2935,7 @@ const serializeAws_json1_1GlueIpList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListDomainsRequest = (
@@ -3011,11 +3003,7 @@ const serializeAws_json1_1NameserverList = (
   input: Nameserver[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Nameserver(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Nameserver(entry, context));
 };
 
 const serializeAws_json1_1RegisterDomainRequest = (
@@ -3120,22 +3108,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TransferDomainRequest = (

--- a/clients/client-route53resolver/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/protocols/Aws_json1_1.ts
@@ -3343,22 +3343,14 @@ const serializeAws_json1_1FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Filters = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1GetResolverEndpointRequest = (
@@ -3440,11 +3432,9 @@ const serializeAws_json1_1IpAddressesRequest = (
   input: IpAddressRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IpAddressRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1IpAddressRequest(entry, context)
+  );
 };
 
 const serializeAws_json1_1ListResolverEndpointIpAddressesRequest = (
@@ -3570,11 +3560,7 @@ const serializeAws_json1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -3592,22 +3578,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -3642,11 +3620,7 @@ const serializeAws_json1_1TargetList = (
   input: TargetAddress[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TargetAddress(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TargetAddress(entry, context));
 };
 
 const serializeAws_json1_1UntagResourceRequest = (

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
@@ -829,11 +829,7 @@ const serializeAws_restJson1_1ContentClassifiers = (
   input: (ContentClassifier | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1HumanLoopInputContent = (

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -10950,11 +10950,7 @@ const serializeAws_json1_1AdditionalCodeRepositoryNamesOrUrls = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AlgorithmSpecification = (
@@ -11015,13 +11011,9 @@ const serializeAws_json1_1AlgorithmValidationProfiles = (
   input: AlgorithmValidationProfile[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1AlgorithmValidationProfile(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AlgorithmValidationProfile(entry, context)
+  );
 };
 
 const serializeAws_json1_1AlgorithmValidationSpecification = (
@@ -11096,11 +11088,7 @@ const serializeAws_json1_1AttributeNames = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AutoMLChannel = (
@@ -11141,11 +11129,7 @@ const serializeAws_json1_1AutoMLInputDataConfig = (
   input: AutoMLChannel[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AutoMLChannel(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1AutoMLChannel(entry, context));
 };
 
 const serializeAws_json1_1AutoMLJobCompletionCriteria = (
@@ -11284,11 +11268,7 @@ const serializeAws_json1_1CaptureOptionList = (
   input: CaptureOption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CaptureOption(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CaptureOption(entry, context));
 };
 
 const serializeAws_json1_1CategoricalParameterRange = (
@@ -11326,13 +11306,9 @@ const serializeAws_json1_1CategoricalParameterRanges = (
   input: CategoricalParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1CategoricalParameterRange(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CategoricalParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1Channel = (
@@ -11411,11 +11387,9 @@ const serializeAws_json1_1ChannelSpecifications = (
   input: ChannelSpecification[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ChannelSpecification(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ChannelSpecification(entry, context)
+  );
 };
 
 const serializeAws_json1_1CheckpointConfig = (
@@ -11436,11 +11410,7 @@ const serializeAws_json1_1Cidrs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CognitoMemberDefinition = (
@@ -11483,11 +11453,9 @@ const serializeAws_json1_1CollectionConfigurations = (
   input: CollectionConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CollectionConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CollectionConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1CollectionParameters = (
@@ -11504,22 +11472,14 @@ const serializeAws_json1_1CompressionTypes = (
   input: (CompressionType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContainerArguments = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContainerDefinition = (
@@ -11555,44 +11515,30 @@ const serializeAws_json1_1ContainerDefinitionList = (
   input: ContainerDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ContainerDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContainerDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1ContainerEntrypoint = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContentClassifiers = (
   input: (ContentClassifier | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContentTypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ContinuousParameterRange = (
@@ -11633,11 +11579,9 @@ const serializeAws_json1_1ContinuousParameterRanges = (
   input: ContinuousParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ContinuousParameterRange(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ContinuousParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateAlgorithmInput = (
@@ -12663,11 +12607,7 @@ const serializeAws_json1_1CsvContentTypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DataCaptureConfig = (
@@ -12807,11 +12747,9 @@ const serializeAws_json1_1DebugRuleConfigurations = (
   input: DebugRuleConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DebugRuleConfiguration(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DebugRuleConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1DeleteAlgorithmInput = (
@@ -13369,11 +13307,9 @@ const serializeAws_json1_1DesiredWeightAndCapacityList = (
   input: DesiredWeightAndCapacity[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DesiredWeightAndCapacity(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DesiredWeightAndCapacity(entry, context)
+  );
 };
 
 const serializeAws_json1_1DisassociateTrialComponentRequest = (
@@ -13478,11 +13414,7 @@ const serializeAws_json1_1FilterList = (
   input: Filter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Filter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Filter(entry, context));
 };
 
 const serializeAws_json1_1FlowDefinitionOutputConfig = (
@@ -13503,11 +13435,7 @@ const serializeAws_json1_1FlowDefinitionTaskKeywords = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetSearchSuggestionsRequest = (
@@ -13779,13 +13707,9 @@ const serializeAws_json1_1HyperParameterSpecifications = (
   input: HyperParameterSpecification[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1HyperParameterSpecification(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1HyperParameterSpecification(entry, context)
+  );
 };
 
 const serializeAws_json1_1HyperParameterTrainingJobDefinition = (
@@ -13880,13 +13804,9 @@ const serializeAws_json1_1HyperParameterTrainingJobDefinitions = (
   input: HyperParameterTrainingJobDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1HyperParameterTrainingJobDefinition(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1HyperParameterTrainingJobDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1HyperParameterTuningJobConfig = (
@@ -13950,13 +13870,9 @@ const serializeAws_json1_1HyperParameterTuningJobObjectives = (
   input: HyperParameterTuningJobObjective[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1HyperParameterTuningJobObjective(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1HyperParameterTuningJobObjective(entry, context)
+  );
 };
 
 const serializeAws_json1_1HyperParameterTuningJobWarmStartConfig = (
@@ -14055,22 +13971,14 @@ const serializeAws_json1_1InputDataConfig = (
   input: Channel[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Channel(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Channel(entry, context));
 };
 
 const serializeAws_json1_1InputModes = (
   input: (TrainingInputMode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IntegerParameterRange = (
@@ -14111,22 +14019,16 @@ const serializeAws_json1_1IntegerParameterRanges = (
   input: IntegerParameterRange[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IntegerParameterRange(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1IntegerParameterRange(entry, context)
+  );
 };
 
 const serializeAws_json1_1JsonContentTypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1JupyterServerAppSettings = (
@@ -15288,11 +15190,7 @@ const serializeAws_json1_1ListTrialComponentKey256 = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListTrialComponentsRequest = (
@@ -15436,11 +15334,9 @@ const serializeAws_json1_1MemberDefinitions = (
   input: MemberDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MemberDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MemberDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1MetricDefinition = (
@@ -15461,11 +15357,9 @@ const serializeAws_json1_1MetricDefinitionList = (
   input: MetricDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MetricDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MetricDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1ModelPackageContainerDefinition = (
@@ -15495,13 +15389,9 @@ const serializeAws_json1_1ModelPackageContainerDefinitionList = (
   input: ModelPackageContainerDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ModelPackageContainerDefinition(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ModelPackageContainerDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1ModelPackageValidationProfile = (
@@ -15527,13 +15417,9 @@ const serializeAws_json1_1ModelPackageValidationProfiles = (
   input: ModelPackageValidationProfile[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ModelPackageValidationProfile(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ModelPackageValidationProfile(entry, context)
+  );
 };
 
 const serializeAws_json1_1ModelPackageValidationSpecification = (
@@ -15647,11 +15533,7 @@ const serializeAws_json1_1MonitoringContainerArguments = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MonitoringEnvironmentMap = (
@@ -15682,11 +15564,9 @@ const serializeAws_json1_1MonitoringInputs = (
   input: MonitoringInput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MonitoringInput(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MonitoringInput(entry, context)
+  );
 };
 
 const serializeAws_json1_1MonitoringJobDefinition = (
@@ -15789,11 +15669,9 @@ const serializeAws_json1_1MonitoringOutputs = (
   input: MonitoringOutput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MonitoringOutput(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MonitoringOutput(entry, context)
+  );
 };
 
 const serializeAws_json1_1MonitoringResources = (
@@ -15892,11 +15770,7 @@ const serializeAws_json1_1NestedFiltersList = (
   input: NestedFilters[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1NestedFilters(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1NestedFilters(entry, context));
 };
 
 const serializeAws_json1_1NetworkConfig = (
@@ -15920,24 +15794,16 @@ const serializeAws_json1_1NotebookInstanceAcceleratorTypes = (
   input: (NotebookInstanceAcceleratorType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1NotebookInstanceLifecycleConfigList = (
   input: NotebookInstanceLifecycleHook[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1NotebookInstanceLifecycleHook(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1NotebookInstanceLifecycleHook(entry, context)
+  );
 };
 
 const serializeAws_json1_1NotebookInstanceLifecycleHook = (
@@ -16058,11 +15924,7 @@ const serializeAws_json1_1ParameterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ParentHyperParameterTuningJob = (
@@ -16081,13 +15943,9 @@ const serializeAws_json1_1ParentHyperParameterTuningJobs = (
   input: ParentHyperParameterTuningJob[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ParentHyperParameterTuningJob(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ParentHyperParameterTuningJob(entry, context)
+  );
 };
 
 const serializeAws_json1_1ProcessingClusterConfig = (
@@ -16141,11 +15999,9 @@ const serializeAws_json1_1ProcessingInputs = (
   input: ProcessingInput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProcessingInput(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProcessingInput(entry, context)
+  );
 };
 
 const serializeAws_json1_1ProcessingOutput = (
@@ -16186,11 +16042,9 @@ const serializeAws_json1_1ProcessingOutputs = (
   input: ProcessingOutput[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProcessingOutput(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProcessingOutput(entry, context)
+  );
 };
 
 const serializeAws_json1_1ProcessingResources = (
@@ -16291,11 +16145,9 @@ const serializeAws_json1_1ProductionVariantList = (
   input: ProductionVariant[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProductionVariant(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProductionVariant(entry, context)
+  );
 };
 
 const serializeAws_json1_1PropertyNameQuery = (
@@ -16327,11 +16179,7 @@ const serializeAws_json1_1RealtimeInferenceInstanceTypes = (
   input: (ProductionVariantInstanceType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RenderUiTemplateRequest = (
@@ -16420,11 +16268,7 @@ const serializeAws_json1_1ResponseMIMETypes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RetentionPolicy = (
@@ -16515,11 +16359,9 @@ const serializeAws_json1_1SearchExpressionList = (
   input: SearchExpression[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SearchExpression(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SearchExpression(entry, context)
+  );
 };
 
 const serializeAws_json1_1SearchRequest = (
@@ -16555,11 +16397,7 @@ const serializeAws_json1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SharingSettings = (
@@ -16608,11 +16446,9 @@ const serializeAws_json1_1SourceAlgorithmList = (
   input: SourceAlgorithm[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SourceAlgorithm(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SourceAlgorithm(entry, context)
+  );
 };
 
 const serializeAws_json1_1SourceAlgorithmSpecification = (
@@ -16780,11 +16616,7 @@ const serializeAws_json1_1Subnets = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SuggestionQuery = (
@@ -16816,33 +16648,21 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TaskKeywords = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TensorBoardAppSettings = (
@@ -16877,11 +16697,7 @@ const serializeAws_json1_1TrainingInstanceTypes = (
   input: (TrainingInstanceType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TrainingJobDefinition = (
@@ -17030,11 +16846,7 @@ const serializeAws_json1_1TransformInstanceTypes = (
   input: (TransformInstanceType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TransformJobDefinition = (
@@ -17648,11 +17460,7 @@ const serializeAws_json1_1VpcSecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1AddTagsOutput = (

--- a/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
@@ -1215,44 +1215,28 @@ const serializeAws_restJson1_1CurrencyList = (
   input: (CurrencyCode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1DurationsList = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1FilterValuesList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanDescriptionsList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanOfferingFilterElement = (
@@ -1276,13 +1260,9 @@ const serializeAws_restJson1_1SavingsPlanOfferingFiltersList = (
   input: SavingsPlanOfferingFilterElement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1SavingsPlanOfferingFilterElement(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SavingsPlanOfferingFilterElement(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SavingsPlanOfferingRateFilterElement = (
@@ -1306,148 +1286,93 @@ const serializeAws_restJson1_1SavingsPlanOfferingRateFiltersList = (
   input: SavingsPlanOfferingRateFilterElement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1SavingsPlanOfferingRateFilterElement(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SavingsPlanOfferingRateFilterElement(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1UUIDs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanOperationList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanPaymentOptionList = (
   input: (SavingsPlanPaymentOption | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanProductTypeList = (
   input: (SavingsPlanProductType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanRateOperationList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanRateServiceCodeList = (
   input: (SavingsPlanRateServiceCode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanRateUsageTypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanServiceCodeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanTypeList = (
   input: (SavingsPlanType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanUsageTypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ListOfStrings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanFilter = (
@@ -1471,22 +1396,16 @@ const serializeAws_restJson1_1SavingsPlanFilterList = (
   input: SavingsPlanFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SavingsPlanFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SavingsPlanFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SavingsPlanIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SavingsPlanRateFilter = (
@@ -1510,35 +1429,23 @@ const serializeAws_restJson1_1SavingsPlanRateFilterList = (
   input: SavingsPlanRateFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1SavingsPlanRateFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SavingsPlanRateFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SavingsPlanStateList = (
   input: (SavingsPlanState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagMap = (

--- a/clients/client-schemas/protocols/Aws_restJson1_1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1_1.ts
@@ -5050,11 +5050,7 @@ const serializeAws_restJson1_1__listOfGetDiscoveredSchemaVersionItemInput = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1DiscovererSummary = (

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -2650,11 +2650,7 @@ const serializeAws_json1_1SecretVersionStagesType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -2672,22 +2668,14 @@ const serializeAws_json1_1TagKeyListType = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagListType = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (

--- a/clients/client-securityhub/protocols/Aws_restJson1_1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1_1.ts
@@ -5757,33 +5757,23 @@ const serializeAws_restJson1_1AccountDetailsList = (
   input: AccountDetails[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AccountDetails(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AccountDetails(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AccountIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1ArnList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1AvailabilityZone = (
@@ -5804,11 +5794,9 @@ const serializeAws_restJson1_1AvailabilityZones = (
   input: AvailabilityZone[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AvailabilityZone(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AvailabilityZone(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AwsCloudFrontDistributionDetails = (
@@ -5891,16 +5879,9 @@ const serializeAws_restJson1_1AwsCloudFrontDistributionOriginItemList = (
   input: AwsCloudFrontDistributionOriginItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1AwsCloudFrontDistributionOriginItem(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AwsCloudFrontDistributionOriginItem(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AwsCloudFrontDistributionOrigins = (
@@ -6258,13 +6239,9 @@ const serializeAws_restJson1_1AwsLambdaFunctionLayerList = (
   input: AwsLambdaFunctionLayer[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1AwsLambdaFunctionLayer(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AwsLambdaFunctionLayer(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AwsLambdaFunctionTracingConfig = (
@@ -7017,11 +6994,9 @@ const serializeAws_restJson1_1AwsSecurityFindingList = (
   input: AwsSecurityFinding[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1AwsSecurityFinding(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AwsSecurityFinding(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AwsSnsTopicDetails = (
@@ -7067,13 +7042,9 @@ const serializeAws_restJson1_1AwsSnsTopicSubscriptionList = (
   input: AwsSnsTopicSubscription[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1AwsSnsTopicSubscription(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1AwsSnsTopicSubscription(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1AwsSqsQueueDetails = (
@@ -7152,11 +7123,7 @@ const serializeAws_restJson1_1DateFilterList = (
   input: DateFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1DateFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1DateFilter(entry, context));
 };
 
 const serializeAws_restJson1_1DateRange = (
@@ -7198,11 +7165,7 @@ const serializeAws_restJson1_1IpFilterList = (
   input: IpFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1IpFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1IpFilter(entry, context));
 };
 
 const serializeAws_restJson1_1KeywordFilter = (
@@ -7220,11 +7183,9 @@ const serializeAws_restJson1_1KeywordFilterList = (
   input: KeywordFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1KeywordFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1KeywordFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1LoadBalancerState = (
@@ -7265,11 +7226,7 @@ const serializeAws_restJson1_1MalwareList = (
   input: Malware[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Malware(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Malware(entry, context));
 };
 
 const serializeAws_restJson1_1MapFilter = (
@@ -7293,11 +7250,7 @@ const serializeAws_restJson1_1MapFilterList = (
   input: MapFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1MapFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1MapFilter(entry, context));
 };
 
 const serializeAws_restJson1_1Network = (
@@ -7345,11 +7298,7 @@ const serializeAws_restJson1_1NonEmptyStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Note = (
@@ -7404,11 +7353,9 @@ const serializeAws_restJson1_1NumberFilterList = (
   input: NumberFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1NumberFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1NumberFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1ProcessDetails = (
@@ -7469,11 +7416,9 @@ const serializeAws_restJson1_1RelatedFindingList = (
   input: RelatedFinding[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1RelatedFinding(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1RelatedFinding(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Remediation = (
@@ -7613,22 +7558,14 @@ const serializeAws_restJson1_1ResourceList = (
   input: Resource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Resource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Resource(entry, context));
 };
 
 const serializeAws_restJson1_1SecurityGroups = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1Severity = (
@@ -7649,11 +7586,9 @@ const serializeAws_restJson1_1SortCriteria = (
   input: SortCriterion[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SortCriterion(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SortCriterion(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SortCriterion = (
@@ -7684,11 +7619,7 @@ const serializeAws_restJson1_1StandardsSubscriptionArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1StandardsSubscriptionRequest = (
@@ -7714,13 +7645,9 @@ const serializeAws_restJson1_1StandardsSubscriptionRequests = (
   input: StandardsSubscriptionRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1StandardsSubscriptionRequest(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1StandardsSubscriptionRequest(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StringFilter = (
@@ -7741,22 +7668,16 @@ const serializeAws_restJson1_1StringFilterList = (
   input: StringFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1StringFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1StringFilter(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TagMap = (
@@ -7799,22 +7720,16 @@ const serializeAws_restJson1_1ThreatIntelIndicatorList = (
   input: ThreatIntelIndicator[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ThreatIntelIndicator(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ThreatIntelIndicator(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1ActionTarget = (

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
@@ -2606,57 +2606,41 @@ const serializeAws_restJson1_1__listOfApplicationPolicyStatement = (
   input: ApplicationPolicyStatement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1ApplicationPolicyStatement(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ApplicationPolicyStatement(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfParameterValue = (
   input: ParameterValue[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1ParameterValue(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1ParameterValue(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfRollbackTrigger = (
   input: RollbackTrigger[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1RollbackTrigger(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1RollbackTrigger(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1__listOfTag = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1__listOf__string = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1ApplicationDependencySummary = (

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -2424,7 +2424,9 @@ const deserializeAws_json1_1AssociateTagOptionWithResourceCommandError = async (
 export const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchAssociateServiceActionWithProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchAssociateServiceActionWithProvisioningArtifactCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactCommandError(
       output,
@@ -2448,7 +2450,9 @@ export const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningAr
 const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchAssociateServiceActionWithProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchAssociateServiceActionWithProvisioningArtifactCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)
@@ -2490,7 +2494,9 @@ const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactC
 export const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput
+> => {
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifactCommandError(
       output,
@@ -2514,7 +2520,9 @@ export const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisionin
 const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifactCommandError = async (
   output: __HttpResponse,
   context: __SerdeContext
-): Promise<BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput> => {
+): Promise<
+  BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput
+> => {
   const parsedOutput: any = {
     ...output,
     body: await parseBody(output.body, context)
@@ -8616,11 +8624,7 @@ const serializeAws_json1_1AddTags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1AssociateBudgetWithResourceInput = (
@@ -8739,11 +8743,7 @@ const serializeAws_json1_1CopyOptions = (
   input: (CopyOption | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CopyProductInput = (
@@ -9517,11 +9517,7 @@ const serializeAws_json1_1ExecutionParameterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetAWSOrganizationsAccessStatusInput = (
@@ -9878,11 +9874,7 @@ const serializeAws_json1_1NotificationArns = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OrganizationNode = (
@@ -9903,11 +9895,7 @@ const serializeAws_json1_1ProductViewFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ProductViewFilters = (
@@ -10001,11 +9989,7 @@ const serializeAws_json1_1ProvisionedProductViewFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ProvisioningArtifactInfo = (
@@ -10062,11 +10046,9 @@ const serializeAws_json1_1ProvisioningParameters = (
   input: ProvisioningParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ProvisioningParameter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ProvisioningParameter(entry, context)
+  );
 };
 
 const serializeAws_json1_1ProvisioningPreferences = (
@@ -10265,11 +10247,9 @@ const serializeAws_json1_1ServiceActionAssociations = (
   input: ServiceActionAssociation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ServiceActionAssociation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ServiceActionAssociation(entry, context)
+  );
 };
 
 const serializeAws_json1_1ServiceActionDefinitionMap = (
@@ -10286,16 +10266,9 @@ const serializeAws_json1_1SourceProvisioningArtifactProperties = (
   input: { [key: string]: string }[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1SourceProvisioningArtifactPropertiesMap(
-        entry,
-        context
-      )
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SourceProvisioningArtifactPropertiesMap(entry, context)
+  );
 };
 
 const serializeAws_json1_1SourceProvisioningArtifactPropertiesMap = (
@@ -10312,22 +10285,14 @@ const serializeAws_json1_1StackSetAccounts = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StackSetRegions = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -10345,22 +10310,14 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TerminateProvisionedProductInput = (
@@ -10614,13 +10571,9 @@ const serializeAws_json1_1UpdateProvisioningParameters = (
   input: UpdateProvisioningParameter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1UpdateProvisioningParameter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1UpdateProvisioningParameter(entry, context)
+  );
 };
 
 const serializeAws_json1_1UpdateProvisioningPreferences = (

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -2558,22 +2558,14 @@ const serializeAws_json1_1DnsRecordList = (
   input: DnsRecord[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DnsRecord(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DnsRecord(entry, context));
 };
 
 const serializeAws_json1_1FilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetInstanceRequest = (
@@ -2678,11 +2670,7 @@ const serializeAws_json1_1InstanceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListInstancesRequest = (
@@ -2786,11 +2774,9 @@ const serializeAws_json1_1NamespaceFilters = (
   input: NamespaceFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1NamespaceFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1NamespaceFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1OperationFilter = (
@@ -2817,11 +2803,9 @@ const serializeAws_json1_1OperationFilters = (
   input: OperationFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OperationFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1OperationFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1RegisterInstanceRequest = (
@@ -2897,11 +2881,7 @@ const serializeAws_json1_1ServiceFilters = (
   input: ServiceFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ServiceFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ServiceFilter(entry, context));
 };
 
 const serializeAws_json1_1UpdateInstanceCustomHealthStatusRequest = (

--- a/clients/client-sesv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1_1.ts
@@ -6769,11 +6769,7 @@ const serializeAws_restJson1_1SuppressionListReasons = (
   input: (SuppressionListReason | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SuppressionOptions = (
@@ -6810,11 +6806,7 @@ const serializeAws_restJson1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1Tag(entry, context));
 };
 
 const serializeAws_restJson1_1Body = (
@@ -6868,13 +6860,9 @@ const serializeAws_restJson1_1CloudWatchDimensionConfigurations = (
   input: CloudWatchDimensionConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1CloudWatchDimensionConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1CloudWatchDimensionConfiguration(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1Content = (
@@ -6973,24 +6961,16 @@ const serializeAws_restJson1_1DomainDeliverabilityTrackingOptions = (
   input: DomainDeliverabilityTrackingOption[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1DomainDeliverabilityTrackingOption(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1DomainDeliverabilityTrackingOption(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1EmailAddressList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1EmailContent = (
@@ -7067,11 +7047,7 @@ const serializeAws_restJson1_1EventTypes = (
   input: (EventType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1InboxPlacementTrackingOption = (
@@ -7095,11 +7071,7 @@ const serializeAws_restJson1_1IspNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1KinesisFirehoseDestination = (
@@ -7151,11 +7123,7 @@ const serializeAws_restJson1_1MessageTagList = (
   input: MessageTag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1MessageTag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1MessageTag(entry, context));
 };
 
 const serializeAws_restJson1_1PinpointDestination = (

--- a/clients/client-sfn/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/protocols/Aws_json1_0.ts
@@ -2784,11 +2784,7 @@ const serializeAws_json1_0LogDestinationList = (
   input: LogDestination[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0LogDestination(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0LogDestination(entry, context));
 };
 
 const serializeAws_json1_0LoggingConfiguration = (
@@ -3106,22 +3102,14 @@ const serializeAws_json1_0TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0Tag(entry, context));
 };
 
 const serializeAws_json1_0TagResourceInput = (

--- a/clients/client-shield/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/protocols/Aws_json1_1.ts
@@ -2446,11 +2446,9 @@ const serializeAws_json1_1EmergencyContactList = (
   input: EmergencyContact[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EmergencyContact(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EmergencyContact(entry, context)
+  );
 };
 
 const serializeAws_json1_1GetSubscriptionStateRequest = (
@@ -2511,11 +2509,7 @@ const serializeAws_json1_1ResourceArnFilterList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TimeRange = (

--- a/clients/client-sms/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/protocols/Aws_json1_1.ts
@@ -3731,11 +3731,7 @@ const serializeAws_json1_1AppIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateAppRequest = (
@@ -4168,13 +4164,9 @@ const serializeAws_json1_1ServerGroupLaunchConfigurations = (
   input: ServerGroupLaunchConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ServerGroupLaunchConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ServerGroupLaunchConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1ServerGroupReplicationConfiguration = (
@@ -4200,24 +4192,16 @@ const serializeAws_json1_1ServerGroupReplicationConfigurations = (
   input: ServerGroupReplicationConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ServerGroupReplicationConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ServerGroupReplicationConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1ServerGroups = (
   input: ServerGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ServerGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ServerGroup(entry, context));
 };
 
 const serializeAws_json1_1ServerLaunchConfiguration = (
@@ -4262,24 +4246,16 @@ const serializeAws_json1_1ServerLaunchConfigurations = (
   input: ServerLaunchConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ServerLaunchConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ServerLaunchConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1ServerList = (
   input: Server[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Server(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Server(entry, context));
 };
 
 const serializeAws_json1_1ServerReplicationConfiguration = (
@@ -4305,13 +4281,9 @@ const serializeAws_json1_1ServerReplicationConfigurations = (
   input: ServerReplicationConfiguration[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ServerReplicationConfiguration(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ServerReplicationConfiguration(entry, context)
+  );
 };
 
 const serializeAws_json1_1ServerReplicationParameters = (
@@ -4394,11 +4366,7 @@ const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TerminateAppRequest = (
@@ -4536,11 +4504,9 @@ const serializeAws_json1_1VmServerAddressList = (
   input: VmServerAddress[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1VmServerAddress(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1VmServerAddress(entry, context)
+  );
 };
 
 const deserializeAws_json1_1AppSummary = (

--- a/clients/client-snowball/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/protocols/Aws_json1_1.ts
@@ -2265,11 +2265,7 @@ const serializeAws_json1_1Ec2AmiResourceList = (
   input: Ec2AmiResource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Ec2AmiResource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Ec2AmiResource(entry, context));
 };
 
 const serializeAws_json1_1EventTriggerDefinition = (
@@ -2287,11 +2283,9 @@ const serializeAws_json1_1EventTriggerDefinitionList = (
   input: EventTriggerDefinition[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1EventTriggerDefinition(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1EventTriggerDefinition(entry, context)
+  );
 };
 
 const serializeAws_json1_1GetJobManifestRequest = (
@@ -2365,11 +2359,7 @@ const serializeAws_json1_1JobStateList = (
   input: (JobState | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1KeyRange = (
@@ -2409,11 +2399,7 @@ const serializeAws_json1_1LambdaResourceList = (
   input: LambdaResource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1LambdaResource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1LambdaResource(entry, context));
 };
 
 const serializeAws_json1_1ListClusterJobsRequest = (
@@ -2516,11 +2502,7 @@ const serializeAws_json1_1S3ResourceList = (
   input: S3Resource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1S3Resource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1S3Resource(entry, context));
 };
 
 const serializeAws_json1_1UpdateClusterRequest = (

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -16124,22 +16124,14 @@ const serializeAws_json1_1AccountIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Accounts = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AddTagsToResourceRequest = (
@@ -16180,13 +16172,9 @@ const serializeAws_json1_1AssociationExecutionFilterList = (
   input: AssociationExecutionFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1AssociationExecutionFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AssociationExecutionFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1AssociationExecutionTargetsFilter = (
@@ -16207,13 +16195,9 @@ const serializeAws_json1_1AssociationExecutionTargetsFilterList = (
   input: AssociationExecutionTargetsFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1AssociationExecutionTargetsFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AssociationExecutionTargetsFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1AssociationFilter = (
@@ -16234,22 +16218,16 @@ const serializeAws_json1_1AssociationFilterList = (
   input: AssociationFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AssociationFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AssociationFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1AssociationIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AssociationStatus = (
@@ -16296,22 +16274,16 @@ const serializeAws_json1_1AttachmentsSourceList = (
   input: AttachmentsSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1AttachmentsSource(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AttachmentsSource(entry, context)
+  );
 };
 
 const serializeAws_json1_1AttachmentsSourceValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AutomationExecutionFilter = (
@@ -16337,24 +16309,16 @@ const serializeAws_json1_1AutomationExecutionFilterList = (
   input: AutomationExecutionFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1AutomationExecutionFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1AutomationExecutionFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1AutomationExecutionFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AutomationParameterMap = (
@@ -16374,22 +16338,14 @@ const serializeAws_json1_1AutomationParameterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CalendarNameOrARNList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CancelCommandRequest = (
@@ -16452,11 +16408,7 @@ const serializeAws_json1_1CommandFilterList = (
   input: CommandFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1CommandFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1CommandFilter(entry, context));
 };
 
 const serializeAws_json1_1ComplianceExecutionSummary = (
@@ -16518,33 +16470,23 @@ const serializeAws_json1_1ComplianceItemEntryList = (
   input: ComplianceItemEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ComplianceItemEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ComplianceItemEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1ComplianceResourceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ComplianceResourceTypeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ComplianceStringFilter = (
@@ -16571,22 +16513,16 @@ const serializeAws_json1_1ComplianceStringFilterList = (
   input: ComplianceStringFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ComplianceStringFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ComplianceStringFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1ComplianceStringFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateActivationRequest = (
@@ -16637,13 +16573,9 @@ const serializeAws_json1_1CreateAssociationBatchRequestEntries = (
   input: CreateAssociationBatchRequestEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1CreateAssociationBatchRequestEntry(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1CreateAssociationBatchRequestEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1CreateAssociationBatchRequestEntry = (
@@ -17188,13 +17120,9 @@ const serializeAws_json1_1DescribeActivationsFilterList = (
   input: DescribeActivationsFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1DescribeActivationsFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DescribeActivationsFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1DescribeActivationsRequest = (
@@ -17899,11 +17827,7 @@ const serializeAws_json1_1DocumentFilterList = (
   input: DocumentFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DocumentFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1DocumentFilter(entry, context));
 };
 
 const serializeAws_json1_1DocumentKeyValuesFilter = (
@@ -17927,22 +17851,16 @@ const serializeAws_json1_1DocumentKeyValuesFilterList = (
   input: DocumentKeyValuesFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DocumentKeyValuesFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DocumentKeyValuesFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1DocumentKeyValuesFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DocumentRequires = (
@@ -17963,11 +17881,9 @@ const serializeAws_json1_1DocumentRequiresList = (
   input: DocumentRequires[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1DocumentRequires(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1DocumentRequires(entry, context)
+  );
 };
 
 const serializeAws_json1_1GetAutomationExecutionRequest = (
@@ -18375,11 +18291,7 @@ const serializeAws_json1_1InstanceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InstanceInformationFilter = (
@@ -18405,24 +18317,16 @@ const serializeAws_json1_1InstanceInformationFilterList = (
   input: InstanceInformationFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1InstanceInformationFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InstanceInformationFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1InstanceInformationFilterValueSet = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InstanceInformationStringFilter = (
@@ -18448,13 +18352,9 @@ const serializeAws_json1_1InstanceInformationStringFilterList = (
   input: InstanceInformationStringFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1InstanceInformationStringFilter(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InstanceInformationStringFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1InstancePatchStateFilter = (
@@ -18481,22 +18381,16 @@ const serializeAws_json1_1InstancePatchStateFilterList = (
   input: InstancePatchStateFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InstancePatchStateFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InstancePatchStateFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1InstancePatchStateFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InventoryAggregator = (
@@ -18526,11 +18420,9 @@ const serializeAws_json1_1InventoryAggregatorList = (
   input: InventoryAggregator[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InventoryAggregator(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InventoryAggregator(entry, context)
+  );
 };
 
 const serializeAws_json1_1InventoryFilter = (
@@ -18557,22 +18449,16 @@ const serializeAws_json1_1InventoryFilterList = (
   input: InventoryFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InventoryFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InventoryFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1InventoryFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1InventoryGroup = (
@@ -18596,11 +18482,7 @@ const serializeAws_json1_1InventoryGroupList = (
   input: InventoryGroup[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InventoryGroup(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1InventoryGroup(entry, context));
 };
 
 const serializeAws_json1_1InventoryItem = (
@@ -18659,33 +18541,23 @@ const serializeAws_json1_1InventoryItemEntryList = (
   input: { [key: string]: string }[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InventoryItemEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1InventoryItemEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1InventoryItemList = (
   input: InventoryItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1InventoryItem(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1InventoryItem(entry, context));
 };
 
 const serializeAws_json1_1KeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1LabelParameterVersionRequest = (
@@ -19031,22 +18903,16 @@ const serializeAws_json1_1MaintenanceWindowFilterList = (
   input: MaintenanceWindowFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MaintenanceWindowFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1MaintenanceWindowFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1MaintenanceWindowFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MaintenanceWindowLambdaParameters = (
@@ -19192,11 +19058,7 @@ const serializeAws_json1_1MaintenanceWindowTaskParameterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1MaintenanceWindowTaskParameters = (
@@ -19269,11 +19131,7 @@ const serializeAws_json1_1NotificationEventList = (
   input: (NotificationEvent | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OpsAggregator = (
@@ -19315,11 +19173,7 @@ const serializeAws_json1_1OpsAggregatorList = (
   input: OpsAggregator[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OpsAggregator(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1OpsAggregator(entry, context));
 };
 
 const serializeAws_json1_1OpsAggregatorValueMap = (
@@ -19356,22 +19210,14 @@ const serializeAws_json1_1OpsFilterList = (
   input: OpsFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OpsFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1OpsFilter(entry, context));
 };
 
 const serializeAws_json1_1OpsFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OpsItemDataValue = (
@@ -19412,22 +19258,14 @@ const serializeAws_json1_1OpsItemFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OpsItemFilters = (
   input: OpsItemFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OpsItemFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1OpsItemFilter(entry, context));
 };
 
 const serializeAws_json1_1OpsItemNotification = (
@@ -19445,11 +19283,9 @@ const serializeAws_json1_1OpsItemNotifications = (
   input: OpsItemNotification[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OpsItemNotification(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1OpsItemNotification(entry, context)
+  );
 };
 
 const serializeAws_json1_1OpsItemOperationalData = (
@@ -19466,11 +19302,7 @@ const serializeAws_json1_1OpsItemOpsDataKeysList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1OpsResultAttribute = (
@@ -19488,33 +19320,23 @@ const serializeAws_json1_1OpsResultAttributeList = (
   input: OpsResultAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1OpsResultAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1OpsResultAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1ParameterLabelList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ParameterNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ParameterStringFilter = (
@@ -19541,33 +19363,23 @@ const serializeAws_json1_1ParameterStringFilterList = (
   input: ParameterStringFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ParameterStringFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ParameterStringFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1ParameterStringFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ParameterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Parameters = (
@@ -19601,22 +19413,16 @@ const serializeAws_json1_1ParametersFilterList = (
   input: ParametersFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ParametersFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ParametersFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1ParametersFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PatchFilter = (
@@ -19654,33 +19460,21 @@ const serializeAws_json1_1PatchFilterList = (
   input: PatchFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PatchFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PatchFilter(entry, context));
 };
 
 const serializeAws_json1_1PatchFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PatchIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PatchOrchestratorFilter = (
@@ -19704,22 +19498,16 @@ const serializeAws_json1_1PatchOrchestratorFilterList = (
   input: PatchOrchestratorFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PatchOrchestratorFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1PatchOrchestratorFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1PatchOrchestratorFilterValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PatchRule = (
@@ -19763,11 +19551,7 @@ const serializeAws_json1_1PatchRuleList = (
   input: PatchRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PatchRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PatchRule(entry, context));
 };
 
 const serializeAws_json1_1PatchSource = (
@@ -19794,22 +19578,14 @@ const serializeAws_json1_1PatchSourceList = (
   input: PatchSource[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1PatchSource(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1PatchSource(entry, context));
 };
 
 const serializeAws_json1_1PatchSourceProductList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PutComplianceItemsRequest = (
@@ -19905,11 +19681,7 @@ const serializeAws_json1_1Regions = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RegisterDefaultPatchBaselineRequest = (
@@ -20050,11 +19822,7 @@ const serializeAws_json1_1RelatedOpsItems = (
   input: RelatedOpsItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RelatedOpsItem(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1RelatedOpsItem(entry, context));
 };
 
 const serializeAws_json1_1RemoveTagsFromResourceRequest = (
@@ -20119,13 +19887,9 @@ const serializeAws_json1_1ResourceDataSyncOrganizationalUnitList = (
   input: ResourceDataSyncOrganizationalUnit[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1ResourceDataSyncOrganizationalUnit(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ResourceDataSyncOrganizationalUnit(entry, context)
+  );
 };
 
 const serializeAws_json1_1ResourceDataSyncS3Destination = (
@@ -20185,11 +19949,7 @@ const serializeAws_json1_1ResourceDataSyncSourceRegionList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ResultAttribute = (
@@ -20207,11 +19967,9 @@ const serializeAws_json1_1ResultAttributeList = (
   input: ResultAttribute[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ResultAttribute(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ResultAttribute(entry, context)
+  );
 };
 
 const serializeAws_json1_1ResumeSessionRequest = (
@@ -20353,22 +20111,14 @@ const serializeAws_json1_1SessionFilterList = (
   input: SessionFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SessionFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1SessionFilter(entry, context));
 };
 
 const serializeAws_json1_1SessionManagerParameterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1SessionManagerParameters = (
@@ -20492,22 +20242,16 @@ const serializeAws_json1_1StepExecutionFilterList = (
   input: StepExecutionFilter[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1StepExecutionFilter(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1StepExecutionFilter(entry, context)
+  );
 };
 
 const serializeAws_json1_1StepExecutionFilterValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StopAutomationExecutionRequest = (
@@ -20528,11 +20272,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -20550,11 +20290,7 @@ const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1Target = (
@@ -20605,11 +20341,7 @@ const serializeAws_json1_1TargetLocations = (
   input: TargetLocation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TargetLocation(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TargetLocation(entry, context));
 };
 
 const serializeAws_json1_1TargetMap = (
@@ -20626,44 +20358,28 @@ const serializeAws_json1_1TargetMapValueList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TargetMaps = (
   input: { [key: string]: string[] }[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TargetMap(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1TargetMap(entry, context));
 };
 
 const serializeAws_json1_1TargetValues = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Targets = (
   input: Target[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Target(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Target(entry, context));
 };
 
 const serializeAws_json1_1TerminateSessionRequest = (

--- a/clients/client-sso-oidc/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sso-oidc/protocols/Aws_restJson1_1.ts
@@ -841,11 +841,7 @@ const serializeAws_restJson1_1Scopes = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-storage-gateway/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/protocols/Aws_json1_1.ts
@@ -7360,11 +7360,7 @@ const serializeAws_json1_1DiskIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListGatewaysInput = (
@@ -7532,11 +7528,7 @@ const serializeAws_json1_1VolumeARNs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1AddCacheInput = (
@@ -8199,55 +8191,35 @@ const serializeAws_json1_1FileShareARNList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FileShareClientList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FileShareUserList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1FolderList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Hosts = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1JoinDomainInput = (
@@ -8505,33 +8477,21 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TapeARNs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1UpdateGatewayInformationInput = (
@@ -8688,11 +8648,7 @@ const serializeAws_json1_1VTLDeviceARNs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1ActivateGatewayOutput = (

--- a/clients/client-support/protocols/Aws_json1_1.ts
+++ b/clients/client-support/protocols/Aws_json1_1.ts
@@ -1571,11 +1571,7 @@ const serializeAws_json1_1Attachments = (
   input: Attachment[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Attachment(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Attachment(entry, context));
 };
 
 const serializeAws_json1_1AddAttachmentsToSetRequest = (
@@ -1622,22 +1618,14 @@ const serializeAws_json1_1CaseIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CcEmailAddressList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateCaseRequest = (
@@ -1793,11 +1781,7 @@ const serializeAws_json1_1ServiceCodeList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DescribeTrustedAdvisorCheckRefreshStatusesRequest = (
@@ -1868,11 +1852,7 @@ const serializeAws_json1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1Attachment = (

--- a/clients/client-swf/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/protocols/Aws_json1_0.ts
@@ -4129,11 +4129,7 @@ const serializeAws_json1_0DecisionList = (
   input: Decision[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0Decision(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0Decision(entry, context));
 };
 
 const serializeAws_json1_0ExecutionTimeFilter = (
@@ -4224,22 +4220,14 @@ const serializeAws_json1_0ResourceTagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0ResourceTagList = (
   input: ResourceTag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_0ResourceTag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_0ResourceTag(entry, context));
 };
 
 const serializeAws_json1_0ScheduleActivityTaskDecisionAttributes = (
@@ -4412,11 +4400,7 @@ const serializeAws_json1_0TagList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_0TaskList = (

--- a/clients/client-textract/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/protocols/Aws_json1_1.ts
@@ -1334,11 +1334,7 @@ const serializeAws_json1_1ContentClassifiers = (
   input: (ContentClassifier | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DetectDocumentTextRequest = (
@@ -1390,11 +1386,7 @@ const serializeAws_json1_1FeatureTypes = (
   input: (FeatureType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1GetDocumentAnalysisRequest = (

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -1889,11 +1889,7 @@ const serializeAws_json1_1Phrases = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Settings = (
@@ -2012,11 +2008,7 @@ const serializeAws_json1_1Words = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_json1_1BadRequestException = (

--- a/clients/client-transfer/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/protocols/Aws_json1_1.ts
@@ -2312,11 +2312,7 @@ const serializeAws_json1_1AddressAllocationIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateServerRequest = (
@@ -2509,11 +2505,9 @@ const serializeAws_json1_1HomeDirectoryMappings = (
   input: HomeDirectoryMapEntry[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1HomeDirectoryMapEntry(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1HomeDirectoryMapEntry(entry, context)
+  );
 };
 
 const serializeAws_json1_1IdentityProviderDetails = (
@@ -2621,11 +2615,7 @@ const serializeAws_json1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -2643,11 +2633,7 @@ const serializeAws_json1_1TagKeys = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -2668,11 +2654,7 @@ const serializeAws_json1_1Tags = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TestIdentityProviderRequest = (

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -1433,11 +1433,7 @@ const serializeAws_json1_1ResourceNameList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1StartTextTranslationJobRequest = (
@@ -1504,11 +1500,7 @@ const serializeAws_json1_1TargetLanguageCodeStringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TerminologyData = (

--- a/clients/client-waf-regional/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/protocols/Aws_json1_1.ts
@@ -10554,11 +10554,9 @@ const serializeAws_json1_1ByteMatchSetUpdates = (
   input: ByteMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ByteMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ByteMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1ByteMatchTuple = (
@@ -10993,11 +10991,7 @@ const serializeAws_json1_1ExcludedRules = (
   input: ExcludedRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ExcludedRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ExcludedRule(entry, context));
 };
 
 const serializeAws_json1_1FieldToMatch = (
@@ -11049,11 +11043,9 @@ const serializeAws_json1_1GeoMatchSetUpdates = (
   input: GeoMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1GeoMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1GeoMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1GetByteMatchSetRequest = (
@@ -11301,11 +11293,7 @@ const serializeAws_json1_1IPSetUpdates = (
   input: IPSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IPSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1IPSetUpdate(entry, context));
 };
 
 const serializeAws_json1_1ListActivatedRulesInRuleGroupRequest = (
@@ -11542,11 +11530,7 @@ const serializeAws_json1_1LogDestinationConfigs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1LoggingConfiguration = (
@@ -11625,11 +11609,7 @@ const serializeAws_json1_1RedactedFields = (
   input: FieldToMatch[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FieldToMatch(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1FieldToMatch(entry, context));
 };
 
 const serializeAws_json1_1RegexMatchSetUpdate = (
@@ -11653,11 +11633,9 @@ const serializeAws_json1_1RegexMatchSetUpdates = (
   input: RegexMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RegexMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RegexMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1RegexMatchTuple = (
@@ -11698,11 +11676,9 @@ const serializeAws_json1_1RegexPatternSetUpdates = (
   input: RegexPatternSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RegexPatternSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RegexPatternSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1RuleGroupUpdate = (
@@ -11726,11 +11702,9 @@ const serializeAws_json1_1RuleGroupUpdates = (
   input: RuleGroupUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RuleGroupUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RuleGroupUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1RuleUpdate = (
@@ -11754,11 +11728,7 @@ const serializeAws_json1_1RuleUpdates = (
   input: RuleUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RuleUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1RuleUpdate(entry, context));
 };
 
 const serializeAws_json1_1SizeConstraint = (
@@ -11805,11 +11775,9 @@ const serializeAws_json1_1SizeConstraintSetUpdates = (
   input: SizeConstraintSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SizeConstraintSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SizeConstraintSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1SqlInjectionMatchSetUpdate = (
@@ -11835,13 +11803,9 @@ const serializeAws_json1_1SqlInjectionMatchSetUpdates = (
   input: SqlInjectionMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1SqlInjectionMatchSetUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SqlInjectionMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1SqlInjectionMatchTuple = (
@@ -11876,22 +11840,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -12231,11 +12187,7 @@ const serializeAws_json1_1WebACLUpdates = (
   input: WebACLUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1WebACLUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1WebACLUpdate(entry, context));
 };
 
 const serializeAws_json1_1XssMatchSetUpdate = (
@@ -12259,11 +12211,9 @@ const serializeAws_json1_1XssMatchSetUpdates = (
   input: XssMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1XssMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1XssMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1XssMatchTuple = (

--- a/clients/client-waf/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/protocols/Aws_json1_1.ts
@@ -9995,11 +9995,9 @@ const serializeAws_json1_1ByteMatchSetUpdates = (
   input: ByteMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ByteMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1ByteMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1ByteMatchTuple = (
@@ -10434,11 +10432,7 @@ const serializeAws_json1_1ExcludedRules = (
   input: ExcludedRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ExcludedRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ExcludedRule(entry, context));
 };
 
 const serializeAws_json1_1FieldToMatch = (
@@ -10490,11 +10484,9 @@ const serializeAws_json1_1GeoMatchSetUpdates = (
   input: GeoMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1GeoMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1GeoMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1GetByteMatchSetRequest = (
@@ -10742,11 +10734,7 @@ const serializeAws_json1_1IPSetUpdates = (
   input: IPSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IPSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1IPSetUpdate(entry, context));
 };
 
 const serializeAws_json1_1ListActivatedRulesInRuleGroupRequest = (
@@ -10983,11 +10971,7 @@ const serializeAws_json1_1LogDestinationConfigs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1LoggingConfiguration = (
@@ -11066,11 +11050,7 @@ const serializeAws_json1_1RedactedFields = (
   input: FieldToMatch[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FieldToMatch(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1FieldToMatch(entry, context));
 };
 
 const serializeAws_json1_1RegexMatchSetUpdate = (
@@ -11094,11 +11074,9 @@ const serializeAws_json1_1RegexMatchSetUpdates = (
   input: RegexMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RegexMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RegexMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1RegexMatchTuple = (
@@ -11139,11 +11117,9 @@ const serializeAws_json1_1RegexPatternSetUpdates = (
   input: RegexPatternSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RegexPatternSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RegexPatternSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1RuleGroupUpdate = (
@@ -11167,11 +11143,9 @@ const serializeAws_json1_1RuleGroupUpdates = (
   input: RuleGroupUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RuleGroupUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1RuleGroupUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1RuleUpdate = (
@@ -11195,11 +11169,7 @@ const serializeAws_json1_1RuleUpdates = (
   input: RuleUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RuleUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1RuleUpdate(entry, context));
 };
 
 const serializeAws_json1_1SizeConstraint = (
@@ -11246,11 +11216,9 @@ const serializeAws_json1_1SizeConstraintSetUpdates = (
   input: SizeConstraintSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SizeConstraintSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SizeConstraintSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1SqlInjectionMatchSetUpdate = (
@@ -11276,13 +11244,9 @@ const serializeAws_json1_1SqlInjectionMatchSetUpdates = (
   input: SqlInjectionMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_json1_1SqlInjectionMatchSetUpdate(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1SqlInjectionMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1SqlInjectionMatchTuple = (
@@ -11317,22 +11281,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -11672,11 +11628,7 @@ const serializeAws_json1_1WebACLUpdates = (
   input: WebACLUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1WebACLUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1WebACLUpdate(entry, context));
 };
 
 const serializeAws_json1_1XssMatchSetUpdate = (
@@ -11700,11 +11652,9 @@ const serializeAws_json1_1XssMatchSetUpdates = (
   input: XssMatchSetUpdate[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1XssMatchSetUpdate(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1XssMatchSetUpdate(entry, context)
+  );
 };
 
 const serializeAws_json1_1XssMatchTuple = (

--- a/clients/client-wafv2/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/protocols/Aws_json1_1.ts
@@ -4789,11 +4789,7 @@ const serializeAws_json1_1CountryCodes = (
   input: (CountryCode | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1CreateIPSetRequest = (
@@ -5068,11 +5064,7 @@ const serializeAws_json1_1ExcludedRules = (
   input: ExcludedRule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ExcludedRule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ExcludedRule(entry, context));
 };
 
 const serializeAws_json1_1FieldToMatch = (
@@ -5270,11 +5262,7 @@ const serializeAws_json1_1IPAddresses = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IPSetReferenceStatement = (
@@ -5425,11 +5413,7 @@ const serializeAws_json1_1LogDestinationConfigs = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1LoggingConfiguration = (
@@ -5583,11 +5567,7 @@ const serializeAws_json1_1RedactedFields = (
   input: FieldToMatch[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1FieldToMatch(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1FieldToMatch(entry, context));
 };
 
 const serializeAws_json1_1Regex = (
@@ -5628,11 +5608,7 @@ const serializeAws_json1_1RegularExpressionList = (
   input: Regex[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Regex(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Regex(entry, context));
 };
 
 const serializeAws_json1_1Rule = (
@@ -5711,11 +5687,7 @@ const serializeAws_json1_1Rules = (
   input: Rule[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Rule(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Rule(entry, context));
 };
 
 const serializeAws_json1_1SingleHeader = (
@@ -5886,11 +5858,7 @@ const serializeAws_json1_1Statements = (
   input: Statement[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Statement(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Statement(entry, context));
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -5908,22 +5876,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TagResourceRequest = (
@@ -5958,11 +5918,9 @@ const serializeAws_json1_1TextTransformations = (
   input: TextTransformation[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TextTransformation(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1TextTransformation(entry, context)
+  );
 };
 
 const serializeAws_json1_1TimeWindow = (

--- a/clients/client-workdocs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1_1.ts
@@ -7381,22 +7381,16 @@ const serializeAws_restJson1_1SharePrincipalList = (
   input: SharePrincipal[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1SharePrincipal(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SharePrincipal(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SharedLabels = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1StorageRuleType = (

--- a/clients/client-worklink/protocols/Aws_restJson1_1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1_1.ts
@@ -4448,22 +4448,14 @@ const serializeAws_restJson1_1SecurityGroupIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1DeviceSummary = (

--- a/clients/client-workmail/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/protocols/Aws_json1_1.ts
@@ -5221,11 +5221,7 @@ const serializeAws_json1_1PermissionValues = (
   input: (PermissionType | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1PutMailboxPermissionsRequest = (

--- a/clients/client-workspaces/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/protocols/Aws_json1_1.ts
@@ -4677,11 +4677,7 @@ const serializeAws_json1_1BundleIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ClientProperties = (
@@ -5004,11 +5000,7 @@ const serializeAws_json1_1DirectoryIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1DisassociateIpGroupsRequest = (
@@ -5055,22 +5047,14 @@ const serializeAws_json1_1IpGroupIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IpRevokedRuleList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1IpRuleItem = (
@@ -5091,11 +5075,7 @@ const serializeAws_json1_1IpRuleList = (
   input: IpRuleItem[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1IpRuleItem(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1IpRuleItem(entry, context));
 };
 
 const serializeAws_json1_1ListAvailableManagementCidrRangesRequest = (
@@ -5265,11 +5245,7 @@ const serializeAws_json1_1RebootWorkspaceRequests = (
   input: RebootRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RebootRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1RebootRequest(entry, context));
 };
 
 const serializeAws_json1_1RebootWorkspacesRequest = (
@@ -5303,11 +5279,7 @@ const serializeAws_json1_1RebuildWorkspaceRequests = (
   input: RebuildRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1RebuildRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1RebuildRequest(entry, context));
 };
 
 const serializeAws_json1_1RebuildWorkspacesRequest = (
@@ -5359,11 +5331,7 @@ const serializeAws_json1_1ResourceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1RestoreWorkspaceRequest = (
@@ -5432,11 +5400,7 @@ const serializeAws_json1_1StartWorkspaceRequests = (
   input: StartRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1StartRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1StartRequest(entry, context));
 };
 
 const serializeAws_json1_1StartWorkspacesRequest = (
@@ -5470,11 +5434,7 @@ const serializeAws_json1_1StopWorkspaceRequests = (
   input: StopRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1StopRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1StopRequest(entry, context));
 };
 
 const serializeAws_json1_1StopWorkspacesRequest = (
@@ -5497,11 +5457,7 @@ const serializeAws_json1_1SubnetIds = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1Tag = (input: Tag, context: __SerdeContext): any => {
@@ -5519,22 +5475,14 @@ const serializeAws_json1_1TagKeyList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1TagList = (
   input: Tag[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1Tag(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1Tag(entry, context));
 };
 
 const serializeAws_json1_1TerminateRequest = (
@@ -5552,11 +5500,9 @@ const serializeAws_json1_1TerminateWorkspaceRequests = (
   input: TerminateRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1TerminateRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1TerminateRequest(entry, context)
+  );
 };
 
 const serializeAws_json1_1TerminateWorkspacesRequest = (
@@ -5649,22 +5595,14 @@ const serializeAws_json1_1WorkspaceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1WorkspaceImageIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1WorkspaceProperties = (
@@ -5732,11 +5670,9 @@ const serializeAws_json1_1WorkspaceRequestList = (
   input: WorkspaceRequest[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1WorkspaceRequest(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_json1_1WorkspaceRequest(entry, context)
+  );
 };
 
 const deserializeAws_json1_1AccessDeniedException = (

--- a/clients/client-xray/protocols/Aws_restJson1_1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1_1.ts
@@ -2592,13 +2592,9 @@ const serializeAws_restJson1_1SamplingStatisticsDocumentList = (
   input: SamplingStatisticsDocument[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(
-      serializeAws_restJson1_1SamplingStatisticsDocument(entry, context)
-    );
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1SamplingStatisticsDocument(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1SamplingStrategy = (
@@ -2650,33 +2646,23 @@ const serializeAws_restJson1_1TelemetryRecordList = (
   input: TelemetryRecord[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1TelemetryRecord(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1TelemetryRecord(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1TraceIdList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TraceSegmentDocumentList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const deserializeAws_restJson1_1Alias = (

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -58,11 +58,9 @@ final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
         TypeScriptWriter writer = context.getWriter();
         Shape target = context.getModel().expectShape(shape.getMember().getTarget());
 
-        writer.write("const contents = [];");
-        writer.openBlock("for (let entry of input) {", "}", () ->
+        writer.openBlock("return input.map(entry => ", ");", () ->
                 // Dispatch to the input value provider for any additional handling.
-                writer.write("contents.push($L);", target.accept(getMemberVisitor("entry"))));
-        writer.write("return contents;");
+                writer.write("$L", target.accept(getMemberVisitor("entry"))));
     }
 
     @Override

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -427,55 +427,35 @@ const serializeAws_json1_1ListOfKitchenSinks = (
   input: KitchenSink[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1KitchenSink(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1KitchenSink(entry, context));
 };
 
 const serializeAws_json1_1ListOfListOfStrings = (
   input: string[][],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1ListOfStrings(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1ListOfStrings(entry, context));
 };
 
 const serializeAws_json1_1ListOfMapsOfStrings = (
   input: { [key: string]: string }[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1MapOfStrings(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1MapOfStrings(entry, context));
 };
 
 const serializeAws_json1_1ListOfStrings = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_json1_1ListOfStructs = (
   input: SimpleStruct[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_json1_1SimpleStruct(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_json1_1SimpleStruct(entry, context));
 };
 
 const serializeAws_json1_1MapOfKitchenSinks = (

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1_1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1_1.ts
@@ -3141,11 +3141,9 @@ const serializeAws_restJson1_1StructureList = (
   input: StructureListMember[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1StructureListMember(entry, context));
-  }
-  return contents;
+  return input.map(entry =>
+    serializeAws_restJson1_1StructureListMember(entry, context)
+  );
 };
 
 const serializeAws_restJson1_1StructureListMember = (
@@ -3166,22 +3164,14 @@ const serializeAws_restJson1_1BooleanList = (
   input: boolean[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1FooEnumList = (
   input: (FooEnum | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1FooEnumMap = (
@@ -3198,11 +3188,7 @@ const serializeAws_restJson1_1FooEnumSet = (
   input: (FooEnum | string)[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1GreetingStruct = (
@@ -3220,55 +3206,35 @@ const serializeAws_restJson1_1IntegerList = (
   input: number[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1NestedStringList = (
   input: string[][],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(serializeAws_restJson1_1StringList(entry, context));
-  }
-  return contents;
+  return input.map(entry => serializeAws_restJson1_1StringList(entry, context));
 };
 
 const serializeAws_restJson1_1StringList = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1StringSet = (
   input: string[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(entry);
-  }
-  return contents;
+  return input.map(entry => entry);
 };
 
 const serializeAws_restJson1_1TimestampList = (
   input: Date[],
   context: __SerdeContext
 ): any => {
-  const contents = [];
-  for (let entry of input) {
-    contents.push(Math.round(entry.getTime() / 1000));
-  }
-  return contents;
+  return input.map(entry => Math.round(entry.getTime() / 1000));
 };
 
 const deserializeAws_restJson1_1ComplexNestedErrorData = (


### PR DESCRIPTION
*Issue #, if available:*
Similar to https://github.com/aws/aws-sdk-js-v3/pull/1153

*Description of changes:*
removes contents from JsonShape serializeCollection

Before:
```typescript
const serializeAws_restJson1_1InlineArchiveRulesList = (
  input: InlineArchiveRule[],
  context: __SerdeContext
): any => {
  const contents = [];
  for (let entry of input) {
    contents.push(serializeAws_restJson1_1InlineArchiveRule(entry, context));
  }
  return contents;
};
```

After:
```typescript
const serializeAws_restJson1_1InlineArchiveRulesList = (
  input: InlineArchiveRule[],
  context: __SerdeContext
): any => {
  return input.map(entry =>
    serializeAws_restJson1_1InlineArchiveRule(entry, context)
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
