### PR TITLE
chore: remove bodyParams from restJson serInputDocument

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
@@ -114,29 +114,22 @@ export const serializeAws_restJson1_1CreateAnalyzerCommand = async (
   };
   let resolvedPath = "/analyzer";
   let body: any;
-  const bodyParams: any = {};
-  if (input.analyzerName !== undefined) {
-    bodyParams["analyzerName"] = input.analyzerName;
-  }
-  if (input.archiveRules !== undefined) {
-    bodyParams["archiveRules"] = serializeAws_restJson1_1InlineArchiveRulesList(
-      input.archiveRules,
-      context
-    );
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagsMap(input.tags, context);
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.analyzerName !== undefined && {
+      analyzerName: input.analyzerName
+    }),
+    ...(input.archiveRules !== undefined && {
+      archiveRules: serializeAws_restJson1_1InlineArchiveRulesList(
+        input.archiveRules,
+        context
+      )
+    }),
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagsMap(input.tags, context)
+    }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -172,23 +165,13 @@ export const serializeAws_restJson1_1CreateArchiveRuleCommand = async (
     throw new Error("No value provided for input HTTP label: analyzerName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.filter !== undefined) {
-    bodyParams["filter"] = serializeAws_restJson1_1FilterCriteriaMap(
-      input.filter,
-      context
-    );
-  }
-  if (input.ruleName !== undefined) {
-    bodyParams["ruleName"] = input.ruleName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.filter !== undefined && {
+      filter: serializeAws_restJson1_1FilterCriteriaMap(input.filter, context)
+    }),
+    ...(input.ruleName !== undefined && { ruleName: input.ruleName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -445,20 +428,14 @@ export const serializeAws_restJson1_1ListAnalyzedResourcesCommand = async (
   };
   let resolvedPath = "/analyzed-resource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.analyzerArn !== undefined) {
-    bodyParams["analyzerArn"] = input.analyzerArn;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.resourceType !== undefined) {
-    bodyParams["resourceType"] = input.resourceType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.analyzerArn !== undefined && { analyzerArn: input.analyzerArn }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.resourceType !== undefined && {
+      resourceType: input.resourceType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -551,29 +528,17 @@ export const serializeAws_restJson1_1ListFindingsCommand = async (
   };
   let resolvedPath = "/finding";
   let body: any;
-  const bodyParams: any = {};
-  if (input.analyzerArn !== undefined) {
-    bodyParams["analyzerArn"] = input.analyzerArn;
-  }
-  if (input.filter !== undefined) {
-    bodyParams["filter"] = serializeAws_restJson1_1FilterCriteriaMap(
-      input.filter,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.sort !== undefined) {
-    bodyParams["sort"] = serializeAws_restJson1_1SortCriteria(
-      input.sort,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.analyzerArn !== undefined && { analyzerArn: input.analyzerArn }),
+    ...(input.filter !== undefined && {
+      filter: serializeAws_restJson1_1FilterCriteriaMap(input.filter, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.sort !== undefined && {
+      sort: serializeAws_restJson1_1SortCriteria(input.sort, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -630,14 +595,10 @@ export const serializeAws_restJson1_1StartResourceScanCommand = async (
   };
   let resolvedPath = "/resource/scan";
   let body: any;
-  const bodyParams: any = {};
-  if (input.analyzerArn !== undefined) {
-    bodyParams["analyzerArn"] = input.analyzerArn;
-  }
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.analyzerArn !== undefined && { analyzerArn: input.analyzerArn }),
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -673,11 +634,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagsMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagsMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -766,20 +727,12 @@ export const serializeAws_restJson1_1UpdateArchiveRuleCommand = async (
     throw new Error("No value provided for input HTTP label: ruleName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.filter !== undefined) {
-    bodyParams["filter"] = serializeAws_restJson1_1FilterCriteriaMap(
-      input.filter,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.filter !== undefined && {
+      filter: serializeAws_restJson1_1FilterCriteriaMap(input.filter, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -801,29 +754,15 @@ export const serializeAws_restJson1_1UpdateFindingsCommand = async (
   };
   let resolvedPath = "/finding";
   let body: any;
-  const bodyParams: any = {};
-  if (input.analyzerArn !== undefined) {
-    bodyParams["analyzerArn"] = input.analyzerArn;
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.ids !== undefined) {
-    bodyParams["ids"] = serializeAws_restJson1_1FindingIdList(
-      input.ids,
-      context
-    );
-  }
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.analyzerArn !== undefined && { analyzerArn: input.analyzerArn }),
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.ids !== undefined && {
+      ids: serializeAws_restJson1_1FindingIdList(input.ids, context)
+    }),
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.status !== undefined && { status: input.status })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-amplify/protocols/Aws_restJson1_1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1_1.ts
@@ -193,77 +193,57 @@ export const serializeAws_restJson1_1CreateAppCommand = async (
   };
   let resolvedPath = "/apps";
   let body: any;
-  const bodyParams: any = {};
-  if (input.accessToken !== undefined) {
-    bodyParams["accessToken"] = input.accessToken;
-  }
-  if (input.autoBranchCreationConfig !== undefined) {
-    bodyParams[
-      "autoBranchCreationConfig"
-    ] = serializeAws_restJson1_1AutoBranchCreationConfig(
-      input.autoBranchCreationConfig,
-      context
-    );
-  }
-  if (input.autoBranchCreationPatterns !== undefined) {
-    bodyParams[
-      "autoBranchCreationPatterns"
-    ] = serializeAws_restJson1_1AutoBranchCreationPatterns(
-      input.autoBranchCreationPatterns,
-      context
-    );
-  }
-  if (input.basicAuthCredentials !== undefined) {
-    bodyParams["basicAuthCredentials"] = input.basicAuthCredentials;
-  }
-  if (input.buildSpec !== undefined) {
-    bodyParams["buildSpec"] = input.buildSpec;
-  }
-  if (input.customRules !== undefined) {
-    bodyParams["customRules"] = serializeAws_restJson1_1CustomRules(
-      input.customRules,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.enableAutoBranchCreation !== undefined) {
-    bodyParams["enableAutoBranchCreation"] = input.enableAutoBranchCreation;
-  }
-  if (input.enableBasicAuth !== undefined) {
-    bodyParams["enableBasicAuth"] = input.enableBasicAuth;
-  }
-  if (input.enableBranchAutoBuild !== undefined) {
-    bodyParams["enableBranchAutoBuild"] = input.enableBranchAutoBuild;
-  }
-  if (input.environmentVariables !== undefined) {
-    bodyParams[
-      "environmentVariables"
-    ] = serializeAws_restJson1_1EnvironmentVariables(
-      input.environmentVariables,
-      context
-    );
-  }
-  if (input.iamServiceRoleArn !== undefined) {
-    bodyParams["iamServiceRoleArn"] = input.iamServiceRoleArn;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.oauthToken !== undefined) {
-    bodyParams["oauthToken"] = input.oauthToken;
-  }
-  if (input.platform !== undefined) {
-    bodyParams["platform"] = input.platform;
-  }
-  if (input.repository !== undefined) {
-    bodyParams["repository"] = input.repository;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.accessToken !== undefined && { accessToken: input.accessToken }),
+    ...(input.autoBranchCreationConfig !== undefined && {
+      autoBranchCreationConfig: serializeAws_restJson1_1AutoBranchCreationConfig(
+        input.autoBranchCreationConfig,
+        context
+      )
+    }),
+    ...(input.autoBranchCreationPatterns !== undefined && {
+      autoBranchCreationPatterns: serializeAws_restJson1_1AutoBranchCreationPatterns(
+        input.autoBranchCreationPatterns,
+        context
+      )
+    }),
+    ...(input.basicAuthCredentials !== undefined && {
+      basicAuthCredentials: input.basicAuthCredentials
+    }),
+    ...(input.buildSpec !== undefined && { buildSpec: input.buildSpec }),
+    ...(input.customRules !== undefined && {
+      customRules: serializeAws_restJson1_1CustomRules(
+        input.customRules,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.enableAutoBranchCreation !== undefined && {
+      enableAutoBranchCreation: input.enableAutoBranchCreation
+    }),
+    ...(input.enableBasicAuth !== undefined && {
+      enableBasicAuth: input.enableBasicAuth
+    }),
+    ...(input.enableBranchAutoBuild !== undefined && {
+      enableBranchAutoBuild: input.enableBranchAutoBuild
+    }),
+    ...(input.environmentVariables !== undefined && {
+      environmentVariables: serializeAws_restJson1_1EnvironmentVariables(
+        input.environmentVariables,
+        context
+      )
+    }),
+    ...(input.iamServiceRoleArn !== undefined && {
+      iamServiceRoleArn: input.iamServiceRoleArn
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.oauthToken !== undefined && { oauthToken: input.oauthToken }),
+    ...(input.platform !== undefined && { platform: input.platform }),
+    ...(input.repository !== undefined && { repository: input.repository }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -297,17 +277,15 @@ export const serializeAws_restJson1_1CreateBackendEnvironmentCommand = async (
     throw new Error("No value provided for input HTTP label: appId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.deploymentArtifacts !== undefined) {
-    bodyParams["deploymentArtifacts"] = input.deploymentArtifacts;
-  }
-  if (input.environmentName !== undefined) {
-    bodyParams["environmentName"] = input.environmentName;
-  }
-  if (input.stackName !== undefined) {
-    bodyParams["stackName"] = input.stackName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.deploymentArtifacts !== undefined && {
+      deploymentArtifacts: input.deploymentArtifacts
+    }),
+    ...(input.environmentName !== undefined && {
+      environmentName: input.environmentName
+    }),
+    ...(input.stackName !== undefined && { stackName: input.stackName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -341,61 +319,45 @@ export const serializeAws_restJson1_1CreateBranchCommand = async (
     throw new Error("No value provided for input HTTP label: appId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.backendEnvironmentArn !== undefined) {
-    bodyParams["backendEnvironmentArn"] = input.backendEnvironmentArn;
-  }
-  if (input.basicAuthCredentials !== undefined) {
-    bodyParams["basicAuthCredentials"] = input.basicAuthCredentials;
-  }
-  if (input.branchName !== undefined) {
-    bodyParams["branchName"] = input.branchName;
-  }
-  if (input.buildSpec !== undefined) {
-    bodyParams["buildSpec"] = input.buildSpec;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.displayName !== undefined) {
-    bodyParams["displayName"] = input.displayName;
-  }
-  if (input.enableAutoBuild !== undefined) {
-    bodyParams["enableAutoBuild"] = input.enableAutoBuild;
-  }
-  if (input.enableBasicAuth !== undefined) {
-    bodyParams["enableBasicAuth"] = input.enableBasicAuth;
-  }
-  if (input.enableNotification !== undefined) {
-    bodyParams["enableNotification"] = input.enableNotification;
-  }
-  if (input.enablePullRequestPreview !== undefined) {
-    bodyParams["enablePullRequestPreview"] = input.enablePullRequestPreview;
-  }
-  if (input.environmentVariables !== undefined) {
-    bodyParams[
-      "environmentVariables"
-    ] = serializeAws_restJson1_1EnvironmentVariables(
-      input.environmentVariables,
-      context
-    );
-  }
-  if (input.framework !== undefined) {
-    bodyParams["framework"] = input.framework;
-  }
-  if (input.pullRequestEnvironmentName !== undefined) {
-    bodyParams["pullRequestEnvironmentName"] = input.pullRequestEnvironmentName;
-  }
-  if (input.stage !== undefined) {
-    bodyParams["stage"] = input.stage;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.ttl !== undefined) {
-    bodyParams["ttl"] = input.ttl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.backendEnvironmentArn !== undefined && {
+      backendEnvironmentArn: input.backendEnvironmentArn
+    }),
+    ...(input.basicAuthCredentials !== undefined && {
+      basicAuthCredentials: input.basicAuthCredentials
+    }),
+    ...(input.branchName !== undefined && { branchName: input.branchName }),
+    ...(input.buildSpec !== undefined && { buildSpec: input.buildSpec }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.displayName !== undefined && { displayName: input.displayName }),
+    ...(input.enableAutoBuild !== undefined && {
+      enableAutoBuild: input.enableAutoBuild
+    }),
+    ...(input.enableBasicAuth !== undefined && {
+      enableBasicAuth: input.enableBasicAuth
+    }),
+    ...(input.enableNotification !== undefined && {
+      enableNotification: input.enableNotification
+    }),
+    ...(input.enablePullRequestPreview !== undefined && {
+      enablePullRequestPreview: input.enablePullRequestPreview
+    }),
+    ...(input.environmentVariables !== undefined && {
+      environmentVariables: serializeAws_restJson1_1EnvironmentVariables(
+        input.environmentVariables,
+        context
+      )
+    }),
+    ...(input.framework !== undefined && { framework: input.framework }),
+    ...(input.pullRequestEnvironmentName !== undefined && {
+      pullRequestEnvironmentName: input.pullRequestEnvironmentName
+    }),
+    ...(input.stage !== undefined && { stage: input.stage }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.ttl !== undefined && { ttl: input.ttl })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -441,14 +403,11 @@ export const serializeAws_restJson1_1CreateDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.fileMap !== undefined) {
-    bodyParams["fileMap"] = serializeAws_restJson1_1FileMap(
-      input.fileMap,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.fileMap !== undefined && {
+      fileMap: serializeAws_restJson1_1FileMap(input.fileMap, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -482,20 +441,18 @@ export const serializeAws_restJson1_1CreateDomainAssociationCommand = async (
     throw new Error("No value provided for input HTTP label: appId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.domainName !== undefined) {
-    bodyParams["domainName"] = input.domainName;
-  }
-  if (input.enableAutoSubDomain !== undefined) {
-    bodyParams["enableAutoSubDomain"] = input.enableAutoSubDomain;
-  }
-  if (input.subDomainSettings !== undefined) {
-    bodyParams["subDomainSettings"] = serializeAws_restJson1_1SubDomainSettings(
-      input.subDomainSettings,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.domainName !== undefined && { domainName: input.domainName }),
+    ...(input.enableAutoSubDomain !== undefined && {
+      enableAutoSubDomain: input.enableAutoSubDomain
+    }),
+    ...(input.subDomainSettings !== undefined && {
+      subDomainSettings: serializeAws_restJson1_1SubDomainSettings(
+        input.subDomainSettings,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -529,14 +486,10 @@ export const serializeAws_restJson1_1CreateWebhookCommand = async (
     throw new Error("No value provided for input HTTP label: appId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.branchName !== undefined) {
-    bodyParams["branchName"] = input.branchName;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.branchName !== undefined && { branchName: input.branchName }),
+    ...(input.description !== undefined && { description: input.description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -830,17 +783,15 @@ export const serializeAws_restJson1_1GenerateAccessLogsCommand = async (
     throw new Error("No value provided for input HTTP label: appId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.domainName !== undefined) {
-    bodyParams["domainName"] = input.domainName;
-  }
-  if (input.endTime !== undefined) {
-    bodyParams["endTime"] = Math.round(input.endTime.getTime() / 1000);
-  }
-  if (input.startTime !== undefined) {
-    bodyParams["startTime"] = Math.round(input.startTime.getTime() / 1000);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.domainName !== undefined && { domainName: input.domainName }),
+    ...(input.endTime !== undefined && {
+      endTime: Math.round(input.endTime.getTime() / 1000)
+    }),
+    ...(input.startTime !== undefined && {
+      startTime: Math.round(input.startTime.getTime() / 1000)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1266,11 +1217,11 @@ export const serializeAws_restJson1_1ListBackendEnvironmentsCommand = async (
     ...(input.nextToken !== undefined && { nextToken: input.nextToken })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.environmentName !== undefined) {
-    bodyParams["environmentName"] = input.environmentName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.environmentName !== undefined && {
+      environmentName: input.environmentName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1524,14 +1475,10 @@ export const serializeAws_restJson1_1StartDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobId !== undefined) {
-    bodyParams["jobId"] = input.jobId;
-  }
-  if (input.sourceUrl !== undefined) {
-    bodyParams["sourceUrl"] = input.sourceUrl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobId !== undefined && { jobId: input.jobId }),
+    ...(input.sourceUrl !== undefined && { sourceUrl: input.sourceUrl })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1577,26 +1524,18 @@ export const serializeAws_restJson1_1StartJobCommand = async (
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.commitId !== undefined) {
-    bodyParams["commitId"] = input.commitId;
-  }
-  if (input.commitMessage !== undefined) {
-    bodyParams["commitMessage"] = input.commitMessage;
-  }
-  if (input.commitTime !== undefined) {
-    bodyParams["commitTime"] = Math.round(input.commitTime.getTime() / 1000);
-  }
-  if (input.jobId !== undefined) {
-    bodyParams["jobId"] = input.jobId;
-  }
-  if (input.jobReason !== undefined) {
-    bodyParams["jobReason"] = input.jobReason;
-  }
-  if (input.jobType !== undefined) {
-    bodyParams["jobType"] = input.jobType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.commitId !== undefined && { commitId: input.commitId }),
+    ...(input.commitMessage !== undefined && {
+      commitMessage: input.commitMessage
+    }),
+    ...(input.commitTime !== undefined && {
+      commitTime: Math.round(input.commitTime.getTime() / 1000)
+    }),
+    ...(input.jobId !== undefined && { jobId: input.jobId }),
+    ...(input.jobReason !== undefined && { jobReason: input.jobReason }),
+    ...(input.jobType !== undefined && { jobType: input.jobType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1689,11 +1628,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1768,74 +1707,54 @@ export const serializeAws_restJson1_1UpdateAppCommand = async (
     throw new Error("No value provided for input HTTP label: appId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.accessToken !== undefined) {
-    bodyParams["accessToken"] = input.accessToken;
-  }
-  if (input.autoBranchCreationConfig !== undefined) {
-    bodyParams[
-      "autoBranchCreationConfig"
-    ] = serializeAws_restJson1_1AutoBranchCreationConfig(
-      input.autoBranchCreationConfig,
-      context
-    );
-  }
-  if (input.autoBranchCreationPatterns !== undefined) {
-    bodyParams[
-      "autoBranchCreationPatterns"
-    ] = serializeAws_restJson1_1AutoBranchCreationPatterns(
-      input.autoBranchCreationPatterns,
-      context
-    );
-  }
-  if (input.basicAuthCredentials !== undefined) {
-    bodyParams["basicAuthCredentials"] = input.basicAuthCredentials;
-  }
-  if (input.buildSpec !== undefined) {
-    bodyParams["buildSpec"] = input.buildSpec;
-  }
-  if (input.customRules !== undefined) {
-    bodyParams["customRules"] = serializeAws_restJson1_1CustomRules(
-      input.customRules,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.enableAutoBranchCreation !== undefined) {
-    bodyParams["enableAutoBranchCreation"] = input.enableAutoBranchCreation;
-  }
-  if (input.enableBasicAuth !== undefined) {
-    bodyParams["enableBasicAuth"] = input.enableBasicAuth;
-  }
-  if (input.enableBranchAutoBuild !== undefined) {
-    bodyParams["enableBranchAutoBuild"] = input.enableBranchAutoBuild;
-  }
-  if (input.environmentVariables !== undefined) {
-    bodyParams[
-      "environmentVariables"
-    ] = serializeAws_restJson1_1EnvironmentVariables(
-      input.environmentVariables,
-      context
-    );
-  }
-  if (input.iamServiceRoleArn !== undefined) {
-    bodyParams["iamServiceRoleArn"] = input.iamServiceRoleArn;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.oauthToken !== undefined) {
-    bodyParams["oauthToken"] = input.oauthToken;
-  }
-  if (input.platform !== undefined) {
-    bodyParams["platform"] = input.platform;
-  }
-  if (input.repository !== undefined) {
-    bodyParams["repository"] = input.repository;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.accessToken !== undefined && { accessToken: input.accessToken }),
+    ...(input.autoBranchCreationConfig !== undefined && {
+      autoBranchCreationConfig: serializeAws_restJson1_1AutoBranchCreationConfig(
+        input.autoBranchCreationConfig,
+        context
+      )
+    }),
+    ...(input.autoBranchCreationPatterns !== undefined && {
+      autoBranchCreationPatterns: serializeAws_restJson1_1AutoBranchCreationPatterns(
+        input.autoBranchCreationPatterns,
+        context
+      )
+    }),
+    ...(input.basicAuthCredentials !== undefined && {
+      basicAuthCredentials: input.basicAuthCredentials
+    }),
+    ...(input.buildSpec !== undefined && { buildSpec: input.buildSpec }),
+    ...(input.customRules !== undefined && {
+      customRules: serializeAws_restJson1_1CustomRules(
+        input.customRules,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.enableAutoBranchCreation !== undefined && {
+      enableAutoBranchCreation: input.enableAutoBranchCreation
+    }),
+    ...(input.enableBasicAuth !== undefined && {
+      enableBasicAuth: input.enableBasicAuth
+    }),
+    ...(input.enableBranchAutoBuild !== undefined && {
+      enableBranchAutoBuild: input.enableBranchAutoBuild
+    }),
+    ...(input.environmentVariables !== undefined && {
+      environmentVariables: serializeAws_restJson1_1EnvironmentVariables(
+        input.environmentVariables,
+        context
+      )
+    }),
+    ...(input.iamServiceRoleArn !== undefined && {
+      iamServiceRoleArn: input.iamServiceRoleArn
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.oauthToken !== undefined && { oauthToken: input.oauthToken }),
+    ...(input.platform !== undefined && { platform: input.platform }),
+    ...(input.repository !== undefined && { repository: input.repository })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1881,55 +1800,41 @@ export const serializeAws_restJson1_1UpdateBranchCommand = async (
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.backendEnvironmentArn !== undefined) {
-    bodyParams["backendEnvironmentArn"] = input.backendEnvironmentArn;
-  }
-  if (input.basicAuthCredentials !== undefined) {
-    bodyParams["basicAuthCredentials"] = input.basicAuthCredentials;
-  }
-  if (input.buildSpec !== undefined) {
-    bodyParams["buildSpec"] = input.buildSpec;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.displayName !== undefined) {
-    bodyParams["displayName"] = input.displayName;
-  }
-  if (input.enableAutoBuild !== undefined) {
-    bodyParams["enableAutoBuild"] = input.enableAutoBuild;
-  }
-  if (input.enableBasicAuth !== undefined) {
-    bodyParams["enableBasicAuth"] = input.enableBasicAuth;
-  }
-  if (input.enableNotification !== undefined) {
-    bodyParams["enableNotification"] = input.enableNotification;
-  }
-  if (input.enablePullRequestPreview !== undefined) {
-    bodyParams["enablePullRequestPreview"] = input.enablePullRequestPreview;
-  }
-  if (input.environmentVariables !== undefined) {
-    bodyParams[
-      "environmentVariables"
-    ] = serializeAws_restJson1_1EnvironmentVariables(
-      input.environmentVariables,
-      context
-    );
-  }
-  if (input.framework !== undefined) {
-    bodyParams["framework"] = input.framework;
-  }
-  if (input.pullRequestEnvironmentName !== undefined) {
-    bodyParams["pullRequestEnvironmentName"] = input.pullRequestEnvironmentName;
-  }
-  if (input.stage !== undefined) {
-    bodyParams["stage"] = input.stage;
-  }
-  if (input.ttl !== undefined) {
-    bodyParams["ttl"] = input.ttl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.backendEnvironmentArn !== undefined && {
+      backendEnvironmentArn: input.backendEnvironmentArn
+    }),
+    ...(input.basicAuthCredentials !== undefined && {
+      basicAuthCredentials: input.basicAuthCredentials
+    }),
+    ...(input.buildSpec !== undefined && { buildSpec: input.buildSpec }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.displayName !== undefined && { displayName: input.displayName }),
+    ...(input.enableAutoBuild !== undefined && {
+      enableAutoBuild: input.enableAutoBuild
+    }),
+    ...(input.enableBasicAuth !== undefined && {
+      enableBasicAuth: input.enableBasicAuth
+    }),
+    ...(input.enableNotification !== undefined && {
+      enableNotification: input.enableNotification
+    }),
+    ...(input.enablePullRequestPreview !== undefined && {
+      enablePullRequestPreview: input.enablePullRequestPreview
+    }),
+    ...(input.environmentVariables !== undefined && {
+      environmentVariables: serializeAws_restJson1_1EnvironmentVariables(
+        input.environmentVariables,
+        context
+      )
+    }),
+    ...(input.framework !== undefined && { framework: input.framework }),
+    ...(input.pullRequestEnvironmentName !== undefined && {
+      pullRequestEnvironmentName: input.pullRequestEnvironmentName
+    }),
+    ...(input.stage !== undefined && { stage: input.stage }),
+    ...(input.ttl !== undefined && { ttl: input.ttl })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1975,17 +1880,17 @@ export const serializeAws_restJson1_1UpdateDomainAssociationCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.enableAutoSubDomain !== undefined) {
-    bodyParams["enableAutoSubDomain"] = input.enableAutoSubDomain;
-  }
-  if (input.subDomainSettings !== undefined) {
-    bodyParams["subDomainSettings"] = serializeAws_restJson1_1SubDomainSettings(
-      input.subDomainSettings,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.enableAutoSubDomain !== undefined && {
+      enableAutoSubDomain: input.enableAutoSubDomain
+    }),
+    ...(input.subDomainSettings !== undefined && {
+      subDomainSettings: serializeAws_restJson1_1SubDomainSettings(
+        input.subDomainSettings,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2019,14 +1924,10 @@ export const serializeAws_restJson1_1UpdateWebhookCommand = async (
     throw new Error("No value provided for input HTTP label: webhookId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.branchName !== undefined) {
-    bodyParams["branchName"] = input.branchName;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.branchName !== undefined && { branchName: input.branchName }),
+    ...(input.description !== undefined && { description: input.description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
@@ -547,50 +547,33 @@ export const serializeAws_restJson1_1CreateApiKeyCommand = async (
   };
   let resolvedPath = "/apikeys";
   let body: any;
-  const bodyParams: any = {};
-  if (input.customerId !== undefined) {
-    bodyParams["customerId"] = input.customerId;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.enabled !== undefined) {
-    bodyParams["enabled"] = input.enabled;
-  }
-  if (input.generateDistinctId !== undefined) {
-    bodyParams["generateDistinctId"] = input.generateDistinctId;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.stageKeys !== undefined) {
-    bodyParams["stageKeys"] = serializeAws_restJson1_1ListOfStageKeys(
-      input.stageKeys,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  if (input.value !== undefined) {
-    bodyParams["value"] = input.value;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.customerId !== undefined && { customerId: input.customerId }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.enabled !== undefined && { enabled: input.enabled }),
+    ...(input.generateDistinctId !== undefined && {
+      generateDistinctId: input.generateDistinctId
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.stageKeys !== undefined && {
+      stageKeys: serializeAws_restJson1_1ListOfStageKeys(
+        input.stageKeys,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title }),
+    ...(input.value !== undefined && { value: input.value })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -624,52 +607,40 @@ export const serializeAws_restJson1_1CreateAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.authType !== undefined) {
-    bodyParams["authType"] = input.authType;
-  }
-  if (input.authorizerCredentials !== undefined) {
-    bodyParams["authorizerCredentials"] = input.authorizerCredentials;
-  }
-  if (input.authorizerResultTtlInSeconds !== undefined) {
-    bodyParams["authorizerResultTtlInSeconds"] =
-      input.authorizerResultTtlInSeconds;
-  }
-  if (input.authorizerUri !== undefined) {
-    bodyParams["authorizerUri"] = input.authorizerUri;
-  }
-  if (input.identitySource !== undefined) {
-    bodyParams["identitySource"] = input.identitySource;
-  }
-  if (input.identityValidationExpression !== undefined) {
-    bodyParams["identityValidationExpression"] =
-      input.identityValidationExpression;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.providerARNs !== undefined) {
-    bodyParams["providerARNs"] = serializeAws_restJson1_1ListOfARNs(
-      input.providerARNs,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.authType !== undefined && { authType: input.authType }),
+    ...(input.authorizerCredentials !== undefined && {
+      authorizerCredentials: input.authorizerCredentials
+    }),
+    ...(input.authorizerResultTtlInSeconds !== undefined && {
+      authorizerResultTtlInSeconds: input.authorizerResultTtlInSeconds
+    }),
+    ...(input.authorizerUri !== undefined && {
+      authorizerUri: input.authorizerUri
+    }),
+    ...(input.identitySource !== undefined && {
+      identitySource: input.identitySource
+    }),
+    ...(input.identityValidationExpression !== undefined && {
+      identityValidationExpression: input.identityValidationExpression
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.providerARNs !== undefined && {
+      providerARNs: serializeAws_restJson1_1ListOfARNs(
+        input.providerARNs,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -703,32 +674,20 @@ export const serializeAws_restJson1_1CreateBasePathMappingCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.basePath !== undefined) {
-    bodyParams["basePath"] = input.basePath;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.restApiId !== undefined) {
-    bodyParams["restApiId"] = input.restApiId;
-  }
-  if (input.stage !== undefined) {
-    bodyParams["stage"] = input.stage;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.basePath !== undefined && { basePath: input.basePath }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.restApiId !== undefined && { restApiId: input.restApiId }),
+    ...(input.stage !== undefined && { stage: input.stage }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -762,55 +721,43 @@ export const serializeAws_restJson1_1CreateDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.cacheClusterEnabled !== undefined) {
-    bodyParams["cacheClusterEnabled"] = input.cacheClusterEnabled;
-  }
-  if (input.cacheClusterSize !== undefined) {
-    bodyParams["cacheClusterSize"] = input.cacheClusterSize;
-  }
-  if (input.canarySettings !== undefined) {
-    bodyParams[
-      "canarySettings"
-    ] = serializeAws_restJson1_1DeploymentCanarySettings(
-      input.canarySettings,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.stageDescription !== undefined) {
-    bodyParams["stageDescription"] = input.stageDescription;
-  }
-  if (input.stageName !== undefined) {
-    bodyParams["stageName"] = input.stageName;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  if (input.tracingEnabled !== undefined) {
-    bodyParams["tracingEnabled"] = input.tracingEnabled;
-  }
-  if (input.variables !== undefined) {
-    bodyParams["variables"] = serializeAws_restJson1_1MapOfStringToString(
-      input.variables,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.cacheClusterEnabled !== undefined && {
+      cacheClusterEnabled: input.cacheClusterEnabled
+    }),
+    ...(input.cacheClusterSize !== undefined && {
+      cacheClusterSize: input.cacheClusterSize
+    }),
+    ...(input.canarySettings !== undefined && {
+      canarySettings: serializeAws_restJson1_1DeploymentCanarySettings(
+        input.canarySettings,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.stageDescription !== undefined && {
+      stageDescription: input.stageDescription
+    }),
+    ...(input.stageName !== undefined && { stageName: input.stageName }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title }),
+    ...(input.tracingEnabled !== undefined && {
+      tracingEnabled: input.tracingEnabled
+    }),
+    ...(input.variables !== undefined && {
+      variables: serializeAws_restJson1_1MapOfStringToString(
+        input.variables,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -844,32 +791,24 @@ export const serializeAws_restJson1_1CreateDocumentationPartCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.location !== undefined) {
-    bodyParams["location"] = serializeAws_restJson1_1DocumentationPartLocation(
-      input.location,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.properties !== undefined) {
-    bodyParams["properties"] = input.properties;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.location !== undefined && {
+      location: serializeAws_restJson1_1DocumentationPartLocation(
+        input.location,
+        context
+      )
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.properties !== undefined && { properties: input.properties }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -903,32 +842,22 @@ export const serializeAws_restJson1_1CreateDocumentationVersionCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.documentationVersion !== undefined) {
-    bodyParams["documentationVersion"] = input.documentationVersion;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.stageName !== undefined) {
-    bodyParams["stageName"] = input.stageName;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.documentationVersion !== undefined && {
+      documentationVersion: input.documentationVersion
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.stageName !== undefined && { stageName: input.stageName }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -950,64 +879,51 @@ export const serializeAws_restJson1_1CreateDomainNameCommand = async (
   };
   let resolvedPath = "/domainnames";
   let body: any;
-  const bodyParams: any = {};
-  if (input.certificateArn !== undefined) {
-    bodyParams["certificateArn"] = input.certificateArn;
-  }
-  if (input.certificateBody !== undefined) {
-    bodyParams["certificateBody"] = input.certificateBody;
-  }
-  if (input.certificateChain !== undefined) {
-    bodyParams["certificateChain"] = input.certificateChain;
-  }
-  if (input.certificateName !== undefined) {
-    bodyParams["certificateName"] = input.certificateName;
-  }
-  if (input.certificatePrivateKey !== undefined) {
-    bodyParams["certificatePrivateKey"] = input.certificatePrivateKey;
-  }
-  if (input.domainName !== undefined) {
-    bodyParams["domainName"] = input.domainName;
-  }
-  if (input.endpointConfiguration !== undefined) {
-    bodyParams[
-      "endpointConfiguration"
-    ] = serializeAws_restJson1_1EndpointConfiguration(
-      input.endpointConfiguration,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.regionalCertificateArn !== undefined) {
-    bodyParams["regionalCertificateArn"] = input.regionalCertificateArn;
-  }
-  if (input.regionalCertificateName !== undefined) {
-    bodyParams["regionalCertificateName"] = input.regionalCertificateName;
-  }
-  if (input.securityPolicy !== undefined) {
-    bodyParams["securityPolicy"] = input.securityPolicy;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.certificateArn !== undefined && {
+      certificateArn: input.certificateArn
+    }),
+    ...(input.certificateBody !== undefined && {
+      certificateBody: input.certificateBody
+    }),
+    ...(input.certificateChain !== undefined && {
+      certificateChain: input.certificateChain
+    }),
+    ...(input.certificateName !== undefined && {
+      certificateName: input.certificateName
+    }),
+    ...(input.certificatePrivateKey !== undefined && {
+      certificatePrivateKey: input.certificatePrivateKey
+    }),
+    ...(input.domainName !== undefined && { domainName: input.domainName }),
+    ...(input.endpointConfiguration !== undefined && {
+      endpointConfiguration: serializeAws_restJson1_1EndpointConfiguration(
+        input.endpointConfiguration,
+        context
+      )
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.regionalCertificateArn !== undefined && {
+      regionalCertificateArn: input.regionalCertificateArn
+    }),
+    ...(input.regionalCertificateName !== undefined && {
+      regionalCertificateName: input.regionalCertificateName
+    }),
+    ...(input.securityPolicy !== undefined && {
+      securityPolicy: input.securityPolicy
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1041,32 +957,20 @@ export const serializeAws_restJson1_1CreateModelCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.contentType !== undefined) {
-    bodyParams["contentType"] = input.contentType;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.schema !== undefined) {
-    bodyParams["schema"] = input.schema;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.contentType !== undefined && { contentType: input.contentType }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.schema !== undefined && { schema: input.schema }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1100,29 +1004,23 @@ export const serializeAws_restJson1_1CreateRequestValidatorCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  if (input.validateRequestBody !== undefined) {
-    bodyParams["validateRequestBody"] = input.validateRequestBody;
-  }
-  if (input.validateRequestParameters !== undefined) {
-    bodyParams["validateRequestParameters"] = input.validateRequestParameters;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title }),
+    ...(input.validateRequestBody !== undefined && {
+      validateRequestBody: input.validateRequestBody
+    }),
+    ...(input.validateRequestParameters !== undefined && {
+      validateRequestParameters: input.validateRequestParameters
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1168,26 +1066,18 @@ export const serializeAws_restJson1_1CreateResourceCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.pathPart !== undefined) {
-    bodyParams["pathPart"] = input.pathPart;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.pathPart !== undefined && { pathPart: input.pathPart }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1209,61 +1099,42 @@ export const serializeAws_restJson1_1CreateRestApiCommand = async (
   };
   let resolvedPath = "/restapis";
   let body: any;
-  const bodyParams: any = {};
-  if (input.apiKeySource !== undefined) {
-    bodyParams["apiKeySource"] = input.apiKeySource;
-  }
-  if (input.binaryMediaTypes !== undefined) {
-    bodyParams["binaryMediaTypes"] = serializeAws_restJson1_1ListOfString(
-      input.binaryMediaTypes,
-      context
-    );
-  }
-  if (input.cloneFrom !== undefined) {
-    bodyParams["cloneFrom"] = input.cloneFrom;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.endpointConfiguration !== undefined) {
-    bodyParams[
-      "endpointConfiguration"
-    ] = serializeAws_restJson1_1EndpointConfiguration(
-      input.endpointConfiguration,
-      context
-    );
-  }
-  if (input.minimumCompressionSize !== undefined) {
-    bodyParams["minimumCompressionSize"] = input.minimumCompressionSize;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.policy !== undefined) {
-    bodyParams["policy"] = input.policy;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  if (input.version !== undefined) {
-    bodyParams["version"] = input.version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.apiKeySource !== undefined && {
+      apiKeySource: input.apiKeySource
+    }),
+    ...(input.binaryMediaTypes !== undefined && {
+      binaryMediaTypes: serializeAws_restJson1_1ListOfString(
+        input.binaryMediaTypes,
+        context
+      )
+    }),
+    ...(input.cloneFrom !== undefined && { cloneFrom: input.cloneFrom }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.endpointConfiguration !== undefined && {
+      endpointConfiguration: serializeAws_restJson1_1EndpointConfiguration(
+        input.endpointConfiguration,
+        context
+      )
+    }),
+    ...(input.minimumCompressionSize !== undefined && {
+      minimumCompressionSize: input.minimumCompressionSize
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.policy !== undefined && { policy: input.policy }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title }),
+    ...(input.version !== undefined && { version: input.version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1297,62 +1168,49 @@ export const serializeAws_restJson1_1CreateStageCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.cacheClusterEnabled !== undefined) {
-    bodyParams["cacheClusterEnabled"] = input.cacheClusterEnabled;
-  }
-  if (input.cacheClusterSize !== undefined) {
-    bodyParams["cacheClusterSize"] = input.cacheClusterSize;
-  }
-  if (input.canarySettings !== undefined) {
-    bodyParams["canarySettings"] = serializeAws_restJson1_1CanarySettings(
-      input.canarySettings,
-      context
-    );
-  }
-  if (input.deploymentId !== undefined) {
-    bodyParams["deploymentId"] = input.deploymentId;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.documentationVersion !== undefined) {
-    bodyParams["documentationVersion"] = input.documentationVersion;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.stageName !== undefined) {
-    bodyParams["stageName"] = input.stageName;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  if (input.tracingEnabled !== undefined) {
-    bodyParams["tracingEnabled"] = input.tracingEnabled;
-  }
-  if (input.variables !== undefined) {
-    bodyParams["variables"] = serializeAws_restJson1_1MapOfStringToString(
-      input.variables,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.cacheClusterEnabled !== undefined && {
+      cacheClusterEnabled: input.cacheClusterEnabled
+    }),
+    ...(input.cacheClusterSize !== undefined && {
+      cacheClusterSize: input.cacheClusterSize
+    }),
+    ...(input.canarySettings !== undefined && {
+      canarySettings: serializeAws_restJson1_1CanarySettings(
+        input.canarySettings,
+        context
+      )
+    }),
+    ...(input.deploymentId !== undefined && {
+      deploymentId: input.deploymentId
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.documentationVersion !== undefined && {
+      documentationVersion: input.documentationVersion
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.stageName !== undefined && { stageName: input.stageName }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title }),
+    ...(input.tracingEnabled !== undefined && {
+      tracingEnabled: input.tracingEnabled
+    }),
+    ...(input.variables !== undefined && {
+      variables: serializeAws_restJson1_1MapOfStringToString(
+        input.variables,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1374,50 +1232,36 @@ export const serializeAws_restJson1_1CreateUsagePlanCommand = async (
   };
   let resolvedPath = "/usageplans";
   let body: any;
-  const bodyParams: any = {};
-  if (input.apiStages !== undefined) {
-    bodyParams["apiStages"] = serializeAws_restJson1_1ListOfApiStage(
-      input.apiStages,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.quota !== undefined) {
-    bodyParams["quota"] = serializeAws_restJson1_1QuotaSettings(
-      input.quota,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.throttle !== undefined) {
-    bodyParams["throttle"] = serializeAws_restJson1_1ThrottleSettings(
-      input.throttle,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.apiStages !== undefined && {
+      apiStages: serializeAws_restJson1_1ListOfApiStage(
+        input.apiStages,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.quota !== undefined && {
+      quota: serializeAws_restJson1_1QuotaSettings(input.quota, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.throttle !== undefined && {
+      throttle: serializeAws_restJson1_1ThrottleSettings(
+        input.throttle,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1453,29 +1297,19 @@ export const serializeAws_restJson1_1CreateUsagePlanKeyCommand = async (
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.keyId !== undefined) {
-    bodyParams["keyId"] = input.keyId;
-  }
-  if (input.keyType !== undefined) {
-    bodyParams["keyType"] = input.keyType;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.keyId !== undefined && { keyId: input.keyId }),
+    ...(input.keyType !== undefined && { keyType: input.keyType }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1497,38 +1331,27 @@ export const serializeAws_restJson1_1CreateVpcLinkCommand = async (
   };
   let resolvedPath = "/vpclinks";
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.targetArns !== undefined) {
-    bodyParams["targetArns"] = serializeAws_restJson1_1ListOfString(
-      input.targetArns,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.targetArns !== undefined && {
+      targetArns: serializeAws_restJson1_1ListOfString(
+        input.targetArns,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1562,23 +1385,17 @@ export const serializeAws_restJson1_1DeleteApiKeyCommand = async (
     throw new Error("No value provided for input HTTP label: apiKey.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1626,23 +1443,17 @@ export const serializeAws_restJson1_1DeleteAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1688,23 +1499,17 @@ export const serializeAws_restJson1_1DeleteBasePathMappingCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1742,23 +1547,17 @@ export const serializeAws_restJson1_1DeleteClientCertificateCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1806,23 +1605,17 @@ export const serializeAws_restJson1_1DeleteDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1873,23 +1666,17 @@ export const serializeAws_restJson1_1DeleteDocumentationPartCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1940,23 +1727,17 @@ export const serializeAws_restJson1_1DeleteDocumentationVersionCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1990,23 +1771,17 @@ export const serializeAws_restJson1_1DeleteDomainNameCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2054,23 +1829,17 @@ export const serializeAws_restJson1_1DeleteGatewayResponseCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2129,23 +1898,17 @@ export const serializeAws_restJson1_1DeleteIntegrationCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2216,23 +1979,17 @@ export const serializeAws_restJson1_1DeleteIntegrationResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2291,23 +2048,17 @@ export const serializeAws_restJson1_1DeleteMethodCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2378,23 +2129,17 @@ export const serializeAws_restJson1_1DeleteMethodResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2440,23 +2185,17 @@ export const serializeAws_restJson1_1DeleteModelCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2507,23 +2246,17 @@ export const serializeAws_restJson1_1DeleteRequestValidatorCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2569,23 +2302,17 @@ export const serializeAws_restJson1_1DeleteResourceCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2619,23 +2346,17 @@ export const serializeAws_restJson1_1DeleteRestApiCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2681,23 +2402,17 @@ export const serializeAws_restJson1_1DeleteStageCommand = async (
     throw new Error("No value provided for input HTTP label: stageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2733,23 +2448,17 @@ export const serializeAws_restJson1_1DeleteUsagePlanCommand = async (
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2797,23 +2506,17 @@ export const serializeAws_restJson1_1DeleteUsagePlanKeyCommand = async (
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2847,23 +2550,17 @@ export const serializeAws_restJson1_1DeleteVpcLinkCommand = async (
     throw new Error("No value provided for input HTTP label: vpcLinkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2910,23 +2607,17 @@ export const serializeAws_restJson1_1FlushStageAuthorizersCacheCommand = async (
     throw new Error("No value provided for input HTTP label: stageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2972,23 +2663,17 @@ export const serializeAws_restJson1_1FlushStageCacheCommand = async (
     throw new Error("No value provided for input HTTP label: stageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3010,32 +2695,21 @@ export const serializeAws_restJson1_1GenerateClientCertificateCommand = async (
   };
   let resolvedPath = "/clientcertificates";
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3057,23 +2731,17 @@ export const serializeAws_restJson1_1GetAccountCommand = async (
   };
   let resolvedPath = "/account";
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3112,23 +2780,17 @@ export const serializeAws_restJson1_1GetApiKeyCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3160,23 +2822,17 @@ export const serializeAws_restJson1_1GetApiKeysCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3225,23 +2881,17 @@ export const serializeAws_restJson1_1GetAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3279,23 +2929,17 @@ export const serializeAws_restJson1_1GetAuthorizersCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3342,23 +2986,17 @@ export const serializeAws_restJson1_1GetBasePathMappingCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3396,23 +3034,17 @@ export const serializeAws_restJson1_1GetBasePathMappingsCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3451,23 +3083,17 @@ export const serializeAws_restJson1_1GetClientCertificateCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3493,23 +3119,17 @@ export const serializeAws_restJson1_1GetClientCertificatesCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3563,23 +3183,17 @@ export const serializeAws_restJson1_1GetDeploymentCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3618,23 +3232,17 @@ export const serializeAws_restJson1_1GetDeploymentsCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3686,23 +3294,17 @@ export const serializeAws_restJson1_1GetDocumentationPartCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3746,23 +3348,17 @@ export const serializeAws_restJson1_1GetDocumentationPartsCommand = async (
     ...(input.type !== undefined && { type: input.type })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3814,23 +3410,17 @@ export const serializeAws_restJson1_1GetDocumentationVersionCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3868,23 +3458,17 @@ export const serializeAws_restJson1_1GetDocumentationVersionsCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3919,23 +3503,17 @@ export const serializeAws_restJson1_1GetDomainNameCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3961,23 +3539,17 @@ export const serializeAws_restJson1_1GetDomainNamesCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4038,14 +3610,14 @@ export const serializeAws_restJson1_1GetExportCommand = async (
     throw new Error("No value provided for input HTTP label: stageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1MapOfStringToString(
-      input.parameters,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1MapOfStringToString(
+        input.parameters,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4093,23 +3665,17 @@ export const serializeAws_restJson1_1GetGatewayResponseCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4147,23 +3713,17 @@ export const serializeAws_restJson1_1GetGatewayResponsesCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4223,23 +3783,17 @@ export const serializeAws_restJson1_1GetIntegrationCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4310,23 +3864,17 @@ export const serializeAws_restJson1_1GetIntegrationResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4385,23 +3933,17 @@ export const serializeAws_restJson1_1GetMethodCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4472,23 +4014,17 @@ export const serializeAws_restJson1_1GetMethodResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4537,23 +4073,17 @@ export const serializeAws_restJson1_1GetModelCommand = async (
     ...(input.flatten !== undefined && { flatten: input.flatten.toString() })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4601,23 +4131,17 @@ export const serializeAws_restJson1_1GetModelTemplateCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4655,23 +4179,17 @@ export const serializeAws_restJson1_1GetModelsCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4723,23 +4241,17 @@ export const serializeAws_restJson1_1GetRequestValidatorCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4777,23 +4289,17 @@ export const serializeAws_restJson1_1GetRequestValidatorsCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4845,23 +4351,17 @@ export const serializeAws_restJson1_1GetResourceCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4903,23 +4403,17 @@ export const serializeAws_restJson1_1GetResourcesCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4954,23 +4448,17 @@ export const serializeAws_restJson1_1GetRestApiCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4996,23 +4484,17 @@ export const serializeAws_restJson1_1GetRestApisCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5071,14 +4553,14 @@ export const serializeAws_restJson1_1GetSdkCommand = async (
     throw new Error("No value provided for input HTTP label: stageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1MapOfStringToString(
-      input.parameters,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1MapOfStringToString(
+        input.parameters,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5112,23 +4594,17 @@ export const serializeAws_restJson1_1GetSdkTypeCommand = async (
     throw new Error("No value provided for input HTTP label: id.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5154,23 +4630,17 @@ export const serializeAws_restJson1_1GetSdkTypesCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5217,23 +4687,17 @@ export const serializeAws_restJson1_1GetStageCommand = async (
     throw new Error("No value provided for input HTTP label: stageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5272,23 +4736,17 @@ export const serializeAws_restJson1_1GetStagesCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5329,23 +4787,17 @@ export const serializeAws_restJson1_1GetTagsCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5389,23 +4841,17 @@ export const serializeAws_restJson1_1GetUsageCommand = async (
     ...(input.startDate !== undefined && { startDate: input.startDate })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5442,23 +4888,17 @@ export const serializeAws_restJson1_1GetUsagePlanCommand = async (
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5506,23 +4946,17 @@ export const serializeAws_restJson1_1GetUsagePlanKeyCommand = async (
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5563,23 +4997,17 @@ export const serializeAws_restJson1_1GetUsagePlanKeysCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5607,23 +5035,17 @@ export const serializeAws_restJson1_1GetUsagePlansCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5658,23 +5080,17 @@ export const serializeAws_restJson1_1GetVpcLinkCommand = async (
     throw new Error("No value provided for input HTTP label: vpcLinkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5700,23 +5116,17 @@ export const serializeAws_restJson1_1GetVpcLinksCommand = async (
     ...(input.position !== undefined && { position: input.position })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5746,23 +5156,17 @@ export const serializeAws_restJson1_1ImportApiKeysCommand = async (
     ...(input.format !== undefined && { format: input.format })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5803,23 +5207,17 @@ export const serializeAws_restJson1_1ImportDocumentationPartsCommand = async (
     ...(input.mode !== undefined && { mode: input.mode })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5848,29 +5246,23 @@ export const serializeAws_restJson1_1ImportRestApiCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1MapOfStringToString(
-      input.parameters,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1MapOfStringToString(
+        input.parameters,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5919,42 +5311,30 @@ export const serializeAws_restJson1_1PutGatewayResponseCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.responseParameters !== undefined) {
-    bodyParams[
-      "responseParameters"
-    ] = serializeAws_restJson1_1MapOfStringToString(
-      input.responseParameters,
-      context
-    );
-  }
-  if (input.responseTemplates !== undefined) {
-    bodyParams[
-      "responseTemplates"
-    ] = serializeAws_restJson1_1MapOfStringToString(
-      input.responseTemplates,
-      context
-    );
-  }
-  if (input.statusCode !== undefined) {
-    bodyParams["statusCode"] = input.statusCode;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.responseParameters !== undefined && {
+      responseParameters: serializeAws_restJson1_1MapOfStringToString(
+        input.responseParameters,
+        context
+      )
+    }),
+    ...(input.responseTemplates !== undefined && {
+      responseTemplates: serializeAws_restJson1_1MapOfStringToString(
+        input.responseTemplates,
+        context
+      )
+    }),
+    ...(input.statusCode !== undefined && { statusCode: input.statusCode }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6013,75 +5393,59 @@ export const serializeAws_restJson1_1PutIntegrationCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.cacheKeyParameters !== undefined) {
-    bodyParams["cacheKeyParameters"] = serializeAws_restJson1_1ListOfString(
-      input.cacheKeyParameters,
-      context
-    );
-  }
-  if (input.cacheNamespace !== undefined) {
-    bodyParams["cacheNamespace"] = input.cacheNamespace;
-  }
-  if (input.connectionId !== undefined) {
-    bodyParams["connectionId"] = input.connectionId;
-  }
-  if (input.connectionType !== undefined) {
-    bodyParams["connectionType"] = input.connectionType;
-  }
-  if (input.contentHandling !== undefined) {
-    bodyParams["contentHandling"] = input.contentHandling;
-  }
-  if (input.credentials !== undefined) {
-    bodyParams["credentials"] = input.credentials;
-  }
-  if (input.integrationHttpMethod !== undefined) {
-    bodyParams["httpMethod"] = input.integrationHttpMethod;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.passthroughBehavior !== undefined) {
-    bodyParams["passthroughBehavior"] = input.passthroughBehavior;
-  }
-  if (input.requestParameters !== undefined) {
-    bodyParams[
-      "requestParameters"
-    ] = serializeAws_restJson1_1MapOfStringToString(
-      input.requestParameters,
-      context
-    );
-  }
-  if (input.requestTemplates !== undefined) {
-    bodyParams[
-      "requestTemplates"
-    ] = serializeAws_restJson1_1MapOfStringToString(
-      input.requestTemplates,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.timeoutInMillis !== undefined) {
-    bodyParams["timeoutInMillis"] = input.timeoutInMillis;
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  if (input.uri !== undefined) {
-    bodyParams["uri"] = input.uri;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.cacheKeyParameters !== undefined && {
+      cacheKeyParameters: serializeAws_restJson1_1ListOfString(
+        input.cacheKeyParameters,
+        context
+      )
+    }),
+    ...(input.cacheNamespace !== undefined && {
+      cacheNamespace: input.cacheNamespace
+    }),
+    ...(input.connectionId !== undefined && {
+      connectionId: input.connectionId
+    }),
+    ...(input.connectionType !== undefined && {
+      connectionType: input.connectionType
+    }),
+    ...(input.contentHandling !== undefined && {
+      contentHandling: input.contentHandling
+    }),
+    ...(input.credentials !== undefined && { credentials: input.credentials }),
+    ...(input.integrationHttpMethod !== undefined && {
+      httpMethod: input.integrationHttpMethod
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.passthroughBehavior !== undefined && {
+      passthroughBehavior: input.passthroughBehavior
+    }),
+    ...(input.requestParameters !== undefined && {
+      requestParameters: serializeAws_restJson1_1MapOfStringToString(
+        input.requestParameters,
+        context
+      )
+    }),
+    ...(input.requestTemplates !== undefined && {
+      requestTemplates: serializeAws_restJson1_1MapOfStringToString(
+        input.requestTemplates,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.timeoutInMillis !== undefined && {
+      timeoutInMillis: input.timeoutInMillis
+    }),
+    ...(input.title !== undefined && { title: input.title }),
+    ...(input.type !== undefined && { type: input.type }),
+    ...(input.uri !== undefined && { uri: input.uri })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6152,45 +5516,35 @@ export const serializeAws_restJson1_1PutIntegrationResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.contentHandling !== undefined) {
-    bodyParams["contentHandling"] = input.contentHandling;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.responseParameters !== undefined) {
-    bodyParams[
-      "responseParameters"
-    ] = serializeAws_restJson1_1MapOfStringToString(
-      input.responseParameters,
-      context
-    );
-  }
-  if (input.responseTemplates !== undefined) {
-    bodyParams[
-      "responseTemplates"
-    ] = serializeAws_restJson1_1MapOfStringToString(
-      input.responseTemplates,
-      context
-    );
-  }
-  if (input.selectionPattern !== undefined) {
-    bodyParams["selectionPattern"] = input.selectionPattern;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.contentHandling !== undefined && {
+      contentHandling: input.contentHandling
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.responseParameters !== undefined && {
+      responseParameters: serializeAws_restJson1_1MapOfStringToString(
+        input.responseParameters,
+        context
+      )
+    }),
+    ...(input.responseTemplates !== undefined && {
+      responseTemplates: serializeAws_restJson1_1MapOfStringToString(
+        input.responseTemplates,
+        context
+      )
+    }),
+    ...(input.selectionPattern !== undefined && {
+      selectionPattern: input.selectionPattern
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6249,58 +5603,50 @@ export const serializeAws_restJson1_1PutMethodCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.apiKeyRequired !== undefined) {
-    bodyParams["apiKeyRequired"] = input.apiKeyRequired;
-  }
-  if (input.authorizationScopes !== undefined) {
-    bodyParams["authorizationScopes"] = serializeAws_restJson1_1ListOfString(
-      input.authorizationScopes,
-      context
-    );
-  }
-  if (input.authorizationType !== undefined) {
-    bodyParams["authorizationType"] = input.authorizationType;
-  }
-  if (input.authorizerId !== undefined) {
-    bodyParams["authorizerId"] = input.authorizerId;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.operationName !== undefined) {
-    bodyParams["operationName"] = input.operationName;
-  }
-  if (input.requestModels !== undefined) {
-    bodyParams["requestModels"] = serializeAws_restJson1_1MapOfStringToString(
-      input.requestModels,
-      context
-    );
-  }
-  if (input.requestParameters !== undefined) {
-    bodyParams[
-      "requestParameters"
-    ] = serializeAws_restJson1_1MapOfStringToBoolean(
-      input.requestParameters,
-      context
-    );
-  }
-  if (input.requestValidatorId !== undefined) {
-    bodyParams["requestValidatorId"] = input.requestValidatorId;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.apiKeyRequired !== undefined && {
+      apiKeyRequired: input.apiKeyRequired
+    }),
+    ...(input.authorizationScopes !== undefined && {
+      authorizationScopes: serializeAws_restJson1_1ListOfString(
+        input.authorizationScopes,
+        context
+      )
+    }),
+    ...(input.authorizationType !== undefined && {
+      authorizationType: input.authorizationType
+    }),
+    ...(input.authorizerId !== undefined && {
+      authorizerId: input.authorizerId
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.operationName !== undefined && {
+      operationName: input.operationName
+    }),
+    ...(input.requestModels !== undefined && {
+      requestModels: serializeAws_restJson1_1MapOfStringToString(
+        input.requestModels,
+        context
+      )
+    }),
+    ...(input.requestParameters !== undefined && {
+      requestParameters: serializeAws_restJson1_1MapOfStringToBoolean(
+        input.requestParameters,
+        context
+      )
+    }),
+    ...(input.requestValidatorId !== undefined && {
+      requestValidatorId: input.requestValidatorId
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6371,37 +5717,29 @@ export const serializeAws_restJson1_1PutMethodResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.responseModels !== undefined) {
-    bodyParams["responseModels"] = serializeAws_restJson1_1MapOfStringToString(
-      input.responseModels,
-      context
-    );
-  }
-  if (input.responseParameters !== undefined) {
-    bodyParams[
-      "responseParameters"
-    ] = serializeAws_restJson1_1MapOfStringToBoolean(
-      input.responseParameters,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.responseModels !== undefined && {
+      responseModels: serializeAws_restJson1_1MapOfStringToString(
+        input.responseModels,
+        context
+      )
+    }),
+    ...(input.responseParameters !== undefined && {
+      responseParameters: serializeAws_restJson1_1MapOfStringToBoolean(
+        input.responseParameters,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6441,29 +5779,23 @@ export const serializeAws_restJson1_1PutRestApiCommand = async (
     ...(input.mode !== undefined && { mode: input.mode })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1MapOfStringToString(
-      input.parameters,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1MapOfStringToString(
+        input.parameters,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6500,29 +5832,20 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOfStringToString(
-      input.tags,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOfStringToString(input.tags, context)
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6570,40 +5893,36 @@ export const serializeAws_restJson1_1TestInvokeAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.additionalContext !== undefined) {
-    bodyParams[
-      "additionalContext"
-    ] = serializeAws_restJson1_1MapOfStringToString(
-      input.additionalContext,
-      context
-    );
-  }
-  if (input.body !== undefined) {
-    bodyParams["body"] = input.body;
-  }
-  if (input.headers !== undefined) {
-    bodyParams["headers"] = serializeAws_restJson1_1MapOfStringToString(
-      input.headers,
-      context
-    );
-  }
-  if (input.multiValueHeaders !== undefined) {
-    bodyParams["multiValueHeaders"] = serializeAws_restJson1_1MapOfStringToList(
-      input.multiValueHeaders,
-      context
-    );
-  }
-  if (input.pathWithQueryString !== undefined) {
-    bodyParams["pathWithQueryString"] = input.pathWithQueryString;
-  }
-  if (input.stageVariables !== undefined) {
-    bodyParams["stageVariables"] = serializeAws_restJson1_1MapOfStringToString(
-      input.stageVariables,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.additionalContext !== undefined && {
+      additionalContext: serializeAws_restJson1_1MapOfStringToString(
+        input.additionalContext,
+        context
+      )
+    }),
+    ...(input.body !== undefined && { body: input.body }),
+    ...(input.headers !== undefined && {
+      headers: serializeAws_restJson1_1MapOfStringToString(
+        input.headers,
+        context
+      )
+    }),
+    ...(input.multiValueHeaders !== undefined && {
+      multiValueHeaders: serializeAws_restJson1_1MapOfStringToList(
+        input.multiValueHeaders,
+        context
+      )
+    }),
+    ...(input.pathWithQueryString !== undefined && {
+      pathWithQueryString: input.pathWithQueryString
+    }),
+    ...(input.stageVariables !== undefined && {
+      stageVariables: serializeAws_restJson1_1MapOfStringToString(
+        input.stageVariables,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6662,35 +5981,33 @@ export const serializeAws_restJson1_1TestInvokeMethodCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.body !== undefined) {
-    bodyParams["body"] = input.body;
-  }
-  if (input.clientCertificateId !== undefined) {
-    bodyParams["clientCertificateId"] = input.clientCertificateId;
-  }
-  if (input.headers !== undefined) {
-    bodyParams["headers"] = serializeAws_restJson1_1MapOfStringToString(
-      input.headers,
-      context
-    );
-  }
-  if (input.multiValueHeaders !== undefined) {
-    bodyParams["multiValueHeaders"] = serializeAws_restJson1_1MapOfStringToList(
-      input.multiValueHeaders,
-      context
-    );
-  }
-  if (input.pathWithQueryString !== undefined) {
-    bodyParams["pathWithQueryString"] = input.pathWithQueryString;
-  }
-  if (input.stageVariables !== undefined) {
-    bodyParams["stageVariables"] = serializeAws_restJson1_1MapOfStringToString(
-      input.stageVariables,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.body !== undefined && { body: input.body }),
+    ...(input.clientCertificateId !== undefined && {
+      clientCertificateId: input.clientCertificateId
+    }),
+    ...(input.headers !== undefined && {
+      headers: serializeAws_restJson1_1MapOfStringToString(
+        input.headers,
+        context
+      )
+    }),
+    ...(input.multiValueHeaders !== undefined && {
+      multiValueHeaders: serializeAws_restJson1_1MapOfStringToList(
+        input.multiValueHeaders,
+        context
+      )
+    }),
+    ...(input.pathWithQueryString !== undefined && {
+      pathWithQueryString: input.pathWithQueryString
+    }),
+    ...(input.stageVariables !== undefined && {
+      stageVariables: serializeAws_restJson1_1MapOfStringToString(
+        input.stageVariables,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6731,23 +6048,17 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6770,31 +6081,23 @@ export const serializeAws_restJson1_1UpdateAccountCommand = async (
   };
   let resolvedPath = "/account";
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6828,31 +6131,23 @@ export const serializeAws_restJson1_1UpdateApiKeyCommand = async (
     throw new Error("No value provided for input HTTP label: apiKey.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6900,31 +6195,23 @@ export const serializeAws_restJson1_1UpdateAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6970,31 +6257,23 @@ export const serializeAws_restJson1_1UpdateBasePathMappingCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7032,31 +6311,23 @@ export const serializeAws_restJson1_1UpdateClientCertificateCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7104,31 +6375,23 @@ export const serializeAws_restJson1_1UpdateDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7179,31 +6442,23 @@ export const serializeAws_restJson1_1UpdateDocumentationPartCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7254,31 +6509,23 @@ export const serializeAws_restJson1_1UpdateDocumentationVersionCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7312,31 +6559,23 @@ export const serializeAws_restJson1_1UpdateDomainNameCommand = async (
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7384,31 +6623,23 @@ export const serializeAws_restJson1_1UpdateGatewayResponseCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7467,31 +6698,23 @@ export const serializeAws_restJson1_1UpdateIntegrationCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7562,31 +6785,23 @@ export const serializeAws_restJson1_1UpdateIntegrationResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7645,31 +6860,23 @@ export const serializeAws_restJson1_1UpdateMethodCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7740,31 +6947,23 @@ export const serializeAws_restJson1_1UpdateMethodResponseCommand = async (
     throw new Error("No value provided for input HTTP label: statusCode.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7810,31 +7009,23 @@ export const serializeAws_restJson1_1UpdateModelCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7885,31 +7076,23 @@ export const serializeAws_restJson1_1UpdateRequestValidatorCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7955,31 +7138,23 @@ export const serializeAws_restJson1_1UpdateResourceCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8013,31 +7188,23 @@ export const serializeAws_restJson1_1UpdateRestApiCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8083,31 +7250,23 @@ export const serializeAws_restJson1_1UpdateStageCommand = async (
     throw new Error("No value provided for input HTTP label: stageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8155,31 +7314,23 @@ export const serializeAws_restJson1_1UpdateUsageCommand = async (
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8215,31 +7366,23 @@ export const serializeAws_restJson1_1UpdateUsagePlanCommand = async (
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8273,31 +7416,23 @@ export const serializeAws_restJson1_1UpdateVpcLinkCommand = async (
     throw new Error("No value provided for input HTTP label: vpcLinkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.patchOperations !== undefined) {
-    bodyParams[
-      "patchOperations"
-    ] = serializeAws_restJson1_1ListOfPatchOperation(
-      input.patchOperations,
-      context
-    );
-  }
-  if (input.template !== undefined) {
-    bodyParams["template"] = input.template;
-  }
-  if (input.templateSkipList !== undefined) {
-    bodyParams["templateSkipList"] = serializeAws_restJson1_1ListOfString(
-      input.templateSkipList,
-      context
-    );
-  }
-  if (input.title !== undefined) {
-    bodyParams["title"] = input.title;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.patchOperations !== undefined && {
+      patchOperations: serializeAws_restJson1_1ListOfPatchOperation(
+        input.patchOperations,
+        context
+      )
+    }),
+    ...(input.template !== undefined && { template: input.template }),
+    ...(input.templateSkipList !== undefined && {
+      templateSkipList: serializeAws_restJson1_1ListOfString(
+        input.templateSkipList,
+        context
+      )
+    }),
+    ...(input.title !== undefined && { title: input.title })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
@@ -298,47 +298,37 @@ export const serializeAws_restJson1_1CreateApiCommand = async (
   };
   let resolvedPath = "/v2/apis";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ApiKeySelectionExpression !== undefined) {
-    bodyParams["apiKeySelectionExpression"] = input.ApiKeySelectionExpression;
-  }
-  if (input.CorsConfiguration !== undefined) {
-    bodyParams["corsConfiguration"] = serializeAws_restJson1_1Cors(
-      input.CorsConfiguration,
-      context
-    );
-  }
-  if (input.CredentialsArn !== undefined) {
-    bodyParams["credentialsArn"] = input.CredentialsArn;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.DisableSchemaValidation !== undefined) {
-    bodyParams["disableSchemaValidation"] = input.DisableSchemaValidation;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.ProtocolType !== undefined) {
-    bodyParams["protocolType"] = input.ProtocolType;
-  }
-  if (input.RouteKey !== undefined) {
-    bodyParams["routeKey"] = input.RouteKey;
-  }
-  if (input.RouteSelectionExpression !== undefined) {
-    bodyParams["routeSelectionExpression"] = input.RouteSelectionExpression;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.Target !== undefined) {
-    bodyParams["target"] = input.Target;
-  }
-  if (input.Version !== undefined) {
-    bodyParams["version"] = input.Version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ApiKeySelectionExpression !== undefined && {
+      apiKeySelectionExpression: input.ApiKeySelectionExpression
+    }),
+    ...(input.CorsConfiguration !== undefined && {
+      corsConfiguration: serializeAws_restJson1_1Cors(
+        input.CorsConfiguration,
+        context
+      )
+    }),
+    ...(input.CredentialsArn !== undefined && {
+      credentialsArn: input.CredentialsArn
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.DisableSchemaValidation !== undefined && {
+      disableSchemaValidation: input.DisableSchemaValidation
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.ProtocolType !== undefined && {
+      protocolType: input.ProtocolType
+    }),
+    ...(input.RouteKey !== undefined && { routeKey: input.RouteKey }),
+    ...(input.RouteSelectionExpression !== undefined && {
+      routeSelectionExpression: input.RouteSelectionExpression
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.Target !== undefined && { target: input.Target }),
+    ...(input.Version !== undefined && { version: input.Version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -372,17 +362,13 @@ export const serializeAws_restJson1_1CreateApiMappingCommand = async (
     throw new Error("No value provided for input HTTP label: DomainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ApiId !== undefined) {
-    bodyParams["apiId"] = input.ApiId;
-  }
-  if (input.ApiMappingKey !== undefined) {
-    bodyParams["apiMappingKey"] = input.ApiMappingKey;
-  }
-  if (input.Stage !== undefined) {
-    bodyParams["stage"] = input.Stage;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ApiId !== undefined && { apiId: input.ApiId }),
+    ...(input.ApiMappingKey !== undefined && {
+      apiMappingKey: input.ApiMappingKey
+    }),
+    ...(input.Stage !== undefined && { stage: input.Stage })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -416,40 +402,36 @@ export const serializeAws_restJson1_1CreateAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AuthorizerCredentialsArn !== undefined) {
-    bodyParams["authorizerCredentialsArn"] = input.AuthorizerCredentialsArn;
-  }
-  if (input.AuthorizerResultTtlInSeconds !== undefined) {
-    bodyParams["authorizerResultTtlInSeconds"] =
-      input.AuthorizerResultTtlInSeconds;
-  }
-  if (input.AuthorizerType !== undefined) {
-    bodyParams["authorizerType"] = input.AuthorizerType;
-  }
-  if (input.AuthorizerUri !== undefined) {
-    bodyParams["authorizerUri"] = input.AuthorizerUri;
-  }
-  if (input.IdentitySource !== undefined) {
-    bodyParams["identitySource"] = serializeAws_restJson1_1IdentitySourceList(
-      input.IdentitySource,
-      context
-    );
-  }
-  if (input.IdentityValidationExpression !== undefined) {
-    bodyParams["identityValidationExpression"] =
-      input.IdentityValidationExpression;
-  }
-  if (input.JwtConfiguration !== undefined) {
-    bodyParams["jwtConfiguration"] = serializeAws_restJson1_1JWTConfiguration(
-      input.JwtConfiguration,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AuthorizerCredentialsArn !== undefined && {
+      authorizerCredentialsArn: input.AuthorizerCredentialsArn
+    }),
+    ...(input.AuthorizerResultTtlInSeconds !== undefined && {
+      authorizerResultTtlInSeconds: input.AuthorizerResultTtlInSeconds
+    }),
+    ...(input.AuthorizerType !== undefined && {
+      authorizerType: input.AuthorizerType
+    }),
+    ...(input.AuthorizerUri !== undefined && {
+      authorizerUri: input.AuthorizerUri
+    }),
+    ...(input.IdentitySource !== undefined && {
+      identitySource: serializeAws_restJson1_1IdentitySourceList(
+        input.IdentitySource,
+        context
+      )
+    }),
+    ...(input.IdentityValidationExpression !== undefined && {
+      identityValidationExpression: input.IdentityValidationExpression
+    }),
+    ...(input.JwtConfiguration !== undefined && {
+      jwtConfiguration: serializeAws_restJson1_1JWTConfiguration(
+        input.JwtConfiguration,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -483,14 +465,10 @@ export const serializeAws_restJson1_1CreateDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.StageName !== undefined) {
-    bodyParams["stageName"] = input.StageName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.StageName !== undefined && { stageName: input.StageName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -512,22 +490,18 @@ export const serializeAws_restJson1_1CreateDomainNameCommand = async (
   };
   let resolvedPath = "/v2/domainnames";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["domainName"] = input.DomainName;
-  }
-  if (input.DomainNameConfigurations !== undefined) {
-    bodyParams[
-      "domainNameConfigurations"
-    ] = serializeAws_restJson1_1DomainNameConfigurations(
-      input.DomainNameConfigurations,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { domainName: input.DomainName }),
+    ...(input.DomainNameConfigurations !== undefined && {
+      domainNameConfigurations: serializeAws_restJson1_1DomainNameConfigurations(
+        input.DomainNameConfigurations,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -561,59 +535,54 @@ export const serializeAws_restJson1_1CreateIntegrationCommand = async (
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConnectionId !== undefined) {
-    bodyParams["connectionId"] = input.ConnectionId;
-  }
-  if (input.ConnectionType !== undefined) {
-    bodyParams["connectionType"] = input.ConnectionType;
-  }
-  if (input.ContentHandlingStrategy !== undefined) {
-    bodyParams["contentHandlingStrategy"] = input.ContentHandlingStrategy;
-  }
-  if (input.CredentialsArn !== undefined) {
-    bodyParams["credentialsArn"] = input.CredentialsArn;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.IntegrationMethod !== undefined) {
-    bodyParams["integrationMethod"] = input.IntegrationMethod;
-  }
-  if (input.IntegrationType !== undefined) {
-    bodyParams["integrationType"] = input.IntegrationType;
-  }
-  if (input.IntegrationUri !== undefined) {
-    bodyParams["integrationUri"] = input.IntegrationUri;
-  }
-  if (input.PassthroughBehavior !== undefined) {
-    bodyParams["passthroughBehavior"] = input.PassthroughBehavior;
-  }
-  if (input.PayloadFormatVersion !== undefined) {
-    bodyParams["payloadFormatVersion"] = input.PayloadFormatVersion;
-  }
-  if (input.RequestParameters !== undefined) {
-    bodyParams[
-      "requestParameters"
-    ] = serializeAws_restJson1_1IntegrationParameters(
-      input.RequestParameters,
-      context
-    );
-  }
-  if (input.RequestTemplates !== undefined) {
-    bodyParams["requestTemplates"] = serializeAws_restJson1_1TemplateMap(
-      input.RequestTemplates,
-      context
-    );
-  }
-  if (input.TemplateSelectionExpression !== undefined) {
-    bodyParams["templateSelectionExpression"] =
-      input.TemplateSelectionExpression;
-  }
-  if (input.TimeoutInMillis !== undefined) {
-    bodyParams["timeoutInMillis"] = input.TimeoutInMillis;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConnectionId !== undefined && {
+      connectionId: input.ConnectionId
+    }),
+    ...(input.ConnectionType !== undefined && {
+      connectionType: input.ConnectionType
+    }),
+    ...(input.ContentHandlingStrategy !== undefined && {
+      contentHandlingStrategy: input.ContentHandlingStrategy
+    }),
+    ...(input.CredentialsArn !== undefined && {
+      credentialsArn: input.CredentialsArn
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.IntegrationMethod !== undefined && {
+      integrationMethod: input.IntegrationMethod
+    }),
+    ...(input.IntegrationType !== undefined && {
+      integrationType: input.IntegrationType
+    }),
+    ...(input.IntegrationUri !== undefined && {
+      integrationUri: input.IntegrationUri
+    }),
+    ...(input.PassthroughBehavior !== undefined && {
+      passthroughBehavior: input.PassthroughBehavior
+    }),
+    ...(input.PayloadFormatVersion !== undefined && {
+      payloadFormatVersion: input.PayloadFormatVersion
+    }),
+    ...(input.RequestParameters !== undefined && {
+      requestParameters: serializeAws_restJson1_1IntegrationParameters(
+        input.RequestParameters,
+        context
+      )
+    }),
+    ...(input.RequestTemplates !== undefined && {
+      requestTemplates: serializeAws_restJson1_1TemplateMap(
+        input.RequestTemplates,
+        context
+      )
+    }),
+    ...(input.TemplateSelectionExpression !== undefined && {
+      templateSelectionExpression: input.TemplateSelectionExpression
+    }),
+    ...(input.TimeoutInMillis !== undefined && {
+      timeoutInMillis: input.TimeoutInMillis
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -662,32 +631,29 @@ export const serializeAws_restJson1_1CreateIntegrationResponseCommand = async (
     throw new Error("No value provided for input HTTP label: IntegrationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContentHandlingStrategy !== undefined) {
-    bodyParams["contentHandlingStrategy"] = input.ContentHandlingStrategy;
-  }
-  if (input.IntegrationResponseKey !== undefined) {
-    bodyParams["integrationResponseKey"] = input.IntegrationResponseKey;
-  }
-  if (input.ResponseParameters !== undefined) {
-    bodyParams[
-      "responseParameters"
-    ] = serializeAws_restJson1_1IntegrationParameters(
-      input.ResponseParameters,
-      context
-    );
-  }
-  if (input.ResponseTemplates !== undefined) {
-    bodyParams["responseTemplates"] = serializeAws_restJson1_1TemplateMap(
-      input.ResponseTemplates,
-      context
-    );
-  }
-  if (input.TemplateSelectionExpression !== undefined) {
-    bodyParams["templateSelectionExpression"] =
-      input.TemplateSelectionExpression;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContentHandlingStrategy !== undefined && {
+      contentHandlingStrategy: input.ContentHandlingStrategy
+    }),
+    ...(input.IntegrationResponseKey !== undefined && {
+      integrationResponseKey: input.IntegrationResponseKey
+    }),
+    ...(input.ResponseParameters !== undefined && {
+      responseParameters: serializeAws_restJson1_1IntegrationParameters(
+        input.ResponseParameters,
+        context
+      )
+    }),
+    ...(input.ResponseTemplates !== undefined && {
+      responseTemplates: serializeAws_restJson1_1TemplateMap(
+        input.ResponseTemplates,
+        context
+      )
+    }),
+    ...(input.TemplateSelectionExpression !== undefined && {
+      templateSelectionExpression: input.TemplateSelectionExpression
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -721,20 +687,12 @@ export const serializeAws_restJson1_1CreateModelCommand = async (
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContentType !== undefined) {
-    bodyParams["contentType"] = input.ContentType;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Schema !== undefined) {
-    bodyParams["schema"] = input.Schema;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContentType !== undefined && { contentType: input.ContentType }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Schema !== undefined && { schema: input.Schema })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -768,53 +726,46 @@ export const serializeAws_restJson1_1CreateRouteCommand = async (
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ApiKeyRequired !== undefined) {
-    bodyParams["apiKeyRequired"] = input.ApiKeyRequired;
-  }
-  if (input.AuthorizationScopes !== undefined) {
-    bodyParams[
-      "authorizationScopes"
-    ] = serializeAws_restJson1_1AuthorizationScopes(
-      input.AuthorizationScopes,
-      context
-    );
-  }
-  if (input.AuthorizationType !== undefined) {
-    bodyParams["authorizationType"] = input.AuthorizationType;
-  }
-  if (input.AuthorizerId !== undefined) {
-    bodyParams["authorizerId"] = input.AuthorizerId;
-  }
-  if (input.ModelSelectionExpression !== undefined) {
-    bodyParams["modelSelectionExpression"] = input.ModelSelectionExpression;
-  }
-  if (input.OperationName !== undefined) {
-    bodyParams["operationName"] = input.OperationName;
-  }
-  if (input.RequestModels !== undefined) {
-    bodyParams["requestModels"] = serializeAws_restJson1_1RouteModels(
-      input.RequestModels,
-      context
-    );
-  }
-  if (input.RequestParameters !== undefined) {
-    bodyParams["requestParameters"] = serializeAws_restJson1_1RouteParameters(
-      input.RequestParameters,
-      context
-    );
-  }
-  if (input.RouteKey !== undefined) {
-    bodyParams["routeKey"] = input.RouteKey;
-  }
-  if (input.RouteResponseSelectionExpression !== undefined) {
-    bodyParams["routeResponseSelectionExpression"] =
-      input.RouteResponseSelectionExpression;
-  }
-  if (input.Target !== undefined) {
-    bodyParams["target"] = input.Target;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ApiKeyRequired !== undefined && {
+      apiKeyRequired: input.ApiKeyRequired
+    }),
+    ...(input.AuthorizationScopes !== undefined && {
+      authorizationScopes: serializeAws_restJson1_1AuthorizationScopes(
+        input.AuthorizationScopes,
+        context
+      )
+    }),
+    ...(input.AuthorizationType !== undefined && {
+      authorizationType: input.AuthorizationType
+    }),
+    ...(input.AuthorizerId !== undefined && {
+      authorizerId: input.AuthorizerId
+    }),
+    ...(input.ModelSelectionExpression !== undefined && {
+      modelSelectionExpression: input.ModelSelectionExpression
+    }),
+    ...(input.OperationName !== undefined && {
+      operationName: input.OperationName
+    }),
+    ...(input.RequestModels !== undefined && {
+      requestModels: serializeAws_restJson1_1RouteModels(
+        input.RequestModels,
+        context
+      )
+    }),
+    ...(input.RequestParameters !== undefined && {
+      requestParameters: serializeAws_restJson1_1RouteParameters(
+        input.RequestParameters,
+        context
+      )
+    }),
+    ...(input.RouteKey !== undefined && { routeKey: input.RouteKey }),
+    ...(input.RouteResponseSelectionExpression !== undefined && {
+      routeResponseSelectionExpression: input.RouteResponseSelectionExpression
+    }),
+    ...(input.Target !== undefined && { target: input.Target })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -860,26 +811,26 @@ export const serializeAws_restJson1_1CreateRouteResponseCommand = async (
     throw new Error("No value provided for input HTTP label: RouteId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ModelSelectionExpression !== undefined) {
-    bodyParams["modelSelectionExpression"] = input.ModelSelectionExpression;
-  }
-  if (input.ResponseModels !== undefined) {
-    bodyParams["responseModels"] = serializeAws_restJson1_1RouteModels(
-      input.ResponseModels,
-      context
-    );
-  }
-  if (input.ResponseParameters !== undefined) {
-    bodyParams["responseParameters"] = serializeAws_restJson1_1RouteParameters(
-      input.ResponseParameters,
-      context
-    );
-  }
-  if (input.RouteResponseKey !== undefined) {
-    bodyParams["routeResponseKey"] = input.RouteResponseKey;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ModelSelectionExpression !== undefined && {
+      modelSelectionExpression: input.ModelSelectionExpression
+    }),
+    ...(input.ResponseModels !== undefined && {
+      responseModels: serializeAws_restJson1_1RouteModels(
+        input.ResponseModels,
+        context
+      )
+    }),
+    ...(input.ResponseParameters !== undefined && {
+      responseParameters: serializeAws_restJson1_1RouteParameters(
+        input.ResponseParameters,
+        context
+      )
+    }),
+    ...(input.RouteResponseKey !== undefined && {
+      routeResponseKey: input.RouteResponseKey
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -913,50 +864,44 @@ export const serializeAws_restJson1_1CreateStageCommand = async (
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccessLogSettings !== undefined) {
-    bodyParams["accessLogSettings"] = serializeAws_restJson1_1AccessLogSettings(
-      input.AccessLogSettings,
-      context
-    );
-  }
-  if (input.AutoDeploy !== undefined) {
-    bodyParams["autoDeploy"] = input.AutoDeploy;
-  }
-  if (input.ClientCertificateId !== undefined) {
-    bodyParams["clientCertificateId"] = input.ClientCertificateId;
-  }
-  if (input.DefaultRouteSettings !== undefined) {
-    bodyParams["defaultRouteSettings"] = serializeAws_restJson1_1RouteSettings(
-      input.DefaultRouteSettings,
-      context
-    );
-  }
-  if (input.DeploymentId !== undefined) {
-    bodyParams["deploymentId"] = input.DeploymentId;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.RouteSettings !== undefined) {
-    bodyParams["routeSettings"] = serializeAws_restJson1_1RouteSettingsMap(
-      input.RouteSettings,
-      context
-    );
-  }
-  if (input.StageName !== undefined) {
-    bodyParams["stageName"] = input.StageName;
-  }
-  if (input.StageVariables !== undefined) {
-    bodyParams["stageVariables"] = serializeAws_restJson1_1StageVariablesMap(
-      input.StageVariables,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccessLogSettings !== undefined && {
+      accessLogSettings: serializeAws_restJson1_1AccessLogSettings(
+        input.AccessLogSettings,
+        context
+      )
+    }),
+    ...(input.AutoDeploy !== undefined && { autoDeploy: input.AutoDeploy }),
+    ...(input.ClientCertificateId !== undefined && {
+      clientCertificateId: input.ClientCertificateId
+    }),
+    ...(input.DefaultRouteSettings !== undefined && {
+      defaultRouteSettings: serializeAws_restJson1_1RouteSettings(
+        input.DefaultRouteSettings,
+        context
+      )
+    }),
+    ...(input.DeploymentId !== undefined && {
+      deploymentId: input.DeploymentId
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.RouteSettings !== undefined && {
+      routeSettings: serializeAws_restJson1_1RouteSettingsMap(
+        input.RouteSettings,
+        context
+      )
+    }),
+    ...(input.StageName !== undefined && { stageName: input.StageName }),
+    ...(input.StageVariables !== undefined && {
+      stageVariables: serializeAws_restJson1_1StageVariablesMap(
+        input.StageVariables,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2602,11 +2547,9 @@ export const serializeAws_restJson1_1ImportApiCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Body !== undefined) {
-    bodyParams["body"] = input.Body;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Body !== undefined && { body: input.Body })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2647,11 +2590,9 @@ export const serializeAws_restJson1_1ReimportApiCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Body !== undefined) {
-    bodyParams["body"] = input.Body;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Body !== undefined && { body: input.Body })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2688,11 +2629,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2767,41 +2708,31 @@ export const serializeAws_restJson1_1UpdateApiCommand = async (
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ApiKeySelectionExpression !== undefined) {
-    bodyParams["apiKeySelectionExpression"] = input.ApiKeySelectionExpression;
-  }
-  if (input.CorsConfiguration !== undefined) {
-    bodyParams["corsConfiguration"] = serializeAws_restJson1_1Cors(
-      input.CorsConfiguration,
-      context
-    );
-  }
-  if (input.CredentialsArn !== undefined) {
-    bodyParams["credentialsArn"] = input.CredentialsArn;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.DisableSchemaValidation !== undefined) {
-    bodyParams["disableSchemaValidation"] = input.DisableSchemaValidation;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.RouteKey !== undefined) {
-    bodyParams["routeKey"] = input.RouteKey;
-  }
-  if (input.RouteSelectionExpression !== undefined) {
-    bodyParams["routeSelectionExpression"] = input.RouteSelectionExpression;
-  }
-  if (input.Target !== undefined) {
-    bodyParams["target"] = input.Target;
-  }
-  if (input.Version !== undefined) {
-    bodyParams["version"] = input.Version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ApiKeySelectionExpression !== undefined && {
+      apiKeySelectionExpression: input.ApiKeySelectionExpression
+    }),
+    ...(input.CorsConfiguration !== undefined && {
+      corsConfiguration: serializeAws_restJson1_1Cors(
+        input.CorsConfiguration,
+        context
+      )
+    }),
+    ...(input.CredentialsArn !== undefined && {
+      credentialsArn: input.CredentialsArn
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.DisableSchemaValidation !== undefined && {
+      disableSchemaValidation: input.DisableSchemaValidation
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.RouteKey !== undefined && { routeKey: input.RouteKey }),
+    ...(input.RouteSelectionExpression !== undefined && {
+      routeSelectionExpression: input.RouteSelectionExpression
+    }),
+    ...(input.Target !== undefined && { target: input.Target }),
+    ...(input.Version !== undefined && { version: input.Version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2849,17 +2780,13 @@ export const serializeAws_restJson1_1UpdateApiMappingCommand = async (
     throw new Error("No value provided for input HTTP label: DomainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ApiId !== undefined) {
-    bodyParams["apiId"] = input.ApiId;
-  }
-  if (input.ApiMappingKey !== undefined) {
-    bodyParams["apiMappingKey"] = input.ApiMappingKey;
-  }
-  if (input.Stage !== undefined) {
-    bodyParams["stage"] = input.Stage;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ApiId !== undefined && { apiId: input.ApiId }),
+    ...(input.ApiMappingKey !== undefined && {
+      apiMappingKey: input.ApiMappingKey
+    }),
+    ...(input.Stage !== undefined && { stage: input.Stage })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2907,40 +2834,36 @@ export const serializeAws_restJson1_1UpdateAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: AuthorizerId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AuthorizerCredentialsArn !== undefined) {
-    bodyParams["authorizerCredentialsArn"] = input.AuthorizerCredentialsArn;
-  }
-  if (input.AuthorizerResultTtlInSeconds !== undefined) {
-    bodyParams["authorizerResultTtlInSeconds"] =
-      input.AuthorizerResultTtlInSeconds;
-  }
-  if (input.AuthorizerType !== undefined) {
-    bodyParams["authorizerType"] = input.AuthorizerType;
-  }
-  if (input.AuthorizerUri !== undefined) {
-    bodyParams["authorizerUri"] = input.AuthorizerUri;
-  }
-  if (input.IdentitySource !== undefined) {
-    bodyParams["identitySource"] = serializeAws_restJson1_1IdentitySourceList(
-      input.IdentitySource,
-      context
-    );
-  }
-  if (input.IdentityValidationExpression !== undefined) {
-    bodyParams["identityValidationExpression"] =
-      input.IdentityValidationExpression;
-  }
-  if (input.JwtConfiguration !== undefined) {
-    bodyParams["jwtConfiguration"] = serializeAws_restJson1_1JWTConfiguration(
-      input.JwtConfiguration,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AuthorizerCredentialsArn !== undefined && {
+      authorizerCredentialsArn: input.AuthorizerCredentialsArn
+    }),
+    ...(input.AuthorizerResultTtlInSeconds !== undefined && {
+      authorizerResultTtlInSeconds: input.AuthorizerResultTtlInSeconds
+    }),
+    ...(input.AuthorizerType !== undefined && {
+      authorizerType: input.AuthorizerType
+    }),
+    ...(input.AuthorizerUri !== undefined && {
+      authorizerUri: input.AuthorizerUri
+    }),
+    ...(input.IdentitySource !== undefined && {
+      identitySource: serializeAws_restJson1_1IdentitySourceList(
+        input.IdentitySource,
+        context
+      )
+    }),
+    ...(input.IdentityValidationExpression !== undefined && {
+      identityValidationExpression: input.IdentityValidationExpression
+    }),
+    ...(input.JwtConfiguration !== undefined && {
+      jwtConfiguration: serializeAws_restJson1_1JWTConfiguration(
+        input.JwtConfiguration,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2988,11 +2911,9 @@ export const serializeAws_restJson1_1UpdateDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: DeploymentId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3026,16 +2947,14 @@ export const serializeAws_restJson1_1UpdateDomainNameCommand = async (
     throw new Error("No value provided for input HTTP label: DomainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainNameConfigurations !== undefined) {
-    bodyParams[
-      "domainNameConfigurations"
-    ] = serializeAws_restJson1_1DomainNameConfigurations(
-      input.DomainNameConfigurations,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainNameConfigurations !== undefined && {
+      domainNameConfigurations: serializeAws_restJson1_1DomainNameConfigurations(
+        input.DomainNameConfigurations,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3083,59 +3002,54 @@ export const serializeAws_restJson1_1UpdateIntegrationCommand = async (
     throw new Error("No value provided for input HTTP label: IntegrationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConnectionId !== undefined) {
-    bodyParams["connectionId"] = input.ConnectionId;
-  }
-  if (input.ConnectionType !== undefined) {
-    bodyParams["connectionType"] = input.ConnectionType;
-  }
-  if (input.ContentHandlingStrategy !== undefined) {
-    bodyParams["contentHandlingStrategy"] = input.ContentHandlingStrategy;
-  }
-  if (input.CredentialsArn !== undefined) {
-    bodyParams["credentialsArn"] = input.CredentialsArn;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.IntegrationMethod !== undefined) {
-    bodyParams["integrationMethod"] = input.IntegrationMethod;
-  }
-  if (input.IntegrationType !== undefined) {
-    bodyParams["integrationType"] = input.IntegrationType;
-  }
-  if (input.IntegrationUri !== undefined) {
-    bodyParams["integrationUri"] = input.IntegrationUri;
-  }
-  if (input.PassthroughBehavior !== undefined) {
-    bodyParams["passthroughBehavior"] = input.PassthroughBehavior;
-  }
-  if (input.PayloadFormatVersion !== undefined) {
-    bodyParams["payloadFormatVersion"] = input.PayloadFormatVersion;
-  }
-  if (input.RequestParameters !== undefined) {
-    bodyParams[
-      "requestParameters"
-    ] = serializeAws_restJson1_1IntegrationParameters(
-      input.RequestParameters,
-      context
-    );
-  }
-  if (input.RequestTemplates !== undefined) {
-    bodyParams["requestTemplates"] = serializeAws_restJson1_1TemplateMap(
-      input.RequestTemplates,
-      context
-    );
-  }
-  if (input.TemplateSelectionExpression !== undefined) {
-    bodyParams["templateSelectionExpression"] =
-      input.TemplateSelectionExpression;
-  }
-  if (input.TimeoutInMillis !== undefined) {
-    bodyParams["timeoutInMillis"] = input.TimeoutInMillis;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConnectionId !== undefined && {
+      connectionId: input.ConnectionId
+    }),
+    ...(input.ConnectionType !== undefined && {
+      connectionType: input.ConnectionType
+    }),
+    ...(input.ContentHandlingStrategy !== undefined && {
+      contentHandlingStrategy: input.ContentHandlingStrategy
+    }),
+    ...(input.CredentialsArn !== undefined && {
+      credentialsArn: input.CredentialsArn
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.IntegrationMethod !== undefined && {
+      integrationMethod: input.IntegrationMethod
+    }),
+    ...(input.IntegrationType !== undefined && {
+      integrationType: input.IntegrationType
+    }),
+    ...(input.IntegrationUri !== undefined && {
+      integrationUri: input.IntegrationUri
+    }),
+    ...(input.PassthroughBehavior !== undefined && {
+      passthroughBehavior: input.PassthroughBehavior
+    }),
+    ...(input.PayloadFormatVersion !== undefined && {
+      payloadFormatVersion: input.PayloadFormatVersion
+    }),
+    ...(input.RequestParameters !== undefined && {
+      requestParameters: serializeAws_restJson1_1IntegrationParameters(
+        input.RequestParameters,
+        context
+      )
+    }),
+    ...(input.RequestTemplates !== undefined && {
+      requestTemplates: serializeAws_restJson1_1TemplateMap(
+        input.RequestTemplates,
+        context
+      )
+    }),
+    ...(input.TemplateSelectionExpression !== undefined && {
+      templateSelectionExpression: input.TemplateSelectionExpression
+    }),
+    ...(input.TimeoutInMillis !== undefined && {
+      timeoutInMillis: input.TimeoutInMillis
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3200,32 +3114,29 @@ export const serializeAws_restJson1_1UpdateIntegrationResponseCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContentHandlingStrategy !== undefined) {
-    bodyParams["contentHandlingStrategy"] = input.ContentHandlingStrategy;
-  }
-  if (input.IntegrationResponseKey !== undefined) {
-    bodyParams["integrationResponseKey"] = input.IntegrationResponseKey;
-  }
-  if (input.ResponseParameters !== undefined) {
-    bodyParams[
-      "responseParameters"
-    ] = serializeAws_restJson1_1IntegrationParameters(
-      input.ResponseParameters,
-      context
-    );
-  }
-  if (input.ResponseTemplates !== undefined) {
-    bodyParams["responseTemplates"] = serializeAws_restJson1_1TemplateMap(
-      input.ResponseTemplates,
-      context
-    );
-  }
-  if (input.TemplateSelectionExpression !== undefined) {
-    bodyParams["templateSelectionExpression"] =
-      input.TemplateSelectionExpression;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContentHandlingStrategy !== undefined && {
+      contentHandlingStrategy: input.ContentHandlingStrategy
+    }),
+    ...(input.IntegrationResponseKey !== undefined && {
+      integrationResponseKey: input.IntegrationResponseKey
+    }),
+    ...(input.ResponseParameters !== undefined && {
+      responseParameters: serializeAws_restJson1_1IntegrationParameters(
+        input.ResponseParameters,
+        context
+      )
+    }),
+    ...(input.ResponseTemplates !== undefined && {
+      responseTemplates: serializeAws_restJson1_1TemplateMap(
+        input.ResponseTemplates,
+        context
+      )
+    }),
+    ...(input.TemplateSelectionExpression !== undefined && {
+      templateSelectionExpression: input.TemplateSelectionExpression
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3271,20 +3182,12 @@ export const serializeAws_restJson1_1UpdateModelCommand = async (
     throw new Error("No value provided for input HTTP label: ModelId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContentType !== undefined) {
-    bodyParams["contentType"] = input.ContentType;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Schema !== undefined) {
-    bodyParams["schema"] = input.Schema;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContentType !== undefined && { contentType: input.ContentType }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Schema !== undefined && { schema: input.Schema })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3330,53 +3233,46 @@ export const serializeAws_restJson1_1UpdateRouteCommand = async (
     throw new Error("No value provided for input HTTP label: RouteId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ApiKeyRequired !== undefined) {
-    bodyParams["apiKeyRequired"] = input.ApiKeyRequired;
-  }
-  if (input.AuthorizationScopes !== undefined) {
-    bodyParams[
-      "authorizationScopes"
-    ] = serializeAws_restJson1_1AuthorizationScopes(
-      input.AuthorizationScopes,
-      context
-    );
-  }
-  if (input.AuthorizationType !== undefined) {
-    bodyParams["authorizationType"] = input.AuthorizationType;
-  }
-  if (input.AuthorizerId !== undefined) {
-    bodyParams["authorizerId"] = input.AuthorizerId;
-  }
-  if (input.ModelSelectionExpression !== undefined) {
-    bodyParams["modelSelectionExpression"] = input.ModelSelectionExpression;
-  }
-  if (input.OperationName !== undefined) {
-    bodyParams["operationName"] = input.OperationName;
-  }
-  if (input.RequestModels !== undefined) {
-    bodyParams["requestModels"] = serializeAws_restJson1_1RouteModels(
-      input.RequestModels,
-      context
-    );
-  }
-  if (input.RequestParameters !== undefined) {
-    bodyParams["requestParameters"] = serializeAws_restJson1_1RouteParameters(
-      input.RequestParameters,
-      context
-    );
-  }
-  if (input.RouteKey !== undefined) {
-    bodyParams["routeKey"] = input.RouteKey;
-  }
-  if (input.RouteResponseSelectionExpression !== undefined) {
-    bodyParams["routeResponseSelectionExpression"] =
-      input.RouteResponseSelectionExpression;
-  }
-  if (input.Target !== undefined) {
-    bodyParams["target"] = input.Target;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ApiKeyRequired !== undefined && {
+      apiKeyRequired: input.ApiKeyRequired
+    }),
+    ...(input.AuthorizationScopes !== undefined && {
+      authorizationScopes: serializeAws_restJson1_1AuthorizationScopes(
+        input.AuthorizationScopes,
+        context
+      )
+    }),
+    ...(input.AuthorizationType !== undefined && {
+      authorizationType: input.AuthorizationType
+    }),
+    ...(input.AuthorizerId !== undefined && {
+      authorizerId: input.AuthorizerId
+    }),
+    ...(input.ModelSelectionExpression !== undefined && {
+      modelSelectionExpression: input.ModelSelectionExpression
+    }),
+    ...(input.OperationName !== undefined && {
+      operationName: input.OperationName
+    }),
+    ...(input.RequestModels !== undefined && {
+      requestModels: serializeAws_restJson1_1RouteModels(
+        input.RequestModels,
+        context
+      )
+    }),
+    ...(input.RequestParameters !== undefined && {
+      requestParameters: serializeAws_restJson1_1RouteParameters(
+        input.RequestParameters,
+        context
+      )
+    }),
+    ...(input.RouteKey !== undefined && { routeKey: input.RouteKey }),
+    ...(input.RouteResponseSelectionExpression !== undefined && {
+      routeResponseSelectionExpression: input.RouteResponseSelectionExpression
+    }),
+    ...(input.Target !== undefined && { target: input.Target })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3437,26 +3333,26 @@ export const serializeAws_restJson1_1UpdateRouteResponseCommand = async (
     throw new Error("No value provided for input HTTP label: RouteResponseId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ModelSelectionExpression !== undefined) {
-    bodyParams["modelSelectionExpression"] = input.ModelSelectionExpression;
-  }
-  if (input.ResponseModels !== undefined) {
-    bodyParams["responseModels"] = serializeAws_restJson1_1RouteModels(
-      input.ResponseModels,
-      context
-    );
-  }
-  if (input.ResponseParameters !== undefined) {
-    bodyParams["responseParameters"] = serializeAws_restJson1_1RouteParameters(
-      input.ResponseParameters,
-      context
-    );
-  }
-  if (input.RouteResponseKey !== undefined) {
-    bodyParams["routeResponseKey"] = input.RouteResponseKey;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ModelSelectionExpression !== undefined && {
+      modelSelectionExpression: input.ModelSelectionExpression
+    }),
+    ...(input.ResponseModels !== undefined && {
+      responseModels: serializeAws_restJson1_1RouteModels(
+        input.ResponseModels,
+        context
+      )
+    }),
+    ...(input.ResponseParameters !== undefined && {
+      responseParameters: serializeAws_restJson1_1RouteParameters(
+        input.ResponseParameters,
+        context
+      )
+    }),
+    ...(input.RouteResponseKey !== undefined && {
+      routeResponseKey: input.RouteResponseKey
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3502,44 +3398,40 @@ export const serializeAws_restJson1_1UpdateStageCommand = async (
     throw new Error("No value provided for input HTTP label: StageName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccessLogSettings !== undefined) {
-    bodyParams["accessLogSettings"] = serializeAws_restJson1_1AccessLogSettings(
-      input.AccessLogSettings,
-      context
-    );
-  }
-  if (input.AutoDeploy !== undefined) {
-    bodyParams["autoDeploy"] = input.AutoDeploy;
-  }
-  if (input.ClientCertificateId !== undefined) {
-    bodyParams["clientCertificateId"] = input.ClientCertificateId;
-  }
-  if (input.DefaultRouteSettings !== undefined) {
-    bodyParams["defaultRouteSettings"] = serializeAws_restJson1_1RouteSettings(
-      input.DefaultRouteSettings,
-      context
-    );
-  }
-  if (input.DeploymentId !== undefined) {
-    bodyParams["deploymentId"] = input.DeploymentId;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.RouteSettings !== undefined) {
-    bodyParams["routeSettings"] = serializeAws_restJson1_1RouteSettingsMap(
-      input.RouteSettings,
-      context
-    );
-  }
-  if (input.StageVariables !== undefined) {
-    bodyParams["stageVariables"] = serializeAws_restJson1_1StageVariablesMap(
-      input.StageVariables,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccessLogSettings !== undefined && {
+      accessLogSettings: serializeAws_restJson1_1AccessLogSettings(
+        input.AccessLogSettings,
+        context
+      )
+    }),
+    ...(input.AutoDeploy !== undefined && { autoDeploy: input.AutoDeploy }),
+    ...(input.ClientCertificateId !== undefined && {
+      clientCertificateId: input.ClientCertificateId
+    }),
+    ...(input.DefaultRouteSettings !== undefined && {
+      defaultRouteSettings: serializeAws_restJson1_1RouteSettings(
+        input.DefaultRouteSettings,
+        context
+      )
+    }),
+    ...(input.DeploymentId !== undefined && {
+      deploymentId: input.DeploymentId
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.RouteSettings !== undefined && {
+      routeSettings: serializeAws_restJson1_1RouteSettingsMap(
+        input.RouteSettings,
+        context
+      )
+    }),
+    ...(input.StageVariables !== undefined && {
+      stageVariables: serializeAws_restJson1_1StageVariablesMap(
+        input.StageVariables,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
@@ -205,23 +205,16 @@ export const serializeAws_restJson1_1CreateMeshCommand = async (
   };
   let resolvedPath = "/v20190125/meshes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.meshName !== undefined) {
-    bodyParams["meshName"] = input.meshName;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1MeshSpec(input.spec, context);
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.meshName !== undefined && { meshName: input.meshName }),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1MeshSpec(input.spec, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -272,23 +265,16 @@ export const serializeAws_restJson1_1CreateRouteCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.routeName !== undefined) {
-    bodyParams["routeName"] = input.routeName;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1RouteSpec(input.spec, context);
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.routeName !== undefined && { routeName: input.routeName }),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1RouteSpec(input.spec, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -322,26 +308,18 @@ export const serializeAws_restJson1_1CreateVirtualNodeCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1VirtualNodeSpec(
-      input.spec,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.virtualNodeName !== undefined) {
-    bodyParams["virtualNodeName"] = input.virtualNodeName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1VirtualNodeSpec(input.spec, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.virtualNodeName !== undefined && {
+      virtualNodeName: input.virtualNodeName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -375,26 +353,18 @@ export const serializeAws_restJson1_1CreateVirtualRouterCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1VirtualRouterSpec(
-      input.spec,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.virtualRouterName !== undefined) {
-    bodyParams["virtualRouterName"] = input.virtualRouterName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1VirtualRouterSpec(input.spec, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.virtualRouterName !== undefined && {
+      virtualRouterName: input.virtualRouterName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -428,26 +398,18 @@ export const serializeAws_restJson1_1CreateVirtualServiceCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1VirtualServiceSpec(
-      input.spec,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.virtualServiceName !== undefined) {
-    bodyParams["virtualServiceName"] = input.virtualServiceName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1VirtualServiceSpec(input.spec, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.virtualServiceName !== undefined && {
+      virtualServiceName: input.virtualServiceName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1180,11 +1142,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1210,14 +1172,11 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
     ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.tagKeys !== undefined) {
-    bodyParams["tagKeys"] = serializeAws_restJson1_1TagKeyList(
-      input.tagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tagKeys !== undefined && {
+      tagKeys: serializeAws_restJson1_1TagKeyList(input.tagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1252,17 +1211,12 @@ export const serializeAws_restJson1_1UpdateMeshCommand = async (
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1MeshSpec(input.spec, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1MeshSpec(input.spec, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1325,17 +1279,12 @@ export const serializeAws_restJson1_1UpdateRouteCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1RouteSpec(input.spec, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1RouteSpec(input.spec, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1384,20 +1333,12 @@ export const serializeAws_restJson1_1UpdateVirtualNodeCommand = async (
     throw new Error("No value provided for input HTTP label: virtualNodeName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1VirtualNodeSpec(
-      input.spec,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1VirtualNodeSpec(input.spec, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1448,20 +1389,12 @@ export const serializeAws_restJson1_1UpdateVirtualRouterCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1VirtualRouterSpec(
-      input.spec,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1VirtualRouterSpec(input.spec, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1512,20 +1445,12 @@ export const serializeAws_restJson1_1UpdateVirtualServiceCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.spec !== undefined) {
-    bodyParams["spec"] = serializeAws_restJson1_1VirtualServiceSpec(
-      input.spec,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.spec !== undefined && {
+      spec: serializeAws_restJson1_1VirtualServiceSpec(input.spec, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-appconfig/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1_1.ts
@@ -152,17 +152,13 @@ export const serializeAws_restJson1_1CreateApplicationCommand = async (
   };
   let resolvedPath = "/applications";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -198,29 +194,23 @@ export const serializeAws_restJson1_1CreateConfigurationProfileCommand = async (
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.LocationUri !== undefined) {
-    bodyParams["LocationUri"] = input.LocationUri;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.RetrievalRoleArn !== undefined) {
-    bodyParams["RetrievalRoleArn"] = input.RetrievalRoleArn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  if (input.Validators !== undefined) {
-    bodyParams["Validators"] = serializeAws_restJson1_1ValidatorList(
-      input.Validators,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.LocationUri !== undefined && { LocationUri: input.LocationUri }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.RetrievalRoleArn !== undefined && {
+      RetrievalRoleArn: input.RetrievalRoleArn
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    }),
+    ...(input.Validators !== undefined && {
+      Validators: serializeAws_restJson1_1ValidatorList(
+        input.Validators,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -242,33 +232,24 @@ export const serializeAws_restJson1_1CreateDeploymentStrategyCommand = async (
   };
   let resolvedPath = "/deploymentstrategies";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeploymentDurationInMinutes !== undefined) {
-    bodyParams["DeploymentDurationInMinutes"] =
-      input.DeploymentDurationInMinutes;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.FinalBakeTimeInMinutes !== undefined) {
-    bodyParams["FinalBakeTimeInMinutes"] = input.FinalBakeTimeInMinutes;
-  }
-  if (input.GrowthFactor !== undefined) {
-    bodyParams["GrowthFactor"] = input.GrowthFactor;
-  }
-  if (input.GrowthType !== undefined) {
-    bodyParams["GrowthType"] = input.GrowthType;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ReplicateTo !== undefined) {
-    bodyParams["ReplicateTo"] = input.ReplicateTo;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeploymentDurationInMinutes !== undefined && {
+      DeploymentDurationInMinutes: input.DeploymentDurationInMinutes
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.FinalBakeTimeInMinutes !== undefined && {
+      FinalBakeTimeInMinutes: input.FinalBakeTimeInMinutes
+    }),
+    ...(input.GrowthFactor !== undefined && {
+      GrowthFactor: input.GrowthFactor
+    }),
+    ...(input.GrowthType !== undefined && { GrowthType: input.GrowthType }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ReplicateTo !== undefined && { ReplicateTo: input.ReplicateTo }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -304,23 +285,16 @@ export const serializeAws_restJson1_1CreateEnvironmentCommand = async (
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Monitors !== undefined) {
-    bodyParams["Monitors"] = serializeAws_restJson1_1MonitorList(
-      input.Monitors,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Monitors !== undefined && {
+      Monitors: serializeAws_restJson1_1MonitorList(input.Monitors, context)
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1088,23 +1062,21 @@ export const serializeAws_restJson1_1StartDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConfigurationProfileId !== undefined) {
-    bodyParams["ConfigurationProfileId"] = input.ConfigurationProfileId;
-  }
-  if (input.ConfigurationVersion !== undefined) {
-    bodyParams["ConfigurationVersion"] = input.ConfigurationVersion;
-  }
-  if (input.DeploymentStrategyId !== undefined) {
-    bodyParams["DeploymentStrategyId"] = input.DeploymentStrategyId;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConfigurationProfileId !== undefined && {
+      ConfigurationProfileId: input.ConfigurationProfileId
+    }),
+    ...(input.ConfigurationVersion !== undefined && {
+      ConfigurationVersion: input.ConfigurationVersion
+    }),
+    ...(input.DeploymentStrategyId !== undefined && {
+      DeploymentStrategyId: input.DeploymentStrategyId
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1206,11 +1178,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1287,14 +1259,10 @@ export const serializeAws_restJson1_1UpdateApplicationCommand = async (
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1347,23 +1315,19 @@ export const serializeAws_restJson1_1UpdateConfigurationProfileCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.RetrievalRoleArn !== undefined) {
-    bodyParams["RetrievalRoleArn"] = input.RetrievalRoleArn;
-  }
-  if (input.Validators !== undefined) {
-    bodyParams["Validators"] = serializeAws_restJson1_1ValidatorList(
-      input.Validators,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.RetrievalRoleArn !== undefined && {
+      RetrievalRoleArn: input.RetrievalRoleArn
+    }),
+    ...(input.Validators !== undefined && {
+      Validators: serializeAws_restJson1_1ValidatorList(
+        input.Validators,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1401,24 +1365,19 @@ export const serializeAws_restJson1_1UpdateDeploymentStrategyCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeploymentDurationInMinutes !== undefined) {
-    bodyParams["DeploymentDurationInMinutes"] =
-      input.DeploymentDurationInMinutes;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.FinalBakeTimeInMinutes !== undefined) {
-    bodyParams["FinalBakeTimeInMinutes"] = input.FinalBakeTimeInMinutes;
-  }
-  if (input.GrowthFactor !== undefined) {
-    bodyParams["GrowthFactor"] = input.GrowthFactor;
-  }
-  if (input.GrowthType !== undefined) {
-    bodyParams["GrowthType"] = input.GrowthType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeploymentDurationInMinutes !== undefined && {
+      DeploymentDurationInMinutes: input.DeploymentDurationInMinutes
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.FinalBakeTimeInMinutes !== undefined && {
+      FinalBakeTimeInMinutes: input.FinalBakeTimeInMinutes
+    }),
+    ...(input.GrowthFactor !== undefined && {
+      GrowthFactor: input.GrowthFactor
+    }),
+    ...(input.GrowthType !== undefined && { GrowthType: input.GrowthType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1469,20 +1428,13 @@ export const serializeAws_restJson1_1UpdateEnvironmentCommand = async (
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Monitors !== undefined) {
-    bodyParams["Monitors"] = serializeAws_restJson1_1MonitorList(
-      input.Monitors,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Monitors !== undefined && {
+      Monitors: serializeAws_restJson1_1MonitorList(input.Monitors, context)
+    }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-appsync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1_1.ts
@@ -236,23 +236,19 @@ export const serializeAws_restJson1_1CreateApiCacheCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.apiCachingBehavior !== undefined) {
-    bodyParams["apiCachingBehavior"] = input.apiCachingBehavior;
-  }
-  if (input.atRestEncryptionEnabled !== undefined) {
-    bodyParams["atRestEncryptionEnabled"] = input.atRestEncryptionEnabled;
-  }
-  if (input.transitEncryptionEnabled !== undefined) {
-    bodyParams["transitEncryptionEnabled"] = input.transitEncryptionEnabled;
-  }
-  if (input.ttl !== undefined) {
-    bodyParams["ttl"] = input.ttl;
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.apiCachingBehavior !== undefined && {
+      apiCachingBehavior: input.apiCachingBehavior
+    }),
+    ...(input.atRestEncryptionEnabled !== undefined && {
+      atRestEncryptionEnabled: input.atRestEncryptionEnabled
+    }),
+    ...(input.transitEncryptionEnabled !== undefined && {
+      transitEncryptionEnabled: input.transitEncryptionEnabled
+    }),
+    ...(input.ttl !== undefined && { ttl: input.ttl }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -286,14 +282,10 @@ export const serializeAws_restJson1_1CreateApiKeyCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.expires !== undefined) {
-    bodyParams["expires"] = input.expires;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.expires !== undefined && { expires: input.expires })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -327,56 +319,44 @@ export const serializeAws_restJson1_1CreateDataSourceCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.dynamodbConfig !== undefined) {
-    bodyParams[
-      "dynamodbConfig"
-    ] = serializeAws_restJson1_1DynamodbDataSourceConfig(
-      input.dynamodbConfig,
-      context
-    );
-  }
-  if (input.elasticsearchConfig !== undefined) {
-    bodyParams[
-      "elasticsearchConfig"
-    ] = serializeAws_restJson1_1ElasticsearchDataSourceConfig(
-      input.elasticsearchConfig,
-      context
-    );
-  }
-  if (input.httpConfig !== undefined) {
-    bodyParams["httpConfig"] = serializeAws_restJson1_1HttpDataSourceConfig(
-      input.httpConfig,
-      context
-    );
-  }
-  if (input.lambdaConfig !== undefined) {
-    bodyParams["lambdaConfig"] = serializeAws_restJson1_1LambdaDataSourceConfig(
-      input.lambdaConfig,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.relationalDatabaseConfig !== undefined) {
-    bodyParams[
-      "relationalDatabaseConfig"
-    ] = serializeAws_restJson1_1RelationalDatabaseDataSourceConfig(
-      input.relationalDatabaseConfig,
-      context
-    );
-  }
-  if (input.serviceRoleArn !== undefined) {
-    bodyParams["serviceRoleArn"] = input.serviceRoleArn;
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.dynamodbConfig !== undefined && {
+      dynamodbConfig: serializeAws_restJson1_1DynamodbDataSourceConfig(
+        input.dynamodbConfig,
+        context
+      )
+    }),
+    ...(input.elasticsearchConfig !== undefined && {
+      elasticsearchConfig: serializeAws_restJson1_1ElasticsearchDataSourceConfig(
+        input.elasticsearchConfig,
+        context
+      )
+    }),
+    ...(input.httpConfig !== undefined && {
+      httpConfig: serializeAws_restJson1_1HttpDataSourceConfig(
+        input.httpConfig,
+        context
+      )
+    }),
+    ...(input.lambdaConfig !== undefined && {
+      lambdaConfig: serializeAws_restJson1_1LambdaDataSourceConfig(
+        input.lambdaConfig,
+        context
+      )
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.relationalDatabaseConfig !== undefined && {
+      relationalDatabaseConfig: serializeAws_restJson1_1RelationalDatabaseDataSourceConfig(
+        input.relationalDatabaseConfig,
+        context
+      )
+    }),
+    ...(input.serviceRoleArn !== undefined && {
+      serviceRoleArn: input.serviceRoleArn
+    }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -410,26 +390,22 @@ export const serializeAws_restJson1_1CreateFunctionCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.dataSourceName !== undefined) {
-    bodyParams["dataSourceName"] = input.dataSourceName;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.functionVersion !== undefined) {
-    bodyParams["functionVersion"] = input.functionVersion;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.requestMappingTemplate !== undefined) {
-    bodyParams["requestMappingTemplate"] = input.requestMappingTemplate;
-  }
-  if (input.responseMappingTemplate !== undefined) {
-    bodyParams["responseMappingTemplate"] = input.responseMappingTemplate;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.dataSourceName !== undefined && {
+      dataSourceName: input.dataSourceName
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.functionVersion !== undefined && {
+      functionVersion: input.functionVersion
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.requestMappingTemplate !== undefined && {
+      requestMappingTemplate: input.requestMappingTemplate
+    }),
+    ...(input.responseMappingTemplate !== undefined && {
+      responseMappingTemplate: input.responseMappingTemplate
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -451,45 +427,36 @@ export const serializeAws_restJson1_1CreateGraphqlApiCommand = async (
   };
   let resolvedPath = "/apis";
   let body: any;
-  const bodyParams: any = {};
-  if (input.additionalAuthenticationProviders !== undefined) {
-    bodyParams[
-      "additionalAuthenticationProviders"
-    ] = serializeAws_restJson1_1AdditionalAuthenticationProviders(
-      input.additionalAuthenticationProviders,
-      context
-    );
-  }
-  if (input.authenticationType !== undefined) {
-    bodyParams["authenticationType"] = input.authenticationType;
-  }
-  if (input.logConfig !== undefined) {
-    bodyParams["logConfig"] = serializeAws_restJson1_1LogConfig(
-      input.logConfig,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.openIDConnectConfig !== undefined) {
-    bodyParams[
-      "openIDConnectConfig"
-    ] = serializeAws_restJson1_1OpenIDConnectConfig(
-      input.openIDConnectConfig,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.userPoolConfig !== undefined) {
-    bodyParams["userPoolConfig"] = serializeAws_restJson1_1UserPoolConfig(
-      input.userPoolConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.additionalAuthenticationProviders !== undefined && {
+      additionalAuthenticationProviders: serializeAws_restJson1_1AdditionalAuthenticationProviders(
+        input.additionalAuthenticationProviders,
+        context
+      )
+    }),
+    ...(input.authenticationType !== undefined && {
+      authenticationType: input.authenticationType
+    }),
+    ...(input.logConfig !== undefined && {
+      logConfig: serializeAws_restJson1_1LogConfig(input.logConfig, context)
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.openIDConnectConfig !== undefined && {
+      openIDConnectConfig: serializeAws_restJson1_1OpenIDConnectConfig(
+        input.openIDConnectConfig,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.userPoolConfig !== undefined && {
+      userPoolConfig: serializeAws_restJson1_1UserPoolConfig(
+        input.userPoolConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -535,41 +502,34 @@ export const serializeAws_restJson1_1CreateResolverCommand = async (
     throw new Error("No value provided for input HTTP label: typeName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.cachingConfig !== undefined) {
-    bodyParams["cachingConfig"] = serializeAws_restJson1_1CachingConfig(
-      input.cachingConfig,
-      context
-    );
-  }
-  if (input.dataSourceName !== undefined) {
-    bodyParams["dataSourceName"] = input.dataSourceName;
-  }
-  if (input.fieldName !== undefined) {
-    bodyParams["fieldName"] = input.fieldName;
-  }
-  if (input.kind !== undefined) {
-    bodyParams["kind"] = input.kind;
-  }
-  if (input.pipelineConfig !== undefined) {
-    bodyParams["pipelineConfig"] = serializeAws_restJson1_1PipelineConfig(
-      input.pipelineConfig,
-      context
-    );
-  }
-  if (input.requestMappingTemplate !== undefined) {
-    bodyParams["requestMappingTemplate"] = input.requestMappingTemplate;
-  }
-  if (input.responseMappingTemplate !== undefined) {
-    bodyParams["responseMappingTemplate"] = input.responseMappingTemplate;
-  }
-  if (input.syncConfig !== undefined) {
-    bodyParams["syncConfig"] = serializeAws_restJson1_1SyncConfig(
-      input.syncConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.cachingConfig !== undefined && {
+      cachingConfig: serializeAws_restJson1_1CachingConfig(
+        input.cachingConfig,
+        context
+      )
+    }),
+    ...(input.dataSourceName !== undefined && {
+      dataSourceName: input.dataSourceName
+    }),
+    ...(input.fieldName !== undefined && { fieldName: input.fieldName }),
+    ...(input.kind !== undefined && { kind: input.kind }),
+    ...(input.pipelineConfig !== undefined && {
+      pipelineConfig: serializeAws_restJson1_1PipelineConfig(
+        input.pipelineConfig,
+        context
+      )
+    }),
+    ...(input.requestMappingTemplate !== undefined && {
+      requestMappingTemplate: input.requestMappingTemplate
+    }),
+    ...(input.responseMappingTemplate !== undefined && {
+      responseMappingTemplate: input.responseMappingTemplate
+    }),
+    ...(input.syncConfig !== undefined && {
+      syncConfig: serializeAws_restJson1_1SyncConfig(input.syncConfig, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -603,14 +563,10 @@ export const serializeAws_restJson1_1CreateTypeCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.definition !== undefined) {
-    bodyParams["definition"] = input.definition;
-  }
-  if (input.format !== undefined) {
-    bodyParams["format"] = input.format;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.definition !== undefined && { definition: input.definition }),
+    ...(input.format !== undefined && { format: input.format })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1643,11 +1599,11 @@ export const serializeAws_restJson1_1StartSchemaCreationCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.definition !== undefined) {
-    bodyParams["definition"] = context.base64Encoder(input.definition);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.definition !== undefined && {
+      definition: context.base64Encoder(input.definition)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1683,11 +1639,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1762,17 +1718,13 @@ export const serializeAws_restJson1_1UpdateApiCacheCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.apiCachingBehavior !== undefined) {
-    bodyParams["apiCachingBehavior"] = input.apiCachingBehavior;
-  }
-  if (input.ttl !== undefined) {
-    bodyParams["ttl"] = input.ttl;
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.apiCachingBehavior !== undefined && {
+      apiCachingBehavior: input.apiCachingBehavior
+    }),
+    ...(input.ttl !== undefined && { ttl: input.ttl }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1818,14 +1770,10 @@ export const serializeAws_restJson1_1UpdateApiKeyCommand = async (
     throw new Error("No value provided for input HTTP label: id.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.expires !== undefined) {
-    bodyParams["expires"] = input.expires;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.expires !== undefined && { expires: input.expires })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1871,53 +1819,43 @@ export const serializeAws_restJson1_1UpdateDataSourceCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.dynamodbConfig !== undefined) {
-    bodyParams[
-      "dynamodbConfig"
-    ] = serializeAws_restJson1_1DynamodbDataSourceConfig(
-      input.dynamodbConfig,
-      context
-    );
-  }
-  if (input.elasticsearchConfig !== undefined) {
-    bodyParams[
-      "elasticsearchConfig"
-    ] = serializeAws_restJson1_1ElasticsearchDataSourceConfig(
-      input.elasticsearchConfig,
-      context
-    );
-  }
-  if (input.httpConfig !== undefined) {
-    bodyParams["httpConfig"] = serializeAws_restJson1_1HttpDataSourceConfig(
-      input.httpConfig,
-      context
-    );
-  }
-  if (input.lambdaConfig !== undefined) {
-    bodyParams["lambdaConfig"] = serializeAws_restJson1_1LambdaDataSourceConfig(
-      input.lambdaConfig,
-      context
-    );
-  }
-  if (input.relationalDatabaseConfig !== undefined) {
-    bodyParams[
-      "relationalDatabaseConfig"
-    ] = serializeAws_restJson1_1RelationalDatabaseDataSourceConfig(
-      input.relationalDatabaseConfig,
-      context
-    );
-  }
-  if (input.serviceRoleArn !== undefined) {
-    bodyParams["serviceRoleArn"] = input.serviceRoleArn;
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.dynamodbConfig !== undefined && {
+      dynamodbConfig: serializeAws_restJson1_1DynamodbDataSourceConfig(
+        input.dynamodbConfig,
+        context
+      )
+    }),
+    ...(input.elasticsearchConfig !== undefined && {
+      elasticsearchConfig: serializeAws_restJson1_1ElasticsearchDataSourceConfig(
+        input.elasticsearchConfig,
+        context
+      )
+    }),
+    ...(input.httpConfig !== undefined && {
+      httpConfig: serializeAws_restJson1_1HttpDataSourceConfig(
+        input.httpConfig,
+        context
+      )
+    }),
+    ...(input.lambdaConfig !== undefined && {
+      lambdaConfig: serializeAws_restJson1_1LambdaDataSourceConfig(
+        input.lambdaConfig,
+        context
+      )
+    }),
+    ...(input.relationalDatabaseConfig !== undefined && {
+      relationalDatabaseConfig: serializeAws_restJson1_1RelationalDatabaseDataSourceConfig(
+        input.relationalDatabaseConfig,
+        context
+      )
+    }),
+    ...(input.serviceRoleArn !== undefined && {
+      serviceRoleArn: input.serviceRoleArn
+    }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1963,26 +1901,22 @@ export const serializeAws_restJson1_1UpdateFunctionCommand = async (
     throw new Error("No value provided for input HTTP label: functionId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.dataSourceName !== undefined) {
-    bodyParams["dataSourceName"] = input.dataSourceName;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.functionVersion !== undefined) {
-    bodyParams["functionVersion"] = input.functionVersion;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.requestMappingTemplate !== undefined) {
-    bodyParams["requestMappingTemplate"] = input.requestMappingTemplate;
-  }
-  if (input.responseMappingTemplate !== undefined) {
-    bodyParams["responseMappingTemplate"] = input.responseMappingTemplate;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.dataSourceName !== undefined && {
+      dataSourceName: input.dataSourceName
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.functionVersion !== undefined && {
+      functionVersion: input.functionVersion
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.requestMappingTemplate !== undefined && {
+      requestMappingTemplate: input.requestMappingTemplate
+    }),
+    ...(input.responseMappingTemplate !== undefined && {
+      responseMappingTemplate: input.responseMappingTemplate
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2016,42 +1950,33 @@ export const serializeAws_restJson1_1UpdateGraphqlApiCommand = async (
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.additionalAuthenticationProviders !== undefined) {
-    bodyParams[
-      "additionalAuthenticationProviders"
-    ] = serializeAws_restJson1_1AdditionalAuthenticationProviders(
-      input.additionalAuthenticationProviders,
-      context
-    );
-  }
-  if (input.authenticationType !== undefined) {
-    bodyParams["authenticationType"] = input.authenticationType;
-  }
-  if (input.logConfig !== undefined) {
-    bodyParams["logConfig"] = serializeAws_restJson1_1LogConfig(
-      input.logConfig,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.openIDConnectConfig !== undefined) {
-    bodyParams[
-      "openIDConnectConfig"
-    ] = serializeAws_restJson1_1OpenIDConnectConfig(
-      input.openIDConnectConfig,
-      context
-    );
-  }
-  if (input.userPoolConfig !== undefined) {
-    bodyParams["userPoolConfig"] = serializeAws_restJson1_1UserPoolConfig(
-      input.userPoolConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.additionalAuthenticationProviders !== undefined && {
+      additionalAuthenticationProviders: serializeAws_restJson1_1AdditionalAuthenticationProviders(
+        input.additionalAuthenticationProviders,
+        context
+      )
+    }),
+    ...(input.authenticationType !== undefined && {
+      authenticationType: input.authenticationType
+    }),
+    ...(input.logConfig !== undefined && {
+      logConfig: serializeAws_restJson1_1LogConfig(input.logConfig, context)
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.openIDConnectConfig !== undefined && {
+      openIDConnectConfig: serializeAws_restJson1_1OpenIDConnectConfig(
+        input.openIDConnectConfig,
+        context
+      )
+    }),
+    ...(input.userPoolConfig !== undefined && {
+      userPoolConfig: serializeAws_restJson1_1UserPoolConfig(
+        input.userPoolConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2109,38 +2034,33 @@ export const serializeAws_restJson1_1UpdateResolverCommand = async (
     throw new Error("No value provided for input HTTP label: typeName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.cachingConfig !== undefined) {
-    bodyParams["cachingConfig"] = serializeAws_restJson1_1CachingConfig(
-      input.cachingConfig,
-      context
-    );
-  }
-  if (input.dataSourceName !== undefined) {
-    bodyParams["dataSourceName"] = input.dataSourceName;
-  }
-  if (input.kind !== undefined) {
-    bodyParams["kind"] = input.kind;
-  }
-  if (input.pipelineConfig !== undefined) {
-    bodyParams["pipelineConfig"] = serializeAws_restJson1_1PipelineConfig(
-      input.pipelineConfig,
-      context
-    );
-  }
-  if (input.requestMappingTemplate !== undefined) {
-    bodyParams["requestMappingTemplate"] = input.requestMappingTemplate;
-  }
-  if (input.responseMappingTemplate !== undefined) {
-    bodyParams["responseMappingTemplate"] = input.responseMappingTemplate;
-  }
-  if (input.syncConfig !== undefined) {
-    bodyParams["syncConfig"] = serializeAws_restJson1_1SyncConfig(
-      input.syncConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.cachingConfig !== undefined && {
+      cachingConfig: serializeAws_restJson1_1CachingConfig(
+        input.cachingConfig,
+        context
+      )
+    }),
+    ...(input.dataSourceName !== undefined && {
+      dataSourceName: input.dataSourceName
+    }),
+    ...(input.kind !== undefined && { kind: input.kind }),
+    ...(input.pipelineConfig !== undefined && {
+      pipelineConfig: serializeAws_restJson1_1PipelineConfig(
+        input.pipelineConfig,
+        context
+      )
+    }),
+    ...(input.requestMappingTemplate !== undefined && {
+      requestMappingTemplate: input.requestMappingTemplate
+    }),
+    ...(input.responseMappingTemplate !== undefined && {
+      responseMappingTemplate: input.responseMappingTemplate
+    }),
+    ...(input.syncConfig !== undefined && {
+      syncConfig: serializeAws_restJson1_1SyncConfig(input.syncConfig, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2186,14 +2106,10 @@ export const serializeAws_restJson1_1UpdateTypeCommand = async (
     throw new Error("No value provided for input HTTP label: typeName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.definition !== undefined) {
-    bodyParams["definition"] = input.definition;
-  }
-  if (input.format !== undefined) {
-    bodyParams["format"] = input.format;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.definition !== undefined && { definition: input.definition }),
+    ...(input.format !== undefined && { format: input.format })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-backup/protocols/Aws_restJson1_1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1_1.ts
@@ -237,23 +237,23 @@ export const serializeAws_restJson1_1CreateBackupPlanCommand = async (
   };
   let resolvedPath = "/backup/plans";
   let body: any;
-  const bodyParams: any = {};
-  if (input.BackupPlan !== undefined) {
-    bodyParams["BackupPlan"] = serializeAws_restJson1_1BackupPlanInput(
-      input.BackupPlan,
-      context
-    );
-  }
-  if (input.BackupPlanTags !== undefined) {
-    bodyParams["BackupPlanTags"] = serializeAws_restJson1_1Tags(
-      input.BackupPlanTags,
-      context
-    );
-  }
-  if (input.CreatorRequestId !== undefined) {
-    bodyParams["CreatorRequestId"] = input.CreatorRequestId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BackupPlan !== undefined && {
+      BackupPlan: serializeAws_restJson1_1BackupPlanInput(
+        input.BackupPlan,
+        context
+      )
+    }),
+    ...(input.BackupPlanTags !== undefined && {
+      BackupPlanTags: serializeAws_restJson1_1Tags(
+        input.BackupPlanTags,
+        context
+      )
+    }),
+    ...(input.CreatorRequestId !== undefined && {
+      CreatorRequestId: input.CreatorRequestId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -289,17 +289,17 @@ export const serializeAws_restJson1_1CreateBackupSelectionCommand = async (
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BackupSelection !== undefined) {
-    bodyParams["BackupSelection"] = serializeAws_restJson1_1BackupSelection(
-      input.BackupSelection,
-      context
-    );
-  }
-  if (input.CreatorRequestId !== undefined) {
-    bodyParams["CreatorRequestId"] = input.CreatorRequestId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BackupSelection !== undefined && {
+      BackupSelection: serializeAws_restJson1_1BackupSelection(
+        input.BackupSelection,
+        context
+      )
+    }),
+    ...(input.CreatorRequestId !== undefined && {
+      CreatorRequestId: input.CreatorRequestId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -335,20 +335,20 @@ export const serializeAws_restJson1_1CreateBackupVaultCommand = async (
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BackupVaultTags !== undefined) {
-    bodyParams["BackupVaultTags"] = serializeAws_restJson1_1Tags(
-      input.BackupVaultTags,
-      context
-    );
-  }
-  if (input.CreatorRequestId !== undefined) {
-    bodyParams["CreatorRequestId"] = input.CreatorRequestId;
-  }
-  if (input.EncryptionKeyArn !== undefined) {
-    bodyParams["EncryptionKeyArn"] = input.EncryptionKeyArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BackupVaultTags !== undefined && {
+      BackupVaultTags: serializeAws_restJson1_1Tags(
+        input.BackupVaultTags,
+        context
+      )
+    }),
+    ...(input.CreatorRequestId !== undefined && {
+      CreatorRequestId: input.CreatorRequestId
+    }),
+    ...(input.EncryptionKeyArn !== undefined && {
+      EncryptionKeyArn: input.EncryptionKeyArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -911,11 +911,11 @@ export const serializeAws_restJson1_1GetBackupPlanFromJSONCommand = async (
   };
   let resolvedPath = "/backup/template/json/toPlan";
   let body: any;
-  const bodyParams: any = {};
-  if (input.BackupPlanTemplateJson !== undefined) {
-    bodyParams["BackupPlanTemplateJson"] = input.BackupPlanTemplateJson;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BackupPlanTemplateJson !== undefined && {
+      BackupPlanTemplateJson: input.BackupPlanTemplateJson
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1650,11 +1650,9 @@ export const serializeAws_restJson1_1PutBackupVaultAccessPolicyCommand = async (
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Policy !== undefined) {
-    bodyParams["Policy"] = input.Policy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Policy !== undefined && { Policy: input.Policy })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1691,17 +1689,15 @@ export const serializeAws_restJson1_1PutBackupVaultNotificationsCommand = async 
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BackupVaultEvents !== undefined) {
-    bodyParams["BackupVaultEvents"] = serializeAws_restJson1_1BackupVaultEvents(
-      input.BackupVaultEvents,
-      context
-    );
-  }
-  if (input.SNSTopicArn !== undefined) {
-    bodyParams["SNSTopicArn"] = input.SNSTopicArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BackupVaultEvents !== undefined && {
+      BackupVaultEvents: serializeAws_restJson1_1BackupVaultEvents(
+        input.BackupVaultEvents,
+        context
+      )
+    }),
+    ...(input.SNSTopicArn !== undefined && { SNSTopicArn: input.SNSTopicArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1723,38 +1719,31 @@ export const serializeAws_restJson1_1StartBackupJobCommand = async (
   };
   let resolvedPath = "/backup-jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.BackupVaultName !== undefined) {
-    bodyParams["BackupVaultName"] = input.BackupVaultName;
-  }
-  if (input.CompleteWindowMinutes !== undefined) {
-    bodyParams["CompleteWindowMinutes"] = input.CompleteWindowMinutes;
-  }
-  if (input.IamRoleArn !== undefined) {
-    bodyParams["IamRoleArn"] = input.IamRoleArn;
-  }
-  if (input.IdempotencyToken !== undefined) {
-    bodyParams["IdempotencyToken"] = input.IdempotencyToken;
-  }
-  if (input.Lifecycle !== undefined) {
-    bodyParams["Lifecycle"] = serializeAws_restJson1_1Lifecycle(
-      input.Lifecycle,
-      context
-    );
-  }
-  if (input.RecoveryPointTags !== undefined) {
-    bodyParams["RecoveryPointTags"] = serializeAws_restJson1_1Tags(
-      input.RecoveryPointTags,
-      context
-    );
-  }
-  if (input.ResourceArn !== undefined) {
-    bodyParams["ResourceArn"] = input.ResourceArn;
-  }
-  if (input.StartWindowMinutes !== undefined) {
-    bodyParams["StartWindowMinutes"] = input.StartWindowMinutes;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BackupVaultName !== undefined && {
+      BackupVaultName: input.BackupVaultName
+    }),
+    ...(input.CompleteWindowMinutes !== undefined && {
+      CompleteWindowMinutes: input.CompleteWindowMinutes
+    }),
+    ...(input.IamRoleArn !== undefined && { IamRoleArn: input.IamRoleArn }),
+    ...(input.IdempotencyToken !== undefined && {
+      IdempotencyToken: input.IdempotencyToken
+    }),
+    ...(input.Lifecycle !== undefined && {
+      Lifecycle: serializeAws_restJson1_1Lifecycle(input.Lifecycle, context)
+    }),
+    ...(input.RecoveryPointTags !== undefined && {
+      RecoveryPointTags: serializeAws_restJson1_1Tags(
+        input.RecoveryPointTags,
+        context
+      )
+    }),
+    ...(input.ResourceArn !== undefined && { ResourceArn: input.ResourceArn }),
+    ...(input.StartWindowMinutes !== undefined && {
+      StartWindowMinutes: input.StartWindowMinutes
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1776,29 +1765,24 @@ export const serializeAws_restJson1_1StartCopyJobCommand = async (
   };
   let resolvedPath = "/copy-jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DestinationBackupVaultArn !== undefined) {
-    bodyParams["DestinationBackupVaultArn"] = input.DestinationBackupVaultArn;
-  }
-  if (input.IamRoleArn !== undefined) {
-    bodyParams["IamRoleArn"] = input.IamRoleArn;
-  }
-  if (input.IdempotencyToken !== undefined) {
-    bodyParams["IdempotencyToken"] = input.IdempotencyToken;
-  }
-  if (input.Lifecycle !== undefined) {
-    bodyParams["Lifecycle"] = serializeAws_restJson1_1Lifecycle(
-      input.Lifecycle,
-      context
-    );
-  }
-  if (input.RecoveryPointArn !== undefined) {
-    bodyParams["RecoveryPointArn"] = input.RecoveryPointArn;
-  }
-  if (input.SourceBackupVaultName !== undefined) {
-    bodyParams["SourceBackupVaultName"] = input.SourceBackupVaultName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DestinationBackupVaultArn !== undefined && {
+      DestinationBackupVaultArn: input.DestinationBackupVaultArn
+    }),
+    ...(input.IamRoleArn !== undefined && { IamRoleArn: input.IamRoleArn }),
+    ...(input.IdempotencyToken !== undefined && {
+      IdempotencyToken: input.IdempotencyToken
+    }),
+    ...(input.Lifecycle !== undefined && {
+      Lifecycle: serializeAws_restJson1_1Lifecycle(input.Lifecycle, context)
+    }),
+    ...(input.RecoveryPointArn !== undefined && {
+      RecoveryPointArn: input.RecoveryPointArn
+    }),
+    ...(input.SourceBackupVaultName !== undefined && {
+      SourceBackupVaultName: input.SourceBackupVaultName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1820,26 +1804,21 @@ export const serializeAws_restJson1_1StartRestoreJobCommand = async (
   };
   let resolvedPath = "/restore-jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.IamRoleArn !== undefined) {
-    bodyParams["IamRoleArn"] = input.IamRoleArn;
-  }
-  if (input.IdempotencyToken !== undefined) {
-    bodyParams["IdempotencyToken"] = input.IdempotencyToken;
-  }
-  if (input.Metadata !== undefined) {
-    bodyParams["Metadata"] = serializeAws_restJson1_1Metadata(
-      input.Metadata,
-      context
-    );
-  }
-  if (input.RecoveryPointArn !== undefined) {
-    bodyParams["RecoveryPointArn"] = input.RecoveryPointArn;
-  }
-  if (input.ResourceType !== undefined) {
-    bodyParams["ResourceType"] = input.ResourceType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.IamRoleArn !== undefined && { IamRoleArn: input.IamRoleArn }),
+    ...(input.IdempotencyToken !== undefined && {
+      IdempotencyToken: input.IdempotencyToken
+    }),
+    ...(input.Metadata !== undefined && {
+      Metadata: serializeAws_restJson1_1Metadata(input.Metadata, context)
+    }),
+    ...(input.RecoveryPointArn !== undefined && {
+      RecoveryPointArn: input.RecoveryPointArn
+    }),
+    ...(input.ResourceType !== undefined && {
+      ResourceType: input.ResourceType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1910,11 +1889,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1950,14 +1929,11 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.TagKeyList !== undefined) {
-    bodyParams["TagKeyList"] = serializeAws_restJson1_1TagKeyList(
-      input.TagKeyList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TagKeyList !== undefined && {
+      TagKeyList: serializeAws_restJson1_1TagKeyList(input.TagKeyList, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1993,14 +1969,14 @@ export const serializeAws_restJson1_1UpdateBackupPlanCommand = async (
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BackupPlan !== undefined) {
-    bodyParams["BackupPlan"] = serializeAws_restJson1_1BackupPlanInput(
-      input.BackupPlan,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BackupPlan !== undefined && {
+      BackupPlan: serializeAws_restJson1_1BackupPlanInput(
+        input.BackupPlan,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2053,14 +2029,11 @@ export const serializeAws_restJson1_1UpdateRecoveryPointLifecycleCommand = async
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Lifecycle !== undefined) {
-    bodyParams["Lifecycle"] = serializeAws_restJson1_1Lifecycle(
-      input.Lifecycle,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Lifecycle !== undefined && {
+      Lifecycle: serializeAws_restJson1_1Lifecycle(input.Lifecycle, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-batch/protocols/Aws_restJson1_1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1_1.ts
@@ -124,14 +124,10 @@ export const serializeAws_restJson1_1CancelJobCommand = async (
   };
   let resolvedPath = "/v1/canceljob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobId !== undefined) {
-    bodyParams["jobId"] = input.jobId;
-  }
-  if (input.reason !== undefined) {
-    bodyParams["reason"] = input.reason;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobId !== undefined && { jobId: input.jobId }),
+    ...(input.reason !== undefined && { reason: input.reason })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -153,26 +149,20 @@ export const serializeAws_restJson1_1CreateComputeEnvironmentCommand = async (
   };
   let resolvedPath = "/v1/createcomputeenvironment";
   let body: any;
-  const bodyParams: any = {};
-  if (input.computeEnvironmentName !== undefined) {
-    bodyParams["computeEnvironmentName"] = input.computeEnvironmentName;
-  }
-  if (input.computeResources !== undefined) {
-    bodyParams["computeResources"] = serializeAws_restJson1_1ComputeResource(
-      input.computeResources,
-      context
-    );
-  }
-  if (input.serviceRole !== undefined) {
-    bodyParams["serviceRole"] = input.serviceRole;
-  }
-  if (input.state !== undefined) {
-    bodyParams["state"] = input.state;
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.computeEnvironmentName !== undefined && {
+      computeEnvironmentName: input.computeEnvironmentName
+    }),
+    ...(input.computeResources !== undefined && {
+      computeResources: serializeAws_restJson1_1ComputeResource(
+        input.computeResources,
+        context
+      )
+    }),
+    ...(input.serviceRole !== undefined && { serviceRole: input.serviceRole }),
+    ...(input.state !== undefined && { state: input.state }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -194,25 +184,19 @@ export const serializeAws_restJson1_1CreateJobQueueCommand = async (
   };
   let resolvedPath = "/v1/createjobqueue";
   let body: any;
-  const bodyParams: any = {};
-  if (input.computeEnvironmentOrder !== undefined) {
-    bodyParams[
-      "computeEnvironmentOrder"
-    ] = serializeAws_restJson1_1ComputeEnvironmentOrders(
-      input.computeEnvironmentOrder,
-      context
-    );
-  }
-  if (input.jobQueueName !== undefined) {
-    bodyParams["jobQueueName"] = input.jobQueueName;
-  }
-  if (input.priority !== undefined) {
-    bodyParams["priority"] = input.priority;
-  }
-  if (input.state !== undefined) {
-    bodyParams["state"] = input.state;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.computeEnvironmentOrder !== undefined && {
+      computeEnvironmentOrder: serializeAws_restJson1_1ComputeEnvironmentOrders(
+        input.computeEnvironmentOrder,
+        context
+      )
+    }),
+    ...(input.jobQueueName !== undefined && {
+      jobQueueName: input.jobQueueName
+    }),
+    ...(input.priority !== undefined && { priority: input.priority }),
+    ...(input.state !== undefined && { state: input.state })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -234,11 +218,11 @@ export const serializeAws_restJson1_1DeleteComputeEnvironmentCommand = async (
   };
   let resolvedPath = "/v1/deletecomputeenvironment";
   let body: any;
-  const bodyParams: any = {};
-  if (input.computeEnvironment !== undefined) {
-    bodyParams["computeEnvironment"] = input.computeEnvironment;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.computeEnvironment !== undefined && {
+      computeEnvironment: input.computeEnvironment
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -260,11 +244,9 @@ export const serializeAws_restJson1_1DeleteJobQueueCommand = async (
   };
   let resolvedPath = "/v1/deletejobqueue";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobQueue !== undefined) {
-    bodyParams["jobQueue"] = input.jobQueue;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobQueue !== undefined && { jobQueue: input.jobQueue })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -286,11 +268,11 @@ export const serializeAws_restJson1_1DeregisterJobDefinitionCommand = async (
   };
   let resolvedPath = "/v1/deregisterjobdefinition";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobDefinition !== undefined) {
-    bodyParams["jobDefinition"] = input.jobDefinition;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobDefinition !== undefined && {
+      jobDefinition: input.jobDefinition
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -312,20 +294,16 @@ export const serializeAws_restJson1_1DescribeComputeEnvironmentsCommand = async 
   };
   let resolvedPath = "/v1/describecomputeenvironments";
   let body: any;
-  const bodyParams: any = {};
-  if (input.computeEnvironments !== undefined) {
-    bodyParams["computeEnvironments"] = serializeAws_restJson1_1StringList(
-      input.computeEnvironments,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.computeEnvironments !== undefined && {
+      computeEnvironments: serializeAws_restJson1_1StringList(
+        input.computeEnvironments,
+        context
+      )
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -347,26 +325,20 @@ export const serializeAws_restJson1_1DescribeJobDefinitionsCommand = async (
   };
   let resolvedPath = "/v1/describejobdefinitions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobDefinitionName !== undefined) {
-    bodyParams["jobDefinitionName"] = input.jobDefinitionName;
-  }
-  if (input.jobDefinitions !== undefined) {
-    bodyParams["jobDefinitions"] = serializeAws_restJson1_1StringList(
-      input.jobDefinitions,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobDefinitionName !== undefined && {
+      jobDefinitionName: input.jobDefinitionName
+    }),
+    ...(input.jobDefinitions !== undefined && {
+      jobDefinitions: serializeAws_restJson1_1StringList(
+        input.jobDefinitions,
+        context
+      )
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.status !== undefined && { status: input.status })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -388,20 +360,13 @@ export const serializeAws_restJson1_1DescribeJobQueuesCommand = async (
   };
   let resolvedPath = "/v1/describejobqueues";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobQueues !== undefined) {
-    bodyParams["jobQueues"] = serializeAws_restJson1_1StringList(
-      input.jobQueues,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobQueues !== undefined && {
+      jobQueues: serializeAws_restJson1_1StringList(input.jobQueues, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -423,14 +388,11 @@ export const serializeAws_restJson1_1DescribeJobsCommand = async (
   };
   let resolvedPath = "/v1/describejobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobs !== undefined) {
-    bodyParams["jobs"] = serializeAws_restJson1_1StringList(
-      input.jobs,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobs !== undefined && {
+      jobs: serializeAws_restJson1_1StringList(input.jobs, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -452,26 +414,16 @@ export const serializeAws_restJson1_1ListJobsCommand = async (
   };
   let resolvedPath = "/v1/listjobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.arrayJobId !== undefined) {
-    bodyParams["arrayJobId"] = input.arrayJobId;
-  }
-  if (input.jobQueue !== undefined) {
-    bodyParams["jobQueue"] = input.jobQueue;
-  }
-  if (input.jobStatus !== undefined) {
-    bodyParams["jobStatus"] = input.jobStatus;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.multiNodeJobId !== undefined) {
-    bodyParams["multiNodeJobId"] = input.multiNodeJobId;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.arrayJobId !== undefined && { arrayJobId: input.arrayJobId }),
+    ...(input.jobQueue !== undefined && { jobQueue: input.jobQueue }),
+    ...(input.jobStatus !== undefined && { jobStatus: input.jobStatus }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.multiNodeJobId !== undefined && {
+      multiNodeJobId: input.multiNodeJobId
+    }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -493,46 +445,39 @@ export const serializeAws_restJson1_1RegisterJobDefinitionCommand = async (
   };
   let resolvedPath = "/v1/registerjobdefinition";
   let body: any;
-  const bodyParams: any = {};
-  if (input.containerProperties !== undefined) {
-    bodyParams[
-      "containerProperties"
-    ] = serializeAws_restJson1_1ContainerProperties(
-      input.containerProperties,
-      context
-    );
-  }
-  if (input.jobDefinitionName !== undefined) {
-    bodyParams["jobDefinitionName"] = input.jobDefinitionName;
-  }
-  if (input.nodeProperties !== undefined) {
-    bodyParams["nodeProperties"] = serializeAws_restJson1_1NodeProperties(
-      input.nodeProperties,
-      context
-    );
-  }
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1ParametersMap(
-      input.parameters,
-      context
-    );
-  }
-  if (input.retryStrategy !== undefined) {
-    bodyParams["retryStrategy"] = serializeAws_restJson1_1RetryStrategy(
-      input.retryStrategy,
-      context
-    );
-  }
-  if (input.timeout !== undefined) {
-    bodyParams["timeout"] = serializeAws_restJson1_1JobTimeout(
-      input.timeout,
-      context
-    );
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.containerProperties !== undefined && {
+      containerProperties: serializeAws_restJson1_1ContainerProperties(
+        input.containerProperties,
+        context
+      )
+    }),
+    ...(input.jobDefinitionName !== undefined && {
+      jobDefinitionName: input.jobDefinitionName
+    }),
+    ...(input.nodeProperties !== undefined && {
+      nodeProperties: serializeAws_restJson1_1NodeProperties(
+        input.nodeProperties,
+        context
+      )
+    }),
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1ParametersMap(
+        input.parameters,
+        context
+      )
+    }),
+    ...(input.retryStrategy !== undefined && {
+      retryStrategy: serializeAws_restJson1_1RetryStrategy(
+        input.retryStrategy,
+        context
+      )
+    }),
+    ...(input.timeout !== undefined && {
+      timeout: serializeAws_restJson1_1JobTimeout(input.timeout, context)
+    }),
+    ...(input.type !== undefined && { type: input.type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -554,61 +499,52 @@ export const serializeAws_restJson1_1SubmitJobCommand = async (
   };
   let resolvedPath = "/v1/submitjob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.arrayProperties !== undefined) {
-    bodyParams["arrayProperties"] = serializeAws_restJson1_1ArrayProperties(
-      input.arrayProperties,
-      context
-    );
-  }
-  if (input.containerOverrides !== undefined) {
-    bodyParams[
-      "containerOverrides"
-    ] = serializeAws_restJson1_1ContainerOverrides(
-      input.containerOverrides,
-      context
-    );
-  }
-  if (input.dependsOn !== undefined) {
-    bodyParams["dependsOn"] = serializeAws_restJson1_1JobDependencyList(
-      input.dependsOn,
-      context
-    );
-  }
-  if (input.jobDefinition !== undefined) {
-    bodyParams["jobDefinition"] = input.jobDefinition;
-  }
-  if (input.jobName !== undefined) {
-    bodyParams["jobName"] = input.jobName;
-  }
-  if (input.jobQueue !== undefined) {
-    bodyParams["jobQueue"] = input.jobQueue;
-  }
-  if (input.nodeOverrides !== undefined) {
-    bodyParams["nodeOverrides"] = serializeAws_restJson1_1NodeOverrides(
-      input.nodeOverrides,
-      context
-    );
-  }
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1ParametersMap(
-      input.parameters,
-      context
-    );
-  }
-  if (input.retryStrategy !== undefined) {
-    bodyParams["retryStrategy"] = serializeAws_restJson1_1RetryStrategy(
-      input.retryStrategy,
-      context
-    );
-  }
-  if (input.timeout !== undefined) {
-    bodyParams["timeout"] = serializeAws_restJson1_1JobTimeout(
-      input.timeout,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.arrayProperties !== undefined && {
+      arrayProperties: serializeAws_restJson1_1ArrayProperties(
+        input.arrayProperties,
+        context
+      )
+    }),
+    ...(input.containerOverrides !== undefined && {
+      containerOverrides: serializeAws_restJson1_1ContainerOverrides(
+        input.containerOverrides,
+        context
+      )
+    }),
+    ...(input.dependsOn !== undefined && {
+      dependsOn: serializeAws_restJson1_1JobDependencyList(
+        input.dependsOn,
+        context
+      )
+    }),
+    ...(input.jobDefinition !== undefined && {
+      jobDefinition: input.jobDefinition
+    }),
+    ...(input.jobName !== undefined && { jobName: input.jobName }),
+    ...(input.jobQueue !== undefined && { jobQueue: input.jobQueue }),
+    ...(input.nodeOverrides !== undefined && {
+      nodeOverrides: serializeAws_restJson1_1NodeOverrides(
+        input.nodeOverrides,
+        context
+      )
+    }),
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1ParametersMap(
+        input.parameters,
+        context
+      )
+    }),
+    ...(input.retryStrategy !== undefined && {
+      retryStrategy: serializeAws_restJson1_1RetryStrategy(
+        input.retryStrategy,
+        context
+      )
+    }),
+    ...(input.timeout !== undefined && {
+      timeout: serializeAws_restJson1_1JobTimeout(input.timeout, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -630,14 +566,10 @@ export const serializeAws_restJson1_1TerminateJobCommand = async (
   };
   let resolvedPath = "/v1/terminatejob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobId !== undefined) {
-    bodyParams["jobId"] = input.jobId;
-  }
-  if (input.reason !== undefined) {
-    bodyParams["reason"] = input.reason;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobId !== undefined && { jobId: input.jobId }),
+    ...(input.reason !== undefined && { reason: input.reason })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -659,25 +591,19 @@ export const serializeAws_restJson1_1UpdateComputeEnvironmentCommand = async (
   };
   let resolvedPath = "/v1/updatecomputeenvironment";
   let body: any;
-  const bodyParams: any = {};
-  if (input.computeEnvironment !== undefined) {
-    bodyParams["computeEnvironment"] = input.computeEnvironment;
-  }
-  if (input.computeResources !== undefined) {
-    bodyParams[
-      "computeResources"
-    ] = serializeAws_restJson1_1ComputeResourceUpdate(
-      input.computeResources,
-      context
-    );
-  }
-  if (input.serviceRole !== undefined) {
-    bodyParams["serviceRole"] = input.serviceRole;
-  }
-  if (input.state !== undefined) {
-    bodyParams["state"] = input.state;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.computeEnvironment !== undefined && {
+      computeEnvironment: input.computeEnvironment
+    }),
+    ...(input.computeResources !== undefined && {
+      computeResources: serializeAws_restJson1_1ComputeResourceUpdate(
+        input.computeResources,
+        context
+      )
+    }),
+    ...(input.serviceRole !== undefined && { serviceRole: input.serviceRole }),
+    ...(input.state !== undefined && { state: input.state })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -699,25 +625,17 @@ export const serializeAws_restJson1_1UpdateJobQueueCommand = async (
   };
   let resolvedPath = "/v1/updatejobqueue";
   let body: any;
-  const bodyParams: any = {};
-  if (input.computeEnvironmentOrder !== undefined) {
-    bodyParams[
-      "computeEnvironmentOrder"
-    ] = serializeAws_restJson1_1ComputeEnvironmentOrders(
-      input.computeEnvironmentOrder,
-      context
-    );
-  }
-  if (input.jobQueue !== undefined) {
-    bodyParams["jobQueue"] = input.jobQueue;
-  }
-  if (input.priority !== undefined) {
-    bodyParams["priority"] = input.priority;
-  }
-  if (input.state !== undefined) {
-    bodyParams["state"] = input.state;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.computeEnvironmentOrder !== undefined && {
+      computeEnvironmentOrder: serializeAws_restJson1_1ComputeEnvironmentOrders(
+        input.computeEnvironmentOrder,
+        context
+      )
+    }),
+    ...(input.jobQueue !== undefined && { jobQueue: input.jobQueue }),
+    ...(input.priority !== undefined && { priority: input.priority }),
+    ...(input.state !== undefined && { state: input.state })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-chime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1_1.ts
@@ -482,11 +482,11 @@ export const serializeAws_restJson1_1AssociatePhoneNumberWithUserCommand = async
     operation: "associate-phone-number"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.E164PhoneNumber !== undefined) {
-    bodyParams["E164PhoneNumber"] = input.E164PhoneNumber;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.E164PhoneNumber !== undefined && {
+      E164PhoneNumber: input.E164PhoneNumber
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -528,19 +528,17 @@ export const serializeAws_restJson1_1AssociatePhoneNumbersWithVoiceConnectorComm
     operation: "associate-phone-numbers"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.E164PhoneNumbers !== undefined) {
-    bodyParams[
-      "E164PhoneNumbers"
-    ] = serializeAws_restJson1_1E164PhoneNumberList(
-      input.E164PhoneNumbers,
-      context
-    );
-  }
-  if (input.ForceAssociate !== undefined) {
-    bodyParams["ForceAssociate"] = input.ForceAssociate;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.E164PhoneNumbers !== undefined && {
+      E164PhoneNumbers: serializeAws_restJson1_1E164PhoneNumberList(
+        input.E164PhoneNumbers,
+        context
+      )
+    }),
+    ...(input.ForceAssociate !== undefined && {
+      ForceAssociate: input.ForceAssociate
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -582,19 +580,17 @@ export const serializeAws_restJson1_1AssociatePhoneNumbersWithVoiceConnectorGrou
     operation: "associate-phone-numbers"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.E164PhoneNumbers !== undefined) {
-    bodyParams[
-      "E164PhoneNumbers"
-    ] = serializeAws_restJson1_1E164PhoneNumberList(
-      input.E164PhoneNumbers,
-      context
-    );
-  }
-  if (input.ForceAssociate !== undefined) {
-    bodyParams["ForceAssociate"] = input.ForceAssociate;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.E164PhoneNumbers !== undefined && {
+      E164PhoneNumbers: serializeAws_restJson1_1E164PhoneNumberList(
+        input.E164PhoneNumbers,
+        context
+      )
+    }),
+    ...(input.ForceAssociate !== undefined && {
+      ForceAssociate: input.ForceAssociate
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -632,16 +628,14 @@ export const serializeAws_restJson1_1AssociateSigninDelegateGroupsWithAccountCom
     operation: "associate-signin-delegate-groups"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.SigninDelegateGroups !== undefined) {
-    bodyParams[
-      "SigninDelegateGroups"
-    ] = serializeAws_restJson1_1SigninDelegateGroupList(
-      input.SigninDelegateGroups,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SigninDelegateGroups !== undefined && {
+      SigninDelegateGroups: serializeAws_restJson1_1SigninDelegateGroupList(
+        input.SigninDelegateGroups,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -679,16 +673,14 @@ export const serializeAws_restJson1_1BatchCreateAttendeeCommand = async (
     operation: "batch-create"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Attendees !== undefined) {
-    bodyParams[
-      "Attendees"
-    ] = serializeAws_restJson1_1CreateAttendeeRequestItemList(
-      input.Attendees,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Attendees !== undefined && {
+      Attendees: serializeAws_restJson1_1CreateAttendeeRequestItemList(
+        input.Attendees,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -738,16 +730,14 @@ export const serializeAws_restJson1_1BatchCreateRoomMembershipCommand = async (
     operation: "batch-create"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.MembershipItemList !== undefined) {
-    bodyParams[
-      "MembershipItemList"
-    ] = serializeAws_restJson1_1MembershipItemList(
-      input.MembershipItemList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MembershipItemList !== undefined && {
+      MembershipItemList: serializeAws_restJson1_1MembershipItemList(
+        input.MembershipItemList,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -773,14 +763,14 @@ export const serializeAws_restJson1_1BatchDeletePhoneNumberCommand = async (
     operation: "batch-delete"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.PhoneNumberIds !== undefined) {
-    bodyParams["PhoneNumberIds"] = serializeAws_restJson1_1NonEmptyStringList(
-      input.PhoneNumberIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.PhoneNumberIds !== undefined && {
+      PhoneNumberIds: serializeAws_restJson1_1NonEmptyStringList(
+        input.PhoneNumberIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -818,14 +808,11 @@ export const serializeAws_restJson1_1BatchSuspendUserCommand = async (
     operation: "suspend"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.UserIdList !== undefined) {
-    bodyParams["UserIdList"] = serializeAws_restJson1_1UserIdList(
-      input.UserIdList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.UserIdList !== undefined && {
+      UserIdList: serializeAws_restJson1_1UserIdList(input.UserIdList, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -863,14 +850,11 @@ export const serializeAws_restJson1_1BatchUnsuspendUserCommand = async (
     operation: "unsuspend"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.UserIdList !== undefined) {
-    bodyParams["UserIdList"] = serializeAws_restJson1_1UserIdList(
-      input.UserIdList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.UserIdList !== undefined && {
+      UserIdList: serializeAws_restJson1_1UserIdList(input.UserIdList, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -896,16 +880,14 @@ export const serializeAws_restJson1_1BatchUpdatePhoneNumberCommand = async (
     operation: "batch-update"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.UpdatePhoneNumberRequestItems !== undefined) {
-    bodyParams[
-      "UpdatePhoneNumberRequestItems"
-    ] = serializeAws_restJson1_1UpdatePhoneNumberRequestItemList(
-      input.UpdatePhoneNumberRequestItems,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.UpdatePhoneNumberRequestItems !== undefined && {
+      UpdatePhoneNumberRequestItems: serializeAws_restJson1_1UpdatePhoneNumberRequestItemList(
+        input.UpdatePhoneNumberRequestItems,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -940,16 +922,14 @@ export const serializeAws_restJson1_1BatchUpdateUserCommand = async (
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.UpdateUserRequestItems !== undefined) {
-    bodyParams[
-      "UpdateUserRequestItems"
-    ] = serializeAws_restJson1_1UpdateUserRequestItemList(
-      input.UpdateUserRequestItems,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.UpdateUserRequestItems !== undefined && {
+      UpdateUserRequestItems: serializeAws_restJson1_1UpdateUserRequestItemList(
+        input.UpdateUserRequestItems,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -971,11 +951,9 @@ export const serializeAws_restJson1_1CreateAccountCommand = async (
   };
   let resolvedPath = "/accounts";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1009,11 +987,11 @@ export const serializeAws_restJson1_1CreateAttendeeCommand = async (
     throw new Error("No value provided for input HTTP label: MeetingId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ExternalUserId !== undefined) {
-    bodyParams["ExternalUserId"] = input.ExternalUserId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ExternalUserId !== undefined && {
+      ExternalUserId: input.ExternalUserId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1047,14 +1025,10 @@ export const serializeAws_restJson1_1CreateBotCommand = async (
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DisplayName !== undefined) {
-    bodyParams["DisplayName"] = input.DisplayName;
-  }
-  if (input.Domain !== undefined) {
-    bodyParams["Domain"] = input.Domain;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DisplayName !== undefined && { DisplayName: input.DisplayName }),
+    ...(input.Domain !== undefined && { Domain: input.Domain })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1076,28 +1050,19 @@ export const serializeAws_restJson1_1CreateMeetingCommand = async (
   };
   let resolvedPath = "/meetings";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.MediaRegion !== undefined) {
-    bodyParams["MediaRegion"] = input.MediaRegion;
-  }
-  if (input.MeetingHostId !== undefined) {
-    bodyParams["MeetingHostId"] = input.MeetingHostId;
-  }
-  if (input.NotificationsConfiguration !== undefined) {
-    bodyParams[
-      "NotificationsConfiguration"
-    ] = serializeAws_restJson1_1MeetingNotificationConfiguration(
-      input.NotificationsConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.MediaRegion !== undefined && { MediaRegion: input.MediaRegion }),
+    ...(input.MeetingHostId !== undefined && {
+      MeetingHostId: input.MeetingHostId
+    }),
+    ...(input.NotificationsConfiguration !== undefined && {
+      NotificationsConfiguration: serializeAws_restJson1_1MeetingNotificationConfiguration(
+        input.NotificationsConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1119,19 +1084,15 @@ export const serializeAws_restJson1_1CreatePhoneNumberOrderCommand = async (
   };
   let resolvedPath = "/phone-number-orders";
   let body: any;
-  const bodyParams: any = {};
-  if (input.E164PhoneNumbers !== undefined) {
-    bodyParams[
-      "E164PhoneNumbers"
-    ] = serializeAws_restJson1_1E164PhoneNumberList(
-      input.E164PhoneNumbers,
-      context
-    );
-  }
-  if (input.ProductType !== undefined) {
-    bodyParams["ProductType"] = input.ProductType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.E164PhoneNumbers !== undefined && {
+      E164PhoneNumbers: serializeAws_restJson1_1E164PhoneNumberList(
+        input.E164PhoneNumbers,
+        context
+      )
+    }),
+    ...(input.ProductType !== undefined && { ProductType: input.ProductType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1165,17 +1126,10 @@ export const serializeAws_restJson1_1CreateRoomCommand = async (
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1221,14 +1175,10 @@ export const serializeAws_restJson1_1CreateRoomMembershipCommand = async (
     throw new Error("No value provided for input HTTP label: RoomId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.MemberId !== undefined) {
-    bodyParams["MemberId"] = input.MemberId;
-  }
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MemberId !== undefined && { MemberId: input.MemberId }),
+    ...(input.Role !== undefined && { Role: input.Role })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1265,17 +1215,11 @@ export const serializeAws_restJson1_1CreateUserCommand = async (
     operation: "create"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Email !== undefined) {
-    bodyParams["Email"] = input.Email;
-  }
-  if (input.UserType !== undefined) {
-    bodyParams["UserType"] = input.UserType;
-  }
-  if (input.Username !== undefined) {
-    bodyParams["Username"] = input.Username;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Email !== undefined && { Email: input.Email }),
+    ...(input.UserType !== undefined && { UserType: input.UserType }),
+    ...(input.Username !== undefined && { Username: input.Username })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1298,17 +1242,13 @@ export const serializeAws_restJson1_1CreateVoiceConnectorCommand = async (
   };
   let resolvedPath = "/voice-connectors";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AwsRegion !== undefined) {
-    bodyParams["AwsRegion"] = input.AwsRegion;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.RequireEncryption !== undefined) {
-    bodyParams["RequireEncryption"] = input.RequireEncryption;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AwsRegion !== undefined && { AwsRegion: input.AwsRegion }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.RequireEncryption !== undefined && {
+      RequireEncryption: input.RequireEncryption
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1330,19 +1270,15 @@ export const serializeAws_restJson1_1CreateVoiceConnectorGroupCommand = async (
   };
   let resolvedPath = "/voice-connector-groups";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.VoiceConnectorItems !== undefined) {
-    bodyParams[
-      "VoiceConnectorItems"
-    ] = serializeAws_restJson1_1VoiceConnectorItemList(
-      input.VoiceConnectorItems,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.VoiceConnectorItems !== undefined && {
+      VoiceConnectorItems: serializeAws_restJson1_1VoiceConnectorItemList(
+        input.VoiceConnectorItems,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1864,14 +1800,14 @@ export const serializeAws_restJson1_1DeleteVoiceConnectorTerminationCredentialsC
     operation: "delete"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Usernames !== undefined) {
-    bodyParams["Usernames"] = serializeAws_restJson1_1SensitiveStringList(
-      input.Usernames,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Usernames !== undefined && {
+      Usernames: serializeAws_restJson1_1SensitiveStringList(
+        input.Usernames,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1962,16 +1898,14 @@ export const serializeAws_restJson1_1DisassociatePhoneNumbersFromVoiceConnectorC
     operation: "disassociate-phone-numbers"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.E164PhoneNumbers !== undefined) {
-    bodyParams[
-      "E164PhoneNumbers"
-    ] = serializeAws_restJson1_1E164PhoneNumberList(
-      input.E164PhoneNumbers,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.E164PhoneNumbers !== undefined && {
+      E164PhoneNumbers: serializeAws_restJson1_1E164PhoneNumberList(
+        input.E164PhoneNumbers,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2013,16 +1947,14 @@ export const serializeAws_restJson1_1DisassociatePhoneNumbersFromVoiceConnectorG
     operation: "disassociate-phone-numbers"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.E164PhoneNumbers !== undefined) {
-    bodyParams[
-      "E164PhoneNumbers"
-    ] = serializeAws_restJson1_1E164PhoneNumberList(
-      input.E164PhoneNumbers,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.E164PhoneNumbers !== undefined && {
+      E164PhoneNumbers: serializeAws_restJson1_1E164PhoneNumberList(
+        input.E164PhoneNumbers,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2060,14 +1992,14 @@ export const serializeAws_restJson1_1DisassociateSigninDelegateGroupsFromAccount
     operation: "disassociate-signin-delegate-groups"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.GroupNames !== undefined) {
-    bodyParams["GroupNames"] = serializeAws_restJson1_1NonEmptyStringList(
-      input.GroupNames,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GroupNames !== undefined && {
+      GroupNames: serializeAws_restJson1_1NonEmptyStringList(
+        input.GroupNames,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2851,17 +2783,15 @@ export const serializeAws_restJson1_1InviteUsersCommand = async (
     operation: "add"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.UserEmailList !== undefined) {
-    bodyParams["UserEmailList"] = serializeAws_restJson1_1UserEmailList(
-      input.UserEmailList,
-      context
-    );
-  }
-  if (input.UserType !== undefined) {
-    bodyParams["UserType"] = input.UserType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.UserEmailList !== undefined && {
+      UserEmailList: serializeAws_restJson1_1UserEmailList(
+        input.UserEmailList,
+        context
+      )
+    }),
+    ...(input.UserType !== undefined && { UserType: input.UserType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3388,15 +3318,14 @@ export const serializeAws_restJson1_1PutEventsConfigurationCommand = async (
     throw new Error("No value provided for input HTTP label: BotId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.LambdaFunctionArn !== undefined) {
-    bodyParams["LambdaFunctionArn"] = input.LambdaFunctionArn;
-  }
-  if (input.OutboundEventsHTTPSEndpoint !== undefined) {
-    bodyParams["OutboundEventsHTTPSEndpoint"] =
-      input.OutboundEventsHTTPSEndpoint;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.LambdaFunctionArn !== undefined && {
+      LambdaFunctionArn: input.LambdaFunctionArn
+    }),
+    ...(input.OutboundEventsHTTPSEndpoint !== undefined && {
+      OutboundEventsHTTPSEndpoint: input.OutboundEventsHTTPSEndpoint
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3435,16 +3364,14 @@ export const serializeAws_restJson1_1PutVoiceConnectorLoggingConfigurationComman
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.LoggingConfiguration !== undefined) {
-    bodyParams[
-      "LoggingConfiguration"
-    ] = serializeAws_restJson1_1LoggingConfiguration(
-      input.LoggingConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.LoggingConfiguration !== undefined && {
+      LoggingConfiguration: serializeAws_restJson1_1LoggingConfiguration(
+        input.LoggingConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3482,14 +3409,14 @@ export const serializeAws_restJson1_1PutVoiceConnectorOriginationCommand = async
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Origination !== undefined) {
-    bodyParams["Origination"] = serializeAws_restJson1_1Origination(
-      input.Origination,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Origination !== undefined && {
+      Origination: serializeAws_restJson1_1Origination(
+        input.Origination,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3528,16 +3455,14 @@ export const serializeAws_restJson1_1PutVoiceConnectorStreamingConfigurationComm
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.StreamingConfiguration !== undefined) {
-    bodyParams[
-      "StreamingConfiguration"
-    ] = serializeAws_restJson1_1StreamingConfiguration(
-      input.StreamingConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.StreamingConfiguration !== undefined && {
+      StreamingConfiguration: serializeAws_restJson1_1StreamingConfiguration(
+        input.StreamingConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3575,14 +3500,14 @@ export const serializeAws_restJson1_1PutVoiceConnectorTerminationCommand = async
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Termination !== undefined) {
-    bodyParams["Termination"] = serializeAws_restJson1_1Termination(
-      input.Termination,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Termination !== undefined && {
+      Termination: serializeAws_restJson1_1Termination(
+        input.Termination,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3624,14 +3549,14 @@ export const serializeAws_restJson1_1PutVoiceConnectorTerminationCredentialsComm
     operation: "put"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Credentials !== undefined) {
-    bodyParams["Credentials"] = serializeAws_restJson1_1CredentialList(
-      input.Credentials,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Credentials !== undefined && {
+      Credentials: serializeAws_restJson1_1CredentialList(
+        input.Credentials,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3839,11 +3764,9 @@ export const serializeAws_restJson1_1UpdateAccountCommand = async (
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3877,14 +3800,14 @@ export const serializeAws_restJson1_1UpdateAccountSettingsCommand = async (
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountSettings !== undefined) {
-    bodyParams["AccountSettings"] = serializeAws_restJson1_1AccountSettings(
-      input.AccountSettings,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountSettings !== undefined && {
+      AccountSettings: serializeAws_restJson1_1AccountSettings(
+        input.AccountSettings,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3930,11 +3853,9 @@ export const serializeAws_restJson1_1UpdateBotCommand = async (
     throw new Error("No value provided for input HTTP label: BotId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Disabled !== undefined) {
-    bodyParams["Disabled"] = input.Disabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Disabled !== undefined && { Disabled: input.Disabled })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3956,24 +3877,20 @@ export const serializeAws_restJson1_1UpdateGlobalSettingsCommand = async (
   };
   let resolvedPath = "/settings";
   let body: any;
-  const bodyParams: any = {};
-  if (input.BusinessCalling !== undefined) {
-    bodyParams[
-      "BusinessCalling"
-    ] = serializeAws_restJson1_1BusinessCallingSettings(
-      input.BusinessCalling,
-      context
-    );
-  }
-  if (input.VoiceConnector !== undefined) {
-    bodyParams[
-      "VoiceConnector"
-    ] = serializeAws_restJson1_1VoiceConnectorSettings(
-      input.VoiceConnector,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BusinessCalling !== undefined && {
+      BusinessCalling: serializeAws_restJson1_1BusinessCallingSettings(
+        input.BusinessCalling,
+        context
+      )
+    }),
+    ...(input.VoiceConnector !== undefined && {
+      VoiceConnector: serializeAws_restJson1_1VoiceConnectorSettings(
+        input.VoiceConnector,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4009,14 +3926,10 @@ export const serializeAws_restJson1_1UpdatePhoneNumberCommand = async (
     throw new Error("No value provided for input HTTP label: PhoneNumberId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CallingName !== undefined) {
-    bodyParams["CallingName"] = input.CallingName;
-  }
-  if (input.ProductType !== undefined) {
-    bodyParams["ProductType"] = input.ProductType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CallingName !== undefined && { CallingName: input.CallingName }),
+    ...(input.ProductType !== undefined && { ProductType: input.ProductType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4038,11 +3951,9 @@ export const serializeAws_restJson1_1UpdatePhoneNumberSettingsCommand = async (
   };
   let resolvedPath = "/settings/phone-number";
   let body: any;
-  const bodyParams: any = {};
-  if (input.CallingName !== undefined) {
-    bodyParams["CallingName"] = input.CallingName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CallingName !== undefined && { CallingName: input.CallingName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4088,11 +3999,9 @@ export const serializeAws_restJson1_1UpdateRoomCommand = async (
     throw new Error("No value provided for input HTTP label: RoomId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4151,11 +4060,9 @@ export const serializeAws_restJson1_1UpdateRoomMembershipCommand = async (
     throw new Error("No value provided for input HTTP label: RoomId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Role !== undefined && { Role: input.Role })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4201,22 +4108,16 @@ export const serializeAws_restJson1_1UpdateUserCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AlexaForBusinessMetadata !== undefined) {
-    bodyParams[
-      "AlexaForBusinessMetadata"
-    ] = serializeAws_restJson1_1AlexaForBusinessMetadata(
-      input.AlexaForBusinessMetadata,
-      context
-    );
-  }
-  if (input.LicenseType !== undefined) {
-    bodyParams["LicenseType"] = input.LicenseType;
-  }
-  if (input.UserType !== undefined) {
-    bodyParams["UserType"] = input.UserType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AlexaForBusinessMetadata !== undefined && {
+      AlexaForBusinessMetadata: serializeAws_restJson1_1AlexaForBusinessMetadata(
+        input.AlexaForBusinessMetadata,
+        context
+      )
+    }),
+    ...(input.LicenseType !== undefined && { LicenseType: input.LicenseType }),
+    ...(input.UserType !== undefined && { UserType: input.UserType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4262,14 +4163,14 @@ export const serializeAws_restJson1_1UpdateUserSettingsCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.UserSettings !== undefined) {
-    bodyParams["UserSettings"] = serializeAws_restJson1_1UserSettings(
-      input.UserSettings,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.UserSettings !== undefined && {
+      UserSettings: serializeAws_restJson1_1UserSettings(
+        input.UserSettings,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4307,14 +4208,12 @@ export const serializeAws_restJson1_1UpdateVoiceConnectorCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.RequireEncryption !== undefined) {
-    bodyParams["RequireEncryption"] = input.RequireEncryption;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.RequireEncryption !== undefined && {
+      RequireEncryption: input.RequireEncryption
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4352,19 +4251,15 @@ export const serializeAws_restJson1_1UpdateVoiceConnectorGroupCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.VoiceConnectorItems !== undefined) {
-    bodyParams[
-      "VoiceConnectorItems"
-    ] = serializeAws_restJson1_1VoiceConnectorItemList(
-      input.VoiceConnectorItems,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.VoiceConnectorItems !== undefined && {
+      VoiceConnectorItems: serializeAws_restJson1_1VoiceConnectorItemList(
+        input.VoiceConnectorItems,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
@@ -418,28 +418,26 @@ export const serializeAws_restJson1_1AddFacetToObjectCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/facets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ObjectAttributeList !== undefined) {
-    bodyParams[
-      "ObjectAttributeList"
-    ] = serializeAws_restJson1_1AttributeKeyAndValueList(
-      input.ObjectAttributeList,
-      context
-    );
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  if (input.SchemaFacet !== undefined) {
-    bodyParams["SchemaFacet"] = serializeAws_restJson1_1SchemaFacet(
-      input.SchemaFacet,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ObjectAttributeList !== undefined && {
+      ObjectAttributeList: serializeAws_restJson1_1AttributeKeyAndValueList(
+        input.ObjectAttributeList,
+        context
+      )
+    }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    }),
+    ...(input.SchemaFacet !== undefined && {
+      SchemaFacet: serializeAws_restJson1_1SchemaFacet(
+        input.SchemaFacet,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -464,11 +462,11 @@ export const serializeAws_restJson1_1ApplySchemaCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/apply";
   let body: any;
-  const bodyParams: any = {};
-  if (input.PublishedSchemaArn !== undefined) {
-    bodyParams["PublishedSchemaArn"] = input.PublishedSchemaArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.PublishedSchemaArn !== undefined && {
+      PublishedSchemaArn: input.PublishedSchemaArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -493,23 +491,21 @@ export const serializeAws_restJson1_1AttachObjectCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/attach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChildReference !== undefined) {
-    bodyParams["ChildReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ChildReference,
-      context
-    );
-  }
-  if (input.LinkName !== undefined) {
-    bodyParams["LinkName"] = input.LinkName;
-  }
-  if (input.ParentReference !== undefined) {
-    bodyParams["ParentReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ParentReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChildReference !== undefined && {
+      ChildReference: serializeAws_restJson1_1ObjectReference(
+        input.ChildReference,
+        context
+      )
+    }),
+    ...(input.LinkName !== undefined && { LinkName: input.LinkName }),
+    ...(input.ParentReference !== undefined && {
+      ParentReference: serializeAws_restJson1_1ObjectReference(
+        input.ParentReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -534,20 +530,20 @@ export const serializeAws_restJson1_1AttachPolicyCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/attach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  if (input.PolicyReference !== undefined) {
-    bodyParams["PolicyReference"] = serializeAws_restJson1_1ObjectReference(
-      input.PolicyReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    }),
+    ...(input.PolicyReference !== undefined && {
+      PolicyReference: serializeAws_restJson1_1ObjectReference(
+        input.PolicyReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -572,20 +568,20 @@ export const serializeAws_restJson1_1AttachToIndexCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index/attach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.IndexReference !== undefined) {
-    bodyParams["IndexReference"] = serializeAws_restJson1_1ObjectReference(
-      input.IndexReference,
-      context
-    );
-  }
-  if (input.TargetReference !== undefined) {
-    bodyParams["TargetReference"] = serializeAws_restJson1_1ObjectReference(
-      input.TargetReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.IndexReference !== undefined && {
+      IndexReference: serializeAws_restJson1_1ObjectReference(
+        input.IndexReference,
+        context
+      )
+    }),
+    ...(input.TargetReference !== undefined && {
+      TargetReference: serializeAws_restJson1_1ObjectReference(
+        input.TargetReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -610,40 +606,32 @@ export const serializeAws_restJson1_1AttachTypedLinkCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/attach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Attributes !== undefined) {
-    bodyParams[
-      "Attributes"
-    ] = serializeAws_restJson1_1AttributeNameAndValueList(
-      input.Attributes,
-      context
-    );
-  }
-  if (input.SourceObjectReference !== undefined) {
-    bodyParams[
-      "SourceObjectReference"
-    ] = serializeAws_restJson1_1ObjectReference(
-      input.SourceObjectReference,
-      context
-    );
-  }
-  if (input.TargetObjectReference !== undefined) {
-    bodyParams[
-      "TargetObjectReference"
-    ] = serializeAws_restJson1_1ObjectReference(
-      input.TargetObjectReference,
-      context
-    );
-  }
-  if (input.TypedLinkFacet !== undefined) {
-    bodyParams[
-      "TypedLinkFacet"
-    ] = serializeAws_restJson1_1TypedLinkSchemaAndFacetName(
-      input.TypedLinkFacet,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Attributes !== undefined && {
+      Attributes: serializeAws_restJson1_1AttributeNameAndValueList(
+        input.Attributes,
+        context
+      )
+    }),
+    ...(input.SourceObjectReference !== undefined && {
+      SourceObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.SourceObjectReference,
+        context
+      )
+    }),
+    ...(input.TargetObjectReference !== undefined && {
+      TargetObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.TargetObjectReference,
+        context
+      )
+    }),
+    ...(input.TypedLinkFacet !== undefined && {
+      TypedLinkFacet: serializeAws_restJson1_1TypedLinkSchemaAndFacetName(
+        input.TypedLinkFacet,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -671,14 +659,14 @@ export const serializeAws_restJson1_1BatchReadCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/batchread";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Operations !== undefined) {
-    bodyParams["Operations"] = serializeAws_restJson1_1BatchReadOperationList(
-      input.Operations,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Operations !== undefined && {
+      Operations: serializeAws_restJson1_1BatchReadOperationList(
+        input.Operations,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -703,14 +691,14 @@ export const serializeAws_restJson1_1BatchWriteCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/batchwrite";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Operations !== undefined) {
-    bodyParams["Operations"] = serializeAws_restJson1_1BatchWriteOperationList(
-      input.Operations,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Operations !== undefined && {
+      Operations: serializeAws_restJson1_1BatchWriteOperationList(
+        input.Operations,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -735,11 +723,9 @@ export const serializeAws_restJson1_1CreateDirectoryCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/directory/create";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -764,23 +750,17 @@ export const serializeAws_restJson1_1CreateFacetCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/create";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Attributes !== undefined) {
-    bodyParams["Attributes"] = serializeAws_restJson1_1FacetAttributeList(
-      input.Attributes,
-      context
-    );
-  }
-  if (input.FacetStyle !== undefined) {
-    bodyParams["FacetStyle"] = input.FacetStyle;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ObjectType !== undefined) {
-    bodyParams["ObjectType"] = input.ObjectType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Attributes !== undefined && {
+      Attributes: serializeAws_restJson1_1FacetAttributeList(
+        input.Attributes,
+        context
+      )
+    }),
+    ...(input.FacetStyle !== undefined && { FacetStyle: input.FacetStyle }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ObjectType !== undefined && { ObjectType: input.ObjectType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -805,28 +785,22 @@ export const serializeAws_restJson1_1CreateIndexCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index";
   let body: any;
-  const bodyParams: any = {};
-  if (input.IsUnique !== undefined) {
-    bodyParams["IsUnique"] = input.IsUnique;
-  }
-  if (input.LinkName !== undefined) {
-    bodyParams["LinkName"] = input.LinkName;
-  }
-  if (input.OrderedIndexedAttributeList !== undefined) {
-    bodyParams[
-      "OrderedIndexedAttributeList"
-    ] = serializeAws_restJson1_1AttributeKeyList(
-      input.OrderedIndexedAttributeList,
-      context
-    );
-  }
-  if (input.ParentReference !== undefined) {
-    bodyParams["ParentReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ParentReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.IsUnique !== undefined && { IsUnique: input.IsUnique }),
+    ...(input.LinkName !== undefined && { LinkName: input.LinkName }),
+    ...(input.OrderedIndexedAttributeList !== undefined && {
+      OrderedIndexedAttributeList: serializeAws_restJson1_1AttributeKeyList(
+        input.OrderedIndexedAttributeList,
+        context
+      )
+    }),
+    ...(input.ParentReference !== undefined && {
+      ParentReference: serializeAws_restJson1_1ObjectReference(
+        input.ParentReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -851,31 +825,27 @@ export const serializeAws_restJson1_1CreateObjectCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object";
   let body: any;
-  const bodyParams: any = {};
-  if (input.LinkName !== undefined) {
-    bodyParams["LinkName"] = input.LinkName;
-  }
-  if (input.ObjectAttributeList !== undefined) {
-    bodyParams[
-      "ObjectAttributeList"
-    ] = serializeAws_restJson1_1AttributeKeyAndValueList(
-      input.ObjectAttributeList,
-      context
-    );
-  }
-  if (input.ParentReference !== undefined) {
-    bodyParams["ParentReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ParentReference,
-      context
-    );
-  }
-  if (input.SchemaFacets !== undefined) {
-    bodyParams["SchemaFacets"] = serializeAws_restJson1_1SchemaFacetList(
-      input.SchemaFacets,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.LinkName !== undefined && { LinkName: input.LinkName }),
+    ...(input.ObjectAttributeList !== undefined && {
+      ObjectAttributeList: serializeAws_restJson1_1AttributeKeyAndValueList(
+        input.ObjectAttributeList,
+        context
+      )
+    }),
+    ...(input.ParentReference !== undefined && {
+      ParentReference: serializeAws_restJson1_1ObjectReference(
+        input.ParentReference,
+        context
+      )
+    }),
+    ...(input.SchemaFacets !== undefined && {
+      SchemaFacets: serializeAws_restJson1_1SchemaFacetList(
+        input.SchemaFacets,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -897,11 +867,9 @@ export const serializeAws_restJson1_1CreateSchemaCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/create";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -926,14 +894,11 @@ export const serializeAws_restJson1_1CreateTypedLinkFacetCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/create";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Facet !== undefined) {
-    bodyParams["Facet"] = serializeAws_restJson1_1TypedLinkFacet(
-      input.Facet,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Facet !== undefined && {
+      Facet: serializeAws_restJson1_1TypedLinkFacet(input.Facet, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -982,11 +947,9 @@ export const serializeAws_restJson1_1DeleteFacetCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/delete";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1011,14 +974,14 @@ export const serializeAws_restJson1_1DeleteObjectCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/delete";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1067,11 +1030,9 @@ export const serializeAws_restJson1_1DeleteTypedLinkFacetCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/delete";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1096,20 +1057,20 @@ export const serializeAws_restJson1_1DetachFromIndexCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index/detach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.IndexReference !== undefined) {
-    bodyParams["IndexReference"] = serializeAws_restJson1_1ObjectReference(
-      input.IndexReference,
-      context
-    );
-  }
-  if (input.TargetReference !== undefined) {
-    bodyParams["TargetReference"] = serializeAws_restJson1_1ObjectReference(
-      input.TargetReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.IndexReference !== undefined && {
+      IndexReference: serializeAws_restJson1_1ObjectReference(
+        input.IndexReference,
+        context
+      )
+    }),
+    ...(input.TargetReference !== undefined && {
+      TargetReference: serializeAws_restJson1_1ObjectReference(
+        input.TargetReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1134,17 +1095,15 @@ export const serializeAws_restJson1_1DetachObjectCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/detach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.LinkName !== undefined) {
-    bodyParams["LinkName"] = input.LinkName;
-  }
-  if (input.ParentReference !== undefined) {
-    bodyParams["ParentReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ParentReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.LinkName !== undefined && { LinkName: input.LinkName }),
+    ...(input.ParentReference !== undefined && {
+      ParentReference: serializeAws_restJson1_1ObjectReference(
+        input.ParentReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1169,20 +1128,20 @@ export const serializeAws_restJson1_1DetachPolicyCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/detach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  if (input.PolicyReference !== undefined) {
-    bodyParams["PolicyReference"] = serializeAws_restJson1_1ObjectReference(
-      input.PolicyReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    }),
+    ...(input.PolicyReference !== undefined && {
+      PolicyReference: serializeAws_restJson1_1ObjectReference(
+        input.PolicyReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1207,16 +1166,14 @@ export const serializeAws_restJson1_1DetachTypedLinkCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/detach";
   let body: any;
-  const bodyParams: any = {};
-  if (input.TypedLinkSpecifier !== undefined) {
-    bodyParams[
-      "TypedLinkSpecifier"
-    ] = serializeAws_restJson1_1TypedLinkSpecifier(
-      input.TypedLinkSpecifier,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TypedLinkSpecifier !== undefined && {
+      TypedLinkSpecifier: serializeAws_restJson1_1TypedLinkSpecifier(
+        input.TypedLinkSpecifier,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1286,11 +1243,9 @@ export const serializeAws_restJson1_1GetAppliedSchemaVersionCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/getappliedschema";
   let body: any;
-  const bodyParams: any = {};
-  if (input.SchemaArn !== undefined) {
-    bodyParams["SchemaArn"] = input.SchemaArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SchemaArn !== undefined && { SchemaArn: input.SchemaArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1339,11 +1294,9 @@ export const serializeAws_restJson1_1GetFacetCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1369,25 +1322,23 @@ export const serializeAws_restJson1_1GetLinkAttributesCommand = async (
   let resolvedPath =
     "/amazonclouddirectory/2017-01-11/typedlink/attributes/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AttributeNames !== undefined) {
-    bodyParams["AttributeNames"] = serializeAws_restJson1_1AttributeNameList(
-      input.AttributeNames,
-      context
-    );
-  }
-  if (input.ConsistencyLevel !== undefined) {
-    bodyParams["ConsistencyLevel"] = input.ConsistencyLevel;
-  }
-  if (input.TypedLinkSpecifier !== undefined) {
-    bodyParams[
-      "TypedLinkSpecifier"
-    ] = serializeAws_restJson1_1TypedLinkSpecifier(
-      input.TypedLinkSpecifier,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AttributeNames !== undefined && {
+      AttributeNames: serializeAws_restJson1_1AttributeNameList(
+        input.AttributeNames,
+        context
+      )
+    }),
+    ...(input.ConsistencyLevel !== undefined && {
+      ConsistencyLevel: input.ConsistencyLevel
+    }),
+    ...(input.TypedLinkSpecifier !== undefined && {
+      TypedLinkSpecifier: serializeAws_restJson1_1TypedLinkSpecifier(
+        input.TypedLinkSpecifier,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1415,26 +1366,26 @@ export const serializeAws_restJson1_1GetObjectAttributesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/attributes/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AttributeNames !== undefined) {
-    bodyParams["AttributeNames"] = serializeAws_restJson1_1AttributeNameList(
-      input.AttributeNames,
-      context
-    );
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  if (input.SchemaFacet !== undefined) {
-    bodyParams["SchemaFacet"] = serializeAws_restJson1_1SchemaFacet(
-      input.SchemaFacet,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AttributeNames !== undefined && {
+      AttributeNames: serializeAws_restJson1_1AttributeNameList(
+        input.AttributeNames,
+        context
+      )
+    }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    }),
+    ...(input.SchemaFacet !== undefined && {
+      SchemaFacet: serializeAws_restJson1_1SchemaFacet(
+        input.SchemaFacet,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1462,14 +1413,14 @@ export const serializeAws_restJson1_1GetObjectInformationCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/information";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1518,11 +1469,9 @@ export const serializeAws_restJson1_1GetTypedLinkFacetInformationCommand = async
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1544,20 +1493,14 @@ export const serializeAws_restJson1_1ListAppliedSchemaArnsCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/applied";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DirectoryArn !== undefined) {
-    bodyParams["DirectoryArn"] = input.DirectoryArn;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.SchemaArn !== undefined) {
-    bodyParams["SchemaArn"] = input.SchemaArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DirectoryArn !== undefined && {
+      DirectoryArn: input.DirectoryArn
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.SchemaArn !== undefined && { SchemaArn: input.SchemaArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1585,20 +1528,16 @@ export const serializeAws_restJson1_1ListAttachedIndicesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/indices";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.TargetReference !== undefined) {
-    bodyParams["TargetReference"] = serializeAws_restJson1_1ObjectReference(
-      input.TargetReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.TargetReference !== undefined && {
+      TargetReference: serializeAws_restJson1_1ObjectReference(
+        input.TargetReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1620,14 +1559,10 @@ export const serializeAws_restJson1_1ListDevelopmentSchemaArnsCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/development";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1649,17 +1584,11 @@ export const serializeAws_restJson1_1ListDirectoriesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/directory/list";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.state !== undefined) {
-    bodyParams["state"] = input.state;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.state !== undefined && { state: input.state })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1684,17 +1613,11 @@ export const serializeAws_restJson1_1ListFacetAttributesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/attributes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1719,14 +1642,10 @@ export const serializeAws_restJson1_1ListFacetNamesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/list";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1751,39 +1670,31 @@ export const serializeAws_restJson1_1ListIncomingTypedLinksCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/incoming";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConsistencyLevel !== undefined) {
-    bodyParams["ConsistencyLevel"] = input.ConsistencyLevel;
-  }
-  if (input.FilterAttributeRanges !== undefined) {
-    bodyParams[
-      "FilterAttributeRanges"
-    ] = serializeAws_restJson1_1TypedLinkAttributeRangeList(
-      input.FilterAttributeRanges,
-      context
-    );
-  }
-  if (input.FilterTypedLink !== undefined) {
-    bodyParams[
-      "FilterTypedLink"
-    ] = serializeAws_restJson1_1TypedLinkSchemaAndFacetName(
-      input.FilterTypedLink,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConsistencyLevel !== undefined && {
+      ConsistencyLevel: input.ConsistencyLevel
+    }),
+    ...(input.FilterAttributeRanges !== undefined && {
+      FilterAttributeRanges: serializeAws_restJson1_1TypedLinkAttributeRangeList(
+        input.FilterAttributeRanges,
+        context
+      )
+    }),
+    ...(input.FilterTypedLink !== undefined && {
+      FilterTypedLink: serializeAws_restJson1_1TypedLinkSchemaAndFacetName(
+        input.FilterTypedLink,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1811,28 +1722,22 @@ export const serializeAws_restJson1_1ListIndexCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index/targets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.IndexReference !== undefined) {
-    bodyParams["IndexReference"] = serializeAws_restJson1_1ObjectReference(
-      input.IndexReference,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.RangesOnIndexedValues !== undefined) {
-    bodyParams[
-      "RangesOnIndexedValues"
-    ] = serializeAws_restJson1_1ObjectAttributeRangeList(
-      input.RangesOnIndexedValues,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.IndexReference !== undefined && {
+      IndexReference: serializeAws_restJson1_1ObjectReference(
+        input.IndexReference,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.RangesOnIndexedValues !== undefined && {
+      RangesOnIndexedValues: serializeAws_restJson1_1ObjectAttributeRangeList(
+        input.RangesOnIndexedValues,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1854,17 +1759,11 @@ export const serializeAws_restJson1_1ListManagedSchemaArnsCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/managed";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.SchemaArn !== undefined) {
-    bodyParams["SchemaArn"] = input.SchemaArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.SchemaArn !== undefined && { SchemaArn: input.SchemaArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1892,26 +1791,22 @@ export const serializeAws_restJson1_1ListObjectAttributesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/attributes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FacetFilter !== undefined) {
-    bodyParams["FacetFilter"] = serializeAws_restJson1_1SchemaFacet(
-      input.FacetFilter,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FacetFilter !== undefined && {
+      FacetFilter: serializeAws_restJson1_1SchemaFacet(
+        input.FacetFilter,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1939,20 +1834,16 @@ export const serializeAws_restJson1_1ListObjectChildrenCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/children";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1977,20 +1868,16 @@ export const serializeAws_restJson1_1ListObjectParentPathsCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/parentpaths";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2018,24 +1905,19 @@ export const serializeAws_restJson1_1ListObjectParentsCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/parent";
   let body: any;
-  const bodyParams: any = {};
-  if (input.IncludeAllLinksToEachParent !== undefined) {
-    bodyParams["IncludeAllLinksToEachParent"] =
-      input.IncludeAllLinksToEachParent;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.IncludeAllLinksToEachParent !== undefined && {
+      IncludeAllLinksToEachParent: input.IncludeAllLinksToEachParent
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2063,20 +1945,16 @@ export const serializeAws_restJson1_1ListObjectPoliciesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/policy";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2101,39 +1979,31 @@ export const serializeAws_restJson1_1ListOutgoingTypedLinksCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/outgoing";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConsistencyLevel !== undefined) {
-    bodyParams["ConsistencyLevel"] = input.ConsistencyLevel;
-  }
-  if (input.FilterAttributeRanges !== undefined) {
-    bodyParams[
-      "FilterAttributeRanges"
-    ] = serializeAws_restJson1_1TypedLinkAttributeRangeList(
-      input.FilterAttributeRanges,
-      context
-    );
-  }
-  if (input.FilterTypedLink !== undefined) {
-    bodyParams[
-      "FilterTypedLink"
-    ] = serializeAws_restJson1_1TypedLinkSchemaAndFacetName(
-      input.FilterTypedLink,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConsistencyLevel !== undefined && {
+      ConsistencyLevel: input.ConsistencyLevel
+    }),
+    ...(input.FilterAttributeRanges !== undefined && {
+      FilterAttributeRanges: serializeAws_restJson1_1TypedLinkAttributeRangeList(
+        input.FilterAttributeRanges,
+        context
+      )
+    }),
+    ...(input.FilterTypedLink !== undefined && {
+      FilterTypedLink: serializeAws_restJson1_1TypedLinkSchemaAndFacetName(
+        input.FilterTypedLink,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2161,20 +2031,16 @@ export const serializeAws_restJson1_1ListPolicyAttachmentsCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/attachment";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.PolicyReference !== undefined) {
-    bodyParams["PolicyReference"] = serializeAws_restJson1_1ObjectReference(
-      input.PolicyReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.PolicyReference !== undefined && {
+      PolicyReference: serializeAws_restJson1_1ObjectReference(
+        input.PolicyReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2196,17 +2062,11 @@ export const serializeAws_restJson1_1ListPublishedSchemaArnsCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/published";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.SchemaArn !== undefined) {
-    bodyParams["SchemaArn"] = input.SchemaArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.SchemaArn !== undefined && { SchemaArn: input.SchemaArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2228,17 +2088,11 @@ export const serializeAws_restJson1_1ListTagsForResourceCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/tags";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ResourceArn !== undefined) {
-    bodyParams["ResourceArn"] = input.ResourceArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ResourceArn !== undefined && { ResourceArn: input.ResourceArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2264,17 +2118,11 @@ export const serializeAws_restJson1_1ListTypedLinkFacetAttributesCommand = async
   let resolvedPath =
     "/amazonclouddirectory/2017-01-11/typedlink/facet/attributes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2299,14 +2147,10 @@ export const serializeAws_restJson1_1ListTypedLinkFacetNamesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/list";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2331,20 +2175,16 @@ export const serializeAws_restJson1_1LookupPolicyCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/lookup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2369,17 +2209,13 @@ export const serializeAws_restJson1_1PublishSchemaCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/publish";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MinorVersion !== undefined) {
-    bodyParams["MinorVersion"] = input.MinorVersion;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Version !== undefined) {
-    bodyParams["Version"] = input.Version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MinorVersion !== undefined && {
+      MinorVersion: input.MinorVersion
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Version !== undefined && { Version: input.Version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2404,11 +2240,9 @@ export const serializeAws_restJson1_1PutSchemaFromJsonCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/json";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Document !== undefined) {
-    bodyParams["Document"] = input.Document;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Document !== undefined && { Document: input.Document })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2433,20 +2267,20 @@ export const serializeAws_restJson1_1RemoveFacetFromObjectCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/facets/delete";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  if (input.SchemaFacet !== undefined) {
-    bodyParams["SchemaFacet"] = serializeAws_restJson1_1SchemaFacet(
-      input.SchemaFacet,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    }),
+    ...(input.SchemaFacet !== undefined && {
+      SchemaFacet: serializeAws_restJson1_1SchemaFacet(
+        input.SchemaFacet,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2468,14 +2302,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/tags/add";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ResourceArn !== undefined) {
-    bodyParams["ResourceArn"] = input.ResourceArn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ResourceArn !== undefined && { ResourceArn: input.ResourceArn }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2497,17 +2329,12 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/tags/remove";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ResourceArn !== undefined) {
-    bodyParams["ResourceArn"] = input.ResourceArn;
-  }
-  if (input.TagKeys !== undefined) {
-    bodyParams["TagKeys"] = serializeAws_restJson1_1TagKeyList(
-      input.TagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ResourceArn !== undefined && { ResourceArn: input.ResourceArn }),
+    ...(input.TagKeys !== undefined && {
+      TagKeys: serializeAws_restJson1_1TagKeyList(input.TagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2532,22 +2359,16 @@ export const serializeAws_restJson1_1UpdateFacetCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AttributeUpdates !== undefined) {
-    bodyParams[
-      "AttributeUpdates"
-    ] = serializeAws_restJson1_1FacetAttributeUpdateList(
-      input.AttributeUpdates,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ObjectType !== undefined) {
-    bodyParams["ObjectType"] = input.ObjectType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AttributeUpdates !== undefined && {
+      AttributeUpdates: serializeAws_restJson1_1FacetAttributeUpdateList(
+        input.AttributeUpdates,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ObjectType !== undefined && { ObjectType: input.ObjectType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2573,24 +2394,20 @@ export const serializeAws_restJson1_1UpdateLinkAttributesCommand = async (
   let resolvedPath =
     "/amazonclouddirectory/2017-01-11/typedlink/attributes/update";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AttributeUpdates !== undefined) {
-    bodyParams[
-      "AttributeUpdates"
-    ] = serializeAws_restJson1_1LinkAttributeUpdateList(
-      input.AttributeUpdates,
-      context
-    );
-  }
-  if (input.TypedLinkSpecifier !== undefined) {
-    bodyParams[
-      "TypedLinkSpecifier"
-    ] = serializeAws_restJson1_1TypedLinkSpecifier(
-      input.TypedLinkSpecifier,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AttributeUpdates !== undefined && {
+      AttributeUpdates: serializeAws_restJson1_1LinkAttributeUpdateList(
+        input.AttributeUpdates,
+        context
+      )
+    }),
+    ...(input.TypedLinkSpecifier !== undefined && {
+      TypedLinkSpecifier: serializeAws_restJson1_1TypedLinkSpecifier(
+        input.TypedLinkSpecifier,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2615,22 +2432,20 @@ export const serializeAws_restJson1_1UpdateObjectAttributesCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/update";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AttributeUpdates !== undefined) {
-    bodyParams[
-      "AttributeUpdates"
-    ] = serializeAws_restJson1_1ObjectAttributeUpdateList(
-      input.AttributeUpdates,
-      context
-    );
-  }
-  if (input.ObjectReference !== undefined) {
-    bodyParams["ObjectReference"] = serializeAws_restJson1_1ObjectReference(
-      input.ObjectReference,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AttributeUpdates !== undefined && {
+      AttributeUpdates: serializeAws_restJson1_1ObjectAttributeUpdateList(
+        input.AttributeUpdates,
+        context
+      )
+    }),
+    ...(input.ObjectReference !== undefined && {
+      ObjectReference: serializeAws_restJson1_1ObjectReference(
+        input.ObjectReference,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2655,11 +2470,9 @@ export const serializeAws_restJson1_1UpdateSchemaCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/update";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2684,27 +2497,21 @@ export const serializeAws_restJson1_1UpdateTypedLinkFacetCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AttributeUpdates !== undefined) {
-    bodyParams[
-      "AttributeUpdates"
-    ] = serializeAws_restJson1_1TypedLinkFacetAttributeUpdateList(
-      input.AttributeUpdates,
-      context
-    );
-  }
-  if (input.IdentityAttributeOrder !== undefined) {
-    bodyParams[
-      "IdentityAttributeOrder"
-    ] = serializeAws_restJson1_1AttributeNameList(
-      input.IdentityAttributeOrder,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AttributeUpdates !== undefined && {
+      AttributeUpdates: serializeAws_restJson1_1TypedLinkFacetAttributeUpdateList(
+        input.AttributeUpdates,
+        context
+      )
+    }),
+    ...(input.IdentityAttributeOrder !== undefined && {
+      IdentityAttributeOrder: serializeAws_restJson1_1AttributeNameList(
+        input.IdentityAttributeOrder,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2726,17 +2533,15 @@ export const serializeAws_restJson1_1UpgradeAppliedSchemaCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/upgradeapplied";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DirectoryArn !== undefined) {
-    bodyParams["DirectoryArn"] = input.DirectoryArn;
-  }
-  if (input.DryRun !== undefined) {
-    bodyParams["DryRun"] = input.DryRun;
-  }
-  if (input.PublishedSchemaArn !== undefined) {
-    bodyParams["PublishedSchemaArn"] = input.PublishedSchemaArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DirectoryArn !== undefined && {
+      DirectoryArn: input.DirectoryArn
+    }),
+    ...(input.DryRun !== undefined && { DryRun: input.DryRun }),
+    ...(input.PublishedSchemaArn !== undefined && {
+      PublishedSchemaArn: input.PublishedSchemaArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2758,20 +2563,18 @@ export const serializeAws_restJson1_1UpgradePublishedSchemaCommand = async (
   };
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/upgradepublished";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DevelopmentSchemaArn !== undefined) {
-    bodyParams["DevelopmentSchemaArn"] = input.DevelopmentSchemaArn;
-  }
-  if (input.DryRun !== undefined) {
-    bodyParams["DryRun"] = input.DryRun;
-  }
-  if (input.MinorVersion !== undefined) {
-    bodyParams["MinorVersion"] = input.MinorVersion;
-  }
-  if (input.PublishedSchemaArn !== undefined) {
-    bodyParams["PublishedSchemaArn"] = input.PublishedSchemaArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DevelopmentSchemaArn !== undefined && {
+      DevelopmentSchemaArn: input.DevelopmentSchemaArn
+    }),
+    ...(input.DryRun !== undefined && { DryRun: input.DryRun }),
+    ...(input.MinorVersion !== undefined && {
+      MinorVersion: input.MinorVersion
+    }),
+    ...(input.PublishedSchemaArn !== undefined && {
+      PublishedSchemaArn: input.PublishedSchemaArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
@@ -51,20 +51,12 @@ export const serializeAws_restJson1_1AssociateRepositoryCommand = async (
   };
   let resolvedPath = "/associations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.Repository !== undefined) {
-    bodyParams["Repository"] = serializeAws_restJson1_1Repository(
-      input.Repository,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.Repository !== undefined && {
+      Repository: serializeAws_restJson1_1Repository(input.Repository, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1_1.ts
@@ -89,11 +89,11 @@ export const serializeAws_restJson1_1ConfigureAgentCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.fleetInstanceId !== undefined) {
-    bodyParams["fleetInstanceId"] = input.fleetInstanceId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.fleetInstanceId !== undefined && {
+      fleetInstanceId: input.fleetInstanceId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -118,19 +118,17 @@ export const serializeAws_restJson1_1CreateProfilingGroupCommand = async (
     ...(input.clientToken !== undefined && { clientToken: input.clientToken })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.agentOrchestrationConfig !== undefined) {
-    bodyParams[
-      "agentOrchestrationConfig"
-    ] = serializeAws_restJson1_1AgentOrchestrationConfig(
-      input.agentOrchestrationConfig,
-      context
-    );
-  }
-  if (input.profilingGroupName !== undefined) {
-    bodyParams["profilingGroupName"] = input.profilingGroupName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.agentOrchestrationConfig !== undefined && {
+      agentOrchestrationConfig: serializeAws_restJson1_1AgentOrchestrationConfig(
+        input.agentOrchestrationConfig,
+        context
+      )
+    }),
+    ...(input.profilingGroupName !== undefined && {
+      profilingGroupName: input.profilingGroupName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -274,16 +272,14 @@ export const serializeAws_restJson1_1UpdateProfilingGroupCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.agentOrchestrationConfig !== undefined) {
-    bodyParams[
-      "agentOrchestrationConfig"
-    ] = serializeAws_restJson1_1AgentOrchestrationConfig(
-      input.agentOrchestrationConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.agentOrchestrationConfig !== undefined && {
+      agentOrchestrationConfig: serializeAws_restJson1_1AgentOrchestrationConfig(
+        input.agentOrchestrationConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
@@ -89,41 +89,25 @@ export const serializeAws_restJson1_1CreateNotificationRuleCommand = async (
   };
   let resolvedPath = "/createNotificationRule";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.DetailType !== undefined) {
-    bodyParams["DetailType"] = input.DetailType;
-  }
-  if (input.EventTypeIds !== undefined) {
-    bodyParams["EventTypeIds"] = serializeAws_restJson1_1EventTypeIds(
-      input.EventTypeIds,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Resource !== undefined) {
-    bodyParams["Resource"] = input.Resource;
-  }
-  if (input.Status !== undefined) {
-    bodyParams["Status"] = input.Status;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.Targets !== undefined) {
-    bodyParams["Targets"] = serializeAws_restJson1_1Targets(
-      input.Targets,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.DetailType !== undefined && { DetailType: input.DetailType }),
+    ...(input.EventTypeIds !== undefined && {
+      EventTypeIds: serializeAws_restJson1_1EventTypeIds(
+        input.EventTypeIds,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Resource !== undefined && { Resource: input.Resource }),
+    ...(input.Status !== undefined && { Status: input.Status }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.Targets !== undefined && {
+      Targets: serializeAws_restJson1_1Targets(input.Targets, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -145,11 +129,9 @@ export const serializeAws_restJson1_1DeleteNotificationRuleCommand = async (
   };
   let resolvedPath = "/deleteNotificationRule";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -171,14 +153,14 @@ export const serializeAws_restJson1_1DeleteTargetCommand = async (
   };
   let resolvedPath = "/deleteTarget";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ForceUnsubscribeAll !== undefined) {
-    bodyParams["ForceUnsubscribeAll"] = input.ForceUnsubscribeAll;
-  }
-  if (input.TargetAddress !== undefined) {
-    bodyParams["TargetAddress"] = input.TargetAddress;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ForceUnsubscribeAll !== undefined && {
+      ForceUnsubscribeAll: input.ForceUnsubscribeAll
+    }),
+    ...(input.TargetAddress !== undefined && {
+      TargetAddress: input.TargetAddress
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -200,11 +182,9 @@ export const serializeAws_restJson1_1DescribeNotificationRuleCommand = async (
   };
   let resolvedPath = "/describeNotificationRule";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -226,20 +206,16 @@ export const serializeAws_restJson1_1ListEventTypesCommand = async (
   };
   let resolvedPath = "/listEventTypes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1ListEventTypesFilters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1ListEventTypesFilters(
+        input.Filters,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -261,22 +237,16 @@ export const serializeAws_restJson1_1ListNotificationRulesCommand = async (
   };
   let resolvedPath = "/listNotificationRules";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams[
-      "Filters"
-    ] = serializeAws_restJson1_1ListNotificationRulesFilters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1ListNotificationRulesFilters(
+        input.Filters,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -298,11 +268,9 @@ export const serializeAws_restJson1_1ListTagsForResourceCommand = async (
   };
   let resolvedPath = "/listTagsForResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -324,20 +292,16 @@ export const serializeAws_restJson1_1ListTargetsCommand = async (
   };
   let resolvedPath = "/listTargets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1ListTargetsFilters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1ListTargetsFilters(
+        input.Filters,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -359,20 +323,15 @@ export const serializeAws_restJson1_1SubscribeCommand = async (
   };
   let resolvedPath = "/subscribe";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.Target !== undefined) {
-    bodyParams["Target"] = serializeAws_restJson1_1Target(
-      input.Target,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn }),
+    ...(input.ClientRequestToken !== undefined && {
+      ClientRequestToken: input.ClientRequestToken
+    }),
+    ...(input.Target !== undefined && {
+      Target: serializeAws_restJson1_1Target(input.Target, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -394,14 +353,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/tagResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -423,14 +380,12 @@ export const serializeAws_restJson1_1UnsubscribeCommand = async (
   };
   let resolvedPath = "/unsubscribe";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  if (input.TargetAddress !== undefined) {
-    bodyParams["TargetAddress"] = input.TargetAddress;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn }),
+    ...(input.TargetAddress !== undefined && {
+      TargetAddress: input.TargetAddress
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -452,17 +407,12 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
   };
   let resolvedPath = "/untagResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  if (input.TagKeys !== undefined) {
-    bodyParams["TagKeys"] = serializeAws_restJson1_1TagKeys(
-      input.TagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn }),
+    ...(input.TagKeys !== undefined && {
+      TagKeys: serializeAws_restJson1_1TagKeys(input.TagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -484,32 +434,21 @@ export const serializeAws_restJson1_1UpdateNotificationRuleCommand = async (
   };
   let resolvedPath = "/updateNotificationRule";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["Arn"] = input.Arn;
-  }
-  if (input.DetailType !== undefined) {
-    bodyParams["DetailType"] = input.DetailType;
-  }
-  if (input.EventTypeIds !== undefined) {
-    bodyParams["EventTypeIds"] = serializeAws_restJson1_1EventTypeIds(
-      input.EventTypeIds,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Status !== undefined) {
-    bodyParams["Status"] = input.Status;
-  }
-  if (input.Targets !== undefined) {
-    bodyParams["Targets"] = serializeAws_restJson1_1Targets(
-      input.Targets,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { Arn: input.Arn }),
+    ...(input.DetailType !== undefined && { DetailType: input.DetailType }),
+    ...(input.EventTypeIds !== undefined && {
+      EventTypeIds: serializeAws_restJson1_1EventTypeIds(
+        input.EventTypeIds,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Status !== undefined && { Status: input.Status }),
+    ...(input.Targets !== undefined && {
+      Targets: serializeAws_restJson1_1Targets(input.Targets, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
@@ -642,14 +642,10 @@ export const serializeAws_restJson1_1RegisterDeviceCommand = async (
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Platform !== undefined) {
-    bodyParams["Platform"] = input.Platform;
-  }
-  if (input.Token !== undefined) {
-    bodyParams["Token"] = input.Token;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Platform !== undefined && { Platform: input.Platform }),
+    ...(input.Token !== undefined && { Token: input.Token })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -685,14 +681,11 @@ export const serializeAws_restJson1_1SetCognitoEventsCommand = async (
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Events !== undefined) {
-    bodyParams["Events"] = serializeAws_restJson1_1Events(
-      input.Events,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Events !== undefined && {
+      Events: serializeAws_restJson1_1Events(input.Events, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -728,20 +721,17 @@ export const serializeAws_restJson1_1SetIdentityPoolConfigurationCommand = async
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CognitoStreams !== undefined) {
-    bodyParams["CognitoStreams"] = serializeAws_restJson1_1CognitoStreams(
-      input.CognitoStreams,
-      context
-    );
-  }
-  if (input.PushSync !== undefined) {
-    bodyParams["PushSync"] = serializeAws_restJson1_1PushSync(
-      input.PushSync,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CognitoStreams !== undefined && {
+      CognitoStreams: serializeAws_restJson1_1CognitoStreams(
+        input.CognitoStreams,
+        context
+      )
+    }),
+    ...(input.PushSync !== undefined && {
+      PushSync: serializeAws_restJson1_1PushSync(input.PushSync, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -955,20 +945,18 @@ export const serializeAws_restJson1_1UpdateRecordsCommand = async (
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeviceId !== undefined) {
-    bodyParams["DeviceId"] = input.DeviceId;
-  }
-  if (input.RecordPatches !== undefined) {
-    bodyParams["RecordPatches"] = serializeAws_restJson1_1RecordPatchList(
-      input.RecordPatches,
-      context
-    );
-  }
-  if (input.SyncSessionToken !== undefined) {
-    bodyParams["SyncSessionToken"] = input.SyncSessionToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeviceId !== undefined && { DeviceId: input.DeviceId }),
+    ...(input.RecordPatches !== undefined && {
+      RecordPatches: serializeAws_restJson1_1RecordPatchList(
+        input.RecordPatches,
+        context
+      )
+    }),
+    ...(input.SyncSessionToken !== undefined && {
+      SyncSessionToken: input.SyncSessionToken
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-connect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1_1.ts
@@ -194,46 +194,40 @@ export const serializeAws_restJson1_1CreateUserCommand = async (
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DirectoryUserId !== undefined) {
-    bodyParams["DirectoryUserId"] = input.DirectoryUserId;
-  }
-  if (input.HierarchyGroupId !== undefined) {
-    bodyParams["HierarchyGroupId"] = input.HierarchyGroupId;
-  }
-  if (input.IdentityInfo !== undefined) {
-    bodyParams["IdentityInfo"] = serializeAws_restJson1_1UserIdentityInfo(
-      input.IdentityInfo,
-      context
-    );
-  }
-  if (input.Password !== undefined) {
-    bodyParams["Password"] = input.Password;
-  }
-  if (input.PhoneConfig !== undefined) {
-    bodyParams["PhoneConfig"] = serializeAws_restJson1_1UserPhoneConfig(
-      input.PhoneConfig,
-      context
-    );
-  }
-  if (input.RoutingProfileId !== undefined) {
-    bodyParams["RoutingProfileId"] = input.RoutingProfileId;
-  }
-  if (input.SecurityProfileIds !== undefined) {
-    bodyParams[
-      "SecurityProfileIds"
-    ] = serializeAws_restJson1_1SecurityProfileIds(
-      input.SecurityProfileIds,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  if (input.Username !== undefined) {
-    bodyParams["Username"] = input.Username;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DirectoryUserId !== undefined && {
+      DirectoryUserId: input.DirectoryUserId
+    }),
+    ...(input.HierarchyGroupId !== undefined && {
+      HierarchyGroupId: input.HierarchyGroupId
+    }),
+    ...(input.IdentityInfo !== undefined && {
+      IdentityInfo: serializeAws_restJson1_1UserIdentityInfo(
+        input.IdentityInfo,
+        context
+      )
+    }),
+    ...(input.Password !== undefined && { Password: input.Password }),
+    ...(input.PhoneConfig !== undefined && {
+      PhoneConfig: serializeAws_restJson1_1UserPhoneConfig(
+        input.PhoneConfig,
+        context
+      )
+    }),
+    ...(input.RoutingProfileId !== undefined && {
+      RoutingProfileId: input.RoutingProfileId
+    }),
+    ...(input.SecurityProfileIds !== undefined && {
+      SecurityProfileIds: serializeAws_restJson1_1SecurityProfileIds(
+        input.SecurityProfileIds,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    }),
+    ...(input.Username !== undefined && { Username: input.Username })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -488,32 +482,22 @@ export const serializeAws_restJson1_1GetCurrentMetricDataCommand = async (
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CurrentMetrics !== undefined) {
-    bodyParams["CurrentMetrics"] = serializeAws_restJson1_1CurrentMetrics(
-      input.CurrentMetrics,
-      context
-    );
-  }
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1Filters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.Groupings !== undefined) {
-    bodyParams["Groupings"] = serializeAws_restJson1_1Groupings(
-      input.Groupings,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CurrentMetrics !== undefined && {
+      CurrentMetrics: serializeAws_restJson1_1CurrentMetrics(
+        input.CurrentMetrics,
+        context
+      )
+    }),
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1Filters(input.Filters, context)
+    }),
+    ...(input.Groupings !== undefined && {
+      Groupings: serializeAws_restJson1_1Groupings(input.Groupings, context)
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -580,38 +564,28 @@ export const serializeAws_restJson1_1GetMetricDataCommand = async (
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EndTime !== undefined) {
-    bodyParams["EndTime"] = Math.round(input.EndTime.getTime() / 1000);
-  }
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1Filters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.Groupings !== undefined) {
-    bodyParams["Groupings"] = serializeAws_restJson1_1Groupings(
-      input.Groupings,
-      context
-    );
-  }
-  if (input.HistoricalMetrics !== undefined) {
-    bodyParams["HistoricalMetrics"] = serializeAws_restJson1_1HistoricalMetrics(
-      input.HistoricalMetrics,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.StartTime !== undefined) {
-    bodyParams["StartTime"] = Math.round(input.StartTime.getTime() / 1000);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EndTime !== undefined && {
+      EndTime: Math.round(input.EndTime.getTime() / 1000)
+    }),
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1Filters(input.Filters, context)
+    }),
+    ...(input.Groupings !== undefined && {
+      Groupings: serializeAws_restJson1_1Groupings(input.Groupings, context)
+    }),
+    ...(input.HistoricalMetrics !== undefined && {
+      HistoricalMetrics: serializeAws_restJson1_1HistoricalMetrics(
+        input.HistoricalMetrics,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.StartTime !== undefined && {
+      StartTime: Math.round(input.StartTime.getTime() / 1000)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1002,40 +976,28 @@ export const serializeAws_restJson1_1StartChatContactCommand = async (
   };
   let resolvedPath = "/contact/chat";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Attributes !== undefined) {
-    bodyParams["Attributes"] = serializeAws_restJson1_1Attributes(
-      input.Attributes,
-      context
-    );
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["ClientToken"] = input.ClientToken;
-  }
-  if (input.ContactFlowId !== undefined) {
-    bodyParams["ContactFlowId"] = input.ContactFlowId;
-  }
-  if (input.InitialMessage !== undefined) {
-    bodyParams["InitialMessage"] = serializeAws_restJson1_1ChatMessage(
-      input.InitialMessage,
-      context
-    );
-  }
-  if (input.InstanceId !== undefined) {
-    bodyParams["InstanceId"] = input.InstanceId;
-  }
-  if (input.ParticipantDetails !== undefined) {
-    bodyParams[
-      "ParticipantDetails"
-    ] = serializeAws_restJson1_1ParticipantDetails(
-      input.ParticipantDetails,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Attributes !== undefined && {
+      Attributes: serializeAws_restJson1_1Attributes(input.Attributes, context)
+    }),
+    ClientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.ContactFlowId !== undefined && {
+      ContactFlowId: input.ContactFlowId
+    }),
+    ...(input.InitialMessage !== undefined && {
+      InitialMessage: serializeAws_restJson1_1ChatMessage(
+        input.InitialMessage,
+        context
+      )
+    }),
+    ...(input.InstanceId !== undefined && { InstanceId: input.InstanceId }),
+    ...(input.ParticipantDetails !== undefined && {
+      ParticipantDetails: serializeAws_restJson1_1ParticipantDetails(
+        input.ParticipantDetails,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1057,35 +1019,23 @@ export const serializeAws_restJson1_1StartOutboundVoiceContactCommand = async (
   };
   let resolvedPath = "/contact/outbound-voice";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Attributes !== undefined) {
-    bodyParams["Attributes"] = serializeAws_restJson1_1Attributes(
-      input.Attributes,
-      context
-    );
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["ClientToken"] = input.ClientToken;
-  }
-  if (input.ContactFlowId !== undefined) {
-    bodyParams["ContactFlowId"] = input.ContactFlowId;
-  }
-  if (input.DestinationPhoneNumber !== undefined) {
-    bodyParams["DestinationPhoneNumber"] = input.DestinationPhoneNumber;
-  }
-  if (input.InstanceId !== undefined) {
-    bodyParams["InstanceId"] = input.InstanceId;
-  }
-  if (input.QueueId !== undefined) {
-    bodyParams["QueueId"] = input.QueueId;
-  }
-  if (input.SourcePhoneNumber !== undefined) {
-    bodyParams["SourcePhoneNumber"] = input.SourcePhoneNumber;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Attributes !== undefined && {
+      Attributes: serializeAws_restJson1_1Attributes(input.Attributes, context)
+    }),
+    ClientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.ContactFlowId !== undefined && {
+      ContactFlowId: input.ContactFlowId
+    }),
+    ...(input.DestinationPhoneNumber !== undefined && {
+      DestinationPhoneNumber: input.DestinationPhoneNumber
+    }),
+    ...(input.InstanceId !== undefined && { InstanceId: input.InstanceId }),
+    ...(input.QueueId !== undefined && { QueueId: input.QueueId }),
+    ...(input.SourcePhoneNumber !== undefined && {
+      SourcePhoneNumber: input.SourcePhoneNumber
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1107,14 +1057,10 @@ export const serializeAws_restJson1_1StopContactCommand = async (
   };
   let resolvedPath = "/contact/stop";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContactId !== undefined) {
-    bodyParams["ContactId"] = input.ContactId;
-  }
-  if (input.InstanceId !== undefined) {
-    bodyParams["InstanceId"] = input.InstanceId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContactId !== undefined && { ContactId: input.ContactId }),
+    ...(input.InstanceId !== undefined && { InstanceId: input.InstanceId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1150,11 +1096,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1217,20 +1163,15 @@ export const serializeAws_restJson1_1UpdateContactAttributesCommand = async (
   };
   let resolvedPath = "/contact/attributes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Attributes !== undefined) {
-    bodyParams["Attributes"] = serializeAws_restJson1_1Attributes(
-      input.Attributes,
-      context
-    );
-  }
-  if (input.InitialContactId !== undefined) {
-    bodyParams["InitialContactId"] = input.InitialContactId;
-  }
-  if (input.InstanceId !== undefined) {
-    bodyParams["InstanceId"] = input.InstanceId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Attributes !== undefined && {
+      Attributes: serializeAws_restJson1_1Attributes(input.Attributes, context)
+    }),
+    ...(input.InitialContactId !== undefined && {
+      InitialContactId: input.InitialContactId
+    }),
+    ...(input.InstanceId !== undefined && { InstanceId: input.InstanceId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1276,11 +1217,11 @@ export const serializeAws_restJson1_1UpdateUserHierarchyCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.HierarchyGroupId !== undefined) {
-    bodyParams["HierarchyGroupId"] = input.HierarchyGroupId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.HierarchyGroupId !== undefined && {
+      HierarchyGroupId: input.HierarchyGroupId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1326,14 +1267,14 @@ export const serializeAws_restJson1_1UpdateUserIdentityInfoCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.IdentityInfo !== undefined) {
-    bodyParams["IdentityInfo"] = serializeAws_restJson1_1UserIdentityInfo(
-      input.IdentityInfo,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.IdentityInfo !== undefined && {
+      IdentityInfo: serializeAws_restJson1_1UserIdentityInfo(
+        input.IdentityInfo,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1379,14 +1320,14 @@ export const serializeAws_restJson1_1UpdateUserPhoneConfigCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.PhoneConfig !== undefined) {
-    bodyParams["PhoneConfig"] = serializeAws_restJson1_1UserPhoneConfig(
-      input.PhoneConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.PhoneConfig !== undefined && {
+      PhoneConfig: serializeAws_restJson1_1UserPhoneConfig(
+        input.PhoneConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1432,11 +1373,11 @@ export const serializeAws_restJson1_1UpdateUserRoutingProfileCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.RoutingProfileId !== undefined) {
-    bodyParams["RoutingProfileId"] = input.RoutingProfileId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.RoutingProfileId !== undefined && {
+      RoutingProfileId: input.RoutingProfileId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1482,16 +1423,14 @@ export const serializeAws_restJson1_1UpdateUserSecurityProfilesCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SecurityProfileIds !== undefined) {
-    bodyParams[
-      "SecurityProfileIds"
-    ] = serializeAws_restJson1_1SecurityProfileIds(
-      input.SecurityProfileIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SecurityProfileIds !== undefined && {
+      SecurityProfileIds: serializeAws_restJson1_1SecurityProfileIds(
+        input.SecurityProfileIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
@@ -54,14 +54,11 @@ export const serializeAws_restJson1_1CreateParticipantConnectionCommand = async 
   };
   let resolvedPath = "/participant/connection";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = serializeAws_restJson1_1ConnectionTypeList(
-      input.Type,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Type !== undefined && {
+      Type: serializeAws_restJson1_1ConnectionTypeList(input.Type, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -86,14 +83,9 @@ export const serializeAws_restJson1_1DisconnectParticipantCommand = async (
   };
   let resolvedPath = "/participant/disconnect";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["ClientToken"] = input.ClientToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientToken: input.ClientToken ?? generateIdempotencyToken()
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -118,29 +110,21 @@ export const serializeAws_restJson1_1GetTranscriptCommand = async (
   };
   let resolvedPath = "/participant/transcript";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContactId !== undefined) {
-    bodyParams["ContactId"] = input.ContactId;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ScanDirection !== undefined) {
-    bodyParams["ScanDirection"] = input.ScanDirection;
-  }
-  if (input.SortOrder !== undefined) {
-    bodyParams["SortOrder"] = input.SortOrder;
-  }
-  if (input.StartPosition !== undefined) {
-    bodyParams["StartPosition"] = serializeAws_restJson1_1StartPosition(
-      input.StartPosition,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContactId !== undefined && { ContactId: input.ContactId }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ScanDirection !== undefined && {
+      ScanDirection: input.ScanDirection
+    }),
+    ...(input.SortOrder !== undefined && { SortOrder: input.SortOrder }),
+    ...(input.StartPosition !== undefined && {
+      StartPosition: serializeAws_restJson1_1StartPosition(
+        input.StartPosition,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -165,20 +149,11 @@ export const serializeAws_restJson1_1SendEventCommand = async (
   };
   let resolvedPath = "/participant/event";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["ClientToken"] = input.ClientToken;
-  }
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = input.Content;
-  }
-  if (input.ContentType !== undefined) {
-    bodyParams["ContentType"] = input.ContentType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.Content !== undefined && { Content: input.Content }),
+    ...(input.ContentType !== undefined && { ContentType: input.ContentType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -203,20 +178,11 @@ export const serializeAws_restJson1_1SendMessageCommand = async (
   };
   let resolvedPath = "/participant/message";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["ClientToken"] = input.ClientToken;
-  }
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = input.Content;
-  }
-  if (input.ContentType !== undefined) {
-    bodyParams["ContentType"] = input.ContentType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.Content !== undefined && { Content: input.Content }),
+    ...(input.ContentType !== undefined && { ContentType: input.ContentType })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
@@ -174,23 +174,14 @@ export const serializeAws_restJson1_1CreateDataSetCommand = async (
   };
   let resolvedPath = "/v1/data-sets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AssetType !== undefined) {
-    bodyParams["AssetType"] = input.AssetType;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1MapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AssetType !== undefined && { AssetType: input.AssetType }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1MapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -212,17 +203,12 @@ export const serializeAws_restJson1_1CreateJobCommand = async (
   };
   let resolvedPath = "/v1/jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Details !== undefined) {
-    bodyParams["Details"] = serializeAws_restJson1_1RequestDetails(
-      input.Details,
-      context
-    );
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Details !== undefined && {
+      Details: serializeAws_restJson1_1RequestDetails(input.Details, context)
+    }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -256,17 +242,12 @@ export const serializeAws_restJson1_1CreateRevisionCommand = async (
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Comment !== undefined) {
-    bodyParams["Comment"] = input.Comment;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1MapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Comment !== undefined && { Comment: input.Comment }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1MapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -826,14 +807,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1MapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1MapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -933,11 +911,9 @@ export const serializeAws_restJson1_1UpdateAssetCommand = async (
     throw new Error("No value provided for input HTTP label: RevisionId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -971,14 +947,10 @@ export const serializeAws_restJson1_1UpdateDataSetCommand = async (
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1024,14 +996,10 @@ export const serializeAws_restJson1_1UpdateRevisionCommand = async (
     throw new Error("No value provided for input HTTP label: RevisionId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Comment !== undefined) {
-    bodyParams["Comment"] = input.Comment;
-  }
-  if (input.Finalized !== undefined) {
-    bodyParams["Finalized"] = input.Finalized;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Comment !== undefined && { Comment: input.Comment }),
+    ...(input.Finalized !== undefined && { Finalized: input.Finalized })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-detective/protocols/Aws_restJson1_1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1_1.ts
@@ -74,11 +74,9 @@ export const serializeAws_restJson1_1AcceptInvitationCommand = async (
   };
   let resolvedPath = "/invitation";
   let body: any;
-  const bodyParams: any = {};
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -122,20 +120,13 @@ export const serializeAws_restJson1_1CreateMembersCommand = async (
   };
   let resolvedPath = "/graph/members";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Accounts !== undefined) {
-    bodyParams["Accounts"] = serializeAws_restJson1_1AccountList(
-      input.Accounts,
-      context
-    );
-  }
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  if (input.Message !== undefined) {
-    bodyParams["Message"] = input.Message;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Accounts !== undefined && {
+      Accounts: serializeAws_restJson1_1AccountList(input.Accounts, context)
+    }),
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn }),
+    ...(input.Message !== undefined && { Message: input.Message })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -157,11 +148,9 @@ export const serializeAws_restJson1_1DeleteGraphCommand = async (
   };
   let resolvedPath = "/graph/removal";
   let body: any;
-  const bodyParams: any = {};
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -183,17 +172,15 @@ export const serializeAws_restJson1_1DeleteMembersCommand = async (
   };
   let resolvedPath = "/graph/members/removal";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    }),
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -215,11 +202,9 @@ export const serializeAws_restJson1_1DisassociateMembershipCommand = async (
   };
   let resolvedPath = "/membership/removal";
   let body: any;
-  const bodyParams: any = {};
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -241,17 +226,15 @@ export const serializeAws_restJson1_1GetMembersCommand = async (
   };
   let resolvedPath = "/graph/members/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    }),
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -273,14 +256,10 @@ export const serializeAws_restJson1_1ListGraphsCommand = async (
   };
   let resolvedPath = "/graphs/list";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -302,14 +281,10 @@ export const serializeAws_restJson1_1ListInvitationsCommand = async (
   };
   let resolvedPath = "/invitations/list";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -331,17 +306,11 @@ export const serializeAws_restJson1_1ListMembersCommand = async (
   };
   let resolvedPath = "/graph/members/list";
   let body: any;
-  const bodyParams: any = {};
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -363,11 +332,9 @@ export const serializeAws_restJson1_1RejectInvitationCommand = async (
   };
   let resolvedPath = "/invitation/removal";
   let body: any;
-  const bodyParams: any = {};
-  if (input.GraphArn !== undefined) {
-    bodyParams["GraphArn"] = input.GraphArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GraphArn !== undefined && { GraphArn: input.GraphArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-dlm/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1_1.ts
@@ -72,26 +72,22 @@ export const serializeAws_restJson1_1CreateLifecyclePolicyCommand = async (
   };
   let resolvedPath = "/policies";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.ExecutionRoleArn !== undefined) {
-    bodyParams["ExecutionRoleArn"] = input.ExecutionRoleArn;
-  }
-  if (input.PolicyDetails !== undefined) {
-    bodyParams["PolicyDetails"] = serializeAws_restJson1_1PolicyDetails(
-      input.PolicyDetails,
-      context
-    );
-  }
-  if (input.State !== undefined) {
-    bodyParams["State"] = input.State;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.ExecutionRoleArn !== undefined && {
+      ExecutionRoleArn: input.ExecutionRoleArn
+    }),
+    ...(input.PolicyDetails !== undefined && {
+      PolicyDetails: serializeAws_restJson1_1PolicyDetails(
+        input.PolicyDetails,
+        context
+      )
+    }),
+    ...(input.State !== undefined && { State: input.State }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -265,11 +261,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -344,23 +340,19 @@ export const serializeAws_restJson1_1UpdateLifecyclePolicyCommand = async (
     throw new Error("No value provided for input HTTP label: PolicyId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.ExecutionRoleArn !== undefined) {
-    bodyParams["ExecutionRoleArn"] = input.ExecutionRoleArn;
-  }
-  if (input.PolicyDetails !== undefined) {
-    bodyParams["PolicyDetails"] = serializeAws_restJson1_1PolicyDetails(
-      input.PolicyDetails,
-      context
-    );
-  }
-  if (input.State !== undefined) {
-    bodyParams["State"] = input.State;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.ExecutionRoleArn !== undefined && {
+      ExecutionRoleArn: input.ExecutionRoleArn
+    }),
+    ...(input.PolicyDetails !== undefined && {
+      PolicyDetails: serializeAws_restJson1_1PolicyDetails(
+        input.PolicyDetails,
+        context
+      )
+    }),
+    ...(input.State !== undefined && { State: input.State })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-efs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1_1.ts
@@ -152,32 +152,24 @@ export const serializeAws_restJson1_1CreateAccessPointCommand = async (
   };
   let resolvedPath = "/2015-02-01/access-points";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["ClientToken"] = input.ClientToken;
-  }
-  if (input.FileSystemId !== undefined) {
-    bodyParams["FileSystemId"] = input.FileSystemId;
-  }
-  if (input.PosixUser !== undefined) {
-    bodyParams["PosixUser"] = serializeAws_restJson1_1PosixUser(
-      input.PosixUser,
-      context
-    );
-  }
-  if (input.RootDirectory !== undefined) {
-    bodyParams["RootDirectory"] = serializeAws_restJson1_1RootDirectory(
-      input.RootDirectory,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.FileSystemId !== undefined && {
+      FileSystemId: input.FileSystemId
+    }),
+    ...(input.PosixUser !== undefined && {
+      PosixUser: serializeAws_restJson1_1PosixUser(input.PosixUser, context)
+    }),
+    ...(input.RootDirectory !== undefined && {
+      RootDirectory: serializeAws_restJson1_1RootDirectory(
+        input.RootDirectory,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -199,33 +191,23 @@ export const serializeAws_restJson1_1CreateFileSystemCommand = async (
   };
   let resolvedPath = "/2015-02-01/file-systems";
   let body: any;
-  const bodyParams: any = {};
-  if (input.CreationToken === undefined) {
-    input.CreationToken = generateIdempotencyToken();
-  }
-  if (input.CreationToken !== undefined) {
-    bodyParams["CreationToken"] = input.CreationToken;
-  }
-  if (input.Encrypted !== undefined) {
-    bodyParams["Encrypted"] = input.Encrypted;
-  }
-  if (input.KmsKeyId !== undefined) {
-    bodyParams["KmsKeyId"] = input.KmsKeyId;
-  }
-  if (input.PerformanceMode !== undefined) {
-    bodyParams["PerformanceMode"] = input.PerformanceMode;
-  }
-  if (input.ProvisionedThroughputInMibps !== undefined) {
-    bodyParams["ProvisionedThroughputInMibps"] =
-      input.ProvisionedThroughputInMibps;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.ThroughputMode !== undefined) {
-    bodyParams["ThroughputMode"] = input.ThroughputMode;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    CreationToken: input.CreationToken ?? generateIdempotencyToken(),
+    ...(input.Encrypted !== undefined && { Encrypted: input.Encrypted }),
+    ...(input.KmsKeyId !== undefined && { KmsKeyId: input.KmsKeyId }),
+    ...(input.PerformanceMode !== undefined && {
+      PerformanceMode: input.PerformanceMode
+    }),
+    ...(input.ProvisionedThroughputInMibps !== undefined && {
+      ProvisionedThroughputInMibps: input.ProvisionedThroughputInMibps
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.ThroughputMode !== undefined && {
+      ThroughputMode: input.ThroughputMode
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -247,23 +229,19 @@ export const serializeAws_restJson1_1CreateMountTargetCommand = async (
   };
   let resolvedPath = "/2015-02-01/mount-targets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FileSystemId !== undefined) {
-    bodyParams["FileSystemId"] = input.FileSystemId;
-  }
-  if (input.IpAddress !== undefined) {
-    bodyParams["IpAddress"] = input.IpAddress;
-  }
-  if (input.SecurityGroups !== undefined) {
-    bodyParams["SecurityGroups"] = serializeAws_restJson1_1SecurityGroups(
-      input.SecurityGroups,
-      context
-    );
-  }
-  if (input.SubnetId !== undefined) {
-    bodyParams["SubnetId"] = input.SubnetId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FileSystemId !== undefined && {
+      FileSystemId: input.FileSystemId
+    }),
+    ...(input.IpAddress !== undefined && { IpAddress: input.IpAddress }),
+    ...(input.SecurityGroups !== undefined && {
+      SecurityGroups: serializeAws_restJson1_1SecurityGroups(
+        input.SecurityGroups,
+        context
+      )
+    }),
+    ...(input.SubnetId !== undefined && { SubnetId: input.SubnetId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -299,11 +277,11 @@ export const serializeAws_restJson1_1CreateTagsCommand = async (
     throw new Error("No value provided for input HTTP label: FileSystemId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -479,14 +457,11 @@ export const serializeAws_restJson1_1DeleteTagsCommand = async (
     throw new Error("No value provided for input HTTP label: FileSystemId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.TagKeys !== undefined) {
-    bodyParams["TagKeys"] = serializeAws_restJson1_1TagKeys(
-      input.TagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TagKeys !== undefined && {
+      TagKeys: serializeAws_restJson1_1TagKeys(input.TagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -813,14 +788,14 @@ export const serializeAws_restJson1_1ModifyMountTargetSecurityGroupsCommand = as
     throw new Error("No value provided for input HTTP label: MountTargetId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SecurityGroups !== undefined) {
-    bodyParams["SecurityGroups"] = serializeAws_restJson1_1SecurityGroups(
-      input.SecurityGroups,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SecurityGroups !== undefined && {
+      SecurityGroups: serializeAws_restJson1_1SecurityGroups(
+        input.SecurityGroups,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -856,15 +831,12 @@ export const serializeAws_restJson1_1PutFileSystemPolicyCommand = async (
     throw new Error("No value provided for input HTTP label: FileSystemId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BypassPolicyLockoutSafetyCheck !== undefined) {
-    bodyParams["BypassPolicyLockoutSafetyCheck"] =
-      input.BypassPolicyLockoutSafetyCheck;
-  }
-  if (input.Policy !== undefined) {
-    bodyParams["Policy"] = input.Policy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BypassPolicyLockoutSafetyCheck !== undefined && {
+      BypassPolicyLockoutSafetyCheck: input.BypassPolicyLockoutSafetyCheck
+    }),
+    ...(input.Policy !== undefined && { Policy: input.Policy })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -901,14 +873,14 @@ export const serializeAws_restJson1_1PutLifecycleConfigurationCommand = async (
     throw new Error("No value provided for input HTTP label: FileSystemId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.LifecyclePolicies !== undefined) {
-    bodyParams["LifecyclePolicies"] = serializeAws_restJson1_1LifecyclePolicies(
-      input.LifecyclePolicies,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.LifecyclePolicies !== undefined && {
+      LifecyclePolicies: serializeAws_restJson1_1LifecyclePolicies(
+        input.LifecyclePolicies,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -942,11 +914,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -980,14 +952,11 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.TagKeys !== undefined) {
-    bodyParams["TagKeys"] = serializeAws_restJson1_1TagKeys(
-      input.TagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TagKeys !== undefined && {
+      TagKeys: serializeAws_restJson1_1TagKeys(input.TagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1023,15 +992,14 @@ export const serializeAws_restJson1_1UpdateFileSystemCommand = async (
     throw new Error("No value provided for input HTTP label: FileSystemId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ProvisionedThroughputInMibps !== undefined) {
-    bodyParams["ProvisionedThroughputInMibps"] =
-      input.ProvisionedThroughputInMibps;
-  }
-  if (input.ThroughputMode !== undefined) {
-    bodyParams["ThroughputMode"] = input.ThroughputMode;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ProvisionedThroughputInMibps !== undefined && {
+      ProvisionedThroughputInMibps: input.ProvisionedThroughputInMibps
+    }),
+    ...(input.ThroughputMode !== undefined && {
+      ThroughputMode: input.ThroughputMode
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-eks/protocols/Aws_restJson1_1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1_1.ts
@@ -142,38 +142,24 @@ export const serializeAws_restJson1_1CreateClusterCommand = async (
   };
   let resolvedPath = "/clusters";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.logging !== undefined) {
-    bodyParams["logging"] = serializeAws_restJson1_1Logging(
-      input.logging,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.resourcesVpcConfig !== undefined) {
-    bodyParams["resourcesVpcConfig"] = serializeAws_restJson1_1VpcConfigRequest(
-      input.resourcesVpcConfig,
-      context
-    );
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.version !== undefined) {
-    bodyParams["version"] = input.version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.logging !== undefined && {
+      logging: serializeAws_restJson1_1Logging(input.logging, context)
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.resourcesVpcConfig !== undefined && {
+      resourcesVpcConfig: serializeAws_restJson1_1VpcConfigRequest(
+        input.resourcesVpcConfig,
+        context
+      )
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.version !== undefined && { version: input.version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -209,35 +195,27 @@ export const serializeAws_restJson1_1CreateFargateProfileCommand = async (
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.fargateProfileName !== undefined) {
-    bodyParams["fargateProfileName"] = input.fargateProfileName;
-  }
-  if (input.podExecutionRoleArn !== undefined) {
-    bodyParams["podExecutionRoleArn"] = input.podExecutionRoleArn;
-  }
-  if (input.selectors !== undefined) {
-    bodyParams["selectors"] = serializeAws_restJson1_1FargateProfileSelectors(
-      input.selectors,
-      context
-    );
-  }
-  if (input.subnets !== undefined) {
-    bodyParams["subnets"] = serializeAws_restJson1_1StringList(
-      input.subnets,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.fargateProfileName !== undefined && {
+      fargateProfileName: input.fargateProfileName
+    }),
+    ...(input.podExecutionRoleArn !== undefined && {
+      podExecutionRoleArn: input.podExecutionRoleArn
+    }),
+    ...(input.selectors !== undefined && {
+      selectors: serializeAws_restJson1_1FargateProfileSelectors(
+        input.selectors,
+        context
+      )
+    }),
+    ...(input.subnets !== undefined && {
+      subnets: serializeAws_restJson1_1StringList(input.subnets, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -273,67 +251,46 @@ export const serializeAws_restJson1_1CreateNodegroupCommand = async (
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.amiType !== undefined) {
-    bodyParams["amiType"] = input.amiType;
-  }
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.diskSize !== undefined) {
-    bodyParams["diskSize"] = input.diskSize;
-  }
-  if (input.instanceTypes !== undefined) {
-    bodyParams["instanceTypes"] = serializeAws_restJson1_1StringList(
-      input.instanceTypes,
-      context
-    );
-  }
-  if (input.labels !== undefined) {
-    bodyParams["labels"] = serializeAws_restJson1_1labelsMap(
-      input.labels,
-      context
-    );
-  }
-  if (input.nodeRole !== undefined) {
-    bodyParams["nodeRole"] = input.nodeRole;
-  }
-  if (input.nodegroupName !== undefined) {
-    bodyParams["nodegroupName"] = input.nodegroupName;
-  }
-  if (input.releaseVersion !== undefined) {
-    bodyParams["releaseVersion"] = input.releaseVersion;
-  }
-  if (input.remoteAccess !== undefined) {
-    bodyParams["remoteAccess"] = serializeAws_restJson1_1RemoteAccessConfig(
-      input.remoteAccess,
-      context
-    );
-  }
-  if (input.scalingConfig !== undefined) {
-    bodyParams[
-      "scalingConfig"
-    ] = serializeAws_restJson1_1NodegroupScalingConfig(
-      input.scalingConfig,
-      context
-    );
-  }
-  if (input.subnets !== undefined) {
-    bodyParams["subnets"] = serializeAws_restJson1_1StringList(
-      input.subnets,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.version !== undefined) {
-    bodyParams["version"] = input.version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.amiType !== undefined && { amiType: input.amiType }),
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.diskSize !== undefined && { diskSize: input.diskSize }),
+    ...(input.instanceTypes !== undefined && {
+      instanceTypes: serializeAws_restJson1_1StringList(
+        input.instanceTypes,
+        context
+      )
+    }),
+    ...(input.labels !== undefined && {
+      labels: serializeAws_restJson1_1labelsMap(input.labels, context)
+    }),
+    ...(input.nodeRole !== undefined && { nodeRole: input.nodeRole }),
+    ...(input.nodegroupName !== undefined && {
+      nodegroupName: input.nodegroupName
+    }),
+    ...(input.releaseVersion !== undefined && {
+      releaseVersion: input.releaseVersion
+    }),
+    ...(input.remoteAccess !== undefined && {
+      remoteAccess: serializeAws_restJson1_1RemoteAccessConfig(
+        input.remoteAccess,
+        context
+      )
+    }),
+    ...(input.scalingConfig !== undefined && {
+      scalingConfig: serializeAws_restJson1_1NodegroupScalingConfig(
+        input.scalingConfig,
+        context
+      )
+    }),
+    ...(input.subnets !== undefined && {
+      subnets: serializeAws_restJson1_1StringList(input.subnets, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.version !== undefined && { version: input.version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -878,11 +835,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -957,26 +914,18 @@ export const serializeAws_restJson1_1UpdateClusterConfigCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.logging !== undefined) {
-    bodyParams["logging"] = serializeAws_restJson1_1Logging(
-      input.logging,
-      context
-    );
-  }
-  if (input.resourcesVpcConfig !== undefined) {
-    bodyParams["resourcesVpcConfig"] = serializeAws_restJson1_1VpcConfigRequest(
-      input.resourcesVpcConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.logging !== undefined && {
+      logging: serializeAws_restJson1_1Logging(input.logging, context)
+    }),
+    ...(input.resourcesVpcConfig !== undefined && {
+      resourcesVpcConfig: serializeAws_restJson1_1VpcConfigRequest(
+        input.resourcesVpcConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1010,17 +959,10 @@ export const serializeAws_restJson1_1UpdateClusterVersionCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.version !== undefined) {
-    bodyParams["version"] = input.version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.version !== undefined && { version: input.version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1071,28 +1013,18 @@ export const serializeAws_restJson1_1UpdateNodegroupConfigCommand = async (
     throw new Error("No value provided for input HTTP label: nodegroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.labels !== undefined) {
-    bodyParams["labels"] = serializeAws_restJson1_1UpdateLabelsPayload(
-      input.labels,
-      context
-    );
-  }
-  if (input.scalingConfig !== undefined) {
-    bodyParams[
-      "scalingConfig"
-    ] = serializeAws_restJson1_1NodegroupScalingConfig(
-      input.scalingConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.labels !== undefined && {
+      labels: serializeAws_restJson1_1UpdateLabelsPayload(input.labels, context)
+    }),
+    ...(input.scalingConfig !== undefined && {
+      scalingConfig: serializeAws_restJson1_1NodegroupScalingConfig(
+        input.scalingConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1143,23 +1075,14 @@ export const serializeAws_restJson1_1UpdateNodegroupVersionCommand = async (
     throw new Error("No value provided for input HTTP label: nodegroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.force !== undefined) {
-    bodyParams["force"] = input.force;
-  }
-  if (input.releaseVersion !== undefined) {
-    bodyParams["releaseVersion"] = input.releaseVersion;
-  }
-  if (input.version !== undefined) {
-    bodyParams["version"] = input.version;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.force !== undefined && { force: input.force }),
+    ...(input.releaseVersion !== undefined && {
+      releaseVersion: input.releaseVersion
+    }),
+    ...(input.version !== undefined && { version: input.version })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
@@ -88,11 +88,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
@@ -163,50 +163,36 @@ export const serializeAws_restJson1_1CreateJobCommand = async (
   };
   let resolvedPath = "/2012-09-25/jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Input !== undefined) {
-    bodyParams["Input"] = serializeAws_restJson1_1JobInput(
-      input.Input,
-      context
-    );
-  }
-  if (input.Inputs !== undefined) {
-    bodyParams["Inputs"] = serializeAws_restJson1_1JobInputs(
-      input.Inputs,
-      context
-    );
-  }
-  if (input.Output !== undefined) {
-    bodyParams["Output"] = serializeAws_restJson1_1CreateJobOutput(
-      input.Output,
-      context
-    );
-  }
-  if (input.OutputKeyPrefix !== undefined) {
-    bodyParams["OutputKeyPrefix"] = input.OutputKeyPrefix;
-  }
-  if (input.Outputs !== undefined) {
-    bodyParams["Outputs"] = serializeAws_restJson1_1CreateJobOutputs(
-      input.Outputs,
-      context
-    );
-  }
-  if (input.PipelineId !== undefined) {
-    bodyParams["PipelineId"] = input.PipelineId;
-  }
-  if (input.Playlists !== undefined) {
-    bodyParams["Playlists"] = serializeAws_restJson1_1CreateJobPlaylists(
-      input.Playlists,
-      context
-    );
-  }
-  if (input.UserMetadata !== undefined) {
-    bodyParams["UserMetadata"] = serializeAws_restJson1_1UserMetadata(
-      input.UserMetadata,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Input !== undefined && {
+      Input: serializeAws_restJson1_1JobInput(input.Input, context)
+    }),
+    ...(input.Inputs !== undefined && {
+      Inputs: serializeAws_restJson1_1JobInputs(input.Inputs, context)
+    }),
+    ...(input.Output !== undefined && {
+      Output: serializeAws_restJson1_1CreateJobOutput(input.Output, context)
+    }),
+    ...(input.OutputKeyPrefix !== undefined && {
+      OutputKeyPrefix: input.OutputKeyPrefix
+    }),
+    ...(input.Outputs !== undefined && {
+      Outputs: serializeAws_restJson1_1CreateJobOutputs(input.Outputs, context)
+    }),
+    ...(input.PipelineId !== undefined && { PipelineId: input.PipelineId }),
+    ...(input.Playlists !== undefined && {
+      Playlists: serializeAws_restJson1_1CreateJobPlaylists(
+        input.Playlists,
+        context
+      )
+    }),
+    ...(input.UserMetadata !== undefined && {
+      UserMetadata: serializeAws_restJson1_1UserMetadata(
+        input.UserMetadata,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -228,43 +214,35 @@ export const serializeAws_restJson1_1CreatePipelineCommand = async (
   };
   let resolvedPath = "/2012-09-25/pipelines";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AwsKmsKeyArn !== undefined) {
-    bodyParams["AwsKmsKeyArn"] = input.AwsKmsKeyArn;
-  }
-  if (input.ContentConfig !== undefined) {
-    bodyParams["ContentConfig"] = serializeAws_restJson1_1PipelineOutputConfig(
-      input.ContentConfig,
-      context
-    );
-  }
-  if (input.InputBucket !== undefined) {
-    bodyParams["InputBucket"] = input.InputBucket;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Notifications !== undefined) {
-    bodyParams["Notifications"] = serializeAws_restJson1_1Notifications(
-      input.Notifications,
-      context
-    );
-  }
-  if (input.OutputBucket !== undefined) {
-    bodyParams["OutputBucket"] = input.OutputBucket;
-  }
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  if (input.ThumbnailConfig !== undefined) {
-    bodyParams[
-      "ThumbnailConfig"
-    ] = serializeAws_restJson1_1PipelineOutputConfig(
-      input.ThumbnailConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AwsKmsKeyArn !== undefined && {
+      AwsKmsKeyArn: input.AwsKmsKeyArn
+    }),
+    ...(input.ContentConfig !== undefined && {
+      ContentConfig: serializeAws_restJson1_1PipelineOutputConfig(
+        input.ContentConfig,
+        context
+      )
+    }),
+    ...(input.InputBucket !== undefined && { InputBucket: input.InputBucket }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Notifications !== undefined && {
+      Notifications: serializeAws_restJson1_1Notifications(
+        input.Notifications,
+        context
+      )
+    }),
+    ...(input.OutputBucket !== undefined && {
+      OutputBucket: input.OutputBucket
+    }),
+    ...(input.Role !== undefined && { Role: input.Role }),
+    ...(input.ThumbnailConfig !== undefined && {
+      ThumbnailConfig: serializeAws_restJson1_1PipelineOutputConfig(
+        input.ThumbnailConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -286,35 +264,20 @@ export const serializeAws_restJson1_1CreatePresetCommand = async (
   };
   let resolvedPath = "/2012-09-25/presets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Audio !== undefined) {
-    bodyParams["Audio"] = serializeAws_restJson1_1AudioParameters(
-      input.Audio,
-      context
-    );
-  }
-  if (input.Container !== undefined) {
-    bodyParams["Container"] = input.Container;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Thumbnails !== undefined) {
-    bodyParams["Thumbnails"] = serializeAws_restJson1_1Thumbnails(
-      input.Thumbnails,
-      context
-    );
-  }
-  if (input.Video !== undefined) {
-    bodyParams["Video"] = serializeAws_restJson1_1VideoParameters(
-      input.Video,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Audio !== undefined && {
+      Audio: serializeAws_restJson1_1AudioParameters(input.Audio, context)
+    }),
+    ...(input.Container !== undefined && { Container: input.Container }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Thumbnails !== undefined && {
+      Thumbnails: serializeAws_restJson1_1Thumbnails(input.Thumbnails, context)
+    }),
+    ...(input.Video !== undefined && {
+      Video: serializeAws_restJson1_1VideoParameters(input.Video, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -629,23 +592,16 @@ export const serializeAws_restJson1_1TestRoleCommand = async (
   };
   let resolvedPath = "/2012-09-25/roleTests";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InputBucket !== undefined) {
-    bodyParams["InputBucket"] = input.InputBucket;
-  }
-  if (input.OutputBucket !== undefined) {
-    bodyParams["OutputBucket"] = input.OutputBucket;
-  }
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  if (input.Topics !== undefined) {
-    bodyParams["Topics"] = serializeAws_restJson1_1SnsTopics(
-      input.Topics,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InputBucket !== undefined && { InputBucket: input.InputBucket }),
+    ...(input.OutputBucket !== undefined && {
+      OutputBucket: input.OutputBucket
+    }),
+    ...(input.Role !== undefined && { Role: input.Role }),
+    ...(input.Topics !== undefined && {
+      Topics: serializeAws_restJson1_1SnsTopics(input.Topics, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -679,40 +635,32 @@ export const serializeAws_restJson1_1UpdatePipelineCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AwsKmsKeyArn !== undefined) {
-    bodyParams["AwsKmsKeyArn"] = input.AwsKmsKeyArn;
-  }
-  if (input.ContentConfig !== undefined) {
-    bodyParams["ContentConfig"] = serializeAws_restJson1_1PipelineOutputConfig(
-      input.ContentConfig,
-      context
-    );
-  }
-  if (input.InputBucket !== undefined) {
-    bodyParams["InputBucket"] = input.InputBucket;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Notifications !== undefined) {
-    bodyParams["Notifications"] = serializeAws_restJson1_1Notifications(
-      input.Notifications,
-      context
-    );
-  }
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  if (input.ThumbnailConfig !== undefined) {
-    bodyParams[
-      "ThumbnailConfig"
-    ] = serializeAws_restJson1_1PipelineOutputConfig(
-      input.ThumbnailConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AwsKmsKeyArn !== undefined && {
+      AwsKmsKeyArn: input.AwsKmsKeyArn
+    }),
+    ...(input.ContentConfig !== undefined && {
+      ContentConfig: serializeAws_restJson1_1PipelineOutputConfig(
+        input.ContentConfig,
+        context
+      )
+    }),
+    ...(input.InputBucket !== undefined && { InputBucket: input.InputBucket }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Notifications !== undefined && {
+      Notifications: serializeAws_restJson1_1Notifications(
+        input.Notifications,
+        context
+      )
+    }),
+    ...(input.Role !== undefined && { Role: input.Role }),
+    ...(input.ThumbnailConfig !== undefined && {
+      ThumbnailConfig: serializeAws_restJson1_1PipelineOutputConfig(
+        input.ThumbnailConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -746,14 +694,14 @@ export const serializeAws_restJson1_1UpdatePipelineNotificationsCommand = async 
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Notifications !== undefined) {
-    bodyParams["Notifications"] = serializeAws_restJson1_1Notifications(
-      input.Notifications,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Notifications !== undefined && {
+      Notifications: serializeAws_restJson1_1Notifications(
+        input.Notifications,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -787,11 +735,9 @@ export const serializeAws_restJson1_1UpdatePipelineStatusCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Status !== undefined) {
-    bodyParams["Status"] = input.Status;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Status !== undefined && { Status: input.Status })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
@@ -166,17 +166,12 @@ export const serializeAws_restJson1_1AddTagsCommand = async (
   };
   let resolvedPath = "/2015-01-01/tags";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ARN !== undefined) {
-    bodyParams["ARN"] = input.ARN;
-  }
-  if (input.TagList !== undefined) {
-    bodyParams["TagList"] = serializeAws_restJson1_1TagList(
-      input.TagList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ARN !== undefined && { ARN: input.ARN }),
+    ...(input.TagList !== undefined && {
+      TagList: serializeAws_restJson1_1TagList(input.TagList, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -198,11 +193,9 @@ export const serializeAws_restJson1_1CancelElasticsearchServiceSoftwareUpdateCom
   };
   let resolvedPath = "/2015-01-01/es/serviceSoftwareUpdate/cancel";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -224,87 +217,69 @@ export const serializeAws_restJson1_1CreateElasticsearchDomainCommand = async (
   };
   let resolvedPath = "/2015-01-01/es/domain";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccessPolicies !== undefined) {
-    bodyParams["AccessPolicies"] = input.AccessPolicies;
-  }
-  if (input.AdvancedOptions !== undefined) {
-    bodyParams["AdvancedOptions"] = serializeAws_restJson1_1AdvancedOptions(
-      input.AdvancedOptions,
-      context
-    );
-  }
-  if (input.CognitoOptions !== undefined) {
-    bodyParams["CognitoOptions"] = serializeAws_restJson1_1CognitoOptions(
-      input.CognitoOptions,
-      context
-    );
-  }
-  if (input.DomainEndpointOptions !== undefined) {
-    bodyParams[
-      "DomainEndpointOptions"
-    ] = serializeAws_restJson1_1DomainEndpointOptions(
-      input.DomainEndpointOptions,
-      context
-    );
-  }
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.EBSOptions !== undefined) {
-    bodyParams["EBSOptions"] = serializeAws_restJson1_1EBSOptions(
-      input.EBSOptions,
-      context
-    );
-  }
-  if (input.ElasticsearchClusterConfig !== undefined) {
-    bodyParams[
-      "ElasticsearchClusterConfig"
-    ] = serializeAws_restJson1_1ElasticsearchClusterConfig(
-      input.ElasticsearchClusterConfig,
-      context
-    );
-  }
-  if (input.ElasticsearchVersion !== undefined) {
-    bodyParams["ElasticsearchVersion"] = input.ElasticsearchVersion;
-  }
-  if (input.EncryptionAtRestOptions !== undefined) {
-    bodyParams[
-      "EncryptionAtRestOptions"
-    ] = serializeAws_restJson1_1EncryptionAtRestOptions(
-      input.EncryptionAtRestOptions,
-      context
-    );
-  }
-  if (input.LogPublishingOptions !== undefined) {
-    bodyParams[
-      "LogPublishingOptions"
-    ] = serializeAws_restJson1_1LogPublishingOptions(
-      input.LogPublishingOptions,
-      context
-    );
-  }
-  if (input.NodeToNodeEncryptionOptions !== undefined) {
-    bodyParams[
-      "NodeToNodeEncryptionOptions"
-    ] = serializeAws_restJson1_1NodeToNodeEncryptionOptions(
-      input.NodeToNodeEncryptionOptions,
-      context
-    );
-  }
-  if (input.SnapshotOptions !== undefined) {
-    bodyParams["SnapshotOptions"] = serializeAws_restJson1_1SnapshotOptions(
-      input.SnapshotOptions,
-      context
-    );
-  }
-  if (input.VPCOptions !== undefined) {
-    bodyParams["VPCOptions"] = serializeAws_restJson1_1VPCOptions(
-      input.VPCOptions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccessPolicies !== undefined && {
+      AccessPolicies: input.AccessPolicies
+    }),
+    ...(input.AdvancedOptions !== undefined && {
+      AdvancedOptions: serializeAws_restJson1_1AdvancedOptions(
+        input.AdvancedOptions,
+        context
+      )
+    }),
+    ...(input.CognitoOptions !== undefined && {
+      CognitoOptions: serializeAws_restJson1_1CognitoOptions(
+        input.CognitoOptions,
+        context
+      )
+    }),
+    ...(input.DomainEndpointOptions !== undefined && {
+      DomainEndpointOptions: serializeAws_restJson1_1DomainEndpointOptions(
+        input.DomainEndpointOptions,
+        context
+      )
+    }),
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.EBSOptions !== undefined && {
+      EBSOptions: serializeAws_restJson1_1EBSOptions(input.EBSOptions, context)
+    }),
+    ...(input.ElasticsearchClusterConfig !== undefined && {
+      ElasticsearchClusterConfig: serializeAws_restJson1_1ElasticsearchClusterConfig(
+        input.ElasticsearchClusterConfig,
+        context
+      )
+    }),
+    ...(input.ElasticsearchVersion !== undefined && {
+      ElasticsearchVersion: input.ElasticsearchVersion
+    }),
+    ...(input.EncryptionAtRestOptions !== undefined && {
+      EncryptionAtRestOptions: serializeAws_restJson1_1EncryptionAtRestOptions(
+        input.EncryptionAtRestOptions,
+        context
+      )
+    }),
+    ...(input.LogPublishingOptions !== undefined && {
+      LogPublishingOptions: serializeAws_restJson1_1LogPublishingOptions(
+        input.LogPublishingOptions,
+        context
+      )
+    }),
+    ...(input.NodeToNodeEncryptionOptions !== undefined && {
+      NodeToNodeEncryptionOptions: serializeAws_restJson1_1NodeToNodeEncryptionOptions(
+        input.NodeToNodeEncryptionOptions,
+        context
+      )
+    }),
+    ...(input.SnapshotOptions !== undefined && {
+      SnapshotOptions: serializeAws_restJson1_1SnapshotOptions(
+        input.SnapshotOptions,
+        context
+      )
+    }),
+    ...(input.VPCOptions !== undefined && {
+      VPCOptions: serializeAws_restJson1_1VPCOptions(input.VPCOptions, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -447,14 +422,14 @@ export const serializeAws_restJson1_1DescribeElasticsearchDomainsCommand = async
   };
   let resolvedPath = "/2015-01-01/es/domain-info";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainNames !== undefined) {
-    bodyParams["DomainNames"] = serializeAws_restJson1_1DomainNameList(
-      input.DomainNames,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainNames !== undefined && {
+      DomainNames: serializeAws_restJson1_1DomainNameList(
+        input.DomainNames,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -812,18 +787,18 @@ export const serializeAws_restJson1_1PurchaseReservedElasticsearchInstanceOfferi
   };
   let resolvedPath = "/2015-01-01/es/purchaseReservedInstanceOffering";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InstanceCount !== undefined) {
-    bodyParams["InstanceCount"] = input.InstanceCount;
-  }
-  if (input.ReservationName !== undefined) {
-    bodyParams["ReservationName"] = input.ReservationName;
-  }
-  if (input.ReservedElasticsearchInstanceOfferingId !== undefined) {
-    bodyParams["ReservedElasticsearchInstanceOfferingId"] =
-      input.ReservedElasticsearchInstanceOfferingId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InstanceCount !== undefined && {
+      InstanceCount: input.InstanceCount
+    }),
+    ...(input.ReservationName !== undefined && {
+      ReservationName: input.ReservationName
+    }),
+    ...(input.ReservedElasticsearchInstanceOfferingId !== undefined && {
+      ReservedElasticsearchInstanceOfferingId:
+        input.ReservedElasticsearchInstanceOfferingId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -845,17 +820,12 @@ export const serializeAws_restJson1_1RemoveTagsCommand = async (
   };
   let resolvedPath = "/2015-01-01/tags-removal";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ARN !== undefined) {
-    bodyParams["ARN"] = input.ARN;
-  }
-  if (input.TagKeys !== undefined) {
-    bodyParams["TagKeys"] = serializeAws_restJson1_1StringList(
-      input.TagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ARN !== undefined && { ARN: input.ARN }),
+    ...(input.TagKeys !== undefined && {
+      TagKeys: serializeAws_restJson1_1StringList(input.TagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -877,11 +847,9 @@ export const serializeAws_restJson1_1StartElasticsearchServiceSoftwareUpdateComm
   };
   let resolvedPath = "/2015-01-01/es/serviceSoftwareUpdate/start";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -915,65 +883,53 @@ export const serializeAws_restJson1_1UpdateElasticsearchDomainConfigCommand = as
     throw new Error("No value provided for input HTTP label: DomainName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccessPolicies !== undefined) {
-    bodyParams["AccessPolicies"] = input.AccessPolicies;
-  }
-  if (input.AdvancedOptions !== undefined) {
-    bodyParams["AdvancedOptions"] = serializeAws_restJson1_1AdvancedOptions(
-      input.AdvancedOptions,
-      context
-    );
-  }
-  if (input.CognitoOptions !== undefined) {
-    bodyParams["CognitoOptions"] = serializeAws_restJson1_1CognitoOptions(
-      input.CognitoOptions,
-      context
-    );
-  }
-  if (input.DomainEndpointOptions !== undefined) {
-    bodyParams[
-      "DomainEndpointOptions"
-    ] = serializeAws_restJson1_1DomainEndpointOptions(
-      input.DomainEndpointOptions,
-      context
-    );
-  }
-  if (input.EBSOptions !== undefined) {
-    bodyParams["EBSOptions"] = serializeAws_restJson1_1EBSOptions(
-      input.EBSOptions,
-      context
-    );
-  }
-  if (input.ElasticsearchClusterConfig !== undefined) {
-    bodyParams[
-      "ElasticsearchClusterConfig"
-    ] = serializeAws_restJson1_1ElasticsearchClusterConfig(
-      input.ElasticsearchClusterConfig,
-      context
-    );
-  }
-  if (input.LogPublishingOptions !== undefined) {
-    bodyParams[
-      "LogPublishingOptions"
-    ] = serializeAws_restJson1_1LogPublishingOptions(
-      input.LogPublishingOptions,
-      context
-    );
-  }
-  if (input.SnapshotOptions !== undefined) {
-    bodyParams["SnapshotOptions"] = serializeAws_restJson1_1SnapshotOptions(
-      input.SnapshotOptions,
-      context
-    );
-  }
-  if (input.VPCOptions !== undefined) {
-    bodyParams["VPCOptions"] = serializeAws_restJson1_1VPCOptions(
-      input.VPCOptions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccessPolicies !== undefined && {
+      AccessPolicies: input.AccessPolicies
+    }),
+    ...(input.AdvancedOptions !== undefined && {
+      AdvancedOptions: serializeAws_restJson1_1AdvancedOptions(
+        input.AdvancedOptions,
+        context
+      )
+    }),
+    ...(input.CognitoOptions !== undefined && {
+      CognitoOptions: serializeAws_restJson1_1CognitoOptions(
+        input.CognitoOptions,
+        context
+      )
+    }),
+    ...(input.DomainEndpointOptions !== undefined && {
+      DomainEndpointOptions: serializeAws_restJson1_1DomainEndpointOptions(
+        input.DomainEndpointOptions,
+        context
+      )
+    }),
+    ...(input.EBSOptions !== undefined && {
+      EBSOptions: serializeAws_restJson1_1EBSOptions(input.EBSOptions, context)
+    }),
+    ...(input.ElasticsearchClusterConfig !== undefined && {
+      ElasticsearchClusterConfig: serializeAws_restJson1_1ElasticsearchClusterConfig(
+        input.ElasticsearchClusterConfig,
+        context
+      )
+    }),
+    ...(input.LogPublishingOptions !== undefined && {
+      LogPublishingOptions: serializeAws_restJson1_1LogPublishingOptions(
+        input.LogPublishingOptions,
+        context
+      )
+    }),
+    ...(input.SnapshotOptions !== undefined && {
+      SnapshotOptions: serializeAws_restJson1_1SnapshotOptions(
+        input.SnapshotOptions,
+        context
+      )
+    }),
+    ...(input.VPCOptions !== undefined && {
+      VPCOptions: serializeAws_restJson1_1VPCOptions(input.VPCOptions, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -995,17 +951,15 @@ export const serializeAws_restJson1_1UpgradeElasticsearchDomainCommand = async (
   };
   let resolvedPath = "/2015-01-01/es/upgradeDomain";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.PerformCheckOnly !== undefined) {
-    bodyParams["PerformCheckOnly"] = input.PerformCheckOnly;
-  }
-  if (input.TargetVersion !== undefined) {
-    bodyParams["TargetVersion"] = input.TargetVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.PerformCheckOnly !== undefined && {
+      PerformCheckOnly: input.PerformCheckOnly
+    }),
+    ...(input.TargetVersion !== undefined && {
+      TargetVersion: input.TargetVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-glacier/protocols/Aws_restJson1_1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1_1.ts
@@ -317,11 +317,11 @@ export const serializeAws_restJson1_1AddTagsToVaultCommand = async (
     operation: "add"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1528,14 +1528,11 @@ export const serializeAws_restJson1_1RemoveTagsFromVaultCommand = async (
     operation: "remove"
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.TagKeys !== undefined) {
-    bodyParams["TagKeys"] = serializeAws_restJson1_1TagKeyList(
-      input.TagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TagKeys !== undefined && {
+      TagKeys: serializeAws_restJson1_1TagKeyList(input.TagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1570,14 +1567,11 @@ export const serializeAws_restJson1_1SetDataRetrievalPolicyCommand = async (
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Policy !== undefined) {
-    bodyParams["Policy"] = serializeAws_restJson1_1DataRetrievalPolicy(
-      input.Policy,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Policy !== undefined && {
+      Policy: serializeAws_restJson1_1DataRetrievalPolicy(input.Policy, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-greengrass/protocols/Aws_restJson1_1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1_1.ts
@@ -438,11 +438,9 @@ export const serializeAws_restJson1_1AssociateRoleToGroupCommand = async (
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.RoleArn !== undefined) {
-    bodyParams["RoleArn"] = input.RoleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.RoleArn !== undefined && { RoleArn: input.RoleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -464,11 +462,9 @@ export const serializeAws_restJson1_1AssociateServiceRoleToAccountCommand = asyn
   };
   let resolvedPath = "/greengrass/servicerole";
   let body: any;
-  const bodyParams: any = {};
-  if (input.RoleArn !== undefined) {
-    bodyParams["RoleArn"] = input.RoleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.RoleArn !== undefined && { RoleArn: input.RoleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -493,22 +489,18 @@ export const serializeAws_restJson1_1CreateConnectorDefinitionCommand = async (
   };
   let resolvedPath = "/greengrass/definition/connectors";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams[
-      "InitialVersion"
-    ] = serializeAws_restJson1_1ConnectorDefinitionVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1ConnectorDefinitionVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -550,14 +542,14 @@ export const serializeAws_restJson1_1CreateConnectorDefinitionVersionCommand = a
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Connectors !== undefined) {
-    bodyParams["Connectors"] = serializeAws_restJson1_1__listOfConnector(
-      input.Connectors,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Connectors !== undefined && {
+      Connectors: serializeAws_restJson1_1__listOfConnector(
+        input.Connectors,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -582,22 +574,18 @@ export const serializeAws_restJson1_1CreateCoreDefinitionCommand = async (
   };
   let resolvedPath = "/greengrass/definition/cores";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams[
-      "InitialVersion"
-    ] = serializeAws_restJson1_1CoreDefinitionVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1CoreDefinitionVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -638,14 +626,11 @@ export const serializeAws_restJson1_1CreateCoreDefinitionVersionCommand = async 
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Cores !== undefined) {
-    bodyParams["Cores"] = serializeAws_restJson1_1__listOfCore(
-      input.Cores,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Cores !== undefined && {
+      Cores: serializeAws_restJson1_1__listOfCore(input.Cores, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -682,17 +667,17 @@ export const serializeAws_restJson1_1CreateDeploymentCommand = async (
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeploymentId !== undefined) {
-    bodyParams["DeploymentId"] = input.DeploymentId;
-  }
-  if (input.DeploymentType !== undefined) {
-    bodyParams["DeploymentType"] = input.DeploymentType;
-  }
-  if (input.GroupVersionId !== undefined) {
-    bodyParams["GroupVersionId"] = input.GroupVersionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeploymentId !== undefined && {
+      DeploymentId: input.DeploymentId
+    }),
+    ...(input.DeploymentType !== undefined && {
+      DeploymentType: input.DeploymentType
+    }),
+    ...(input.GroupVersionId !== undefined && {
+      GroupVersionId: input.GroupVersionId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -717,22 +702,18 @@ export const serializeAws_restJson1_1CreateDeviceDefinitionCommand = async (
   };
   let resolvedPath = "/greengrass/definition/devices";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams[
-      "InitialVersion"
-    ] = serializeAws_restJson1_1DeviceDefinitionVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1DeviceDefinitionVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -774,14 +755,11 @@ export const serializeAws_restJson1_1CreateDeviceDefinitionVersionCommand = asyn
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Devices !== undefined) {
-    bodyParams["Devices"] = serializeAws_restJson1_1__listOfDevice(
-      input.Devices,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Devices !== undefined && {
+      Devices: serializeAws_restJson1_1__listOfDevice(input.Devices, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -806,22 +784,18 @@ export const serializeAws_restJson1_1CreateFunctionDefinitionCommand = async (
   };
   let resolvedPath = "/greengrass/definition/functions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams[
-      "InitialVersion"
-    ] = serializeAws_restJson1_1FunctionDefinitionVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1FunctionDefinitionVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -863,20 +837,20 @@ export const serializeAws_restJson1_1CreateFunctionDefinitionVersionCommand = as
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DefaultConfig !== undefined) {
-    bodyParams["DefaultConfig"] = serializeAws_restJson1_1FunctionDefaultConfig(
-      input.DefaultConfig,
-      context
-    );
-  }
-  if (input.Functions !== undefined) {
-    bodyParams["Functions"] = serializeAws_restJson1_1__listOfFunction(
-      input.Functions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DefaultConfig !== undefined && {
+      DefaultConfig: serializeAws_restJson1_1FunctionDefaultConfig(
+        input.DefaultConfig,
+        context
+      )
+    }),
+    ...(input.Functions !== undefined && {
+      Functions: serializeAws_restJson1_1__listOfFunction(
+        input.Functions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -901,20 +875,18 @@ export const serializeAws_restJson1_1CreateGroupCommand = async (
   };
   let resolvedPath = "/greengrass/groups";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams["InitialVersion"] = serializeAws_restJson1_1GroupVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1GroupVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -987,33 +959,29 @@ export const serializeAws_restJson1_1CreateGroupVersionCommand = async (
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConnectorDefinitionVersionArn !== undefined) {
-    bodyParams["ConnectorDefinitionVersionArn"] =
-      input.ConnectorDefinitionVersionArn;
-  }
-  if (input.CoreDefinitionVersionArn !== undefined) {
-    bodyParams["CoreDefinitionVersionArn"] = input.CoreDefinitionVersionArn;
-  }
-  if (input.DeviceDefinitionVersionArn !== undefined) {
-    bodyParams["DeviceDefinitionVersionArn"] = input.DeviceDefinitionVersionArn;
-  }
-  if (input.FunctionDefinitionVersionArn !== undefined) {
-    bodyParams["FunctionDefinitionVersionArn"] =
-      input.FunctionDefinitionVersionArn;
-  }
-  if (input.LoggerDefinitionVersionArn !== undefined) {
-    bodyParams["LoggerDefinitionVersionArn"] = input.LoggerDefinitionVersionArn;
-  }
-  if (input.ResourceDefinitionVersionArn !== undefined) {
-    bodyParams["ResourceDefinitionVersionArn"] =
-      input.ResourceDefinitionVersionArn;
-  }
-  if (input.SubscriptionDefinitionVersionArn !== undefined) {
-    bodyParams["SubscriptionDefinitionVersionArn"] =
-      input.SubscriptionDefinitionVersionArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConnectorDefinitionVersionArn !== undefined && {
+      ConnectorDefinitionVersionArn: input.ConnectorDefinitionVersionArn
+    }),
+    ...(input.CoreDefinitionVersionArn !== undefined && {
+      CoreDefinitionVersionArn: input.CoreDefinitionVersionArn
+    }),
+    ...(input.DeviceDefinitionVersionArn !== undefined && {
+      DeviceDefinitionVersionArn: input.DeviceDefinitionVersionArn
+    }),
+    ...(input.FunctionDefinitionVersionArn !== undefined && {
+      FunctionDefinitionVersionArn: input.FunctionDefinitionVersionArn
+    }),
+    ...(input.LoggerDefinitionVersionArn !== undefined && {
+      LoggerDefinitionVersionArn: input.LoggerDefinitionVersionArn
+    }),
+    ...(input.ResourceDefinitionVersionArn !== undefined && {
+      ResourceDefinitionVersionArn: input.ResourceDefinitionVersionArn
+    }),
+    ...(input.SubscriptionDefinitionVersionArn !== undefined && {
+      SubscriptionDefinitionVersionArn: input.SubscriptionDefinitionVersionArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1038,22 +1006,18 @@ export const serializeAws_restJson1_1CreateLoggerDefinitionCommand = async (
   };
   let resolvedPath = "/greengrass/definition/loggers";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams[
-      "InitialVersion"
-    ] = serializeAws_restJson1_1LoggerDefinitionVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1LoggerDefinitionVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1095,14 +1059,11 @@ export const serializeAws_restJson1_1CreateLoggerDefinitionVersionCommand = asyn
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Loggers !== undefined) {
-    bodyParams["Loggers"] = serializeAws_restJson1_1__listOfLogger(
-      input.Loggers,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Loggers !== undefined && {
+      Loggers: serializeAws_restJson1_1__listOfLogger(input.Loggers, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1127,22 +1088,18 @@ export const serializeAws_restJson1_1CreateResourceDefinitionCommand = async (
   };
   let resolvedPath = "/greengrass/definition/resources";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams[
-      "InitialVersion"
-    ] = serializeAws_restJson1_1ResourceDefinitionVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1ResourceDefinitionVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1184,14 +1141,14 @@ export const serializeAws_restJson1_1CreateResourceDefinitionVersionCommand = as
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Resources !== undefined) {
-    bodyParams["Resources"] = serializeAws_restJson1_1__listOfResource(
-      input.Resources,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Resources !== undefined && {
+      Resources: serializeAws_restJson1_1__listOfResource(
+        input.Resources,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1216,30 +1173,29 @@ export const serializeAws_restJson1_1CreateSoftwareUpdateJobCommand = async (
   };
   let resolvedPath = "/greengrass/updates";
   let body: any;
-  const bodyParams: any = {};
-  if (input.S3UrlSignerRole !== undefined) {
-    bodyParams["S3UrlSignerRole"] = input.S3UrlSignerRole;
-  }
-  if (input.SoftwareToUpdate !== undefined) {
-    bodyParams["SoftwareToUpdate"] = input.SoftwareToUpdate;
-  }
-  if (input.UpdateAgentLogLevel !== undefined) {
-    bodyParams["UpdateAgentLogLevel"] = input.UpdateAgentLogLevel;
-  }
-  if (input.UpdateTargets !== undefined) {
-    bodyParams["UpdateTargets"] = serializeAws_restJson1_1UpdateTargets(
-      input.UpdateTargets,
-      context
-    );
-  }
-  if (input.UpdateTargetsArchitecture !== undefined) {
-    bodyParams["UpdateTargetsArchitecture"] = input.UpdateTargetsArchitecture;
-  }
-  if (input.UpdateTargetsOperatingSystem !== undefined) {
-    bodyParams["UpdateTargetsOperatingSystem"] =
-      input.UpdateTargetsOperatingSystem;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.S3UrlSignerRole !== undefined && {
+      S3UrlSignerRole: input.S3UrlSignerRole
+    }),
+    ...(input.SoftwareToUpdate !== undefined && {
+      SoftwareToUpdate: input.SoftwareToUpdate
+    }),
+    ...(input.UpdateAgentLogLevel !== undefined && {
+      UpdateAgentLogLevel: input.UpdateAgentLogLevel
+    }),
+    ...(input.UpdateTargets !== undefined && {
+      UpdateTargets: serializeAws_restJson1_1UpdateTargets(
+        input.UpdateTargets,
+        context
+      )
+    }),
+    ...(input.UpdateTargetsArchitecture !== undefined && {
+      UpdateTargetsArchitecture: input.UpdateTargetsArchitecture
+    }),
+    ...(input.UpdateTargetsOperatingSystem !== undefined && {
+      UpdateTargetsOperatingSystem: input.UpdateTargetsOperatingSystem
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1264,22 +1220,18 @@ export const serializeAws_restJson1_1CreateSubscriptionDefinitionCommand = async
   };
   let resolvedPath = "/greengrass/definition/subscriptions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InitialVersion !== undefined) {
-    bodyParams[
-      "InitialVersion"
-    ] = serializeAws_restJson1_1SubscriptionDefinitionVersion(
-      input.InitialVersion,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InitialVersion !== undefined && {
+      InitialVersion: serializeAws_restJson1_1SubscriptionDefinitionVersion(
+        input.InitialVersion,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1321,14 +1273,14 @@ export const serializeAws_restJson1_1CreateSubscriptionDefinitionVersionCommand 
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Subscriptions !== undefined) {
-    bodyParams["Subscriptions"] = serializeAws_restJson1_1__listOfSubscription(
-      input.Subscriptions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Subscriptions !== undefined && {
+      Subscriptions: serializeAws_restJson1_1__listOfSubscription(
+        input.Subscriptions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3431,11 +3383,9 @@ export const serializeAws_restJson1_1ResetDeploymentsCommand = async (
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Force !== undefined) {
-    bodyParams["Force"] = input.Force;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Force !== undefined && { Force: input.Force })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3460,17 +3410,17 @@ export const serializeAws_restJson1_1StartBulkDeploymentCommand = async (
   };
   let resolvedPath = "/greengrass/bulk/deployments";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ExecutionRoleArn !== undefined) {
-    bodyParams["ExecutionRoleArn"] = input.ExecutionRoleArn;
-  }
-  if (input.InputFileUri !== undefined) {
-    bodyParams["InputFileUri"] = input.InputFileUri;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ExecutionRoleArn !== undefined && {
+      ExecutionRoleArn: input.ExecutionRoleArn
+    }),
+    ...(input.InputFileUri !== undefined && {
+      InputFileUri: input.InputFileUri
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3543,11 +3493,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3622,16 +3572,14 @@ export const serializeAws_restJson1_1UpdateConnectivityInfoCommand = async (
     throw new Error("No value provided for input HTTP label: ThingName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConnectivityInfo !== undefined) {
-    bodyParams[
-      "ConnectivityInfo"
-    ] = serializeAws_restJson1_1__listOfConnectivityInfo(
-      input.ConnectivityInfo,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConnectivityInfo !== undefined && {
+      ConnectivityInfo: serializeAws_restJson1_1__listOfConnectivityInfo(
+        input.ConnectivityInfo,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3670,11 +3618,9 @@ export const serializeAws_restJson1_1UpdateConnectorDefinitionCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3712,11 +3658,9 @@ export const serializeAws_restJson1_1UpdateCoreDefinitionCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3754,11 +3698,9 @@ export const serializeAws_restJson1_1UpdateDeviceDefinitionCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3796,11 +3738,9 @@ export const serializeAws_restJson1_1UpdateFunctionDefinitionCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3834,11 +3774,9 @@ export const serializeAws_restJson1_1UpdateGroupCommand = async (
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3873,12 +3811,11 @@ export const serializeAws_restJson1_1UpdateGroupCertificateConfigurationCommand 
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CertificateExpiryInMilliseconds !== undefined) {
-    bodyParams["CertificateExpiryInMilliseconds"] =
-      input.CertificateExpiryInMilliseconds;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CertificateExpiryInMilliseconds !== undefined && {
+      CertificateExpiryInMilliseconds: input.CertificateExpiryInMilliseconds
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3916,11 +3853,9 @@ export const serializeAws_restJson1_1UpdateLoggerDefinitionCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3958,11 +3893,9 @@ export const serializeAws_restJson1_1UpdateResourceDefinitionCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4001,11 +3934,9 @@ export const serializeAws_restJson1_1UpdateSubscriptionDefinitionCommand = async
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-groundstation/protocols/Aws_restJson1_1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1_1.ts
@@ -186,20 +186,18 @@ export const serializeAws_restJson1_1CreateConfigCommand = async (
   };
   let resolvedPath = "/config";
   let body: any;
-  const bodyParams: any = {};
-  if (input.configData !== undefined) {
-    bodyParams["configData"] = serializeAws_restJson1_1ConfigTypeData(
-      input.configData,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagsMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.configData !== undefined && {
+      configData: serializeAws_restJson1_1ConfigTypeData(
+        input.configData,
+        context
+      )
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagsMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -221,17 +219,17 @@ export const serializeAws_restJson1_1CreateDataflowEndpointGroupCommand = async 
   };
   let resolvedPath = "/dataflowEndpointGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.endpointDetails !== undefined) {
-    bodyParams["endpointDetails"] = serializeAws_restJson1_1EndpointDetailsList(
-      input.endpointDetails,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagsMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.endpointDetails !== undefined && {
+      endpointDetails: serializeAws_restJson1_1EndpointDetailsList(
+        input.endpointDetails,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagsMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -253,35 +251,31 @@ export const serializeAws_restJson1_1CreateMissionProfileCommand = async (
   };
   let resolvedPath = "/missionprofile";
   let body: any;
-  const bodyParams: any = {};
-  if (input.contactPostPassDurationSeconds !== undefined) {
-    bodyParams["contactPostPassDurationSeconds"] =
-      input.contactPostPassDurationSeconds;
-  }
-  if (input.contactPrePassDurationSeconds !== undefined) {
-    bodyParams["contactPrePassDurationSeconds"] =
-      input.contactPrePassDurationSeconds;
-  }
-  if (input.dataflowEdges !== undefined) {
-    bodyParams["dataflowEdges"] = serializeAws_restJson1_1DataflowEdgeList(
-      input.dataflowEdges,
-      context
-    );
-  }
-  if (input.minimumViableContactDurationSeconds !== undefined) {
-    bodyParams["minimumViableContactDurationSeconds"] =
-      input.minimumViableContactDurationSeconds;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagsMap(input.tags, context);
-  }
-  if (input.trackingConfigArn !== undefined) {
-    bodyParams["trackingConfigArn"] = input.trackingConfigArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.contactPostPassDurationSeconds !== undefined && {
+      contactPostPassDurationSeconds: input.contactPostPassDurationSeconds
+    }),
+    ...(input.contactPrePassDurationSeconds !== undefined && {
+      contactPrePassDurationSeconds: input.contactPrePassDurationSeconds
+    }),
+    ...(input.dataflowEdges !== undefined && {
+      dataflowEdges: serializeAws_restJson1_1DataflowEdgeList(
+        input.dataflowEdges,
+        context
+      )
+    }),
+    ...(input.minimumViableContactDurationSeconds !== undefined && {
+      minimumViableContactDurationSeconds:
+        input.minimumViableContactDurationSeconds
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagsMap(input.tags, context)
+    }),
+    ...(input.trackingConfigArn !== undefined && {
+      trackingConfigArn: input.trackingConfigArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -602,35 +596,28 @@ export const serializeAws_restJson1_1ListContactsCommand = async (
   };
   let resolvedPath = "/contacts";
   let body: any;
-  const bodyParams: any = {};
-  if (input.endTime !== undefined) {
-    bodyParams["endTime"] = Math.round(input.endTime.getTime() / 1000);
-  }
-  if (input.groundStation !== undefined) {
-    bodyParams["groundStation"] = input.groundStation;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.missionProfileArn !== undefined) {
-    bodyParams["missionProfileArn"] = input.missionProfileArn;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.satelliteArn !== undefined) {
-    bodyParams["satelliteArn"] = input.satelliteArn;
-  }
-  if (input.startTime !== undefined) {
-    bodyParams["startTime"] = Math.round(input.startTime.getTime() / 1000);
-  }
-  if (input.statusList !== undefined) {
-    bodyParams["statusList"] = serializeAws_restJson1_1StatusList(
-      input.statusList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.endTime !== undefined && {
+      endTime: Math.round(input.endTime.getTime() / 1000)
+    }),
+    ...(input.groundStation !== undefined && {
+      groundStation: input.groundStation
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.missionProfileArn !== undefined && {
+      missionProfileArn: input.missionProfileArn
+    }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.satelliteArn !== undefined && {
+      satelliteArn: input.satelliteArn
+    }),
+    ...(input.startTime !== undefined && {
+      startTime: Math.round(input.startTime.getTime() / 1000)
+    }),
+    ...(input.statusList !== undefined && {
+      statusList: serializeAws_restJson1_1StatusList(input.statusList, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -708,26 +695,26 @@ export const serializeAws_restJson1_1ReserveContactCommand = async (
   };
   let resolvedPath = "/contact";
   let body: any;
-  const bodyParams: any = {};
-  if (input.endTime !== undefined) {
-    bodyParams["endTime"] = Math.round(input.endTime.getTime() / 1000);
-  }
-  if (input.groundStation !== undefined) {
-    bodyParams["groundStation"] = input.groundStation;
-  }
-  if (input.missionProfileArn !== undefined) {
-    bodyParams["missionProfileArn"] = input.missionProfileArn;
-  }
-  if (input.satelliteArn !== undefined) {
-    bodyParams["satelliteArn"] = input.satelliteArn;
-  }
-  if (input.startTime !== undefined) {
-    bodyParams["startTime"] = Math.round(input.startTime.getTime() / 1000);
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagsMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.endTime !== undefined && {
+      endTime: Math.round(input.endTime.getTime() / 1000)
+    }),
+    ...(input.groundStation !== undefined && {
+      groundStation: input.groundStation
+    }),
+    ...(input.missionProfileArn !== undefined && {
+      missionProfileArn: input.missionProfileArn
+    }),
+    ...(input.satelliteArn !== undefined && {
+      satelliteArn: input.satelliteArn
+    }),
+    ...(input.startTime !== undefined && {
+      startTime: Math.round(input.startTime.getTime() / 1000)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagsMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -773,17 +760,15 @@ export const serializeAws_restJson1_1UpdateConfigCommand = async (
     throw new Error("No value provided for input HTTP label: configType.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.configData !== undefined) {
-    bodyParams["configData"] = serializeAws_restJson1_1ConfigTypeData(
-      input.configData,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.configData !== undefined && {
+      configData: serializeAws_restJson1_1ConfigTypeData(
+        input.configData,
+        context
+      )
+    }),
+    ...(input.name !== undefined && { name: input.name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -821,32 +806,28 @@ export const serializeAws_restJson1_1UpdateMissionProfileCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.contactPostPassDurationSeconds !== undefined) {
-    bodyParams["contactPostPassDurationSeconds"] =
-      input.contactPostPassDurationSeconds;
-  }
-  if (input.contactPrePassDurationSeconds !== undefined) {
-    bodyParams["contactPrePassDurationSeconds"] =
-      input.contactPrePassDurationSeconds;
-  }
-  if (input.dataflowEdges !== undefined) {
-    bodyParams["dataflowEdges"] = serializeAws_restJson1_1DataflowEdgeList(
-      input.dataflowEdges,
-      context
-    );
-  }
-  if (input.minimumViableContactDurationSeconds !== undefined) {
-    bodyParams["minimumViableContactDurationSeconds"] =
-      input.minimumViableContactDurationSeconds;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.trackingConfigArn !== undefined) {
-    bodyParams["trackingConfigArn"] = input.trackingConfigArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.contactPostPassDurationSeconds !== undefined && {
+      contactPostPassDurationSeconds: input.contactPostPassDurationSeconds
+    }),
+    ...(input.contactPrePassDurationSeconds !== undefined && {
+      contactPrePassDurationSeconds: input.contactPrePassDurationSeconds
+    }),
+    ...(input.dataflowEdges !== undefined && {
+      dataflowEdges: serializeAws_restJson1_1DataflowEdgeList(
+        input.dataflowEdges,
+        context
+      )
+    }),
+    ...(input.minimumViableContactDurationSeconds !== undefined && {
+      minimumViableContactDurationSeconds:
+        input.minimumViableContactDurationSeconds
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.trackingConfigArn !== undefined && {
+      trackingConfigArn: input.trackingConfigArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -868,14 +849,10 @@ export const serializeAws_restJson1_1GetMinuteUsageCommand = async (
   };
   let resolvedPath = "/minute-usage";
   let body: any;
-  const bodyParams: any = {};
-  if (input.month !== undefined) {
-    bodyParams["month"] = input.month;
-  }
-  if (input.year !== undefined) {
-    bodyParams["year"] = input.year;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.month !== undefined && { month: input.month }),
+    ...(input.year !== undefined && { year: input.year })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1037,11 +1014,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagsMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagsMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-guardduty/protocols/Aws_restJson1_1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1_1.ts
@@ -278,14 +278,12 @@ export const serializeAws_restJson1_1AcceptInvitationCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.InvitationId !== undefined) {
-    bodyParams["invitationId"] = input.InvitationId;
-  }
-  if (input.MasterId !== undefined) {
-    bodyParams["masterId"] = input.MasterId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InvitationId !== undefined && {
+      invitationId: input.InvitationId
+    }),
+    ...(input.MasterId !== undefined && { masterId: input.MasterId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -319,14 +317,11 @@ export const serializeAws_restJson1_1ArchiveFindingsCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.FindingIds !== undefined) {
-    bodyParams["findingIds"] = serializeAws_restJson1_1FindingIds(
-      input.FindingIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FindingIds !== undefined && {
+      findingIds: serializeAws_restJson1_1FindingIds(input.FindingIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -348,23 +343,16 @@ export const serializeAws_restJson1_1CreateDetectorCommand = async (
   };
   let resolvedPath = "/detector";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["clientToken"] = input.ClientToken;
-  }
-  if (input.Enable !== undefined) {
-    bodyParams["enable"] = input.Enable;
-  }
-  if (input.FindingPublishingFrequency !== undefined) {
-    bodyParams["findingPublishingFrequency"] = input.FindingPublishingFrequency;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.Enable !== undefined && { enable: input.Enable }),
+    ...(input.FindingPublishingFrequency !== undefined && {
+      findingPublishingFrequency: input.FindingPublishingFrequency
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -398,35 +386,22 @@ export const serializeAws_restJson1_1CreateFilterCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Action !== undefined) {
-    bodyParams["action"] = input.Action;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["clientToken"] = input.ClientToken;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.FindingCriteria !== undefined) {
-    bodyParams["findingCriteria"] = serializeAws_restJson1_1FindingCriteria(
-      input.FindingCriteria,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Rank !== undefined) {
-    bodyParams["rank"] = input.Rank;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Action !== undefined && { action: input.Action }),
+    clientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.FindingCriteria !== undefined && {
+      findingCriteria: serializeAws_restJson1_1FindingCriteria(
+        input.FindingCriteria,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Rank !== undefined && { rank: input.Rank }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -460,29 +435,16 @@ export const serializeAws_restJson1_1CreateIPSetCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Activate !== undefined) {
-    bodyParams["activate"] = input.Activate;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["clientToken"] = input.ClientToken;
-  }
-  if (input.Format !== undefined) {
-    bodyParams["format"] = input.Format;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["location"] = input.Location;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Activate !== undefined && { activate: input.Activate }),
+    clientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.Format !== undefined && { format: input.Format }),
+    ...(input.Location !== undefined && { location: input.Location }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -516,14 +478,14 @@ export const serializeAws_restJson1_1CreateMembersCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountDetails !== undefined) {
-    bodyParams["accountDetails"] = serializeAws_restJson1_1AccountDetails(
-      input.AccountDetails,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountDetails !== undefined && {
+      accountDetails: serializeAws_restJson1_1AccountDetails(
+        input.AccountDetails,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -557,25 +519,18 @@ export const serializeAws_restJson1_1CreatePublishingDestinationCommand = async 
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["clientToken"] = input.ClientToken;
-  }
-  if (input.DestinationProperties !== undefined) {
-    bodyParams[
-      "destinationProperties"
-    ] = serializeAws_restJson1_1DestinationProperties(
-      input.DestinationProperties,
-      context
-    );
-  }
-  if (input.DestinationType !== undefined) {
-    bodyParams["destinationType"] = input.DestinationType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.DestinationProperties !== undefined && {
+      destinationProperties: serializeAws_restJson1_1DestinationProperties(
+        input.DestinationProperties,
+        context
+      )
+    }),
+    ...(input.DestinationType !== undefined && {
+      destinationType: input.DestinationType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -609,14 +564,14 @@ export const serializeAws_restJson1_1CreateSampleFindingsCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.FindingTypes !== undefined) {
-    bodyParams["findingTypes"] = serializeAws_restJson1_1FindingTypes(
-      input.FindingTypes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FindingTypes !== undefined && {
+      findingTypes: serializeAws_restJson1_1FindingTypes(
+        input.FindingTypes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -650,29 +605,16 @@ export const serializeAws_restJson1_1CreateThreatIntelSetCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Activate !== undefined) {
-    bodyParams["activate"] = input.Activate;
-  }
-  if (input.ClientToken === undefined) {
-    input.ClientToken = generateIdempotencyToken();
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["clientToken"] = input.ClientToken;
-  }
-  if (input.Format !== undefined) {
-    bodyParams["format"] = input.Format;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["location"] = input.Location;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Activate !== undefined && { activate: input.Activate }),
+    clientToken: input.ClientToken ?? generateIdempotencyToken(),
+    ...(input.Format !== undefined && { format: input.Format }),
+    ...(input.Location !== undefined && { location: input.Location }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -694,14 +636,11 @@ export const serializeAws_restJson1_1DeclineInvitationsCommand = async (
   };
   let resolvedPath = "/invitation/decline";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -846,14 +785,11 @@ export const serializeAws_restJson1_1DeleteInvitationsCommand = async (
   };
   let resolvedPath = "/invitation/delete";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -887,14 +823,11 @@ export const serializeAws_restJson1_1DeleteMembersCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1106,14 +1039,11 @@ export const serializeAws_restJson1_1DisassociateMembersCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1225,20 +1155,17 @@ export const serializeAws_restJson1_1GetFindingsCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.FindingIds !== undefined) {
-    bodyParams["findingIds"] = serializeAws_restJson1_1FindingIds(
-      input.FindingIds,
-      context
-    );
-  }
-  if (input.SortCriteria !== undefined) {
-    bodyParams["sortCriteria"] = serializeAws_restJson1_1SortCriteria(
-      input.SortCriteria,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FindingIds !== undefined && {
+      findingIds: serializeAws_restJson1_1FindingIds(input.FindingIds, context)
+    }),
+    ...(input.SortCriteria !== undefined && {
+      sortCriteria: serializeAws_restJson1_1SortCriteria(
+        input.SortCriteria,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1272,22 +1199,20 @@ export const serializeAws_restJson1_1GetFindingsStatisticsCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.FindingCriteria !== undefined) {
-    bodyParams["findingCriteria"] = serializeAws_restJson1_1FindingCriteria(
-      input.FindingCriteria,
-      context
-    );
-  }
-  if (input.FindingStatisticTypes !== undefined) {
-    bodyParams[
-      "findingStatisticTypes"
-    ] = serializeAws_restJson1_1FindingStatisticTypes(
-      input.FindingStatisticTypes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FindingCriteria !== undefined && {
+      findingCriteria: serializeAws_restJson1_1FindingCriteria(
+        input.FindingCriteria,
+        context
+      )
+    }),
+    ...(input.FindingStatisticTypes !== undefined && {
+      findingStatisticTypes: serializeAws_restJson1_1FindingStatisticTypes(
+        input.FindingStatisticTypes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1421,14 +1346,11 @@ export const serializeAws_restJson1_1GetMembersCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1511,20 +1433,15 @@ export const serializeAws_restJson1_1InviteMembersCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  if (input.DisableEmailNotification !== undefined) {
-    bodyParams["disableEmailNotification"] = input.DisableEmailNotification;
-  }
-  if (input.Message !== undefined) {
-    bodyParams["message"] = input.Message;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    }),
+    ...(input.DisableEmailNotification !== undefined && {
+      disableEmailNotification: input.DisableEmailNotification
+    }),
+    ...(input.Message !== undefined && { message: input.Message })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1626,26 +1543,22 @@ export const serializeAws_restJson1_1ListFindingsCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.FindingCriteria !== undefined) {
-    bodyParams["findingCriteria"] = serializeAws_restJson1_1FindingCriteria(
-      input.FindingCriteria,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["maxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["nextToken"] = input.NextToken;
-  }
-  if (input.SortCriteria !== undefined) {
-    bodyParams["sortCriteria"] = serializeAws_restJson1_1SortCriteria(
-      input.SortCriteria,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FindingCriteria !== undefined && {
+      findingCriteria: serializeAws_restJson1_1FindingCriteria(
+        input.FindingCriteria,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { maxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { nextToken: input.NextToken }),
+    ...(input.SortCriteria !== undefined && {
+      sortCriteria: serializeAws_restJson1_1SortCriteria(
+        input.SortCriteria,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1905,14 +1818,11 @@ export const serializeAws_restJson1_1StartMonitoringMembersCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1946,14 +1856,11 @@ export const serializeAws_restJson1_1StopMonitoringMembersCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["accountIds"] = serializeAws_restJson1_1AccountIds(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      accountIds: serializeAws_restJson1_1AccountIds(input.AccountIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1989,11 +1896,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2027,14 +1934,11 @@ export const serializeAws_restJson1_1UnarchiveFindingsCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.FindingIds !== undefined) {
-    bodyParams["findingIds"] = serializeAws_restJson1_1FindingIds(
-      input.FindingIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FindingIds !== undefined && {
+      findingIds: serializeAws_restJson1_1FindingIds(input.FindingIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2109,14 +2013,12 @@ export const serializeAws_restJson1_1UpdateDetectorCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Enable !== undefined) {
-    bodyParams["enable"] = input.Enable;
-  }
-  if (input.FindingPublishingFrequency !== undefined) {
-    bodyParams["findingPublishingFrequency"] = input.FindingPublishingFrequency;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Enable !== undefined && { enable: input.Enable }),
+    ...(input.FindingPublishingFrequency !== undefined && {
+      findingPublishingFrequency: input.FindingPublishingFrequency
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2162,23 +2064,17 @@ export const serializeAws_restJson1_1UpdateFilterCommand = async (
     throw new Error("No value provided for input HTTP label: FilterName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Action !== undefined) {
-    bodyParams["action"] = input.Action;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.FindingCriteria !== undefined) {
-    bodyParams["findingCriteria"] = serializeAws_restJson1_1FindingCriteria(
-      input.FindingCriteria,
-      context
-    );
-  }
-  if (input.Rank !== undefined) {
-    bodyParams["rank"] = input.Rank;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Action !== undefined && { action: input.Action }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.FindingCriteria !== undefined && {
+      findingCriteria: serializeAws_restJson1_1FindingCriteria(
+        input.FindingCriteria,
+        context
+      )
+    }),
+    ...(input.Rank !== undefined && { rank: input.Rank })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2212,20 +2108,13 @@ export const serializeAws_restJson1_1UpdateFindingsFeedbackCommand = async (
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Comments !== undefined) {
-    bodyParams["comments"] = input.Comments;
-  }
-  if (input.Feedback !== undefined) {
-    bodyParams["feedback"] = input.Feedback;
-  }
-  if (input.FindingIds !== undefined) {
-    bodyParams["findingIds"] = serializeAws_restJson1_1FindingIds(
-      input.FindingIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Comments !== undefined && { comments: input.Comments }),
+    ...(input.Feedback !== undefined && { feedback: input.Feedback }),
+    ...(input.FindingIds !== undefined && {
+      findingIds: serializeAws_restJson1_1FindingIds(input.FindingIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2271,17 +2160,11 @@ export const serializeAws_restJson1_1UpdateIPSetCommand = async (
     throw new Error("No value provided for input HTTP label: IpSetId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Activate !== undefined) {
-    bodyParams["activate"] = input.Activate;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["location"] = input.Location;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Activate !== undefined && { activate: input.Activate }),
+    ...(input.Location !== undefined && { location: input.Location }),
+    ...(input.Name !== undefined && { name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2330,16 +2213,14 @@ export const serializeAws_restJson1_1UpdatePublishingDestinationCommand = async 
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DestinationProperties !== undefined) {
-    bodyParams[
-      "destinationProperties"
-    ] = serializeAws_restJson1_1DestinationProperties(
-      input.DestinationProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DestinationProperties !== undefined && {
+      destinationProperties: serializeAws_restJson1_1DestinationProperties(
+        input.DestinationProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2389,17 +2270,11 @@ export const serializeAws_restJson1_1UpdateThreatIntelSetCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Activate !== undefined) {
-    bodyParams["activate"] = input.Activate;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["location"] = input.Location;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Activate !== undefined && { activate: input.Activate }),
+    ...(input.Location !== undefined && { location: input.Location }),
+    ...(input.Name !== undefined && { name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
@@ -236,14 +236,12 @@ export const serializeAws_restJson1_1CancelImageCreationCommand = async (
   };
   let resolvedPath = "/CancelImageCreation";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.imageBuildVersionArn !== undefined) {
-    bodyParams["imageBuildVersionArn"] = input.imageBuildVersionArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.imageBuildVersionArn !== undefined && {
+      imageBuildVersionArn: input.imageBuildVersionArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -265,41 +263,24 @@ export const serializeAws_restJson1_1CreateComponentCommand = async (
   };
   let resolvedPath = "/CreateComponent";
   let body: any;
-  const bodyParams: any = {};
-  if (input.changeDescription !== undefined) {
-    bodyParams["changeDescription"] = input.changeDescription;
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.data !== undefined) {
-    bodyParams["data"] = input.data;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.kmsKeyId !== undefined) {
-    bodyParams["kmsKeyId"] = input.kmsKeyId;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.platform !== undefined) {
-    bodyParams["platform"] = input.platform;
-  }
-  if (input.semanticVersion !== undefined) {
-    bodyParams["semanticVersion"] = input.semanticVersion;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.uri !== undefined) {
-    bodyParams["uri"] = input.uri;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.changeDescription !== undefined && {
+      changeDescription: input.changeDescription
+    }),
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.data !== undefined && { data: input.data }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.kmsKeyId !== undefined && { kmsKeyId: input.kmsKeyId }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.platform !== undefined && { platform: input.platform }),
+    ...(input.semanticVersion !== undefined && {
+      semanticVersion: input.semanticVersion
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.uri !== undefined && { uri: input.uri })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -321,29 +302,20 @@ export const serializeAws_restJson1_1CreateDistributionConfigurationCommand = as
   };
   let resolvedPath = "/CreateDistributionConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.distributions !== undefined) {
-    bodyParams["distributions"] = serializeAws_restJson1_1DistributionList(
-      input.distributions,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.distributions !== undefined && {
+      distributions: serializeAws_restJson1_1DistributionList(
+        input.distributions,
+        context
+      )
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -365,36 +337,27 @@ export const serializeAws_restJson1_1CreateImageCommand = async (
   };
   let resolvedPath = "/CreateImage";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.distributionConfigurationArn !== undefined) {
-    bodyParams["distributionConfigurationArn"] =
-      input.distributionConfigurationArn;
-  }
-  if (input.imageRecipeArn !== undefined) {
-    bodyParams["imageRecipeArn"] = input.imageRecipeArn;
-  }
-  if (input.imageTestsConfiguration !== undefined) {
-    bodyParams[
-      "imageTestsConfiguration"
-    ] = serializeAws_restJson1_1ImageTestsConfiguration(
-      input.imageTestsConfiguration,
-      context
-    );
-  }
-  if (input.infrastructureConfigurationArn !== undefined) {
-    bodyParams["infrastructureConfigurationArn"] =
-      input.infrastructureConfigurationArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.distributionConfigurationArn !== undefined && {
+      distributionConfigurationArn: input.distributionConfigurationArn
+    }),
+    ...(input.imageRecipeArn !== undefined && {
+      imageRecipeArn: input.imageRecipeArn
+    }),
+    ...(input.imageTestsConfiguration !== undefined && {
+      imageTestsConfiguration: serializeAws_restJson1_1ImageTestsConfiguration(
+        input.imageTestsConfiguration,
+        context
+      )
+    }),
+    ...(input.infrastructureConfigurationArn !== undefined && {
+      infrastructureConfigurationArn: input.infrastructureConfigurationArn
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -416,51 +379,33 @@ export const serializeAws_restJson1_1CreateImagePipelineCommand = async (
   };
   let resolvedPath = "/CreateImagePipeline";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.distributionConfigurationArn !== undefined) {
-    bodyParams["distributionConfigurationArn"] =
-      input.distributionConfigurationArn;
-  }
-  if (input.imageRecipeArn !== undefined) {
-    bodyParams["imageRecipeArn"] = input.imageRecipeArn;
-  }
-  if (input.imageTestsConfiguration !== undefined) {
-    bodyParams[
-      "imageTestsConfiguration"
-    ] = serializeAws_restJson1_1ImageTestsConfiguration(
-      input.imageTestsConfiguration,
-      context
-    );
-  }
-  if (input.infrastructureConfigurationArn !== undefined) {
-    bodyParams["infrastructureConfigurationArn"] =
-      input.infrastructureConfigurationArn;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.schedule !== undefined) {
-    bodyParams["schedule"] = serializeAws_restJson1_1Schedule(
-      input.schedule,
-      context
-    );
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.distributionConfigurationArn !== undefined && {
+      distributionConfigurationArn: input.distributionConfigurationArn
+    }),
+    ...(input.imageRecipeArn !== undefined && {
+      imageRecipeArn: input.imageRecipeArn
+    }),
+    ...(input.imageTestsConfiguration !== undefined && {
+      imageTestsConfiguration: serializeAws_restJson1_1ImageTestsConfiguration(
+        input.imageTestsConfiguration,
+        context
+      )
+    }),
+    ...(input.infrastructureConfigurationArn !== undefined && {
+      infrastructureConfigurationArn: input.infrastructureConfigurationArn
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.schedule !== undefined && {
+      schedule: serializeAws_restJson1_1Schedule(input.schedule, context)
+    }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -482,45 +427,30 @@ export const serializeAws_restJson1_1CreateImageRecipeCommand = async (
   };
   let resolvedPath = "/CreateImageRecipe";
   let body: any;
-  const bodyParams: any = {};
-  if (input.blockDeviceMappings !== undefined) {
-    bodyParams[
-      "blockDeviceMappings"
-    ] = serializeAws_restJson1_1InstanceBlockDeviceMappings(
-      input.blockDeviceMappings,
-      context
-    );
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.components !== undefined) {
-    bodyParams[
-      "components"
-    ] = serializeAws_restJson1_1ComponentConfigurationList(
-      input.components,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.parentImage !== undefined) {
-    bodyParams["parentImage"] = input.parentImage;
-  }
-  if (input.semanticVersion !== undefined) {
-    bodyParams["semanticVersion"] = input.semanticVersion;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.blockDeviceMappings !== undefined && {
+      blockDeviceMappings: serializeAws_restJson1_1InstanceBlockDeviceMappings(
+        input.blockDeviceMappings,
+        context
+      )
+    }),
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.components !== undefined && {
+      components: serializeAws_restJson1_1ComponentConfigurationList(
+        input.components,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.parentImage !== undefined && { parentImage: input.parentImage }),
+    ...(input.semanticVersion !== undefined && {
+      semanticVersion: input.semanticVersion
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -542,56 +472,38 @@ export const serializeAws_restJson1_1CreateInfrastructureConfigurationCommand = 
   };
   let resolvedPath = "/CreateInfrastructureConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.instanceProfileName !== undefined) {
-    bodyParams["instanceProfileName"] = input.instanceProfileName;
-  }
-  if (input.instanceTypes !== undefined) {
-    bodyParams["instanceTypes"] = serializeAws_restJson1_1InstanceTypeList(
-      input.instanceTypes,
-      context
-    );
-  }
-  if (input.keyPair !== undefined) {
-    bodyParams["keyPair"] = input.keyPair;
-  }
-  if (input.logging !== undefined) {
-    bodyParams["logging"] = serializeAws_restJson1_1Logging(
-      input.logging,
-      context
-    );
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.securityGroupIds !== undefined) {
-    bodyParams["securityGroupIds"] = serializeAws_restJson1_1SecurityGroupIds(
-      input.securityGroupIds,
-      context
-    );
-  }
-  if (input.snsTopicArn !== undefined) {
-    bodyParams["snsTopicArn"] = input.snsTopicArn;
-  }
-  if (input.subnetId !== undefined) {
-    bodyParams["subnetId"] = input.subnetId;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.terminateInstanceOnFailure !== undefined) {
-    bodyParams["terminateInstanceOnFailure"] = input.terminateInstanceOnFailure;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.instanceProfileName !== undefined && {
+      instanceProfileName: input.instanceProfileName
+    }),
+    ...(input.instanceTypes !== undefined && {
+      instanceTypes: serializeAws_restJson1_1InstanceTypeList(
+        input.instanceTypes,
+        context
+      )
+    }),
+    ...(input.keyPair !== undefined && { keyPair: input.keyPair }),
+    ...(input.logging !== undefined && {
+      logging: serializeAws_restJson1_1Logging(input.logging, context)
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.securityGroupIds !== undefined && {
+      securityGroupIds: serializeAws_restJson1_1SecurityGroupIds(
+        input.securityGroupIds,
+        context
+      )
+    }),
+    ...(input.snsTopicArn !== undefined && { snsTopicArn: input.snsTopicArn }),
+    ...(input.subnetId !== undefined && { subnetId: input.subnetId }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.terminateInstanceOnFailure !== undefined && {
+      terminateInstanceOnFailure: input.terminateInstanceOnFailure
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1016,47 +928,26 @@ export const serializeAws_restJson1_1ImportComponentCommand = async (
   };
   let resolvedPath = "/ImportComponent";
   let body: any;
-  const bodyParams: any = {};
-  if (input.changeDescription !== undefined) {
-    bodyParams["changeDescription"] = input.changeDescription;
-  }
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.data !== undefined) {
-    bodyParams["data"] = input.data;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.format !== undefined) {
-    bodyParams["format"] = input.format;
-  }
-  if (input.kmsKeyId !== undefined) {
-    bodyParams["kmsKeyId"] = input.kmsKeyId;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.platform !== undefined) {
-    bodyParams["platform"] = input.platform;
-  }
-  if (input.semanticVersion !== undefined) {
-    bodyParams["semanticVersion"] = input.semanticVersion;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.type !== undefined) {
-    bodyParams["type"] = input.type;
-  }
-  if (input.uri !== undefined) {
-    bodyParams["uri"] = input.uri;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.changeDescription !== undefined && {
+      changeDescription: input.changeDescription
+    }),
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.data !== undefined && { data: input.data }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.format !== undefined && { format: input.format }),
+    ...(input.kmsKeyId !== undefined && { kmsKeyId: input.kmsKeyId }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.platform !== undefined && { platform: input.platform }),
+    ...(input.semanticVersion !== undefined && {
+      semanticVersion: input.semanticVersion
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.type !== undefined && { type: input.type }),
+    ...(input.uri !== undefined && { uri: input.uri })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1078,17 +969,13 @@ export const serializeAws_restJson1_1ListComponentBuildVersionsCommand = async (
   };
   let resolvedPath = "/ListComponentBuildVersions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.componentVersionArn !== undefined) {
-    bodyParams["componentVersionArn"] = input.componentVersionArn;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.componentVersionArn !== undefined && {
+      componentVersionArn: input.componentVersionArn
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1110,23 +997,14 @@ export const serializeAws_restJson1_1ListComponentsCommand = async (
   };
   let resolvedPath = "/ListComponents";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.owner !== undefined) {
-    bodyParams["owner"] = input.owner;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.owner !== undefined && { owner: input.owner })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1148,20 +1026,13 @@ export const serializeAws_restJson1_1ListDistributionConfigurationsCommand = asy
   };
   let resolvedPath = "/ListDistributionConfigurations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1183,23 +1054,16 @@ export const serializeAws_restJson1_1ListImageBuildVersionsCommand = async (
   };
   let resolvedPath = "/ListImageBuildVersions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.imageVersionArn !== undefined) {
-    bodyParams["imageVersionArn"] = input.imageVersionArn;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.imageVersionArn !== undefined && {
+      imageVersionArn: input.imageVersionArn
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1221,23 +1085,16 @@ export const serializeAws_restJson1_1ListImagePipelineImagesCommand = async (
   };
   let resolvedPath = "/ListImagePipelineImages";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.imagePipelineArn !== undefined) {
-    bodyParams["imagePipelineArn"] = input.imagePipelineArn;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.imagePipelineArn !== undefined && {
+      imagePipelineArn: input.imagePipelineArn
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1259,20 +1116,13 @@ export const serializeAws_restJson1_1ListImagePipelinesCommand = async (
   };
   let resolvedPath = "/ListImagePipelines";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1294,23 +1144,14 @@ export const serializeAws_restJson1_1ListImageRecipesCommand = async (
   };
   let resolvedPath = "/ListImageRecipes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.owner !== undefined) {
-    bodyParams["owner"] = input.owner;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.owner !== undefined && { owner: input.owner })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1332,23 +1173,14 @@ export const serializeAws_restJson1_1ListImagesCommand = async (
   };
   let resolvedPath = "/ListImages";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.owner !== undefined) {
-    bodyParams["owner"] = input.owner;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.owner !== undefined && { owner: input.owner })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1370,20 +1202,13 @@ export const serializeAws_restJson1_1ListInfrastructureConfigurationsCommand = a
   };
   let resolvedPath = "/ListInfrastructureConfigurations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1FilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1FilterList(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1440,14 +1265,12 @@ export const serializeAws_restJson1_1PutComponentPolicyCommand = async (
   };
   let resolvedPath = "/PutComponentPolicy";
   let body: any;
-  const bodyParams: any = {};
-  if (input.componentArn !== undefined) {
-    bodyParams["componentArn"] = input.componentArn;
-  }
-  if (input.policy !== undefined) {
-    bodyParams["policy"] = input.policy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.componentArn !== undefined && {
+      componentArn: input.componentArn
+    }),
+    ...(input.policy !== undefined && { policy: input.policy })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1469,14 +1292,10 @@ export const serializeAws_restJson1_1PutImagePolicyCommand = async (
   };
   let resolvedPath = "/PutImagePolicy";
   let body: any;
-  const bodyParams: any = {};
-  if (input.imageArn !== undefined) {
-    bodyParams["imageArn"] = input.imageArn;
-  }
-  if (input.policy !== undefined) {
-    bodyParams["policy"] = input.policy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.imageArn !== undefined && { imageArn: input.imageArn }),
+    ...(input.policy !== undefined && { policy: input.policy })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1498,14 +1317,12 @@ export const serializeAws_restJson1_1PutImageRecipePolicyCommand = async (
   };
   let resolvedPath = "/PutImageRecipePolicy";
   let body: any;
-  const bodyParams: any = {};
-  if (input.imageRecipeArn !== undefined) {
-    bodyParams["imageRecipeArn"] = input.imageRecipeArn;
-  }
-  if (input.policy !== undefined) {
-    bodyParams["policy"] = input.policy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.imageRecipeArn !== undefined && {
+      imageRecipeArn: input.imageRecipeArn
+    }),
+    ...(input.policy !== undefined && { policy: input.policy })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1527,17 +1344,12 @@ export const serializeAws_restJson1_1StartImagePipelineExecutionCommand = async 
   };
   let resolvedPath = "/StartImagePipelineExecution";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.imagePipelineArn !== undefined) {
-    bodyParams["imagePipelineArn"] = input.imagePipelineArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.imagePipelineArn !== undefined && {
+      imagePipelineArn: input.imagePipelineArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1573,11 +1385,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1640,27 +1452,19 @@ export const serializeAws_restJson1_1UpdateDistributionConfigurationCommand = as
   };
   let resolvedPath = "/UpdateDistributionConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.distributionConfigurationArn !== undefined) {
-    bodyParams["distributionConfigurationArn"] =
-      input.distributionConfigurationArn;
-  }
-  if (input.distributions !== undefined) {
-    bodyParams["distributions"] = serializeAws_restJson1_1DistributionList(
-      input.distributions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.distributionConfigurationArn !== undefined && {
+      distributionConfigurationArn: input.distributionConfigurationArn
+    }),
+    ...(input.distributions !== undefined && {
+      distributions: serializeAws_restJson1_1DistributionList(
+        input.distributions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1682,48 +1486,32 @@ export const serializeAws_restJson1_1UpdateImagePipelineCommand = async (
   };
   let resolvedPath = "/UpdateImagePipeline";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.distributionConfigurationArn !== undefined) {
-    bodyParams["distributionConfigurationArn"] =
-      input.distributionConfigurationArn;
-  }
-  if (input.imagePipelineArn !== undefined) {
-    bodyParams["imagePipelineArn"] = input.imagePipelineArn;
-  }
-  if (input.imageRecipeArn !== undefined) {
-    bodyParams["imageRecipeArn"] = input.imageRecipeArn;
-  }
-  if (input.imageTestsConfiguration !== undefined) {
-    bodyParams[
-      "imageTestsConfiguration"
-    ] = serializeAws_restJson1_1ImageTestsConfiguration(
-      input.imageTestsConfiguration,
-      context
-    );
-  }
-  if (input.infrastructureConfigurationArn !== undefined) {
-    bodyParams["infrastructureConfigurationArn"] =
-      input.infrastructureConfigurationArn;
-  }
-  if (input.schedule !== undefined) {
-    bodyParams["schedule"] = serializeAws_restJson1_1Schedule(
-      input.schedule,
-      context
-    );
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.distributionConfigurationArn !== undefined && {
+      distributionConfigurationArn: input.distributionConfigurationArn
+    }),
+    ...(input.imagePipelineArn !== undefined && {
+      imagePipelineArn: input.imagePipelineArn
+    }),
+    ...(input.imageRecipeArn !== undefined && {
+      imageRecipeArn: input.imageRecipeArn
+    }),
+    ...(input.imageTestsConfiguration !== undefined && {
+      imageTestsConfiguration: serializeAws_restJson1_1ImageTestsConfiguration(
+        input.imageTestsConfiguration,
+        context
+      )
+    }),
+    ...(input.infrastructureConfigurationArn !== undefined && {
+      infrastructureConfigurationArn: input.infrastructureConfigurationArn
+    }),
+    ...(input.schedule !== undefined && {
+      schedule: serializeAws_restJson1_1Schedule(input.schedule, context)
+    }),
+    ...(input.status !== undefined && { status: input.status })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1745,54 +1533,37 @@ export const serializeAws_restJson1_1UpdateInfrastructureConfigurationCommand = 
   };
   let resolvedPath = "/UpdateInfrastructureConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.infrastructureConfigurationArn !== undefined) {
-    bodyParams["infrastructureConfigurationArn"] =
-      input.infrastructureConfigurationArn;
-  }
-  if (input.instanceProfileName !== undefined) {
-    bodyParams["instanceProfileName"] = input.instanceProfileName;
-  }
-  if (input.instanceTypes !== undefined) {
-    bodyParams["instanceTypes"] = serializeAws_restJson1_1InstanceTypeList(
-      input.instanceTypes,
-      context
-    );
-  }
-  if (input.keyPair !== undefined) {
-    bodyParams["keyPair"] = input.keyPair;
-  }
-  if (input.logging !== undefined) {
-    bodyParams["logging"] = serializeAws_restJson1_1Logging(
-      input.logging,
-      context
-    );
-  }
-  if (input.securityGroupIds !== undefined) {
-    bodyParams["securityGroupIds"] = serializeAws_restJson1_1SecurityGroupIds(
-      input.securityGroupIds,
-      context
-    );
-  }
-  if (input.snsTopicArn !== undefined) {
-    bodyParams["snsTopicArn"] = input.snsTopicArn;
-  }
-  if (input.subnetId !== undefined) {
-    bodyParams["subnetId"] = input.subnetId;
-  }
-  if (input.terminateInstanceOnFailure !== undefined) {
-    bodyParams["terminateInstanceOnFailure"] = input.terminateInstanceOnFailure;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.infrastructureConfigurationArn !== undefined && {
+      infrastructureConfigurationArn: input.infrastructureConfigurationArn
+    }),
+    ...(input.instanceProfileName !== undefined && {
+      instanceProfileName: input.instanceProfileName
+    }),
+    ...(input.instanceTypes !== undefined && {
+      instanceTypes: serializeAws_restJson1_1InstanceTypeList(
+        input.instanceTypes,
+        context
+      )
+    }),
+    ...(input.keyPair !== undefined && { keyPair: input.keyPair }),
+    ...(input.logging !== undefined && {
+      logging: serializeAws_restJson1_1Logging(input.logging, context)
+    }),
+    ...(input.securityGroupIds !== undefined && {
+      securityGroupIds: serializeAws_restJson1_1SecurityGroupIds(
+        input.securityGroupIds,
+        context
+      )
+    }),
+    ...(input.snsTopicArn !== undefined && { snsTopicArn: input.snsTopicArn }),
+    ...(input.subnetId !== undefined && { subnetId: input.subnetId }),
+    ...(input.terminateInstanceOnFailure !== undefined && {
+      terminateInstanceOnFailure: input.terminateInstanceOnFailure
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
@@ -166,14 +166,11 @@ export const serializeAws_restJson1_1FinalizeDeviceClaimCommand = async (
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -273,17 +270,17 @@ export const serializeAws_restJson1_1InvokeDeviceMethodCommand = async (
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeviceMethod !== undefined) {
-    bodyParams["deviceMethod"] = serializeAws_restJson1_1DeviceMethod(
-      input.DeviceMethod,
-      context
-    );
-  }
-  if (input.DeviceMethodParameters !== undefined) {
-    bodyParams["deviceMethodParameters"] = input.DeviceMethodParameters;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeviceMethod !== undefined && {
+      deviceMethod: serializeAws_restJson1_1DeviceMethod(
+        input.DeviceMethod,
+        context
+      )
+    }),
+    ...(input.DeviceMethodParameters !== undefined && {
+      deviceMethodParameters: input.DeviceMethodParameters
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -433,14 +430,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -548,11 +542,9 @@ export const serializeAws_restJson1_1UpdateDeviceStateCommand = async (
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Enabled !== undefined) {
-    bodyParams["enabled"] = input.Enabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Enabled !== undefined && { enabled: input.Enabled })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
@@ -144,11 +144,9 @@ export const serializeAws_restJson1_1AssociateDeviceWithPlacementCommand = async
     throw new Error("No value provided for input HTTP label: projectName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.deviceId !== undefined) {
-    bodyParams["deviceId"] = input.deviceId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.deviceId !== undefined && { deviceId: input.deviceId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -184,17 +182,17 @@ export const serializeAws_restJson1_1CreatePlacementCommand = async (
     throw new Error("No value provided for input HTTP label: projectName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.attributes !== undefined) {
-    bodyParams["attributes"] = serializeAws_restJson1_1PlacementAttributeMap(
-      input.attributes,
-      context
-    );
-  }
-  if (input.placementName !== undefined) {
-    bodyParams["placementName"] = input.placementName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.attributes !== undefined && {
+      attributes: serializeAws_restJson1_1PlacementAttributeMap(
+        input.attributes,
+        context
+      )
+    }),
+    ...(input.placementName !== undefined && {
+      placementName: input.placementName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -216,23 +214,19 @@ export const serializeAws_restJson1_1CreateProjectCommand = async (
   };
   let resolvedPath = "/projects";
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.placementTemplate !== undefined) {
-    bodyParams["placementTemplate"] = serializeAws_restJson1_1PlacementTemplate(
-      input.placementTemplate,
-      context
-    );
-  }
-  if (input.projectName !== undefined) {
-    bodyParams["projectName"] = input.projectName;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.placementTemplate !== undefined && {
+      placementTemplate: serializeAws_restJson1_1PlacementTemplate(
+        input.placementTemplate,
+        context
+      )
+    }),
+    ...(input.projectName !== undefined && { projectName: input.projectName }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -657,11 +651,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -752,14 +746,14 @@ export const serializeAws_restJson1_1UpdatePlacementCommand = async (
     throw new Error("No value provided for input HTTP label: projectName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.attributes !== undefined) {
-    bodyParams["attributes"] = serializeAws_restJson1_1PlacementAttributeMap(
-      input.attributes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.attributes !== undefined && {
+      attributes: serializeAws_restJson1_1PlacementAttributeMap(
+        input.attributes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -795,17 +789,15 @@ export const serializeAws_restJson1_1UpdateProjectCommand = async (
     throw new Error("No value provided for input HTTP label: projectName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.placementTemplate !== undefined) {
-    bodyParams["placementTemplate"] = serializeAws_restJson1_1PlacementTemplate(
-      input.placementTemplate,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.placementTemplate !== undefined && {
+      placementTemplate: serializeAws_restJson1_1PlacementTemplate(
+        input.placementTemplate,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
@@ -58,14 +58,11 @@ export const serializeAws_restJson1_1BatchPutMessageCommand = async (
   };
   let resolvedPath = "/inputs/messages";
   let body: any;
-  const bodyParams: any = {};
-  if (input.messages !== undefined) {
-    bodyParams["messages"] = serializeAws_restJson1_1Messages(
-      input.messages,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.messages !== undefined && {
+      messages: serializeAws_restJson1_1Messages(input.messages, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -87,14 +84,14 @@ export const serializeAws_restJson1_1BatchUpdateDetectorCommand = async (
   };
   let resolvedPath = "/detectors";
   let body: any;
-  const bodyParams: any = {};
-  if (input.detectors !== undefined) {
-    bodyParams["detectors"] = serializeAws_restJson1_1UpdateDetectorRequests(
-      input.detectors,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.detectors !== undefined && {
+      detectors: serializeAws_restJson1_1UpdateDetectorRequests(
+        input.detectors,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-iot-events/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1_1.ts
@@ -127,34 +127,28 @@ export const serializeAws_restJson1_1CreateDetectorModelCommand = async (
   };
   let resolvedPath = "/detector-models";
   let body: any;
-  const bodyParams: any = {};
-  if (input.detectorModelDefinition !== undefined) {
-    bodyParams[
-      "detectorModelDefinition"
-    ] = serializeAws_restJson1_1DetectorModelDefinition(
-      input.detectorModelDefinition,
-      context
-    );
-  }
-  if (input.detectorModelDescription !== undefined) {
-    bodyParams["detectorModelDescription"] = input.detectorModelDescription;
-  }
-  if (input.detectorModelName !== undefined) {
-    bodyParams["detectorModelName"] = input.detectorModelName;
-  }
-  if (input.evaluationMethod !== undefined) {
-    bodyParams["evaluationMethod"] = input.evaluationMethod;
-  }
-  if (input.key !== undefined) {
-    bodyParams["key"] = input.key;
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.detectorModelDefinition !== undefined && {
+      detectorModelDefinition: serializeAws_restJson1_1DetectorModelDefinition(
+        input.detectorModelDefinition,
+        context
+      )
+    }),
+    ...(input.detectorModelDescription !== undefined && {
+      detectorModelDescription: input.detectorModelDescription
+    }),
+    ...(input.detectorModelName !== undefined && {
+      detectorModelName: input.detectorModelName
+    }),
+    ...(input.evaluationMethod !== undefined && {
+      evaluationMethod: input.evaluationMethod
+    }),
+    ...(input.key !== undefined && { key: input.key }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -176,23 +170,21 @@ export const serializeAws_restJson1_1CreateInputCommand = async (
   };
   let resolvedPath = "/inputs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.inputDefinition !== undefined) {
-    bodyParams["inputDefinition"] = serializeAws_restJson1_1InputDefinition(
-      input.inputDefinition,
-      context
-    );
-  }
-  if (input.inputDescription !== undefined) {
-    bodyParams["inputDescription"] = input.inputDescription;
-  }
-  if (input.inputName !== undefined) {
-    bodyParams["inputName"] = input.inputName;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.inputDefinition !== undefined && {
+      inputDefinition: serializeAws_restJson1_1InputDefinition(
+        input.inputDefinition,
+        context
+      )
+    }),
+    ...(input.inputDescription !== undefined && {
+      inputDescription: input.inputDescription
+    }),
+    ...(input.inputName !== undefined && { inputName: input.inputName }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -507,14 +499,14 @@ export const serializeAws_restJson1_1PutLoggingOptionsCommand = async (
   };
   let resolvedPath = "/logging";
   let body: any;
-  const bodyParams: any = {};
-  if (input.loggingOptions !== undefined) {
-    bodyParams["loggingOptions"] = serializeAws_restJson1_1LoggingOptions(
-      input.loggingOptions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.loggingOptions !== undefined && {
+      loggingOptions: serializeAws_restJson1_1LoggingOptions(
+        input.loggingOptions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -539,11 +531,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -610,25 +602,21 @@ export const serializeAws_restJson1_1UpdateDetectorModelCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.detectorModelDefinition !== undefined) {
-    bodyParams[
-      "detectorModelDefinition"
-    ] = serializeAws_restJson1_1DetectorModelDefinition(
-      input.detectorModelDefinition,
-      context
-    );
-  }
-  if (input.detectorModelDescription !== undefined) {
-    bodyParams["detectorModelDescription"] = input.detectorModelDescription;
-  }
-  if (input.evaluationMethod !== undefined) {
-    bodyParams["evaluationMethod"] = input.evaluationMethod;
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.detectorModelDefinition !== undefined && {
+      detectorModelDefinition: serializeAws_restJson1_1DetectorModelDefinition(
+        input.detectorModelDefinition,
+        context
+      )
+    }),
+    ...(input.detectorModelDescription !== undefined && {
+      detectorModelDescription: input.detectorModelDescription
+    }),
+    ...(input.evaluationMethod !== undefined && {
+      evaluationMethod: input.evaluationMethod
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -662,17 +650,17 @@ export const serializeAws_restJson1_1UpdateInputCommand = async (
     throw new Error("No value provided for input HTTP label: inputName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.inputDefinition !== undefined) {
-    bodyParams["inputDefinition"] = serializeAws_restJson1_1InputDefinition(
-      input.inputDefinition,
-      context
-    );
-  }
-  if (input.inputDescription !== undefined) {
-    bodyParams["inputDescription"] = input.inputDescription;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.inputDefinition !== undefined && {
+      inputDefinition: serializeAws_restJson1_1InputDefinition(
+        input.inputDefinition,
+        context
+      )
+    }),
+    ...(input.inputDescription !== undefined && {
+      inputDescription: input.inputDescription
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
@@ -149,17 +149,17 @@ export const serializeAws_restJson1_1StartNextPendingJobExecutionCommand = async
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.statusDetails !== undefined) {
-    bodyParams["statusDetails"] = serializeAws_restJson1_1DetailsMap(
-      input.statusDetails,
-      context
-    );
-  }
-  if (input.stepTimeoutInMinutes !== undefined) {
-    bodyParams["stepTimeoutInMinutes"] = input.stepTimeoutInMinutes;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.statusDetails !== undefined && {
+      statusDetails: serializeAws_restJson1_1DetailsMap(
+        input.statusDetails,
+        context
+      )
+    }),
+    ...(input.stepTimeoutInMinutes !== undefined && {
+      stepTimeoutInMinutes: input.stepTimeoutInMinutes
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -205,32 +205,30 @@ export const serializeAws_restJson1_1UpdateJobExecutionCommand = async (
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.executionNumber !== undefined) {
-    bodyParams["executionNumber"] = input.executionNumber;
-  }
-  if (input.expectedVersion !== undefined) {
-    bodyParams["expectedVersion"] = input.expectedVersion;
-  }
-  if (input.includeJobDocument !== undefined) {
-    bodyParams["includeJobDocument"] = input.includeJobDocument;
-  }
-  if (input.includeJobExecutionState !== undefined) {
-    bodyParams["includeJobExecutionState"] = input.includeJobExecutionState;
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  if (input.statusDetails !== undefined) {
-    bodyParams["statusDetails"] = serializeAws_restJson1_1DetailsMap(
-      input.statusDetails,
-      context
-    );
-  }
-  if (input.stepTimeoutInMinutes !== undefined) {
-    bodyParams["stepTimeoutInMinutes"] = input.stepTimeoutInMinutes;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.executionNumber !== undefined && {
+      executionNumber: input.executionNumber
+    }),
+    ...(input.expectedVersion !== undefined && {
+      expectedVersion: input.expectedVersion
+    }),
+    ...(input.includeJobDocument !== undefined && {
+      includeJobDocument: input.includeJobDocument
+    }),
+    ...(input.includeJobExecutionState !== undefined && {
+      includeJobExecutionState: input.includeJobExecutionState
+    }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.statusDetails !== undefined && {
+      statusDetails: serializeAws_restJson1_1DetailsMap(
+        input.statusDetails,
+        context
+      )
+    }),
+    ...(input.stepTimeoutInMinutes !== undefined && {
+      stepTimeoutInMinutes: input.stepTimeoutInMinutes
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-iot/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1_1.ts
@@ -1103,16 +1103,14 @@ export const serializeAws_restJson1_1CreateTopicRuleDestinationCommand = async (
   };
   let resolvedPath = "/destinations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.destinationConfiguration !== undefined) {
-    bodyParams[
-      "destinationConfiguration"
-    ] = serializeAws_restJson1_1TopicRuleDestinationConfiguration(
-      input.destinationConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.destinationConfiguration !== undefined && {
+      destinationConfiguration: serializeAws_restJson1_1TopicRuleDestinationConfiguration(
+        input.destinationConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1571,17 +1569,12 @@ export const serializeAws_restJson1_1SetV2LoggingLevelCommand = async (
   };
   let resolvedPath = "/v2LoggingLevel";
   let body: any;
-  const bodyParams: any = {};
-  if (input.logLevel !== undefined) {
-    bodyParams["logLevel"] = input.logLevel;
-  }
-  if (input.logTarget !== undefined) {
-    bodyParams["logTarget"] = serializeAws_restJson1_1LogTarget(
-      input.logTarget,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.logLevel !== undefined && { logLevel: input.logLevel }),
+    ...(input.logTarget !== undefined && {
+      logTarget: serializeAws_restJson1_1LogTarget(input.logTarget, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1603,17 +1596,15 @@ export const serializeAws_restJson1_1SetV2LoggingOptionsCommand = async (
   };
   let resolvedPath = "/v2LoggingOptions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.defaultLogLevel !== undefined) {
-    bodyParams["defaultLogLevel"] = input.defaultLogLevel;
-  }
-  if (input.disableAllLogs !== undefined) {
-    bodyParams["disableAllLogs"] = input.disableAllLogs;
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.defaultLogLevel !== undefined && {
+      defaultLogLevel: input.defaultLogLevel
+    }),
+    ...(input.disableAllLogs !== undefined && {
+      disableAllLogs: input.disableAllLogs
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1635,14 +1626,10 @@ export const serializeAws_restJson1_1UpdateTopicRuleDestinationCommand = async (
   };
   let resolvedPath = "/destinations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.arn !== undefined) {
-    bodyParams["arn"] = input.arn;
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.arn !== undefined && { arn: input.arn }),
+    ...(input.status !== undefined && { status: input.status })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1717,11 +1704,9 @@ export const serializeAws_restJson1_1AttachPolicyCommand = async (
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.target !== undefined) {
-    bodyParams["target"] = input.target;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.target !== undefined && { target: input.target })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1850,26 +1835,24 @@ export const serializeAws_restJson1_1CreateAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: authorizerName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.authorizerFunctionArn !== undefined) {
-    bodyParams["authorizerFunctionArn"] = input.authorizerFunctionArn;
-  }
-  if (input.signingDisabled !== undefined) {
-    bodyParams["signingDisabled"] = input.signingDisabled;
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  if (input.tokenKeyName !== undefined) {
-    bodyParams["tokenKeyName"] = input.tokenKeyName;
-  }
-  if (input.tokenSigningPublicKeys !== undefined) {
-    bodyParams["tokenSigningPublicKeys"] = serializeAws_restJson1_1PublicKeyMap(
-      input.tokenSigningPublicKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.authorizerFunctionArn !== undefined && {
+      authorizerFunctionArn: input.authorizerFunctionArn
+    }),
+    ...(input.signingDisabled !== undefined && {
+      signingDisabled: input.signingDisabled
+    }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.tokenKeyName !== undefined && {
+      tokenKeyName: input.tokenKeyName
+    }),
+    ...(input.tokenSigningPublicKeys !== undefined && {
+      tokenSigningPublicKeys: serializeAws_restJson1_1PublicKeyMap(
+        input.tokenSigningPublicKeys,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1896,11 +1879,11 @@ export const serializeAws_restJson1_1CreateCertificateFromCsrCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.certificateSigningRequest !== undefined) {
-    bodyParams["certificateSigningRequest"] = input.certificateSigningRequest;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.certificateSigningRequest !== undefined && {
+      certificateSigningRequest: input.certificateSigningRequest
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1939,31 +1922,25 @@ export const serializeAws_restJson1_1CreateDomainConfigurationCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.authorizerConfig !== undefined) {
-    bodyParams["authorizerConfig"] = serializeAws_restJson1_1AuthorizerConfig(
-      input.authorizerConfig,
-      context
-    );
-  }
-  if (input.domainName !== undefined) {
-    bodyParams["domainName"] = input.domainName;
-  }
-  if (input.serverCertificateArns !== undefined) {
-    bodyParams[
-      "serverCertificateArns"
-    ] = serializeAws_restJson1_1ServerCertificateArns(
-      input.serverCertificateArns,
-      context
-    );
-  }
-  if (input.serviceType !== undefined) {
-    bodyParams["serviceType"] = input.serviceType;
-  }
-  if (input.validationCertificateArn !== undefined) {
-    bodyParams["validationCertificateArn"] = input.validationCertificateArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.authorizerConfig !== undefined && {
+      authorizerConfig: serializeAws_restJson1_1AuthorizerConfig(
+        input.authorizerConfig,
+        context
+      )
+    }),
+    ...(input.domainName !== undefined && { domainName: input.domainName }),
+    ...(input.serverCertificateArns !== undefined && {
+      serverCertificateArns: serializeAws_restJson1_1ServerCertificateArns(
+        input.serverCertificateArns,
+        context
+      )
+    }),
+    ...(input.serviceType !== undefined && { serviceType: input.serviceType }),
+    ...(input.validationCertificateArn !== undefined && {
+      validationCertificateArn: input.validationCertificateArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2024,11 +2001,11 @@ export const serializeAws_restJson1_1CreatePolicyCommand = async (
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.policyDocument !== undefined) {
-    bodyParams["policyDocument"] = input.policyDocument;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.policyDocument !== undefined && {
+      policyDocument: input.policyDocument
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2067,11 +2044,11 @@ export const serializeAws_restJson1_1CreatePolicyVersionCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.policyDocument !== undefined) {
-    bodyParams["policyDocument"] = input.policyDocument;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.policyDocument !== undefined && {
+      policyDocument: input.policyDocument
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2130,26 +2107,22 @@ export const serializeAws_restJson1_1CreateProvisioningTemplateCommand = async (
   };
   let resolvedPath = "/provisioning-templates";
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.enabled !== undefined) {
-    bodyParams["enabled"] = input.enabled;
-  }
-  if (input.provisioningRoleArn !== undefined) {
-    bodyParams["provisioningRoleArn"] = input.provisioningRoleArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.templateBody !== undefined) {
-    bodyParams["templateBody"] = input.templateBody;
-  }
-  if (input.templateName !== undefined) {
-    bodyParams["templateName"] = input.templateName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.enabled !== undefined && { enabled: input.enabled }),
+    ...(input.provisioningRoleArn !== undefined && {
+      provisioningRoleArn: input.provisioningRoleArn
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.templateBody !== undefined && {
+      templateBody: input.templateBody
+    }),
+    ...(input.templateName !== undefined && {
+      templateName: input.templateName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2190,11 +2163,11 @@ export const serializeAws_restJson1_1CreateProvisioningTemplateVersionCommand = 
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.templateBody !== undefined) {
-    bodyParams["templateBody"] = input.templateBody;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.templateBody !== undefined && {
+      templateBody: input.templateBody
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2229,14 +2202,12 @@ export const serializeAws_restJson1_1CreateRoleAliasCommand = async (
     throw new Error("No value provided for input HTTP label: roleAlias.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.credentialDurationSeconds !== undefined) {
-    bodyParams["credentialDurationSeconds"] = input.credentialDurationSeconds;
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.credentialDurationSeconds !== undefined && {
+      credentialDurationSeconds: input.credentialDurationSeconds
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2943,11 +2914,9 @@ export const serializeAws_restJson1_1DetachPolicyCommand = async (
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.target !== undefined) {
-    bodyParams["target"] = input.target;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.target !== undefined && { target: input.target })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3008,14 +2977,12 @@ export const serializeAws_restJson1_1GetEffectivePoliciesCommand = async (
     ...(input.thingName !== undefined && { thingName: input.thingName })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.cognitoIdentityPoolId !== undefined) {
-    bodyParams["cognitoIdentityPoolId"] = input.cognitoIdentityPoolId;
-  }
-  if (input.principal !== undefined) {
-    bodyParams["principal"] = input.principal;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.cognitoIdentityPoolId !== undefined && {
+      cognitoIdentityPoolId: input.cognitoIdentityPoolId
+    }),
+    ...(input.principal !== undefined && { principal: input.principal })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3645,22 +3612,20 @@ export const serializeAws_restJson1_1RegisterCACertificateCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.caCertificate !== undefined) {
-    bodyParams["caCertificate"] = input.caCertificate;
-  }
-  if (input.registrationConfig !== undefined) {
-    bodyParams[
-      "registrationConfig"
-    ] = serializeAws_restJson1_1RegistrationConfig(
-      input.registrationConfig,
-      context
-    );
-  }
-  if (input.verificationCertificate !== undefined) {
-    bodyParams["verificationCertificate"] = input.verificationCertificate;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.caCertificate !== undefined && {
+      caCertificate: input.caCertificate
+    }),
+    ...(input.registrationConfig !== undefined && {
+      registrationConfig: serializeAws_restJson1_1RegistrationConfig(
+        input.registrationConfig,
+        context
+      )
+    }),
+    ...(input.verificationCertificate !== undefined && {
+      verificationCertificate: input.verificationCertificate
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3688,17 +3653,15 @@ export const serializeAws_restJson1_1RegisterCertificateCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.caCertificatePem !== undefined) {
-    bodyParams["caCertificatePem"] = input.caCertificatePem;
-  }
-  if (input.certificatePem !== undefined) {
-    bodyParams["certificatePem"] = input.certificatePem;
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.caCertificatePem !== undefined && {
+      caCertificatePem: input.caCertificatePem
+    }),
+    ...(input.certificatePem !== undefined && {
+      certificatePem: input.certificatePem
+    }),
+    ...(input.status !== undefined && { status: input.status })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3721,17 +3684,14 @@ export const serializeAws_restJson1_1RegisterThingCommand = async (
   };
   let resolvedPath = "/things";
   let body: any;
-  const bodyParams: any = {};
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1Parameters(
-      input.parameters,
-      context
-    );
-  }
-  if (input.templateBody !== undefined) {
-    bodyParams["templateBody"] = input.templateBody;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1Parameters(input.parameters, context)
+    }),
+    ...(input.templateBody !== undefined && {
+      templateBody: input.templateBody
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3767,11 +3727,11 @@ export const serializeAws_restJson1_1RejectCertificateTransferCommand = async (
     throw new Error("No value provided for input HTTP label: certificateId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.rejectReason !== undefined) {
-    bodyParams["rejectReason"] = input.rejectReason;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.rejectReason !== undefined && {
+      rejectReason: input.rejectReason
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3793,11 +3753,11 @@ export const serializeAws_restJson1_1SetDefaultAuthorizerCommand = async (
   };
   let resolvedPath = "/default-authorizer";
   let body: any;
-  const bodyParams: any = {};
-  if (input.authorizerName !== undefined) {
-    bodyParams["authorizerName"] = input.authorizerName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.authorizerName !== undefined && {
+      authorizerName: input.authorizerName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3869,32 +3829,27 @@ export const serializeAws_restJson1_1TestAuthorizationCommand = async (
     ...(input.clientId !== undefined && { clientId: input.clientId })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.authInfos !== undefined) {
-    bodyParams["authInfos"] = serializeAws_restJson1_1AuthInfos(
-      input.authInfos,
-      context
-    );
-  }
-  if (input.cognitoIdentityPoolId !== undefined) {
-    bodyParams["cognitoIdentityPoolId"] = input.cognitoIdentityPoolId;
-  }
-  if (input.policyNamesToAdd !== undefined) {
-    bodyParams["policyNamesToAdd"] = serializeAws_restJson1_1PolicyNames(
-      input.policyNamesToAdd,
-      context
-    );
-  }
-  if (input.policyNamesToSkip !== undefined) {
-    bodyParams["policyNamesToSkip"] = serializeAws_restJson1_1PolicyNames(
-      input.policyNamesToSkip,
-      context
-    );
-  }
-  if (input.principal !== undefined) {
-    bodyParams["principal"] = input.principal;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.authInfos !== undefined && {
+      authInfos: serializeAws_restJson1_1AuthInfos(input.authInfos, context)
+    }),
+    ...(input.cognitoIdentityPoolId !== undefined && {
+      cognitoIdentityPoolId: input.cognitoIdentityPoolId
+    }),
+    ...(input.policyNamesToAdd !== undefined && {
+      policyNamesToAdd: serializeAws_restJson1_1PolicyNames(
+        input.policyNamesToAdd,
+        context
+      )
+    }),
+    ...(input.policyNamesToSkip !== undefined && {
+      policyNamesToSkip: serializeAws_restJson1_1PolicyNames(
+        input.policyNamesToSkip,
+        context
+      )
+    }),
+    ...(input.principal !== undefined && { principal: input.principal })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3931,32 +3886,27 @@ export const serializeAws_restJson1_1TestInvokeAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: authorizerName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.httpContext !== undefined) {
-    bodyParams["httpContext"] = serializeAws_restJson1_1HttpContext(
-      input.httpContext,
-      context
-    );
-  }
-  if (input.mqttContext !== undefined) {
-    bodyParams["mqttContext"] = serializeAws_restJson1_1MqttContext(
-      input.mqttContext,
-      context
-    );
-  }
-  if (input.tlsContext !== undefined) {
-    bodyParams["tlsContext"] = serializeAws_restJson1_1TlsContext(
-      input.tlsContext,
-      context
-    );
-  }
-  if (input.token !== undefined) {
-    bodyParams["token"] = input.token;
-  }
-  if (input.tokenSignature !== undefined) {
-    bodyParams["tokenSignature"] = input.tokenSignature;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.httpContext !== undefined && {
+      httpContext: serializeAws_restJson1_1HttpContext(
+        input.httpContext,
+        context
+      )
+    }),
+    ...(input.mqttContext !== undefined && {
+      mqttContext: serializeAws_restJson1_1MqttContext(
+        input.mqttContext,
+        context
+      )
+    }),
+    ...(input.tlsContext !== undefined && {
+      tlsContext: serializeAws_restJson1_1TlsContext(input.tlsContext, context)
+    }),
+    ...(input.token !== undefined && { token: input.token }),
+    ...(input.tokenSignature !== undefined && {
+      tokenSignature: input.tokenSignature
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3997,11 +3947,11 @@ export const serializeAws_restJson1_1TransferCertificateCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.transferMessage !== undefined) {
-    bodyParams["transferMessage"] = input.transferMessage;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.transferMessage !== undefined && {
+      transferMessage: input.transferMessage
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4038,23 +3988,21 @@ export const serializeAws_restJson1_1UpdateAuthorizerCommand = async (
     throw new Error("No value provided for input HTTP label: authorizerName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.authorizerFunctionArn !== undefined) {
-    bodyParams["authorizerFunctionArn"] = input.authorizerFunctionArn;
-  }
-  if (input.status !== undefined) {
-    bodyParams["status"] = input.status;
-  }
-  if (input.tokenKeyName !== undefined) {
-    bodyParams["tokenKeyName"] = input.tokenKeyName;
-  }
-  if (input.tokenSigningPublicKeys !== undefined) {
-    bodyParams["tokenSigningPublicKeys"] = serializeAws_restJson1_1PublicKeyMap(
-      input.tokenSigningPublicKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.authorizerFunctionArn !== undefined && {
+      authorizerFunctionArn: input.authorizerFunctionArn
+    }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.tokenKeyName !== undefined && {
+      tokenKeyName: input.tokenKeyName
+    }),
+    ...(input.tokenSigningPublicKeys !== undefined && {
+      tokenSigningPublicKeys: serializeAws_restJson1_1PublicKeyMap(
+        input.tokenSigningPublicKeys,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4096,19 +4044,17 @@ export const serializeAws_restJson1_1UpdateCACertificateCommand = async (
     ...(input.newStatus !== undefined && { newStatus: input.newStatus })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.registrationConfig !== undefined) {
-    bodyParams[
-      "registrationConfig"
-    ] = serializeAws_restJson1_1RegistrationConfig(
-      input.registrationConfig,
-      context
-    );
-  }
-  if (input.removeAutoRegistration !== undefined) {
-    bodyParams["removeAutoRegistration"] = input.removeAutoRegistration;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.registrationConfig !== undefined && {
+      registrationConfig: serializeAws_restJson1_1RegistrationConfig(
+        input.registrationConfig,
+        context
+      )
+    }),
+    ...(input.removeAutoRegistration !== undefined && {
+      removeAutoRegistration: input.removeAutoRegistration
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4186,20 +4132,20 @@ export const serializeAws_restJson1_1UpdateDomainConfigurationCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.authorizerConfig !== undefined) {
-    bodyParams["authorizerConfig"] = serializeAws_restJson1_1AuthorizerConfig(
-      input.authorizerConfig,
-      context
-    );
-  }
-  if (input.domainConfigurationStatus !== undefined) {
-    bodyParams["domainConfigurationStatus"] = input.domainConfigurationStatus;
-  }
-  if (input.removeAuthorizerConfig !== undefined) {
-    bodyParams["removeAuthorizerConfig"] = input.removeAuthorizerConfig;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.authorizerConfig !== undefined && {
+      authorizerConfig: serializeAws_restJson1_1AuthorizerConfig(
+        input.authorizerConfig,
+        context
+      )
+    }),
+    ...(input.domainConfigurationStatus !== undefined && {
+      domainConfigurationStatus: input.domainConfigurationStatus
+    }),
+    ...(input.removeAuthorizerConfig !== undefined && {
+      removeAuthorizerConfig: input.removeAuthorizerConfig
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4235,20 +4181,16 @@ export const serializeAws_restJson1_1UpdateProvisioningTemplateCommand = async (
     throw new Error("No value provided for input HTTP label: templateName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.defaultVersionId !== undefined) {
-    bodyParams["defaultVersionId"] = input.defaultVersionId;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.enabled !== undefined) {
-    bodyParams["enabled"] = input.enabled;
-  }
-  if (input.provisioningRoleArn !== undefined) {
-    bodyParams["provisioningRoleArn"] = input.provisioningRoleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.defaultVersionId !== undefined && {
+      defaultVersionId: input.defaultVersionId
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.enabled !== undefined && { enabled: input.enabled }),
+    ...(input.provisioningRoleArn !== undefined && {
+      provisioningRoleArn: input.provisioningRoleArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4282,14 +4224,12 @@ export const serializeAws_restJson1_1UpdateRoleAliasCommand = async (
     throw new Error("No value provided for input HTTP label: roleAlias.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.credentialDurationSeconds !== undefined) {
-    bodyParams["credentialDurationSeconds"] = input.credentialDurationSeconds;
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.credentialDurationSeconds !== undefined && {
+      credentialDurationSeconds: input.credentialDurationSeconds
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4344,20 +4284,16 @@ export const serializeAws_restJson1_1GetCardinalityCommand = async (
   };
   let resolvedPath = "/indices/cardinality";
   let body: any;
-  const bodyParams: any = {};
-  if (input.aggregationField !== undefined) {
-    bodyParams["aggregationField"] = input.aggregationField;
-  }
-  if (input.indexName !== undefined) {
-    bodyParams["indexName"] = input.indexName;
-  }
-  if (input.queryString !== undefined) {
-    bodyParams["queryString"] = input.queryString;
-  }
-  if (input.queryVersion !== undefined) {
-    bodyParams["queryVersion"] = input.queryVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.aggregationField !== undefined && {
+      aggregationField: input.aggregationField
+    }),
+    ...(input.indexName !== undefined && { indexName: input.indexName }),
+    ...(input.queryString !== undefined && { queryString: input.queryString }),
+    ...(input.queryVersion !== undefined && {
+      queryVersion: input.queryVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4401,26 +4337,19 @@ export const serializeAws_restJson1_1GetPercentilesCommand = async (
   };
   let resolvedPath = "/indices/percentiles";
   let body: any;
-  const bodyParams: any = {};
-  if (input.aggregationField !== undefined) {
-    bodyParams["aggregationField"] = input.aggregationField;
-  }
-  if (input.indexName !== undefined) {
-    bodyParams["indexName"] = input.indexName;
-  }
-  if (input.percents !== undefined) {
-    bodyParams["percents"] = serializeAws_restJson1_1PercentList(
-      input.percents,
-      context
-    );
-  }
-  if (input.queryString !== undefined) {
-    bodyParams["queryString"] = input.queryString;
-  }
-  if (input.queryVersion !== undefined) {
-    bodyParams["queryVersion"] = input.queryVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.aggregationField !== undefined && {
+      aggregationField: input.aggregationField
+    }),
+    ...(input.indexName !== undefined && { indexName: input.indexName }),
+    ...(input.percents !== undefined && {
+      percents: serializeAws_restJson1_1PercentList(input.percents, context)
+    }),
+    ...(input.queryString !== undefined && { queryString: input.queryString }),
+    ...(input.queryVersion !== undefined && {
+      queryVersion: input.queryVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4442,20 +4371,16 @@ export const serializeAws_restJson1_1GetStatisticsCommand = async (
   };
   let resolvedPath = "/indices/statistics";
   let body: any;
-  const bodyParams: any = {};
-  if (input.aggregationField !== undefined) {
-    bodyParams["aggregationField"] = input.aggregationField;
-  }
-  if (input.indexName !== undefined) {
-    bodyParams["indexName"] = input.indexName;
-  }
-  if (input.queryString !== undefined) {
-    bodyParams["queryString"] = input.queryString;
-  }
-  if (input.queryVersion !== undefined) {
-    bodyParams["queryVersion"] = input.queryVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.aggregationField !== undefined && {
+      aggregationField: input.aggregationField
+    }),
+    ...(input.indexName !== undefined && { indexName: input.indexName }),
+    ...(input.queryString !== undefined && { queryString: input.queryString }),
+    ...(input.queryVersion !== undefined && {
+      queryVersion: input.queryVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4505,23 +4430,15 @@ export const serializeAws_restJson1_1SearchIndexCommand = async (
   };
   let resolvedPath = "/indices/search";
   let body: any;
-  const bodyParams: any = {};
-  if (input.indexName !== undefined) {
-    bodyParams["indexName"] = input.indexName;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.queryString !== undefined) {
-    bodyParams["queryString"] = input.queryString;
-  }
-  if (input.queryVersion !== undefined) {
-    bodyParams["queryVersion"] = input.queryVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.indexName !== undefined && { indexName: input.indexName }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.queryString !== undefined && { queryString: input.queryString }),
+    ...(input.queryVersion !== undefined && {
+      queryVersion: input.queryVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4543,24 +4460,20 @@ export const serializeAws_restJson1_1UpdateIndexingConfigurationCommand = async 
   };
   let resolvedPath = "/indexing/config";
   let body: any;
-  const bodyParams: any = {};
-  if (input.thingGroupIndexingConfiguration !== undefined) {
-    bodyParams[
-      "thingGroupIndexingConfiguration"
-    ] = serializeAws_restJson1_1ThingGroupIndexingConfiguration(
-      input.thingGroupIndexingConfiguration,
-      context
-    );
-  }
-  if (input.thingIndexingConfiguration !== undefined) {
-    bodyParams[
-      "thingIndexingConfiguration"
-    ] = serializeAws_restJson1_1ThingIndexingConfiguration(
-      input.thingIndexingConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.thingGroupIndexingConfiguration !== undefined && {
+      thingGroupIndexingConfiguration: serializeAws_restJson1_1ThingGroupIndexingConfiguration(
+        input.thingGroupIndexingConfiguration,
+        context
+      )
+    }),
+    ...(input.thingIndexingConfiguration !== undefined && {
+      thingIndexingConfiguration: serializeAws_restJson1_1ThingIndexingConfiguration(
+        input.thingIndexingConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4594,17 +4507,12 @@ export const serializeAws_restJson1_1AssociateTargetsWithJobCommand = async (
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.comment !== undefined) {
-    bodyParams["comment"] = input.comment;
-  }
-  if (input.targets !== undefined) {
-    bodyParams["targets"] = serializeAws_restJson1_1JobTargets(
-      input.targets,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.comment !== undefined && { comment: input.comment }),
+    ...(input.targets !== undefined && {
+      targets: serializeAws_restJson1_1JobTargets(input.targets, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4641,14 +4549,10 @@ export const serializeAws_restJson1_1CancelJobCommand = async (
     ...(input.force !== undefined && { force: input.force.toString() })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.comment !== undefined) {
-    bodyParams["comment"] = input.comment;
-  }
-  if (input.reasonCode !== undefined) {
-    bodyParams["reasonCode"] = input.reasonCode;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.comment !== undefined && { comment: input.comment }),
+    ...(input.reasonCode !== undefined && { reasonCode: input.reasonCode })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4698,17 +4602,17 @@ export const serializeAws_restJson1_1CancelJobExecutionCommand = async (
     ...(input.force !== undefined && { force: input.force.toString() })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.expectedVersion !== undefined) {
-    bodyParams["expectedVersion"] = input.expectedVersion;
-  }
-  if (input.statusDetails !== undefined) {
-    bodyParams["statusDetails"] = serializeAws_restJson1_1DetailsMap(
-      input.statusDetails,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.expectedVersion !== undefined && {
+      expectedVersion: input.expectedVersion
+    }),
+    ...(input.statusDetails !== undefined && {
+      statusDetails: serializeAws_restJson1_1DetailsMap(
+        input.statusDetails,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4743,57 +4647,46 @@ export const serializeAws_restJson1_1CreateJobCommand = async (
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.abortConfig !== undefined) {
-    bodyParams["abortConfig"] = serializeAws_restJson1_1AbortConfig(
-      input.abortConfig,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.document !== undefined) {
-    bodyParams["document"] = input.document;
-  }
-  if (input.documentSource !== undefined) {
-    bodyParams["documentSource"] = input.documentSource;
-  }
-  if (input.jobExecutionsRolloutConfig !== undefined) {
-    bodyParams[
-      "jobExecutionsRolloutConfig"
-    ] = serializeAws_restJson1_1JobExecutionsRolloutConfig(
-      input.jobExecutionsRolloutConfig,
-      context
-    );
-  }
-  if (input.presignedUrlConfig !== undefined) {
-    bodyParams[
-      "presignedUrlConfig"
-    ] = serializeAws_restJson1_1PresignedUrlConfig(
-      input.presignedUrlConfig,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.targetSelection !== undefined) {
-    bodyParams["targetSelection"] = input.targetSelection;
-  }
-  if (input.targets !== undefined) {
-    bodyParams["targets"] = serializeAws_restJson1_1JobTargets(
-      input.targets,
-      context
-    );
-  }
-  if (input.timeoutConfig !== undefined) {
-    bodyParams["timeoutConfig"] = serializeAws_restJson1_1TimeoutConfig(
-      input.timeoutConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.abortConfig !== undefined && {
+      abortConfig: serializeAws_restJson1_1AbortConfig(
+        input.abortConfig,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.document !== undefined && { document: input.document }),
+    ...(input.documentSource !== undefined && {
+      documentSource: input.documentSource
+    }),
+    ...(input.jobExecutionsRolloutConfig !== undefined && {
+      jobExecutionsRolloutConfig: serializeAws_restJson1_1JobExecutionsRolloutConfig(
+        input.jobExecutionsRolloutConfig,
+        context
+      )
+    }),
+    ...(input.presignedUrlConfig !== undefined && {
+      presignedUrlConfig: serializeAws_restJson1_1PresignedUrlConfig(
+        input.presignedUrlConfig,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.targetSelection !== undefined && {
+      targetSelection: input.targetSelection
+    }),
+    ...(input.targets !== undefined && {
+      targets: serializeAws_restJson1_1JobTargets(input.targets, context)
+    }),
+    ...(input.timeoutConfig !== undefined && {
+      timeoutConfig: serializeAws_restJson1_1TimeoutConfig(
+        input.timeoutConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5165,39 +5058,33 @@ export const serializeAws_restJson1_1UpdateJobCommand = async (
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.abortConfig !== undefined) {
-    bodyParams["abortConfig"] = serializeAws_restJson1_1AbortConfig(
-      input.abortConfig,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.jobExecutionsRolloutConfig !== undefined) {
-    bodyParams[
-      "jobExecutionsRolloutConfig"
-    ] = serializeAws_restJson1_1JobExecutionsRolloutConfig(
-      input.jobExecutionsRolloutConfig,
-      context
-    );
-  }
-  if (input.presignedUrlConfig !== undefined) {
-    bodyParams[
-      "presignedUrlConfig"
-    ] = serializeAws_restJson1_1PresignedUrlConfig(
-      input.presignedUrlConfig,
-      context
-    );
-  }
-  if (input.timeoutConfig !== undefined) {
-    bodyParams["timeoutConfig"] = serializeAws_restJson1_1TimeoutConfig(
-      input.timeoutConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.abortConfig !== undefined && {
+      abortConfig: serializeAws_restJson1_1AbortConfig(
+        input.abortConfig,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.jobExecutionsRolloutConfig !== undefined && {
+      jobExecutionsRolloutConfig: serializeAws_restJson1_1JobExecutionsRolloutConfig(
+        input.jobExecutionsRolloutConfig,
+        context
+      )
+    }),
+    ...(input.presignedUrlConfig !== undefined && {
+      presignedUrlConfig: serializeAws_restJson1_1PresignedUrlConfig(
+        input.presignedUrlConfig,
+        context
+      )
+    }),
+    ...(input.timeoutConfig !== undefined && {
+      timeoutConfig: serializeAws_restJson1_1TimeoutConfig(
+        input.timeoutConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5233,62 +5120,43 @@ export const serializeAws_restJson1_1CreateOTAUpdateCommand = async (
     throw new Error("No value provided for input HTTP label: otaUpdateId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.additionalParameters !== undefined) {
-    bodyParams[
-      "additionalParameters"
-    ] = serializeAws_restJson1_1AdditionalParameterMap(
-      input.additionalParameters,
-      context
-    );
-  }
-  if (input.awsJobExecutionsRolloutConfig !== undefined) {
-    bodyParams[
-      "awsJobExecutionsRolloutConfig"
-    ] = serializeAws_restJson1_1AwsJobExecutionsRolloutConfig(
-      input.awsJobExecutionsRolloutConfig,
-      context
-    );
-  }
-  if (input.awsJobPresignedUrlConfig !== undefined) {
-    bodyParams[
-      "awsJobPresignedUrlConfig"
-    ] = serializeAws_restJson1_1AwsJobPresignedUrlConfig(
-      input.awsJobPresignedUrlConfig,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.files !== undefined) {
-    bodyParams["files"] = serializeAws_restJson1_1OTAUpdateFiles(
-      input.files,
-      context
-    );
-  }
-  if (input.protocols !== undefined) {
-    bodyParams["protocols"] = serializeAws_restJson1_1Protocols(
-      input.protocols,
-      context
-    );
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.targetSelection !== undefined) {
-    bodyParams["targetSelection"] = input.targetSelection;
-  }
-  if (input.targets !== undefined) {
-    bodyParams["targets"] = serializeAws_restJson1_1Targets(
-      input.targets,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.additionalParameters !== undefined && {
+      additionalParameters: serializeAws_restJson1_1AdditionalParameterMap(
+        input.additionalParameters,
+        context
+      )
+    }),
+    ...(input.awsJobExecutionsRolloutConfig !== undefined && {
+      awsJobExecutionsRolloutConfig: serializeAws_restJson1_1AwsJobExecutionsRolloutConfig(
+        input.awsJobExecutionsRolloutConfig,
+        context
+      )
+    }),
+    ...(input.awsJobPresignedUrlConfig !== undefined && {
+      awsJobPresignedUrlConfig: serializeAws_restJson1_1AwsJobPresignedUrlConfig(
+        input.awsJobPresignedUrlConfig,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.files !== undefined && {
+      files: serializeAws_restJson1_1OTAUpdateFiles(input.files, context)
+    }),
+    ...(input.protocols !== undefined && {
+      protocols: serializeAws_restJson1_1Protocols(input.protocols, context)
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.targetSelection !== undefined && {
+      targetSelection: input.targetSelection
+    }),
+    ...(input.targets !== undefined && {
+      targets: serializeAws_restJson1_1Targets(input.targets, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5420,20 +5288,16 @@ export const serializeAws_restJson1_1AddThingToBillingGroupCommand = async (
   };
   let resolvedPath = "/billing-groups/addThingToBillingGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.billingGroupArn !== undefined) {
-    bodyParams["billingGroupArn"] = input.billingGroupArn;
-  }
-  if (input.billingGroupName !== undefined) {
-    bodyParams["billingGroupName"] = input.billingGroupName;
-  }
-  if (input.thingArn !== undefined) {
-    bodyParams["thingArn"] = input.thingArn;
-  }
-  if (input.thingName !== undefined) {
-    bodyParams["thingName"] = input.thingName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.billingGroupArn !== undefined && {
+      billingGroupArn: input.billingGroupArn
+    }),
+    ...(input.billingGroupName !== undefined && {
+      billingGroupName: input.billingGroupName
+    }),
+    ...(input.thingArn !== undefined && { thingArn: input.thingArn }),
+    ...(input.thingName !== undefined && { thingName: input.thingName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5455,23 +5319,19 @@ export const serializeAws_restJson1_1AddThingToThingGroupCommand = async (
   };
   let resolvedPath = "/thing-groups/addThingToThingGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.overrideDynamicGroups !== undefined) {
-    bodyParams["overrideDynamicGroups"] = input.overrideDynamicGroups;
-  }
-  if (input.thingArn !== undefined) {
-    bodyParams["thingArn"] = input.thingArn;
-  }
-  if (input.thingGroupArn !== undefined) {
-    bodyParams["thingGroupArn"] = input.thingGroupArn;
-  }
-  if (input.thingGroupName !== undefined) {
-    bodyParams["thingGroupName"] = input.thingGroupName;
-  }
-  if (input.thingName !== undefined) {
-    bodyParams["thingName"] = input.thingName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.overrideDynamicGroups !== undefined && {
+      overrideDynamicGroups: input.overrideDynamicGroups
+    }),
+    ...(input.thingArn !== undefined && { thingArn: input.thingArn }),
+    ...(input.thingGroupArn !== undefined && {
+      thingGroupArn: input.thingGroupArn
+    }),
+    ...(input.thingGroupName !== undefined && {
+      thingGroupName: input.thingGroupName
+    }),
+    ...(input.thingName !== undefined && { thingName: input.thingName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5545,19 +5405,17 @@ export const serializeAws_restJson1_1CreateBillingGroupCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.billingGroupProperties !== undefined) {
-    bodyParams[
-      "billingGroupProperties"
-    ] = serializeAws_restJson1_1BillingGroupProperties(
-      input.billingGroupProperties,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.billingGroupProperties !== undefined && {
+      billingGroupProperties: serializeAws_restJson1_1BillingGroupProperties(
+        input.billingGroupProperties,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5593,28 +5451,22 @@ export const serializeAws_restJson1_1CreateDynamicThingGroupCommand = async (
     throw new Error("No value provided for input HTTP label: thingGroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.indexName !== undefined) {
-    bodyParams["indexName"] = input.indexName;
-  }
-  if (input.queryString !== undefined) {
-    bodyParams["queryString"] = input.queryString;
-  }
-  if (input.queryVersion !== undefined) {
-    bodyParams["queryVersion"] = input.queryVersion;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.thingGroupProperties !== undefined) {
-    bodyParams[
-      "thingGroupProperties"
-    ] = serializeAws_restJson1_1ThingGroupProperties(
-      input.thingGroupProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.indexName !== undefined && { indexName: input.indexName }),
+    ...(input.queryString !== undefined && { queryString: input.queryString }),
+    ...(input.queryVersion !== undefined && {
+      queryVersion: input.queryVersion
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.thingGroupProperties !== undefined && {
+      thingGroupProperties: serializeAws_restJson1_1ThingGroupProperties(
+        input.thingGroupProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5648,20 +5500,20 @@ export const serializeAws_restJson1_1CreateThingCommand = async (
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.attributePayload !== undefined) {
-    bodyParams["attributePayload"] = serializeAws_restJson1_1AttributePayload(
-      input.attributePayload,
-      context
-    );
-  }
-  if (input.billingGroupName !== undefined) {
-    bodyParams["billingGroupName"] = input.billingGroupName;
-  }
-  if (input.thingTypeName !== undefined) {
-    bodyParams["thingTypeName"] = input.thingTypeName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.attributePayload !== undefined && {
+      attributePayload: serializeAws_restJson1_1AttributePayload(
+        input.attributePayload,
+        context
+      )
+    }),
+    ...(input.billingGroupName !== undefined && {
+      billingGroupName: input.billingGroupName
+    }),
+    ...(input.thingTypeName !== undefined && {
+      thingTypeName: input.thingTypeName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5697,22 +5549,20 @@ export const serializeAws_restJson1_1CreateThingGroupCommand = async (
     throw new Error("No value provided for input HTTP label: thingGroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.parentGroupName !== undefined) {
-    bodyParams["parentGroupName"] = input.parentGroupName;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.thingGroupProperties !== undefined) {
-    bodyParams[
-      "thingGroupProperties"
-    ] = serializeAws_restJson1_1ThingGroupProperties(
-      input.thingGroupProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.parentGroupName !== undefined && {
+      parentGroupName: input.parentGroupName
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.thingGroupProperties !== undefined && {
+      thingGroupProperties: serializeAws_restJson1_1ThingGroupProperties(
+        input.thingGroupProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5748,19 +5598,17 @@ export const serializeAws_restJson1_1CreateThingTypeCommand = async (
     throw new Error("No value provided for input HTTP label: thingTypeName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.thingTypeProperties !== undefined) {
-    bodyParams[
-      "thingTypeProperties"
-    ] = serializeAws_restJson1_1ThingTypeProperties(
-      input.thingTypeProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.thingTypeProperties !== undefined && {
+      thingTypeProperties: serializeAws_restJson1_1ThingTypeProperties(
+        input.thingTypeProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -5995,11 +5843,11 @@ export const serializeAws_restJson1_1DeprecateThingTypeCommand = async (
     throw new Error("No value provided for input HTTP label: thingTypeName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.undoDeprecate !== undefined) {
-    bodyParams["undoDeprecate"] = input.undoDeprecate;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.undoDeprecate !== undefined && {
+      undoDeprecate: input.undoDeprecate
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6675,20 +6523,16 @@ export const serializeAws_restJson1_1RemoveThingFromBillingGroupCommand = async 
   };
   let resolvedPath = "/billing-groups/removeThingFromBillingGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.billingGroupArn !== undefined) {
-    bodyParams["billingGroupArn"] = input.billingGroupArn;
-  }
-  if (input.billingGroupName !== undefined) {
-    bodyParams["billingGroupName"] = input.billingGroupName;
-  }
-  if (input.thingArn !== undefined) {
-    bodyParams["thingArn"] = input.thingArn;
-  }
-  if (input.thingName !== undefined) {
-    bodyParams["thingName"] = input.thingName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.billingGroupArn !== undefined && {
+      billingGroupArn: input.billingGroupArn
+    }),
+    ...(input.billingGroupName !== undefined && {
+      billingGroupName: input.billingGroupName
+    }),
+    ...(input.thingArn !== undefined && { thingArn: input.thingArn }),
+    ...(input.thingName !== undefined && { thingName: input.thingName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6710,20 +6554,16 @@ export const serializeAws_restJson1_1RemoveThingFromThingGroupCommand = async (
   };
   let resolvedPath = "/thing-groups/removeThingFromThingGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.thingArn !== undefined) {
-    bodyParams["thingArn"] = input.thingArn;
-  }
-  if (input.thingGroupArn !== undefined) {
-    bodyParams["thingGroupArn"] = input.thingGroupArn;
-  }
-  if (input.thingGroupName !== undefined) {
-    bodyParams["thingGroupName"] = input.thingGroupName;
-  }
-  if (input.thingName !== undefined) {
-    bodyParams["thingName"] = input.thingName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.thingArn !== undefined && { thingArn: input.thingArn }),
+    ...(input.thingGroupArn !== undefined && {
+      thingGroupArn: input.thingGroupArn
+    }),
+    ...(input.thingGroupName !== undefined && {
+      thingGroupName: input.thingGroupName
+    }),
+    ...(input.thingName !== undefined && { thingName: input.thingName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6745,20 +6585,18 @@ export const serializeAws_restJson1_1StartThingRegistrationTaskCommand = async (
   };
   let resolvedPath = "/thing-registration-tasks";
   let body: any;
-  const bodyParams: any = {};
-  if (input.inputFileBucket !== undefined) {
-    bodyParams["inputFileBucket"] = input.inputFileBucket;
-  }
-  if (input.inputFileKey !== undefined) {
-    bodyParams["inputFileKey"] = input.inputFileKey;
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  if (input.templateBody !== undefined) {
-    bodyParams["templateBody"] = input.templateBody;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.inputFileBucket !== undefined && {
+      inputFileBucket: input.inputFileBucket
+    }),
+    ...(input.inputFileKey !== undefined && {
+      inputFileKey: input.inputFileKey
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn }),
+    ...(input.templateBody !== undefined && {
+      templateBody: input.templateBody
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6813,14 +6651,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/tags";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6842,17 +6678,12 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
   };
   let resolvedPath = "/untag";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.tagKeys !== undefined) {
-    bodyParams["tagKeys"] = serializeAws_restJson1_1TagKeyList(
-      input.tagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.tagKeys !== undefined && {
+      tagKeys: serializeAws_restJson1_1TagKeyList(input.tagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6890,19 +6721,17 @@ export const serializeAws_restJson1_1UpdateBillingGroupCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.billingGroupProperties !== undefined) {
-    bodyParams[
-      "billingGroupProperties"
-    ] = serializeAws_restJson1_1BillingGroupProperties(
-      input.billingGroupProperties,
-      context
-    );
-  }
-  if (input.expectedVersion !== undefined) {
-    bodyParams["expectedVersion"] = input.expectedVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.billingGroupProperties !== undefined && {
+      billingGroupProperties: serializeAws_restJson1_1BillingGroupProperties(
+        input.billingGroupProperties,
+        context
+      )
+    }),
+    ...(input.expectedVersion !== undefined && {
+      expectedVersion: input.expectedVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6938,28 +6767,22 @@ export const serializeAws_restJson1_1UpdateDynamicThingGroupCommand = async (
     throw new Error("No value provided for input HTTP label: thingGroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.expectedVersion !== undefined) {
-    bodyParams["expectedVersion"] = input.expectedVersion;
-  }
-  if (input.indexName !== undefined) {
-    bodyParams["indexName"] = input.indexName;
-  }
-  if (input.queryString !== undefined) {
-    bodyParams["queryString"] = input.queryString;
-  }
-  if (input.queryVersion !== undefined) {
-    bodyParams["queryVersion"] = input.queryVersion;
-  }
-  if (input.thingGroupProperties !== undefined) {
-    bodyParams[
-      "thingGroupProperties"
-    ] = serializeAws_restJson1_1ThingGroupProperties(
-      input.thingGroupProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.expectedVersion !== undefined && {
+      expectedVersion: input.expectedVersion
+    }),
+    ...(input.indexName !== undefined && { indexName: input.indexName }),
+    ...(input.queryString !== undefined && { queryString: input.queryString }),
+    ...(input.queryVersion !== undefined && {
+      queryVersion: input.queryVersion
+    }),
+    ...(input.thingGroupProperties !== undefined && {
+      thingGroupProperties: serializeAws_restJson1_1ThingGroupProperties(
+        input.thingGroupProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -6981,16 +6804,14 @@ export const serializeAws_restJson1_1UpdateEventConfigurationsCommand = async (
   };
   let resolvedPath = "/event-configurations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.eventConfigurations !== undefined) {
-    bodyParams[
-      "eventConfigurations"
-    ] = serializeAws_restJson1_1EventConfigurations(
-      input.eventConfigurations,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.eventConfigurations !== undefined && {
+      eventConfigurations: serializeAws_restJson1_1EventConfigurations(
+        input.eventConfigurations,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7024,23 +6845,23 @@ export const serializeAws_restJson1_1UpdateThingCommand = async (
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.attributePayload !== undefined) {
-    bodyParams["attributePayload"] = serializeAws_restJson1_1AttributePayload(
-      input.attributePayload,
-      context
-    );
-  }
-  if (input.expectedVersion !== undefined) {
-    bodyParams["expectedVersion"] = input.expectedVersion;
-  }
-  if (input.removeThingType !== undefined) {
-    bodyParams["removeThingType"] = input.removeThingType;
-  }
-  if (input.thingTypeName !== undefined) {
-    bodyParams["thingTypeName"] = input.thingTypeName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.attributePayload !== undefined && {
+      attributePayload: serializeAws_restJson1_1AttributePayload(
+        input.attributePayload,
+        context
+      )
+    }),
+    ...(input.expectedVersion !== undefined && {
+      expectedVersion: input.expectedVersion
+    }),
+    ...(input.removeThingType !== undefined && {
+      removeThingType: input.removeThingType
+    }),
+    ...(input.thingTypeName !== undefined && {
+      thingTypeName: input.thingTypeName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7076,19 +6897,17 @@ export const serializeAws_restJson1_1UpdateThingGroupCommand = async (
     throw new Error("No value provided for input HTTP label: thingGroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.expectedVersion !== undefined) {
-    bodyParams["expectedVersion"] = input.expectedVersion;
-  }
-  if (input.thingGroupProperties !== undefined) {
-    bodyParams[
-      "thingGroupProperties"
-    ] = serializeAws_restJson1_1ThingGroupProperties(
-      input.thingGroupProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.expectedVersion !== undefined && {
+      expectedVersion: input.expectedVersion
+    }),
+    ...(input.thingGroupProperties !== undefined && {
+      thingGroupProperties: serializeAws_restJson1_1ThingGroupProperties(
+        input.thingGroupProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7110,26 +6929,24 @@ export const serializeAws_restJson1_1UpdateThingGroupsForThingCommand = async (
   };
   let resolvedPath = "/thing-groups/updateThingGroupsForThing";
   let body: any;
-  const bodyParams: any = {};
-  if (input.overrideDynamicGroups !== undefined) {
-    bodyParams["overrideDynamicGroups"] = input.overrideDynamicGroups;
-  }
-  if (input.thingGroupsToAdd !== undefined) {
-    bodyParams["thingGroupsToAdd"] = serializeAws_restJson1_1ThingGroupList(
-      input.thingGroupsToAdd,
-      context
-    );
-  }
-  if (input.thingGroupsToRemove !== undefined) {
-    bodyParams["thingGroupsToRemove"] = serializeAws_restJson1_1ThingGroupList(
-      input.thingGroupsToRemove,
-      context
-    );
-  }
-  if (input.thingName !== undefined) {
-    bodyParams["thingName"] = input.thingName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.overrideDynamicGroups !== undefined && {
+      overrideDynamicGroups: input.overrideDynamicGroups
+    }),
+    ...(input.thingGroupsToAdd !== undefined && {
+      thingGroupsToAdd: serializeAws_restJson1_1ThingGroupList(
+        input.thingGroupsToAdd,
+        context
+      )
+    }),
+    ...(input.thingGroupsToRemove !== undefined && {
+      thingGroupsToRemove: serializeAws_restJson1_1ThingGroupList(
+        input.thingGroupsToRemove,
+        context
+      )
+    }),
+    ...(input.thingName !== undefined && { thingName: input.thingName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7272,20 +7089,18 @@ export const serializeAws_restJson1_1CreateMitigationActionCommand = async (
     throw new Error("No value provided for input HTTP label: actionName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.actionParams !== undefined) {
-    bodyParams["actionParams"] = serializeAws_restJson1_1MitigationActionParams(
-      input.actionParams,
-      context
-    );
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.actionParams !== undefined && {
+      actionParams: serializeAws_restJson1_1MitigationActionParams(
+        input.actionParams,
+        context
+      )
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7323,28 +7138,20 @@ export const serializeAws_restJson1_1CreateScheduledAuditCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.dayOfMonth !== undefined) {
-    bodyParams["dayOfMonth"] = input.dayOfMonth;
-  }
-  if (input.dayOfWeek !== undefined) {
-    bodyParams["dayOfWeek"] = input.dayOfWeek;
-  }
-  if (input.frequency !== undefined) {
-    bodyParams["frequency"] = input.frequency;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.targetCheckNames !== undefined) {
-    bodyParams[
-      "targetCheckNames"
-    ] = serializeAws_restJson1_1TargetAuditCheckNames(
-      input.targetCheckNames,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.dayOfMonth !== undefined && { dayOfMonth: input.dayOfMonth }),
+    ...(input.dayOfWeek !== undefined && { dayOfWeek: input.dayOfWeek }),
+    ...(input.frequency !== undefined && { frequency: input.frequency }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.targetCheckNames !== undefined && {
+      targetCheckNames: serializeAws_restJson1_1TargetAuditCheckNames(
+        input.targetCheckNames,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7382,34 +7189,29 @@ export const serializeAws_restJson1_1CreateSecurityProfileCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.additionalMetricsToRetain !== undefined) {
-    bodyParams[
-      "additionalMetricsToRetain"
-    ] = serializeAws_restJson1_1AdditionalMetricsToRetainList(
-      input.additionalMetricsToRetain,
-      context
-    );
-  }
-  if (input.alertTargets !== undefined) {
-    bodyParams["alertTargets"] = serializeAws_restJson1_1AlertTargets(
-      input.alertTargets,
-      context
-    );
-  }
-  if (input.behaviors !== undefined) {
-    bodyParams["behaviors"] = serializeAws_restJson1_1Behaviors(
-      input.behaviors,
-      context
-    );
-  }
-  if (input.securityProfileDescription !== undefined) {
-    bodyParams["securityProfileDescription"] = input.securityProfileDescription;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.additionalMetricsToRetain !== undefined && {
+      additionalMetricsToRetain: serializeAws_restJson1_1AdditionalMetricsToRetainList(
+        input.additionalMetricsToRetain,
+        context
+      )
+    }),
+    ...(input.alertTargets !== undefined && {
+      alertTargets: serializeAws_restJson1_1AlertTargets(
+        input.alertTargets,
+        context
+      )
+    }),
+    ...(input.behaviors !== undefined && {
+      behaviors: serializeAws_restJson1_1Behaviors(input.behaviors, context)
+    }),
+    ...(input.securityProfileDescription !== undefined && {
+      securityProfileDescription: input.securityProfileDescription
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -7874,34 +7676,24 @@ export const serializeAws_restJson1_1ListAuditFindingsCommand = async (
   };
   let resolvedPath = "/audit/findings";
   let body: any;
-  const bodyParams: any = {};
-  if (input.checkName !== undefined) {
-    bodyParams["checkName"] = input.checkName;
-  }
-  if (input.endTime !== undefined) {
-    bodyParams["endTime"] = Math.round(input.endTime.getTime() / 1000);
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.resourceIdentifier !== undefined) {
-    bodyParams[
-      "resourceIdentifier"
-    ] = serializeAws_restJson1_1ResourceIdentifier(
-      input.resourceIdentifier,
-      context
-    );
-  }
-  if (input.startTime !== undefined) {
-    bodyParams["startTime"] = Math.round(input.startTime.getTime() / 1000);
-  }
-  if (input.taskId !== undefined) {
-    bodyParams["taskId"] = input.taskId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.checkName !== undefined && { checkName: input.checkName }),
+    ...(input.endTime !== undefined && {
+      endTime: Math.round(input.endTime.getTime() / 1000)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.resourceIdentifier !== undefined && {
+      resourceIdentifier: serializeAws_restJson1_1ResourceIdentifier(
+        input.resourceIdentifier,
+        context
+      )
+    }),
+    ...(input.startTime !== undefined && {
+      startTime: Math.round(input.startTime.getTime() / 1000)
+    }),
+    ...(input.taskId !== undefined && { taskId: input.taskId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8242,30 +8034,21 @@ export const serializeAws_restJson1_1StartAuditMitigationActionsTaskCommand = as
     throw new Error("No value provided for input HTTP label: taskId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.auditCheckToActionsMapping !== undefined) {
-    bodyParams[
-      "auditCheckToActionsMapping"
-    ] = serializeAws_restJson1_1AuditCheckToActionsMapping(
-      input.auditCheckToActionsMapping,
-      context
-    );
-  }
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.target !== undefined) {
-    bodyParams[
-      "target"
-    ] = serializeAws_restJson1_1AuditMitigationActionsTaskTarget(
-      input.target,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.auditCheckToActionsMapping !== undefined && {
+      auditCheckToActionsMapping: serializeAws_restJson1_1AuditCheckToActionsMapping(
+        input.auditCheckToActionsMapping,
+        context
+      )
+    }),
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.target !== undefined && {
+      target: serializeAws_restJson1_1AuditMitigationActionsTaskTarget(
+        input.target,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8287,16 +8070,14 @@ export const serializeAws_restJson1_1StartOnDemandAuditTaskCommand = async (
   };
   let resolvedPath = "/audit/tasks";
   let body: any;
-  const bodyParams: any = {};
-  if (input.targetCheckNames !== undefined) {
-    bodyParams[
-      "targetCheckNames"
-    ] = serializeAws_restJson1_1TargetAuditCheckNames(
-      input.targetCheckNames,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.targetCheckNames !== undefined && {
+      targetCheckNames: serializeAws_restJson1_1TargetAuditCheckNames(
+        input.targetCheckNames,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8318,27 +8099,21 @@ export const serializeAws_restJson1_1UpdateAccountAuditConfigurationCommand = as
   };
   let resolvedPath = "/audit/configuration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.auditCheckConfigurations !== undefined) {
-    bodyParams[
-      "auditCheckConfigurations"
-    ] = serializeAws_restJson1_1AuditCheckConfigurations(
-      input.auditCheckConfigurations,
-      context
-    );
-  }
-  if (input.auditNotificationTargetConfigurations !== undefined) {
-    bodyParams[
-      "auditNotificationTargetConfigurations"
-    ] = serializeAws_restJson1_1AuditNotificationTargetConfigurations(
-      input.auditNotificationTargetConfigurations,
-      context
-    );
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.auditCheckConfigurations !== undefined && {
+      auditCheckConfigurations: serializeAws_restJson1_1AuditCheckConfigurations(
+        input.auditCheckConfigurations,
+        context
+      )
+    }),
+    ...(input.auditNotificationTargetConfigurations !== undefined && {
+      auditNotificationTargetConfigurations: serializeAws_restJson1_1AuditNotificationTargetConfigurations(
+        input.auditNotificationTargetConfigurations,
+        context
+      )
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8372,17 +8147,15 @@ export const serializeAws_restJson1_1UpdateMitigationActionCommand = async (
     throw new Error("No value provided for input HTTP label: actionName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.actionParams !== undefined) {
-    bodyParams["actionParams"] = serializeAws_restJson1_1MitigationActionParams(
-      input.actionParams,
-      context
-    );
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.actionParams !== undefined && {
+      actionParams: serializeAws_restJson1_1MitigationActionParams(
+        input.actionParams,
+        context
+      )
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8420,25 +8193,17 @@ export const serializeAws_restJson1_1UpdateScheduledAuditCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.dayOfMonth !== undefined) {
-    bodyParams["dayOfMonth"] = input.dayOfMonth;
-  }
-  if (input.dayOfWeek !== undefined) {
-    bodyParams["dayOfWeek"] = input.dayOfWeek;
-  }
-  if (input.frequency !== undefined) {
-    bodyParams["frequency"] = input.frequency;
-  }
-  if (input.targetCheckNames !== undefined) {
-    bodyParams[
-      "targetCheckNames"
-    ] = serializeAws_restJson1_1TargetAuditCheckNames(
-      input.targetCheckNames,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.dayOfMonth !== undefined && { dayOfMonth: input.dayOfMonth }),
+    ...(input.dayOfWeek !== undefined && { dayOfWeek: input.dayOfWeek }),
+    ...(input.frequency !== undefined && { frequency: input.frequency }),
+    ...(input.targetCheckNames !== undefined && {
+      targetCheckNames: serializeAws_restJson1_1TargetAuditCheckNames(
+        input.targetCheckNames,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8481,41 +8246,35 @@ export const serializeAws_restJson1_1UpdateSecurityProfileCommand = async (
     })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.additionalMetricsToRetain !== undefined) {
-    bodyParams[
-      "additionalMetricsToRetain"
-    ] = serializeAws_restJson1_1AdditionalMetricsToRetainList(
-      input.additionalMetricsToRetain,
-      context
-    );
-  }
-  if (input.alertTargets !== undefined) {
-    bodyParams["alertTargets"] = serializeAws_restJson1_1AlertTargets(
-      input.alertTargets,
-      context
-    );
-  }
-  if (input.behaviors !== undefined) {
-    bodyParams["behaviors"] = serializeAws_restJson1_1Behaviors(
-      input.behaviors,
-      context
-    );
-  }
-  if (input.deleteAdditionalMetricsToRetain !== undefined) {
-    bodyParams["deleteAdditionalMetricsToRetain"] =
-      input.deleteAdditionalMetricsToRetain;
-  }
-  if (input.deleteAlertTargets !== undefined) {
-    bodyParams["deleteAlertTargets"] = input.deleteAlertTargets;
-  }
-  if (input.deleteBehaviors !== undefined) {
-    bodyParams["deleteBehaviors"] = input.deleteBehaviors;
-  }
-  if (input.securityProfileDescription !== undefined) {
-    bodyParams["securityProfileDescription"] = input.securityProfileDescription;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.additionalMetricsToRetain !== undefined && {
+      additionalMetricsToRetain: serializeAws_restJson1_1AdditionalMetricsToRetainList(
+        input.additionalMetricsToRetain,
+        context
+      )
+    }),
+    ...(input.alertTargets !== undefined && {
+      alertTargets: serializeAws_restJson1_1AlertTargets(
+        input.alertTargets,
+        context
+      )
+    }),
+    ...(input.behaviors !== undefined && {
+      behaviors: serializeAws_restJson1_1Behaviors(input.behaviors, context)
+    }),
+    ...(input.deleteAdditionalMetricsToRetain !== undefined && {
+      deleteAdditionalMetricsToRetain: input.deleteAdditionalMetricsToRetain
+    }),
+    ...(input.deleteAlertTargets !== undefined && {
+      deleteAlertTargets: input.deleteAlertTargets
+    }),
+    ...(input.deleteBehaviors !== undefined && {
+      deleteBehaviors: input.deleteBehaviors
+    }),
+    ...(input.securityProfileDescription !== undefined && {
+      securityProfileDescription: input.securityProfileDescription
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8538,14 +8297,11 @@ export const serializeAws_restJson1_1ValidateSecurityProfileBehaviorsCommand = a
   };
   let resolvedPath = "/security-profile-behaviors/validate";
   let body: any;
-  const bodyParams: any = {};
-  if (input.behaviors !== undefined) {
-    bodyParams["behaviors"] = serializeAws_restJson1_1Behaviors(
-      input.behaviors,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.behaviors !== undefined && {
+      behaviors: serializeAws_restJson1_1Behaviors(input.behaviors, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8579,23 +8335,16 @@ export const serializeAws_restJson1_1CreateStreamCommand = async (
     throw new Error("No value provided for input HTTP label: streamId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.files !== undefined) {
-    bodyParams["files"] = serializeAws_restJson1_1StreamFiles(
-      input.files,
-      context
-    );
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.files !== undefined && {
+      files: serializeAws_restJson1_1StreamFiles(input.files, context)
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -8726,20 +8475,13 @@ export const serializeAws_restJson1_1UpdateStreamCommand = async (
     throw new Error("No value provided for input HTTP label: streamId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.files !== undefined) {
-    bodyParams["files"] = serializeAws_restJson1_1StreamFiles(
-      input.files,
-      context
-    );
-  }
-  if (input.roleArn !== undefined) {
-    bodyParams["roleArn"] = input.roleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.files !== undefined && {
+      files: serializeAws_restJson1_1StreamFiles(input.files, context)
+    }),
+    ...(input.roleArn !== undefined && { roleArn: input.roleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
@@ -278,26 +278,24 @@ export const serializeAws_restJson1_1CreateChannelCommand = async (
   };
   let resolvedPath = "/channels";
   let body: any;
-  const bodyParams: any = {};
-  if (input.channelName !== undefined) {
-    bodyParams["channelName"] = input.channelName;
-  }
-  if (input.channelStorage !== undefined) {
-    bodyParams["channelStorage"] = serializeAws_restJson1_1ChannelStorage(
-      input.channelStorage,
-      context
-    );
-  }
-  if (input.retentionPeriod !== undefined) {
-    bodyParams["retentionPeriod"] = serializeAws_restJson1_1RetentionPeriod(
-      input.retentionPeriod,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.channelName !== undefined && { channelName: input.channelName }),
+    ...(input.channelStorage !== undefined && {
+      channelStorage: serializeAws_restJson1_1ChannelStorage(
+        input.channelStorage,
+        context
+      )
+    }),
+    ...(input.retentionPeriod !== undefined && {
+      retentionPeriod: serializeAws_restJson1_1RetentionPeriod(
+        input.retentionPeriod,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -319,48 +317,36 @@ export const serializeAws_restJson1_1CreateDatasetCommand = async (
   };
   let resolvedPath = "/datasets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.actions !== undefined) {
-    bodyParams["actions"] = serializeAws_restJson1_1DatasetActions(
-      input.actions,
-      context
-    );
-  }
-  if (input.contentDeliveryRules !== undefined) {
-    bodyParams[
-      "contentDeliveryRules"
-    ] = serializeAws_restJson1_1DatasetContentDeliveryRules(
-      input.contentDeliveryRules,
-      context
-    );
-  }
-  if (input.datasetName !== undefined) {
-    bodyParams["datasetName"] = input.datasetName;
-  }
-  if (input.retentionPeriod !== undefined) {
-    bodyParams["retentionPeriod"] = serializeAws_restJson1_1RetentionPeriod(
-      input.retentionPeriod,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  if (input.triggers !== undefined) {
-    bodyParams["triggers"] = serializeAws_restJson1_1DatasetTriggers(
-      input.triggers,
-      context
-    );
-  }
-  if (input.versioningConfiguration !== undefined) {
-    bodyParams[
-      "versioningConfiguration"
-    ] = serializeAws_restJson1_1VersioningConfiguration(
-      input.versioningConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.actions !== undefined && {
+      actions: serializeAws_restJson1_1DatasetActions(input.actions, context)
+    }),
+    ...(input.contentDeliveryRules !== undefined && {
+      contentDeliveryRules: serializeAws_restJson1_1DatasetContentDeliveryRules(
+        input.contentDeliveryRules,
+        context
+      )
+    }),
+    ...(input.datasetName !== undefined && { datasetName: input.datasetName }),
+    ...(input.retentionPeriod !== undefined && {
+      retentionPeriod: serializeAws_restJson1_1RetentionPeriod(
+        input.retentionPeriod,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    }),
+    ...(input.triggers !== undefined && {
+      triggers: serializeAws_restJson1_1DatasetTriggers(input.triggers, context)
+    }),
+    ...(input.versioningConfiguration !== undefined && {
+      versioningConfiguration: serializeAws_restJson1_1VersioningConfiguration(
+        input.versioningConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -417,26 +403,26 @@ export const serializeAws_restJson1_1CreateDatastoreCommand = async (
   };
   let resolvedPath = "/datastores";
   let body: any;
-  const bodyParams: any = {};
-  if (input.datastoreName !== undefined) {
-    bodyParams["datastoreName"] = input.datastoreName;
-  }
-  if (input.datastoreStorage !== undefined) {
-    bodyParams["datastoreStorage"] = serializeAws_restJson1_1DatastoreStorage(
-      input.datastoreStorage,
-      context
-    );
-  }
-  if (input.retentionPeriod !== undefined) {
-    bodyParams["retentionPeriod"] = serializeAws_restJson1_1RetentionPeriod(
-      input.retentionPeriod,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.datastoreName !== undefined && {
+      datastoreName: input.datastoreName
+    }),
+    ...(input.datastoreStorage !== undefined && {
+      datastoreStorage: serializeAws_restJson1_1DatastoreStorage(
+        input.datastoreStorage,
+        context
+      )
+    }),
+    ...(input.retentionPeriod !== undefined && {
+      retentionPeriod: serializeAws_restJson1_1RetentionPeriod(
+        input.retentionPeriod,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -458,22 +444,20 @@ export const serializeAws_restJson1_1CreatePipelineCommand = async (
   };
   let resolvedPath = "/pipelines";
   let body: any;
-  const bodyParams: any = {};
-  if (input.pipelineActivities !== undefined) {
-    bodyParams[
-      "pipelineActivities"
-    ] = serializeAws_restJson1_1PipelineActivities(
-      input.pipelineActivities,
-      context
-    );
-  }
-  if (input.pipelineName !== undefined) {
-    bodyParams["pipelineName"] = input.pipelineName;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.pipelineActivities !== undefined && {
+      pipelineActivities: serializeAws_restJson1_1PipelineActivities(
+        input.pipelineActivities,
+        context
+      )
+    }),
+    ...(input.pipelineName !== undefined && {
+      pipelineName: input.pipelineName
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1076,14 +1060,14 @@ export const serializeAws_restJson1_1PutLoggingOptionsCommand = async (
   };
   let resolvedPath = "/logging";
   let body: any;
-  const bodyParams: any = {};
-  if (input.loggingOptions !== undefined) {
-    bodyParams["loggingOptions"] = serializeAws_restJson1_1LoggingOptions(
-      input.loggingOptions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.loggingOptions !== undefined && {
+      loggingOptions: serializeAws_restJson1_1LoggingOptions(
+        input.loggingOptions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1105,20 +1089,17 @@ export const serializeAws_restJson1_1RunPipelineActivityCommand = async (
   };
   let resolvedPath = "/pipelineactivities/run";
   let body: any;
-  const bodyParams: any = {};
-  if (input.payloads !== undefined) {
-    bodyParams["payloads"] = serializeAws_restJson1_1MessagePayloads(
-      input.payloads,
-      context
-    );
-  }
-  if (input.pipelineActivity !== undefined) {
-    bodyParams["pipelineActivity"] = serializeAws_restJson1_1PipelineActivity(
-      input.pipelineActivity,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.payloads !== undefined && {
+      payloads: serializeAws_restJson1_1MessagePayloads(input.payloads, context)
+    }),
+    ...(input.pipelineActivity !== undefined && {
+      pipelineActivity: serializeAws_restJson1_1PipelineActivity(
+        input.pipelineActivity,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1201,14 +1182,14 @@ export const serializeAws_restJson1_1StartPipelineReprocessingCommand = async (
     throw new Error("No value provided for input HTTP label: pipelineName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.endTime !== undefined) {
-    bodyParams["endTime"] = Math.round(input.endTime.getTime() / 1000);
-  }
-  if (input.startTime !== undefined) {
-    bodyParams["startTime"] = Math.round(input.startTime.getTime() / 1000);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.endTime !== undefined && {
+      endTime: Math.round(input.endTime.getTime() / 1000)
+    }),
+    ...(input.startTime !== undefined && {
+      startTime: Math.round(input.startTime.getTime() / 1000)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1233,11 +1214,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1302,20 +1283,20 @@ export const serializeAws_restJson1_1UpdateChannelCommand = async (
     throw new Error("No value provided for input HTTP label: channelName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.channelStorage !== undefined) {
-    bodyParams["channelStorage"] = serializeAws_restJson1_1ChannelStorage(
-      input.channelStorage,
-      context
-    );
-  }
-  if (input.retentionPeriod !== undefined) {
-    bodyParams["retentionPeriod"] = serializeAws_restJson1_1RetentionPeriod(
-      input.retentionPeriod,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.channelStorage !== undefined && {
+      channelStorage: serializeAws_restJson1_1ChannelStorage(
+        input.channelStorage,
+        context
+      )
+    }),
+    ...(input.retentionPeriod !== undefined && {
+      retentionPeriod: serializeAws_restJson1_1RetentionPeriod(
+        input.retentionPeriod,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1351,42 +1332,32 @@ export const serializeAws_restJson1_1UpdateDatasetCommand = async (
     throw new Error("No value provided for input HTTP label: datasetName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.actions !== undefined) {
-    bodyParams["actions"] = serializeAws_restJson1_1DatasetActions(
-      input.actions,
-      context
-    );
-  }
-  if (input.contentDeliveryRules !== undefined) {
-    bodyParams[
-      "contentDeliveryRules"
-    ] = serializeAws_restJson1_1DatasetContentDeliveryRules(
-      input.contentDeliveryRules,
-      context
-    );
-  }
-  if (input.retentionPeriod !== undefined) {
-    bodyParams["retentionPeriod"] = serializeAws_restJson1_1RetentionPeriod(
-      input.retentionPeriod,
-      context
-    );
-  }
-  if (input.triggers !== undefined) {
-    bodyParams["triggers"] = serializeAws_restJson1_1DatasetTriggers(
-      input.triggers,
-      context
-    );
-  }
-  if (input.versioningConfiguration !== undefined) {
-    bodyParams[
-      "versioningConfiguration"
-    ] = serializeAws_restJson1_1VersioningConfiguration(
-      input.versioningConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.actions !== undefined && {
+      actions: serializeAws_restJson1_1DatasetActions(input.actions, context)
+    }),
+    ...(input.contentDeliveryRules !== undefined && {
+      contentDeliveryRules: serializeAws_restJson1_1DatasetContentDeliveryRules(
+        input.contentDeliveryRules,
+        context
+      )
+    }),
+    ...(input.retentionPeriod !== undefined && {
+      retentionPeriod: serializeAws_restJson1_1RetentionPeriod(
+        input.retentionPeriod,
+        context
+      )
+    }),
+    ...(input.triggers !== undefined && {
+      triggers: serializeAws_restJson1_1DatasetTriggers(input.triggers, context)
+    }),
+    ...(input.versioningConfiguration !== undefined && {
+      versioningConfiguration: serializeAws_restJson1_1VersioningConfiguration(
+        input.versioningConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1422,20 +1393,20 @@ export const serializeAws_restJson1_1UpdateDatastoreCommand = async (
     throw new Error("No value provided for input HTTP label: datastoreName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.datastoreStorage !== undefined) {
-    bodyParams["datastoreStorage"] = serializeAws_restJson1_1DatastoreStorage(
-      input.datastoreStorage,
-      context
-    );
-  }
-  if (input.retentionPeriod !== undefined) {
-    bodyParams["retentionPeriod"] = serializeAws_restJson1_1RetentionPeriod(
-      input.retentionPeriod,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.datastoreStorage !== undefined && {
+      datastoreStorage: serializeAws_restJson1_1DatastoreStorage(
+        input.datastoreStorage,
+        context
+      )
+    }),
+    ...(input.retentionPeriod !== undefined && {
+      retentionPeriod: serializeAws_restJson1_1RetentionPeriod(
+        input.retentionPeriod,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1471,16 +1442,14 @@ export const serializeAws_restJson1_1UpdatePipelineCommand = async (
     throw new Error("No value provided for input HTTP label: pipelineName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.pipelineActivities !== undefined) {
-    bodyParams[
-      "pipelineActivities"
-    ] = serializeAws_restJson1_1PipelineActivities(
-      input.pipelineActivities,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.pipelineActivities !== undefined && {
+      pipelineActivities: serializeAws_restJson1_1PipelineActivities(
+        input.pipelineActivities,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1502,17 +1471,12 @@ export const serializeAws_restJson1_1BatchPutMessageCommand = async (
   };
   let resolvedPath = "/messages/batch";
   let body: any;
-  const bodyParams: any = {};
-  if (input.channelName !== undefined) {
-    bodyParams["channelName"] = input.channelName;
-  }
-  if (input.messages !== undefined) {
-    bodyParams["messages"] = serializeAws_restJson1_1Messages(
-      input.messages,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.channelName !== undefined && { channelName: input.channelName }),
+    ...(input.messages !== undefined && {
+      messages: serializeAws_restJson1_1Messages(input.messages, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-kafka/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1_1.ts
@@ -140,60 +140,51 @@ export const serializeAws_restJson1_1CreateClusterCommand = async (
   };
   let resolvedPath = "/v1/clusters";
   let body: any;
-  const bodyParams: any = {};
-  if (input.BrokerNodeGroupInfo !== undefined) {
-    bodyParams[
-      "brokerNodeGroupInfo"
-    ] = serializeAws_restJson1_1BrokerNodeGroupInfo(
-      input.BrokerNodeGroupInfo,
-      context
-    );
-  }
-  if (input.ClientAuthentication !== undefined) {
-    bodyParams[
-      "clientAuthentication"
-    ] = serializeAws_restJson1_1ClientAuthentication(
-      input.ClientAuthentication,
-      context
-    );
-  }
-  if (input.ClusterName !== undefined) {
-    bodyParams["clusterName"] = input.ClusterName;
-  }
-  if (input.ConfigurationInfo !== undefined) {
-    bodyParams["configurationInfo"] = serializeAws_restJson1_1ConfigurationInfo(
-      input.ConfigurationInfo,
-      context
-    );
-  }
-  if (input.EncryptionInfo !== undefined) {
-    bodyParams["encryptionInfo"] = serializeAws_restJson1_1EncryptionInfo(
-      input.EncryptionInfo,
-      context
-    );
-  }
-  if (input.EnhancedMonitoring !== undefined) {
-    bodyParams["enhancedMonitoring"] = input.EnhancedMonitoring;
-  }
-  if (input.KafkaVersion !== undefined) {
-    bodyParams["kafkaVersion"] = input.KafkaVersion;
-  }
-  if (input.NumberOfBrokerNodes !== undefined) {
-    bodyParams["numberOfBrokerNodes"] = input.NumberOfBrokerNodes;
-  }
-  if (input.OpenMonitoring !== undefined) {
-    bodyParams["openMonitoring"] = serializeAws_restJson1_1OpenMonitoringInfo(
-      input.OpenMonitoring,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BrokerNodeGroupInfo !== undefined && {
+      brokerNodeGroupInfo: serializeAws_restJson1_1BrokerNodeGroupInfo(
+        input.BrokerNodeGroupInfo,
+        context
+      )
+    }),
+    ...(input.ClientAuthentication !== undefined && {
+      clientAuthentication: serializeAws_restJson1_1ClientAuthentication(
+        input.ClientAuthentication,
+        context
+      )
+    }),
+    ...(input.ClusterName !== undefined && { clusterName: input.ClusterName }),
+    ...(input.ConfigurationInfo !== undefined && {
+      configurationInfo: serializeAws_restJson1_1ConfigurationInfo(
+        input.ConfigurationInfo,
+        context
+      )
+    }),
+    ...(input.EncryptionInfo !== undefined && {
+      encryptionInfo: serializeAws_restJson1_1EncryptionInfo(
+        input.EncryptionInfo,
+        context
+      )
+    }),
+    ...(input.EnhancedMonitoring !== undefined && {
+      enhancedMonitoring: input.EnhancedMonitoring
+    }),
+    ...(input.KafkaVersion !== undefined && {
+      kafkaVersion: input.KafkaVersion
+    }),
+    ...(input.NumberOfBrokerNodes !== undefined && {
+      numberOfBrokerNodes: input.NumberOfBrokerNodes
+    }),
+    ...(input.OpenMonitoring !== undefined && {
+      openMonitoring: serializeAws_restJson1_1OpenMonitoringInfo(
+        input.OpenMonitoring,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -215,25 +206,19 @@ export const serializeAws_restJson1_1CreateConfigurationCommand = async (
   };
   let resolvedPath = "/v1/configurations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.KafkaVersions !== undefined) {
-    bodyParams["kafkaVersions"] = serializeAws_restJson1_1__listOf__string(
-      input.KafkaVersions,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.ServerProperties !== undefined) {
-    bodyParams["serverProperties"] = context.base64Encoder(
-      input.ServerProperties
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.KafkaVersions !== undefined && {
+      kafkaVersions: serializeAws_restJson1_1__listOf__string(
+        input.KafkaVersions,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.ServerProperties !== undefined && {
+      serverProperties: context.base64Encoder(input.ServerProperties)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -703,14 +688,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -785,14 +767,14 @@ export const serializeAws_restJson1_1UpdateBrokerCountCommand = async (
     throw new Error("No value provided for input HTTP label: ClusterArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["currentVersion"] = input.CurrentVersion;
-  }
-  if (input.TargetNumberOfBrokerNodes !== undefined) {
-    bodyParams["targetNumberOfBrokerNodes"] = input.TargetNumberOfBrokerNodes;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CurrentVersion !== undefined && {
+      currentVersion: input.CurrentVersion
+    }),
+    ...(input.TargetNumberOfBrokerNodes !== undefined && {
+      targetNumberOfBrokerNodes: input.TargetNumberOfBrokerNodes
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -826,19 +808,17 @@ export const serializeAws_restJson1_1UpdateBrokerStorageCommand = async (
     throw new Error("No value provided for input HTTP label: ClusterArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["currentVersion"] = input.CurrentVersion;
-  }
-  if (input.TargetBrokerEBSVolumeInfo !== undefined) {
-    bodyParams[
-      "targetBrokerEBSVolumeInfo"
-    ] = serializeAws_restJson1_1__listOfBrokerEBSVolumeInfo(
-      input.TargetBrokerEBSVolumeInfo,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CurrentVersion !== undefined && {
+      currentVersion: input.CurrentVersion
+    }),
+    ...(input.TargetBrokerEBSVolumeInfo !== undefined && {
+      targetBrokerEBSVolumeInfo: serializeAws_restJson1_1__listOfBrokerEBSVolumeInfo(
+        input.TargetBrokerEBSVolumeInfo,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -872,17 +852,17 @@ export const serializeAws_restJson1_1UpdateClusterConfigurationCommand = async (
     throw new Error("No value provided for input HTTP label: ClusterArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConfigurationInfo !== undefined) {
-    bodyParams["configurationInfo"] = serializeAws_restJson1_1ConfigurationInfo(
-      input.ConfigurationInfo,
-      context
-    );
-  }
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["currentVersion"] = input.CurrentVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConfigurationInfo !== undefined && {
+      configurationInfo: serializeAws_restJson1_1ConfigurationInfo(
+        input.ConfigurationInfo,
+        context
+      )
+    }),
+    ...(input.CurrentVersion !== undefined && {
+      currentVersion: input.CurrentVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -916,20 +896,20 @@ export const serializeAws_restJson1_1UpdateMonitoringCommand = async (
     throw new Error("No value provided for input HTTP label: ClusterArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["currentVersion"] = input.CurrentVersion;
-  }
-  if (input.EnhancedMonitoring !== undefined) {
-    bodyParams["enhancedMonitoring"] = input.EnhancedMonitoring;
-  }
-  if (input.OpenMonitoring !== undefined) {
-    bodyParams["openMonitoring"] = serializeAws_restJson1_1OpenMonitoringInfo(
-      input.OpenMonitoring,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CurrentVersion !== undefined && {
+      currentVersion: input.CurrentVersion
+    }),
+    ...(input.EnhancedMonitoring !== undefined && {
+      enhancedMonitoring: input.EnhancedMonitoring
+    }),
+    ...(input.OpenMonitoring !== undefined && {
+      openMonitoring: serializeAws_restJson1_1OpenMonitoringInfo(
+        input.OpenMonitoring,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1_1.ts
@@ -52,37 +52,29 @@ export const serializeAws_restJson1_1GetDASHStreamingSessionURLCommand = async (
   };
   let resolvedPath = "/getDASHStreamingSessionURL";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DASHFragmentSelector !== undefined) {
-    bodyParams[
-      "DASHFragmentSelector"
-    ] = serializeAws_restJson1_1DASHFragmentSelector(
-      input.DASHFragmentSelector,
-      context
-    );
-  }
-  if (input.DisplayFragmentNumber !== undefined) {
-    bodyParams["DisplayFragmentNumber"] = input.DisplayFragmentNumber;
-  }
-  if (input.DisplayFragmentTimestamp !== undefined) {
-    bodyParams["DisplayFragmentTimestamp"] = input.DisplayFragmentTimestamp;
-  }
-  if (input.Expires !== undefined) {
-    bodyParams["Expires"] = input.Expires;
-  }
-  if (input.MaxManifestFragmentResults !== undefined) {
-    bodyParams["MaxManifestFragmentResults"] = input.MaxManifestFragmentResults;
-  }
-  if (input.PlaybackMode !== undefined) {
-    bodyParams["PlaybackMode"] = input.PlaybackMode;
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DASHFragmentSelector !== undefined && {
+      DASHFragmentSelector: serializeAws_restJson1_1DASHFragmentSelector(
+        input.DASHFragmentSelector,
+        context
+      )
+    }),
+    ...(input.DisplayFragmentNumber !== undefined && {
+      DisplayFragmentNumber: input.DisplayFragmentNumber
+    }),
+    ...(input.DisplayFragmentTimestamp !== undefined && {
+      DisplayFragmentTimestamp: input.DisplayFragmentTimestamp
+    }),
+    ...(input.Expires !== undefined && { Expires: input.Expires }),
+    ...(input.MaxManifestFragmentResults !== undefined && {
+      MaxManifestFragmentResults: input.MaxManifestFragmentResults
+    }),
+    ...(input.PlaybackMode !== undefined && {
+      PlaybackMode: input.PlaybackMode
+    }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -104,41 +96,32 @@ export const serializeAws_restJson1_1GetHLSStreamingSessionURLCommand = async (
   };
   let resolvedPath = "/getHLSStreamingSessionURL";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContainerFormat !== undefined) {
-    bodyParams["ContainerFormat"] = input.ContainerFormat;
-  }
-  if (input.DiscontinuityMode !== undefined) {
-    bodyParams["DiscontinuityMode"] = input.DiscontinuityMode;
-  }
-  if (input.DisplayFragmentTimestamp !== undefined) {
-    bodyParams["DisplayFragmentTimestamp"] = input.DisplayFragmentTimestamp;
-  }
-  if (input.Expires !== undefined) {
-    bodyParams["Expires"] = input.Expires;
-  }
-  if (input.HLSFragmentSelector !== undefined) {
-    bodyParams[
-      "HLSFragmentSelector"
-    ] = serializeAws_restJson1_1HLSFragmentSelector(
-      input.HLSFragmentSelector,
-      context
-    );
-  }
-  if (input.MaxMediaPlaylistFragmentResults !== undefined) {
-    bodyParams["MaxMediaPlaylistFragmentResults"] =
-      input.MaxMediaPlaylistFragmentResults;
-  }
-  if (input.PlaybackMode !== undefined) {
-    bodyParams["PlaybackMode"] = input.PlaybackMode;
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContainerFormat !== undefined && {
+      ContainerFormat: input.ContainerFormat
+    }),
+    ...(input.DiscontinuityMode !== undefined && {
+      DiscontinuityMode: input.DiscontinuityMode
+    }),
+    ...(input.DisplayFragmentTimestamp !== undefined && {
+      DisplayFragmentTimestamp: input.DisplayFragmentTimestamp
+    }),
+    ...(input.Expires !== undefined && { Expires: input.Expires }),
+    ...(input.HLSFragmentSelector !== undefined && {
+      HLSFragmentSelector: serializeAws_restJson1_1HLSFragmentSelector(
+        input.HLSFragmentSelector,
+        context
+      )
+    }),
+    ...(input.MaxMediaPlaylistFragmentResults !== undefined && {
+      MaxMediaPlaylistFragmentResults: input.MaxMediaPlaylistFragmentResults
+    }),
+    ...(input.PlaybackMode !== undefined && {
+      PlaybackMode: input.PlaybackMode
+    }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -160,17 +143,15 @@ export const serializeAws_restJson1_1GetMediaForFragmentListCommand = async (
   };
   let resolvedPath = "/getMediaForFragmentList";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Fragments !== undefined) {
-    bodyParams["Fragments"] = serializeAws_restJson1_1FragmentNumberList(
-      input.Fragments,
-      context
-    );
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Fragments !== undefined && {
+      Fragments: serializeAws_restJson1_1FragmentNumberList(
+        input.Fragments,
+        context
+      )
+    }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -192,23 +173,17 @@ export const serializeAws_restJson1_1ListFragmentsCommand = async (
   };
   let resolvedPath = "/listFragments";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FragmentSelector !== undefined) {
-    bodyParams["FragmentSelector"] = serializeAws_restJson1_1FragmentSelector(
-      input.FragmentSelector,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FragmentSelector !== undefined && {
+      FragmentSelector: serializeAws_restJson1_1FragmentSelector(
+        input.FragmentSelector,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-kinesis-video-media/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video-media/protocols/Aws_restJson1_1.ts
@@ -32,20 +32,16 @@ export const serializeAws_restJson1_1GetMediaCommand = async (
   };
   let resolvedPath = "/getMedia";
   let body: any;
-  const bodyParams: any = {};
-  if (input.StartSelector !== undefined) {
-    bodyParams["StartSelector"] = serializeAws_restJson1_1StartSelector(
-      input.StartSelector,
-      context
-    );
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.StartSelector !== undefined && {
+      StartSelector: serializeAws_restJson1_1StartSelector(
+        input.StartSelector,
+        context
+      )
+    }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-kinesis-video-signaling/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video-signaling/protocols/Aws_restJson1_1.ts
@@ -36,20 +36,12 @@ export const serializeAws_restJson1_1GetIceServerConfigCommand = async (
   };
   let resolvedPath = "/v1/get-ice-server-config";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelARN !== undefined) {
-    bodyParams["ChannelARN"] = input.ChannelARN;
-  }
-  if (input.ClientId !== undefined) {
-    bodyParams["ClientId"] = input.ClientId;
-  }
-  if (input.Service !== undefined) {
-    bodyParams["Service"] = input.Service;
-  }
-  if (input.Username !== undefined) {
-    bodyParams["Username"] = input.Username;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelARN !== undefined && { ChannelARN: input.ChannelARN }),
+    ...(input.ClientId !== undefined && { ClientId: input.ClientId }),
+    ...(input.Service !== undefined && { Service: input.Service }),
+    ...(input.Username !== undefined && { Username: input.Username })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -71,17 +63,15 @@ export const serializeAws_restJson1_1SendAlexaOfferToMasterCommand = async (
   };
   let resolvedPath = "/v1/send-alexa-offer-to-master";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelARN !== undefined) {
-    bodyParams["ChannelARN"] = input.ChannelARN;
-  }
-  if (input.MessagePayload !== undefined) {
-    bodyParams["MessagePayload"] = input.MessagePayload;
-  }
-  if (input.SenderClientId !== undefined) {
-    bodyParams["SenderClientId"] = input.SenderClientId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelARN !== undefined && { ChannelARN: input.ChannelARN }),
+    ...(input.MessagePayload !== undefined && {
+      MessagePayload: input.MessagePayload
+    }),
+    ...(input.SenderClientId !== undefined && {
+      SenderClientId: input.SenderClientId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
@@ -119,28 +119,19 @@ export const serializeAws_restJson1_1CreateSignalingChannelCommand = async (
   };
   let resolvedPath = "/createSignalingChannel";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelName !== undefined) {
-    bodyParams["ChannelName"] = input.ChannelName;
-  }
-  if (input.ChannelType !== undefined) {
-    bodyParams["ChannelType"] = input.ChannelType;
-  }
-  if (input.SingleMasterConfiguration !== undefined) {
-    bodyParams[
-      "SingleMasterConfiguration"
-    ] = serializeAws_restJson1_1SingleMasterConfiguration(
-      input.SingleMasterConfiguration,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagOnCreateList(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelName !== undefined && { ChannelName: input.ChannelName }),
+    ...(input.ChannelType !== undefined && { ChannelType: input.ChannelType }),
+    ...(input.SingleMasterConfiguration !== undefined && {
+      SingleMasterConfiguration: serializeAws_restJson1_1SingleMasterConfiguration(
+        input.SingleMasterConfiguration,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagOnCreateList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -162,29 +153,18 @@ export const serializeAws_restJson1_1CreateStreamCommand = async (
   };
   let resolvedPath = "/createStream";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DataRetentionInHours !== undefined) {
-    bodyParams["DataRetentionInHours"] = input.DataRetentionInHours;
-  }
-  if (input.DeviceName !== undefined) {
-    bodyParams["DeviceName"] = input.DeviceName;
-  }
-  if (input.KmsKeyId !== undefined) {
-    bodyParams["KmsKeyId"] = input.KmsKeyId;
-  }
-  if (input.MediaType !== undefined) {
-    bodyParams["MediaType"] = input.MediaType;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1ResourceTags(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DataRetentionInHours !== undefined && {
+      DataRetentionInHours: input.DataRetentionInHours
+    }),
+    ...(input.DeviceName !== undefined && { DeviceName: input.DeviceName }),
+    ...(input.KmsKeyId !== undefined && { KmsKeyId: input.KmsKeyId }),
+    ...(input.MediaType !== undefined && { MediaType: input.MediaType }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1ResourceTags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -206,14 +186,12 @@ export const serializeAws_restJson1_1DeleteSignalingChannelCommand = async (
   };
   let resolvedPath = "/deleteSignalingChannel";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelARN !== undefined) {
-    bodyParams["ChannelARN"] = input.ChannelARN;
-  }
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["CurrentVersion"] = input.CurrentVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelARN !== undefined && { ChannelARN: input.ChannelARN }),
+    ...(input.CurrentVersion !== undefined && {
+      CurrentVersion: input.CurrentVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -235,14 +213,12 @@ export const serializeAws_restJson1_1DeleteStreamCommand = async (
   };
   let resolvedPath = "/deleteStream";
   let body: any;
-  const bodyParams: any = {};
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["CurrentVersion"] = input.CurrentVersion;
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CurrentVersion !== undefined && {
+      CurrentVersion: input.CurrentVersion
+    }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -264,14 +240,10 @@ export const serializeAws_restJson1_1DescribeSignalingChannelCommand = async (
   };
   let resolvedPath = "/describeSignalingChannel";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelARN !== undefined) {
-    bodyParams["ChannelARN"] = input.ChannelARN;
-  }
-  if (input.ChannelName !== undefined) {
-    bodyParams["ChannelName"] = input.ChannelName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelARN !== undefined && { ChannelARN: input.ChannelARN }),
+    ...(input.ChannelName !== undefined && { ChannelName: input.ChannelName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -293,14 +265,10 @@ export const serializeAws_restJson1_1DescribeStreamCommand = async (
   };
   let resolvedPath = "/describeStream";
   let body: any;
-  const bodyParams: any = {};
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -322,17 +290,11 @@ export const serializeAws_restJson1_1GetDataEndpointCommand = async (
   };
   let resolvedPath = "/getDataEndpoint";
   let body: any;
-  const bodyParams: any = {};
-  if (input.APIName !== undefined) {
-    bodyParams["APIName"] = input.APIName;
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.APIName !== undefined && { APIName: input.APIName }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -354,19 +316,15 @@ export const serializeAws_restJson1_1GetSignalingChannelEndpointCommand = async 
   };
   let resolvedPath = "/getSignalingChannelEndpoint";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelARN !== undefined) {
-    bodyParams["ChannelARN"] = input.ChannelARN;
-  }
-  if (input.SingleMasterChannelEndpointConfiguration !== undefined) {
-    bodyParams[
-      "SingleMasterChannelEndpointConfiguration"
-    ] = serializeAws_restJson1_1SingleMasterChannelEndpointConfiguration(
-      input.SingleMasterChannelEndpointConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelARN !== undefined && { ChannelARN: input.ChannelARN }),
+    ...(input.SingleMasterChannelEndpointConfiguration !== undefined && {
+      SingleMasterChannelEndpointConfiguration: serializeAws_restJson1_1SingleMasterChannelEndpointConfiguration(
+        input.SingleMasterChannelEndpointConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -388,22 +346,16 @@ export const serializeAws_restJson1_1ListSignalingChannelsCommand = async (
   };
   let resolvedPath = "/listSignalingChannels";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelNameCondition !== undefined) {
-    bodyParams[
-      "ChannelNameCondition"
-    ] = serializeAws_restJson1_1ChannelNameCondition(
-      input.ChannelNameCondition,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelNameCondition !== undefined && {
+      ChannelNameCondition: serializeAws_restJson1_1ChannelNameCondition(
+        input.ChannelNameCondition,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -425,22 +377,16 @@ export const serializeAws_restJson1_1ListStreamsCommand = async (
   };
   let resolvedPath = "/listStreams";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.StreamNameCondition !== undefined) {
-    bodyParams[
-      "StreamNameCondition"
-    ] = serializeAws_restJson1_1StreamNameCondition(
-      input.StreamNameCondition,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.StreamNameCondition !== undefined && {
+      StreamNameCondition: serializeAws_restJson1_1StreamNameCondition(
+        input.StreamNameCondition,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -462,14 +408,10 @@ export const serializeAws_restJson1_1ListTagsForResourceCommand = async (
   };
   let resolvedPath = "/ListTagsForResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ResourceARN !== undefined) {
-    bodyParams["ResourceARN"] = input.ResourceARN;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ResourceARN !== undefined && { ResourceARN: input.ResourceARN })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -491,17 +433,11 @@ export const serializeAws_restJson1_1ListTagsForStreamCommand = async (
   };
   let resolvedPath = "/listTagsForStream";
   let body: any;
-  const bodyParams: any = {};
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -523,14 +459,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/TagResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ResourceARN !== undefined) {
-    bodyParams["ResourceARN"] = input.ResourceARN;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ResourceARN !== undefined && { ResourceARN: input.ResourceARN }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -552,20 +486,13 @@ export const serializeAws_restJson1_1TagStreamCommand = async (
   };
   let resolvedPath = "/tagStream";
   let body: any;
-  const bodyParams: any = {};
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1ResourceTags(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1ResourceTags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -587,17 +514,12 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
   };
   let resolvedPath = "/UntagResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ResourceARN !== undefined) {
-    bodyParams["ResourceARN"] = input.ResourceARN;
-  }
-  if (input.TagKeyList !== undefined) {
-    bodyParams["TagKeyList"] = serializeAws_restJson1_1TagKeyList(
-      input.TagKeyList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ResourceARN !== undefined && { ResourceARN: input.ResourceARN }),
+    ...(input.TagKeyList !== undefined && {
+      TagKeyList: serializeAws_restJson1_1TagKeyList(input.TagKeyList, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -619,20 +541,13 @@ export const serializeAws_restJson1_1UntagStreamCommand = async (
   };
   let resolvedPath = "/untagStream";
   let body: any;
-  const bodyParams: any = {};
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  if (input.TagKeyList !== undefined) {
-    bodyParams["TagKeyList"] = serializeAws_restJson1_1TagKeyList(
-      input.TagKeyList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName }),
+    ...(input.TagKeyList !== undefined && {
+      TagKeyList: serializeAws_restJson1_1TagKeyList(input.TagKeyList, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -654,23 +569,17 @@ export const serializeAws_restJson1_1UpdateDataRetentionCommand = async (
   };
   let resolvedPath = "/updateDataRetention";
   let body: any;
-  const bodyParams: any = {};
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["CurrentVersion"] = input.CurrentVersion;
-  }
-  if (input.DataRetentionChangeInHours !== undefined) {
-    bodyParams["DataRetentionChangeInHours"] = input.DataRetentionChangeInHours;
-  }
-  if (input.Operation !== undefined) {
-    bodyParams["Operation"] = input.Operation;
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CurrentVersion !== undefined && {
+      CurrentVersion: input.CurrentVersion
+    }),
+    ...(input.DataRetentionChangeInHours !== undefined && {
+      DataRetentionChangeInHours: input.DataRetentionChangeInHours
+    }),
+    ...(input.Operation !== undefined && { Operation: input.Operation }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -692,22 +601,18 @@ export const serializeAws_restJson1_1UpdateSignalingChannelCommand = async (
   };
   let resolvedPath = "/updateSignalingChannel";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelARN !== undefined) {
-    bodyParams["ChannelARN"] = input.ChannelARN;
-  }
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["CurrentVersion"] = input.CurrentVersion;
-  }
-  if (input.SingleMasterConfiguration !== undefined) {
-    bodyParams[
-      "SingleMasterConfiguration"
-    ] = serializeAws_restJson1_1SingleMasterConfiguration(
-      input.SingleMasterConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelARN !== undefined && { ChannelARN: input.ChannelARN }),
+    ...(input.CurrentVersion !== undefined && {
+      CurrentVersion: input.CurrentVersion
+    }),
+    ...(input.SingleMasterConfiguration !== undefined && {
+      SingleMasterConfiguration: serializeAws_restJson1_1SingleMasterConfiguration(
+        input.SingleMasterConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -729,23 +634,15 @@ export const serializeAws_restJson1_1UpdateStreamCommand = async (
   };
   let resolvedPath = "/updateStream";
   let body: any;
-  const bodyParams: any = {};
-  if (input.CurrentVersion !== undefined) {
-    bodyParams["CurrentVersion"] = input.CurrentVersion;
-  }
-  if (input.DeviceName !== undefined) {
-    bodyParams["DeviceName"] = input.DeviceName;
-  }
-  if (input.MediaType !== undefined) {
-    bodyParams["MediaType"] = input.MediaType;
-  }
-  if (input.StreamARN !== undefined) {
-    bodyParams["StreamARN"] = input.StreamARN;
-  }
-  if (input.StreamName !== undefined) {
-    bodyParams["StreamName"] = input.StreamName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CurrentVersion !== undefined && {
+      CurrentVersion: input.CurrentVersion
+    }),
+    ...(input.DeviceName !== undefined && { DeviceName: input.DeviceName }),
+    ...(input.MediaType !== undefined && { MediaType: input.MediaType }),
+    ...(input.StreamARN !== undefined && { StreamARN: input.StreamARN }),
+    ...(input.StreamName !== undefined && { StreamName: input.StreamName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-lambda/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1_1.ts
@@ -305,20 +305,14 @@ export const serializeAws_restJson1_1AddLayerVersionPermissionCommand = async (
     ...(input.RevisionId !== undefined && { RevisionId: input.RevisionId })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Action !== undefined) {
-    bodyParams["Action"] = input.Action;
-  }
-  if (input.OrganizationId !== undefined) {
-    bodyParams["OrganizationId"] = input.OrganizationId;
-  }
-  if (input.Principal !== undefined) {
-    bodyParams["Principal"] = input.Principal;
-  }
-  if (input.StatementId !== undefined) {
-    bodyParams["StatementId"] = input.StatementId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Action !== undefined && { Action: input.Action }),
+    ...(input.OrganizationId !== undefined && {
+      OrganizationId: input.OrganizationId
+    }),
+    ...(input.Principal !== undefined && { Principal: input.Principal }),
+    ...(input.StatementId !== undefined && { StatementId: input.StatementId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -358,29 +352,19 @@ export const serializeAws_restJson1_1AddPermissionCommand = async (
     ...(input.Qualifier !== undefined && { Qualifier: input.Qualifier })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Action !== undefined) {
-    bodyParams["Action"] = input.Action;
-  }
-  if (input.EventSourceToken !== undefined) {
-    bodyParams["EventSourceToken"] = input.EventSourceToken;
-  }
-  if (input.Principal !== undefined) {
-    bodyParams["Principal"] = input.Principal;
-  }
-  if (input.RevisionId !== undefined) {
-    bodyParams["RevisionId"] = input.RevisionId;
-  }
-  if (input.SourceAccount !== undefined) {
-    bodyParams["SourceAccount"] = input.SourceAccount;
-  }
-  if (input.SourceArn !== undefined) {
-    bodyParams["SourceArn"] = input.SourceArn;
-  }
-  if (input.StatementId !== undefined) {
-    bodyParams["StatementId"] = input.StatementId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Action !== undefined && { Action: input.Action }),
+    ...(input.EventSourceToken !== undefined && {
+      EventSourceToken: input.EventSourceToken
+    }),
+    ...(input.Principal !== undefined && { Principal: input.Principal }),
+    ...(input.RevisionId !== undefined && { RevisionId: input.RevisionId }),
+    ...(input.SourceAccount !== undefined && {
+      SourceAccount: input.SourceAccount
+    }),
+    ...(input.SourceArn !== undefined && { SourceArn: input.SourceArn }),
+    ...(input.StatementId !== undefined && { StatementId: input.StatementId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -417,25 +401,19 @@ export const serializeAws_restJson1_1CreateAliasCommand = async (
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.FunctionVersion !== undefined) {
-    bodyParams["FunctionVersion"] = input.FunctionVersion;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.RoutingConfig !== undefined) {
-    bodyParams[
-      "RoutingConfig"
-    ] = serializeAws_restJson1_1AliasRoutingConfiguration(
-      input.RoutingConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.FunctionVersion !== undefined && {
+      FunctionVersion: input.FunctionVersion
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.RoutingConfig !== undefined && {
+      RoutingConfig: serializeAws_restJson1_1AliasRoutingConfiguration(
+        input.RoutingConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -457,50 +435,45 @@ export const serializeAws_restJson1_1CreateEventSourceMappingCommand = async (
   };
   let resolvedPath = "/2015-03-31/event-source-mappings";
   let body: any;
-  const bodyParams: any = {};
-  if (input.BatchSize !== undefined) {
-    bodyParams["BatchSize"] = input.BatchSize;
-  }
-  if (input.BisectBatchOnFunctionError !== undefined) {
-    bodyParams["BisectBatchOnFunctionError"] = input.BisectBatchOnFunctionError;
-  }
-  if (input.DestinationConfig !== undefined) {
-    bodyParams["DestinationConfig"] = serializeAws_restJson1_1DestinationConfig(
-      input.DestinationConfig,
-      context
-    );
-  }
-  if (input.Enabled !== undefined) {
-    bodyParams["Enabled"] = input.Enabled;
-  }
-  if (input.EventSourceArn !== undefined) {
-    bodyParams["EventSourceArn"] = input.EventSourceArn;
-  }
-  if (input.FunctionName !== undefined) {
-    bodyParams["FunctionName"] = input.FunctionName;
-  }
-  if (input.MaximumBatchingWindowInSeconds !== undefined) {
-    bodyParams["MaximumBatchingWindowInSeconds"] =
-      input.MaximumBatchingWindowInSeconds;
-  }
-  if (input.MaximumRecordAgeInSeconds !== undefined) {
-    bodyParams["MaximumRecordAgeInSeconds"] = input.MaximumRecordAgeInSeconds;
-  }
-  if (input.MaximumRetryAttempts !== undefined) {
-    bodyParams["MaximumRetryAttempts"] = input.MaximumRetryAttempts;
-  }
-  if (input.ParallelizationFactor !== undefined) {
-    bodyParams["ParallelizationFactor"] = input.ParallelizationFactor;
-  }
-  if (input.StartingPosition !== undefined) {
-    bodyParams["StartingPosition"] = input.StartingPosition;
-  }
-  if (input.StartingPositionTimestamp !== undefined) {
-    bodyParams["StartingPositionTimestamp"] = Math.round(
-      input.StartingPositionTimestamp.getTime() / 1000
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BatchSize !== undefined && { BatchSize: input.BatchSize }),
+    ...(input.BisectBatchOnFunctionError !== undefined && {
+      BisectBatchOnFunctionError: input.BisectBatchOnFunctionError
+    }),
+    ...(input.DestinationConfig !== undefined && {
+      DestinationConfig: serializeAws_restJson1_1DestinationConfig(
+        input.DestinationConfig,
+        context
+      )
+    }),
+    ...(input.Enabled !== undefined && { Enabled: input.Enabled }),
+    ...(input.EventSourceArn !== undefined && {
+      EventSourceArn: input.EventSourceArn
+    }),
+    ...(input.FunctionName !== undefined && {
+      FunctionName: input.FunctionName
+    }),
+    ...(input.MaximumBatchingWindowInSeconds !== undefined && {
+      MaximumBatchingWindowInSeconds: input.MaximumBatchingWindowInSeconds
+    }),
+    ...(input.MaximumRecordAgeInSeconds !== undefined && {
+      MaximumRecordAgeInSeconds: input.MaximumRecordAgeInSeconds
+    }),
+    ...(input.MaximumRetryAttempts !== undefined && {
+      MaximumRetryAttempts: input.MaximumRetryAttempts
+    }),
+    ...(input.ParallelizationFactor !== undefined && {
+      ParallelizationFactor: input.ParallelizationFactor
+    }),
+    ...(input.StartingPosition !== undefined && {
+      StartingPosition: input.StartingPosition
+    }),
+    ...(input.StartingPositionTimestamp !== undefined && {
+      StartingPositionTimestamp: Math.round(
+        input.StartingPositionTimestamp.getTime() / 1000
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -522,74 +495,49 @@ export const serializeAws_restJson1_1CreateFunctionCommand = async (
   };
   let resolvedPath = "/2015-03-31/functions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Code !== undefined) {
-    bodyParams["Code"] = serializeAws_restJson1_1FunctionCode(
-      input.Code,
-      context
-    );
-  }
-  if (input.DeadLetterConfig !== undefined) {
-    bodyParams["DeadLetterConfig"] = serializeAws_restJson1_1DeadLetterConfig(
-      input.DeadLetterConfig,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Environment !== undefined) {
-    bodyParams["Environment"] = serializeAws_restJson1_1Environment(
-      input.Environment,
-      context
-    );
-  }
-  if (input.FunctionName !== undefined) {
-    bodyParams["FunctionName"] = input.FunctionName;
-  }
-  if (input.Handler !== undefined) {
-    bodyParams["Handler"] = input.Handler;
-  }
-  if (input.KMSKeyArn !== undefined) {
-    bodyParams["KMSKeyArn"] = input.KMSKeyArn;
-  }
-  if (input.Layers !== undefined) {
-    bodyParams["Layers"] = serializeAws_restJson1_1LayerList(
-      input.Layers,
-      context
-    );
-  }
-  if (input.MemorySize !== undefined) {
-    bodyParams["MemorySize"] = input.MemorySize;
-  }
-  if (input.Publish !== undefined) {
-    bodyParams["Publish"] = input.Publish;
-  }
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  if (input.Runtime !== undefined) {
-    bodyParams["Runtime"] = input.Runtime;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.Timeout !== undefined) {
-    bodyParams["Timeout"] = input.Timeout;
-  }
-  if (input.TracingConfig !== undefined) {
-    bodyParams["TracingConfig"] = serializeAws_restJson1_1TracingConfig(
-      input.TracingConfig,
-      context
-    );
-  }
-  if (input.VpcConfig !== undefined) {
-    bodyParams["VpcConfig"] = serializeAws_restJson1_1VpcConfig(
-      input.VpcConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Code !== undefined && {
+      Code: serializeAws_restJson1_1FunctionCode(input.Code, context)
+    }),
+    ...(input.DeadLetterConfig !== undefined && {
+      DeadLetterConfig: serializeAws_restJson1_1DeadLetterConfig(
+        input.DeadLetterConfig,
+        context
+      )
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Environment !== undefined && {
+      Environment: serializeAws_restJson1_1Environment(
+        input.Environment,
+        context
+      )
+    }),
+    ...(input.FunctionName !== undefined && {
+      FunctionName: input.FunctionName
+    }),
+    ...(input.Handler !== undefined && { Handler: input.Handler }),
+    ...(input.KMSKeyArn !== undefined && { KMSKeyArn: input.KMSKeyArn }),
+    ...(input.Layers !== undefined && {
+      Layers: serializeAws_restJson1_1LayerList(input.Layers, context)
+    }),
+    ...(input.MemorySize !== undefined && { MemorySize: input.MemorySize }),
+    ...(input.Publish !== undefined && { Publish: input.Publish }),
+    ...(input.Role !== undefined && { Role: input.Role }),
+    ...(input.Runtime !== undefined && { Runtime: input.Runtime }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.Timeout !== undefined && { Timeout: input.Timeout }),
+    ...(input.TracingConfig !== undefined && {
+      TracingConfig: serializeAws_restJson1_1TracingConfig(
+        input.TracingConfig,
+        context
+      )
+    }),
+    ...(input.VpcConfig !== undefined && {
+      VpcConfig: serializeAws_restJson1_1VpcConfig(input.VpcConfig, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1779,28 +1727,22 @@ export const serializeAws_restJson1_1PublishLayerVersionCommand = async (
     throw new Error("No value provided for input HTTP label: LayerName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CompatibleRuntimes !== undefined) {
-    bodyParams[
-      "CompatibleRuntimes"
-    ] = serializeAws_restJson1_1CompatibleRuntimes(
-      input.CompatibleRuntimes,
-      context
-    );
-  }
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = serializeAws_restJson1_1LayerVersionContentInput(
-      input.Content,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.LicenseInfo !== undefined) {
-    bodyParams["LicenseInfo"] = input.LicenseInfo;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CompatibleRuntimes !== undefined && {
+      CompatibleRuntimes: serializeAws_restJson1_1CompatibleRuntimes(
+        input.CompatibleRuntimes,
+        context
+      )
+    }),
+    ...(input.Content !== undefined && {
+      Content: serializeAws_restJson1_1LayerVersionContentInput(
+        input.Content,
+        context
+      )
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.LicenseInfo !== undefined && { LicenseInfo: input.LicenseInfo })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1836,17 +1778,11 @@ export const serializeAws_restJson1_1PublishVersionCommand = async (
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CodeSha256 !== undefined) {
-    bodyParams["CodeSha256"] = input.CodeSha256;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.RevisionId !== undefined) {
-    bodyParams["RevisionId"] = input.RevisionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CodeSha256 !== undefined && { CodeSha256: input.CodeSha256 }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.RevisionId !== undefined && { RevisionId: input.RevisionId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1882,12 +1818,11 @@ export const serializeAws_restJson1_1PutFunctionConcurrencyCommand = async (
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ReservedConcurrentExecutions !== undefined) {
-    bodyParams["ReservedConcurrentExecutions"] =
-      input.ReservedConcurrentExecutions;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ReservedConcurrentExecutions !== undefined && {
+      ReservedConcurrentExecutions: input.ReservedConcurrentExecutions
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1926,20 +1861,20 @@ export const serializeAws_restJson1_1PutFunctionEventInvokeConfigCommand = async
     ...(input.Qualifier !== undefined && { Qualifier: input.Qualifier })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.DestinationConfig !== undefined) {
-    bodyParams["DestinationConfig"] = serializeAws_restJson1_1DestinationConfig(
-      input.DestinationConfig,
-      context
-    );
-  }
-  if (input.MaximumEventAgeInSeconds !== undefined) {
-    bodyParams["MaximumEventAgeInSeconds"] = input.MaximumEventAgeInSeconds;
-  }
-  if (input.MaximumRetryAttempts !== undefined) {
-    bodyParams["MaximumRetryAttempts"] = input.MaximumRetryAttempts;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DestinationConfig !== undefined && {
+      DestinationConfig: serializeAws_restJson1_1DestinationConfig(
+        input.DestinationConfig,
+        context
+      )
+    }),
+    ...(input.MaximumEventAgeInSeconds !== undefined && {
+      MaximumEventAgeInSeconds: input.MaximumEventAgeInSeconds
+    }),
+    ...(input.MaximumRetryAttempts !== undefined && {
+      MaximumRetryAttempts: input.MaximumRetryAttempts
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1980,12 +1915,11 @@ export const serializeAws_restJson1_1PutProvisionedConcurrencyConfigCommand = as
     ...(input.Qualifier !== undefined && { Qualifier: input.Qualifier })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.ProvisionedConcurrentExecutions !== undefined) {
-    bodyParams["ProvisionedConcurrentExecutions"] =
-      input.ProvisionedConcurrentExecutions;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ProvisionedConcurrentExecutions !== undefined && {
+      ProvisionedConcurrentExecutions: input.ProvisionedConcurrentExecutions
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2141,11 +2075,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: Resource.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2232,25 +2166,19 @@ export const serializeAws_restJson1_1UpdateAliasCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.FunctionVersion !== undefined) {
-    bodyParams["FunctionVersion"] = input.FunctionVersion;
-  }
-  if (input.RevisionId !== undefined) {
-    bodyParams["RevisionId"] = input.RevisionId;
-  }
-  if (input.RoutingConfig !== undefined) {
-    bodyParams[
-      "RoutingConfig"
-    ] = serializeAws_restJson1_1AliasRoutingConfiguration(
-      input.RoutingConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.FunctionVersion !== undefined && {
+      FunctionVersion: input.FunctionVersion
+    }),
+    ...(input.RevisionId !== undefined && { RevisionId: input.RevisionId }),
+    ...(input.RoutingConfig !== undefined && {
+      RoutingConfig: serializeAws_restJson1_1AliasRoutingConfiguration(
+        input.RoutingConfig,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2284,39 +2212,34 @@ export const serializeAws_restJson1_1UpdateEventSourceMappingCommand = async (
     throw new Error("No value provided for input HTTP label: UUID.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BatchSize !== undefined) {
-    bodyParams["BatchSize"] = input.BatchSize;
-  }
-  if (input.BisectBatchOnFunctionError !== undefined) {
-    bodyParams["BisectBatchOnFunctionError"] = input.BisectBatchOnFunctionError;
-  }
-  if (input.DestinationConfig !== undefined) {
-    bodyParams["DestinationConfig"] = serializeAws_restJson1_1DestinationConfig(
-      input.DestinationConfig,
-      context
-    );
-  }
-  if (input.Enabled !== undefined) {
-    bodyParams["Enabled"] = input.Enabled;
-  }
-  if (input.FunctionName !== undefined) {
-    bodyParams["FunctionName"] = input.FunctionName;
-  }
-  if (input.MaximumBatchingWindowInSeconds !== undefined) {
-    bodyParams["MaximumBatchingWindowInSeconds"] =
-      input.MaximumBatchingWindowInSeconds;
-  }
-  if (input.MaximumRecordAgeInSeconds !== undefined) {
-    bodyParams["MaximumRecordAgeInSeconds"] = input.MaximumRecordAgeInSeconds;
-  }
-  if (input.MaximumRetryAttempts !== undefined) {
-    bodyParams["MaximumRetryAttempts"] = input.MaximumRetryAttempts;
-  }
-  if (input.ParallelizationFactor !== undefined) {
-    bodyParams["ParallelizationFactor"] = input.ParallelizationFactor;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BatchSize !== undefined && { BatchSize: input.BatchSize }),
+    ...(input.BisectBatchOnFunctionError !== undefined && {
+      BisectBatchOnFunctionError: input.BisectBatchOnFunctionError
+    }),
+    ...(input.DestinationConfig !== undefined && {
+      DestinationConfig: serializeAws_restJson1_1DestinationConfig(
+        input.DestinationConfig,
+        context
+      )
+    }),
+    ...(input.Enabled !== undefined && { Enabled: input.Enabled }),
+    ...(input.FunctionName !== undefined && {
+      FunctionName: input.FunctionName
+    }),
+    ...(input.MaximumBatchingWindowInSeconds !== undefined && {
+      MaximumBatchingWindowInSeconds: input.MaximumBatchingWindowInSeconds
+    }),
+    ...(input.MaximumRecordAgeInSeconds !== undefined && {
+      MaximumRecordAgeInSeconds: input.MaximumRecordAgeInSeconds
+    }),
+    ...(input.MaximumRetryAttempts !== undefined && {
+      MaximumRetryAttempts: input.MaximumRetryAttempts
+    }),
+    ...(input.ParallelizationFactor !== undefined && {
+      ParallelizationFactor: input.ParallelizationFactor
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2352,29 +2275,19 @@ export const serializeAws_restJson1_1UpdateFunctionCodeCommand = async (
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DryRun !== undefined) {
-    bodyParams["DryRun"] = input.DryRun;
-  }
-  if (input.Publish !== undefined) {
-    bodyParams["Publish"] = input.Publish;
-  }
-  if (input.RevisionId !== undefined) {
-    bodyParams["RevisionId"] = input.RevisionId;
-  }
-  if (input.S3Bucket !== undefined) {
-    bodyParams["S3Bucket"] = input.S3Bucket;
-  }
-  if (input.S3Key !== undefined) {
-    bodyParams["S3Key"] = input.S3Key;
-  }
-  if (input.S3ObjectVersion !== undefined) {
-    bodyParams["S3ObjectVersion"] = input.S3ObjectVersion;
-  }
-  if (input.ZipFile !== undefined) {
-    bodyParams["ZipFile"] = context.base64Encoder(input.ZipFile);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DryRun !== undefined && { DryRun: input.DryRun }),
+    ...(input.Publish !== undefined && { Publish: input.Publish }),
+    ...(input.RevisionId !== undefined && { RevisionId: input.RevisionId }),
+    ...(input.S3Bucket !== undefined && { S3Bucket: input.S3Bucket }),
+    ...(input.S3Key !== undefined && { S3Key: input.S3Key }),
+    ...(input.S3ObjectVersion !== undefined && {
+      S3ObjectVersion: input.S3ObjectVersion
+    }),
+    ...(input.ZipFile !== undefined && {
+      ZipFile: context.base64Encoder(input.ZipFile)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2410,62 +2323,40 @@ export const serializeAws_restJson1_1UpdateFunctionConfigurationCommand = async 
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeadLetterConfig !== undefined) {
-    bodyParams["DeadLetterConfig"] = serializeAws_restJson1_1DeadLetterConfig(
-      input.DeadLetterConfig,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Environment !== undefined) {
-    bodyParams["Environment"] = serializeAws_restJson1_1Environment(
-      input.Environment,
-      context
-    );
-  }
-  if (input.Handler !== undefined) {
-    bodyParams["Handler"] = input.Handler;
-  }
-  if (input.KMSKeyArn !== undefined) {
-    bodyParams["KMSKeyArn"] = input.KMSKeyArn;
-  }
-  if (input.Layers !== undefined) {
-    bodyParams["Layers"] = serializeAws_restJson1_1LayerList(
-      input.Layers,
-      context
-    );
-  }
-  if (input.MemorySize !== undefined) {
-    bodyParams["MemorySize"] = input.MemorySize;
-  }
-  if (input.RevisionId !== undefined) {
-    bodyParams["RevisionId"] = input.RevisionId;
-  }
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  if (input.Runtime !== undefined) {
-    bodyParams["Runtime"] = input.Runtime;
-  }
-  if (input.Timeout !== undefined) {
-    bodyParams["Timeout"] = input.Timeout;
-  }
-  if (input.TracingConfig !== undefined) {
-    bodyParams["TracingConfig"] = serializeAws_restJson1_1TracingConfig(
-      input.TracingConfig,
-      context
-    );
-  }
-  if (input.VpcConfig !== undefined) {
-    bodyParams["VpcConfig"] = serializeAws_restJson1_1VpcConfig(
-      input.VpcConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeadLetterConfig !== undefined && {
+      DeadLetterConfig: serializeAws_restJson1_1DeadLetterConfig(
+        input.DeadLetterConfig,
+        context
+      )
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Environment !== undefined && {
+      Environment: serializeAws_restJson1_1Environment(
+        input.Environment,
+        context
+      )
+    }),
+    ...(input.Handler !== undefined && { Handler: input.Handler }),
+    ...(input.KMSKeyArn !== undefined && { KMSKeyArn: input.KMSKeyArn }),
+    ...(input.Layers !== undefined && {
+      Layers: serializeAws_restJson1_1LayerList(input.Layers, context)
+    }),
+    ...(input.MemorySize !== undefined && { MemorySize: input.MemorySize }),
+    ...(input.RevisionId !== undefined && { RevisionId: input.RevisionId }),
+    ...(input.Role !== undefined && { Role: input.Role }),
+    ...(input.Runtime !== undefined && { Runtime: input.Runtime }),
+    ...(input.Timeout !== undefined && { Timeout: input.Timeout }),
+    ...(input.TracingConfig !== undefined && {
+      TracingConfig: serializeAws_restJson1_1TracingConfig(
+        input.TracingConfig,
+        context
+      )
+    }),
+    ...(input.VpcConfig !== undefined && {
+      VpcConfig: serializeAws_restJson1_1VpcConfig(input.VpcConfig, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2504,20 +2395,20 @@ export const serializeAws_restJson1_1UpdateFunctionEventInvokeConfigCommand = as
     ...(input.Qualifier !== undefined && { Qualifier: input.Qualifier })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.DestinationConfig !== undefined) {
-    bodyParams["DestinationConfig"] = serializeAws_restJson1_1DestinationConfig(
-      input.DestinationConfig,
-      context
-    );
-  }
-  if (input.MaximumEventAgeInSeconds !== undefined) {
-    bodyParams["MaximumEventAgeInSeconds"] = input.MaximumEventAgeInSeconds;
-  }
-  if (input.MaximumRetryAttempts !== undefined) {
-    bodyParams["MaximumRetryAttempts"] = input.MaximumRetryAttempts;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DestinationConfig !== undefined && {
+      DestinationConfig: serializeAws_restJson1_1DestinationConfig(
+        input.DestinationConfig,
+        context
+      )
+    }),
+    ...(input.MaximumEventAgeInSeconds !== undefined && {
+      MaximumEventAgeInSeconds: input.MaximumEventAgeInSeconds
+    }),
+    ...(input.MaximumRetryAttempts !== undefined && {
+      MaximumRetryAttempts: input.MaximumRetryAttempts
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
@@ -212,11 +212,9 @@ export const serializeAws_restJson1_1CreateBotVersionCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.checksum !== undefined) {
-    bodyParams["checksum"] = input.checksum;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.checksum !== undefined && { checksum: input.checksum })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -250,11 +248,9 @@ export const serializeAws_restJson1_1CreateIntentVersionCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.checksum !== undefined) {
-    bodyParams["checksum"] = input.checksum;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.checksum !== undefined && { checksum: input.checksum })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -288,11 +284,9 @@ export const serializeAws_restJson1_1CreateSlotTypeVersionCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.checksum !== undefined) {
-    bodyParams["checksum"] = input.checksum;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.checksum !== undefined && { checksum: input.checksum })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1458,53 +1452,42 @@ export const serializeAws_restJson1_1PutBotCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.abortStatement !== undefined) {
-    bodyParams["abortStatement"] = serializeAws_restJson1_1Statement(
-      input.abortStatement,
-      context
-    );
-  }
-  if (input.checksum !== undefined) {
-    bodyParams["checksum"] = input.checksum;
-  }
-  if (input.childDirected !== undefined) {
-    bodyParams["childDirected"] = input.childDirected;
-  }
-  if (input.clarificationPrompt !== undefined) {
-    bodyParams["clarificationPrompt"] = serializeAws_restJson1_1Prompt(
-      input.clarificationPrompt,
-      context
-    );
-  }
-  if (input.createVersion !== undefined) {
-    bodyParams["createVersion"] = input.createVersion;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.detectSentiment !== undefined) {
-    bodyParams["detectSentiment"] = input.detectSentiment;
-  }
-  if (input.idleSessionTTLInSeconds !== undefined) {
-    bodyParams["idleSessionTTLInSeconds"] = input.idleSessionTTLInSeconds;
-  }
-  if (input.intents !== undefined) {
-    bodyParams["intents"] = serializeAws_restJson1_1IntentList(
-      input.intents,
-      context
-    );
-  }
-  if (input.locale !== undefined) {
-    bodyParams["locale"] = input.locale;
-  }
-  if (input.processBehavior !== undefined) {
-    bodyParams["processBehavior"] = input.processBehavior;
-  }
-  if (input.voiceId !== undefined) {
-    bodyParams["voiceId"] = input.voiceId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.abortStatement !== undefined && {
+      abortStatement: serializeAws_restJson1_1Statement(
+        input.abortStatement,
+        context
+      )
+    }),
+    ...(input.checksum !== undefined && { checksum: input.checksum }),
+    ...(input.childDirected !== undefined && {
+      childDirected: input.childDirected
+    }),
+    ...(input.clarificationPrompt !== undefined && {
+      clarificationPrompt: serializeAws_restJson1_1Prompt(
+        input.clarificationPrompt,
+        context
+      )
+    }),
+    ...(input.createVersion !== undefined && {
+      createVersion: input.createVersion
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.detectSentiment !== undefined && {
+      detectSentiment: input.detectSentiment
+    }),
+    ...(input.idleSessionTTLInSeconds !== undefined && {
+      idleSessionTTLInSeconds: input.idleSessionTTLInSeconds
+    }),
+    ...(input.intents !== undefined && {
+      intents: serializeAws_restJson1_1IntentList(input.intents, context)
+    }),
+    ...(input.locale !== undefined && { locale: input.locale }),
+    ...(input.processBehavior !== undefined && {
+      processBehavior: input.processBehavior
+    }),
+    ...(input.voiceId !== undefined && { voiceId: input.voiceId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1550,25 +1533,17 @@ export const serializeAws_restJson1_1PutBotAliasCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.botVersion !== undefined) {
-    bodyParams["botVersion"] = input.botVersion;
-  }
-  if (input.checksum !== undefined) {
-    bodyParams["checksum"] = input.checksum;
-  }
-  if (input.conversationLogs !== undefined) {
-    bodyParams[
-      "conversationLogs"
-    ] = serializeAws_restJson1_1ConversationLogsRequest(
-      input.conversationLogs,
-      context
-    );
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.botVersion !== undefined && { botVersion: input.botVersion }),
+    ...(input.checksum !== undefined && { checksum: input.checksum }),
+    ...(input.conversationLogs !== undefined && {
+      conversationLogs: serializeAws_restJson1_1ConversationLogsRequest(
+        input.conversationLogs,
+        context
+      )
+    }),
+    ...(input.description !== undefined && { description: input.description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1602,72 +1577,61 @@ export const serializeAws_restJson1_1PutIntentCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.checksum !== undefined) {
-    bodyParams["checksum"] = input.checksum;
-  }
-  if (input.conclusionStatement !== undefined) {
-    bodyParams["conclusionStatement"] = serializeAws_restJson1_1Statement(
-      input.conclusionStatement,
-      context
-    );
-  }
-  if (input.confirmationPrompt !== undefined) {
-    bodyParams["confirmationPrompt"] = serializeAws_restJson1_1Prompt(
-      input.confirmationPrompt,
-      context
-    );
-  }
-  if (input.createVersion !== undefined) {
-    bodyParams["createVersion"] = input.createVersion;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.dialogCodeHook !== undefined) {
-    bodyParams["dialogCodeHook"] = serializeAws_restJson1_1CodeHook(
-      input.dialogCodeHook,
-      context
-    );
-  }
-  if (input.followUpPrompt !== undefined) {
-    bodyParams["followUpPrompt"] = serializeAws_restJson1_1FollowUpPrompt(
-      input.followUpPrompt,
-      context
-    );
-  }
-  if (input.fulfillmentActivity !== undefined) {
-    bodyParams[
-      "fulfillmentActivity"
-    ] = serializeAws_restJson1_1FulfillmentActivity(
-      input.fulfillmentActivity,
-      context
-    );
-  }
-  if (input.parentIntentSignature !== undefined) {
-    bodyParams["parentIntentSignature"] = input.parentIntentSignature;
-  }
-  if (input.rejectionStatement !== undefined) {
-    bodyParams["rejectionStatement"] = serializeAws_restJson1_1Statement(
-      input.rejectionStatement,
-      context
-    );
-  }
-  if (input.sampleUtterances !== undefined) {
-    bodyParams[
-      "sampleUtterances"
-    ] = serializeAws_restJson1_1IntentUtteranceList(
-      input.sampleUtterances,
-      context
-    );
-  }
-  if (input.slots !== undefined) {
-    bodyParams["slots"] = serializeAws_restJson1_1SlotList(
-      input.slots,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.checksum !== undefined && { checksum: input.checksum }),
+    ...(input.conclusionStatement !== undefined && {
+      conclusionStatement: serializeAws_restJson1_1Statement(
+        input.conclusionStatement,
+        context
+      )
+    }),
+    ...(input.confirmationPrompt !== undefined && {
+      confirmationPrompt: serializeAws_restJson1_1Prompt(
+        input.confirmationPrompt,
+        context
+      )
+    }),
+    ...(input.createVersion !== undefined && {
+      createVersion: input.createVersion
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.dialogCodeHook !== undefined && {
+      dialogCodeHook: serializeAws_restJson1_1CodeHook(
+        input.dialogCodeHook,
+        context
+      )
+    }),
+    ...(input.followUpPrompt !== undefined && {
+      followUpPrompt: serializeAws_restJson1_1FollowUpPrompt(
+        input.followUpPrompt,
+        context
+      )
+    }),
+    ...(input.fulfillmentActivity !== undefined && {
+      fulfillmentActivity: serializeAws_restJson1_1FulfillmentActivity(
+        input.fulfillmentActivity,
+        context
+      )
+    }),
+    ...(input.parentIntentSignature !== undefined && {
+      parentIntentSignature: input.parentIntentSignature
+    }),
+    ...(input.rejectionStatement !== undefined && {
+      rejectionStatement: serializeAws_restJson1_1Statement(
+        input.rejectionStatement,
+        context
+      )
+    }),
+    ...(input.sampleUtterances !== undefined && {
+      sampleUtterances: serializeAws_restJson1_1IntentUtteranceList(
+        input.sampleUtterances,
+        context
+      )
+    }),
+    ...(input.slots !== undefined && {
+      slots: serializeAws_restJson1_1SlotList(input.slots, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1701,26 +1665,22 @@ export const serializeAws_restJson1_1PutSlotTypeCommand = async (
     throw new Error("No value provided for input HTTP label: name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.checksum !== undefined) {
-    bodyParams["checksum"] = input.checksum;
-  }
-  if (input.createVersion !== undefined) {
-    bodyParams["createVersion"] = input.createVersion;
-  }
-  if (input.description !== undefined) {
-    bodyParams["description"] = input.description;
-  }
-  if (input.enumerationValues !== undefined) {
-    bodyParams["enumerationValues"] = serializeAws_restJson1_1EnumerationValues(
-      input.enumerationValues,
-      context
-    );
-  }
-  if (input.valueSelectionStrategy !== undefined) {
-    bodyParams["valueSelectionStrategy"] = input.valueSelectionStrategy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.checksum !== undefined && { checksum: input.checksum }),
+    ...(input.createVersion !== undefined && {
+      createVersion: input.createVersion
+    }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.enumerationValues !== undefined && {
+      enumerationValues: serializeAws_restJson1_1EnumerationValues(
+        input.enumerationValues,
+        context
+      )
+    }),
+    ...(input.valueSelectionStrategy !== undefined && {
+      valueSelectionStrategy: input.valueSelectionStrategy
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1742,17 +1702,17 @@ export const serializeAws_restJson1_1StartImportCommand = async (
   };
   let resolvedPath = "/imports";
   let body: any;
-  const bodyParams: any = {};
-  if (input.mergeStrategy !== undefined) {
-    bodyParams["mergeStrategy"] = input.mergeStrategy;
-  }
-  if (input.payload !== undefined) {
-    bodyParams["payload"] = context.base64Encoder(input.payload);
-  }
-  if (input.resourceType !== undefined) {
-    bodyParams["resourceType"] = input.resourceType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.mergeStrategy !== undefined && {
+      mergeStrategy: input.mergeStrategy
+    }),
+    ...(input.payload !== undefined && {
+      payload: context.base64Encoder(input.payload)
+    }),
+    ...(input.resourceType !== undefined && {
+      resourceType: input.resourceType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
@@ -293,23 +293,21 @@ export const serializeAws_restJson1_1PostTextCommand = async (
     throw new Error("No value provided for input HTTP label: userId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.inputText !== undefined) {
-    bodyParams["inputText"] = input.inputText;
-  }
-  if (input.requestAttributes !== undefined) {
-    bodyParams["requestAttributes"] = serializeAws_restJson1_1StringMap(
-      input.requestAttributes,
-      context
-    );
-  }
-  if (input.sessionAttributes !== undefined) {
-    bodyParams["sessionAttributes"] = serializeAws_restJson1_1StringMap(
-      input.sessionAttributes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.inputText !== undefined && { inputText: input.inputText }),
+    ...(input.requestAttributes !== undefined && {
+      requestAttributes: serializeAws_restJson1_1StringMap(
+        input.requestAttributes,
+        context
+      )
+    }),
+    ...(input.sessionAttributes !== undefined && {
+      sessionAttributes: serializeAws_restJson1_1StringMap(
+        input.sessionAttributes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -368,28 +366,26 @@ export const serializeAws_restJson1_1PutSessionCommand = async (
     throw new Error("No value provided for input HTTP label: userId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.dialogAction !== undefined) {
-    bodyParams["dialogAction"] = serializeAws_restJson1_1DialogAction(
-      input.dialogAction,
-      context
-    );
-  }
-  if (input.recentIntentSummaryView !== undefined) {
-    bodyParams[
-      "recentIntentSummaryView"
-    ] = serializeAws_restJson1_1IntentSummaryList(
-      input.recentIntentSummaryView,
-      context
-    );
-  }
-  if (input.sessionAttributes !== undefined) {
-    bodyParams["sessionAttributes"] = serializeAws_restJson1_1StringMap(
-      input.sessionAttributes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.dialogAction !== undefined && {
+      dialogAction: serializeAws_restJson1_1DialogAction(
+        input.dialogAction,
+        context
+      )
+    }),
+    ...(input.recentIntentSummaryView !== undefined && {
+      recentIntentSummaryView: serializeAws_restJson1_1IntentSummaryList(
+        input.recentIntentSummaryView,
+        context
+      )
+    }),
+    ...(input.sessionAttributes !== undefined && {
+      sessionAttributes: serializeAws_restJson1_1StringMap(
+        input.sessionAttributes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
@@ -145,25 +145,18 @@ export const serializeAws_restJson1_1CreateMemberCommand = async (
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.InvitationId !== undefined) {
-    bodyParams["InvitationId"] = input.InvitationId;
-  }
-  if (input.MemberConfiguration !== undefined) {
-    bodyParams[
-      "MemberConfiguration"
-    ] = serializeAws_restJson1_1MemberConfiguration(
-      input.MemberConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.InvitationId !== undefined && {
+      InvitationId: input.InvitationId
+    }),
+    ...(input.MemberConfiguration !== undefined && {
+      MemberConfiguration: serializeAws_restJson1_1MemberConfiguration(
+        input.MemberConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -185,48 +178,33 @@ export const serializeAws_restJson1_1CreateNetworkCommand = async (
   };
   let resolvedPath = "/networks";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Framework !== undefined) {
-    bodyParams["Framework"] = input.Framework;
-  }
-  if (input.FrameworkConfiguration !== undefined) {
-    bodyParams[
-      "FrameworkConfiguration"
-    ] = serializeAws_restJson1_1NetworkFrameworkConfiguration(
-      input.FrameworkConfiguration,
-      context
-    );
-  }
-  if (input.FrameworkVersion !== undefined) {
-    bodyParams["FrameworkVersion"] = input.FrameworkVersion;
-  }
-  if (input.MemberConfiguration !== undefined) {
-    bodyParams[
-      "MemberConfiguration"
-    ] = serializeAws_restJson1_1MemberConfiguration(
-      input.MemberConfiguration,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.VotingPolicy !== undefined) {
-    bodyParams["VotingPolicy"] = serializeAws_restJson1_1VotingPolicy(
-      input.VotingPolicy,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Framework !== undefined && { Framework: input.Framework }),
+    ...(input.FrameworkConfiguration !== undefined && {
+      FrameworkConfiguration: serializeAws_restJson1_1NetworkFrameworkConfiguration(
+        input.FrameworkConfiguration,
+        context
+      )
+    }),
+    ...(input.FrameworkVersion !== undefined && {
+      FrameworkVersion: input.FrameworkVersion
+    }),
+    ...(input.MemberConfiguration !== undefined && {
+      MemberConfiguration: serializeAws_restJson1_1MemberConfiguration(
+        input.MemberConfiguration,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.VotingPolicy !== undefined && {
+      VotingPolicy: serializeAws_restJson1_1VotingPolicy(
+        input.VotingPolicy,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -272,20 +250,15 @@ export const serializeAws_restJson1_1CreateNodeCommand = async (
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.NodeConfiguration !== undefined) {
-    bodyParams["NodeConfiguration"] = serializeAws_restJson1_1NodeConfiguration(
-      input.NodeConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.NodeConfiguration !== undefined && {
+      NodeConfiguration: serializeAws_restJson1_1NodeConfiguration(
+        input.NodeConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -319,26 +292,14 @@ export const serializeAws_restJson1_1CreateProposalCommand = async (
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Actions !== undefined) {
-    bodyParams["Actions"] = serializeAws_restJson1_1ProposalActions(
-      input.Actions,
-      context
-    );
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.MemberId !== undefined) {
-    bodyParams["MemberId"] = input.MemberId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Actions !== undefined && {
+      Actions: serializeAws_restJson1_1ProposalActions(input.Actions, context)
+    }),
+    ClientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.MemberId !== undefined && { MemberId: input.MemberId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -948,14 +909,12 @@ export const serializeAws_restJson1_1VoteOnProposalCommand = async (
     throw new Error("No value provided for input HTTP label: ProposalId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Vote !== undefined) {
-    bodyParams["Vote"] = input.Vote;
-  }
-  if (input.VoterMemberId !== undefined) {
-    bodyParams["VoterMemberId"] = input.VoterMemberId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Vote !== undefined && { Vote: input.Vote }),
+    ...(input.VoterMemberId !== undefined && {
+      VoterMemberId: input.VoterMemberId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
@@ -142,26 +142,17 @@ export const serializeAws_restJson1_1ListChangeSetsCommand = async (
   };
   let resolvedPath = "/ListChangeSets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Catalog !== undefined) {
-    bodyParams["Catalog"] = input.Catalog;
-  }
-  if (input.FilterList !== undefined) {
-    bodyParams["FilterList"] = serializeAws_restJson1_1FilterList(
-      input.FilterList,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.Sort !== undefined) {
-    bodyParams["Sort"] = serializeAws_restJson1_1Sort(input.Sort, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Catalog !== undefined && { Catalog: input.Catalog }),
+    ...(input.FilterList !== undefined && {
+      FilterList: serializeAws_restJson1_1FilterList(input.FilterList, context)
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.Sort !== undefined && {
+      Sort: serializeAws_restJson1_1Sort(input.Sort, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -183,29 +174,18 @@ export const serializeAws_restJson1_1ListEntitiesCommand = async (
   };
   let resolvedPath = "/ListEntities";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Catalog !== undefined) {
-    bodyParams["Catalog"] = input.Catalog;
-  }
-  if (input.EntityType !== undefined) {
-    bodyParams["EntityType"] = input.EntityType;
-  }
-  if (input.FilterList !== undefined) {
-    bodyParams["FilterList"] = serializeAws_restJson1_1FilterList(
-      input.FilterList,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.Sort !== undefined) {
-    bodyParams["Sort"] = serializeAws_restJson1_1Sort(input.Sort, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Catalog !== undefined && { Catalog: input.Catalog }),
+    ...(input.EntityType !== undefined && { EntityType: input.EntityType }),
+    ...(input.FilterList !== undefined && {
+      FilterList: serializeAws_restJson1_1FilterList(input.FilterList, context)
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.Sort !== undefined && {
+      Sort: serializeAws_restJson1_1Sort(input.Sort, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -227,23 +207,21 @@ export const serializeAws_restJson1_1StartChangeSetCommand = async (
   };
   let resolvedPath = "/StartChangeSet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Catalog !== undefined) {
-    bodyParams["Catalog"] = input.Catalog;
-  }
-  if (input.ChangeSet !== undefined) {
-    bodyParams["ChangeSet"] = serializeAws_restJson1_1RequestedChangeList(
-      input.ChangeSet,
-      context
-    );
-  }
-  if (input.ChangeSetName !== undefined) {
-    bodyParams["ChangeSetName"] = input.ChangeSetName;
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["ClientRequestToken"] = input.ClientRequestToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Catalog !== undefined && { Catalog: input.Catalog }),
+    ...(input.ChangeSet !== undefined && {
+      ChangeSet: serializeAws_restJson1_1RequestedChangeList(
+        input.ChangeSet,
+        context
+      )
+    }),
+    ...(input.ChangeSetName !== undefined && {
+      ChangeSetName: input.ChangeSetName
+    }),
+    ...(input.ClientRequestToken !== undefined && {
+      ClientRequestToken: input.ClientRequestToken
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
@@ -126,14 +126,14 @@ export const serializeAws_restJson1_1AddFlowOutputsCommand = async (
     throw new Error("No value provided for input HTTP label: FlowArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Outputs !== undefined) {
-    bodyParams["outputs"] = serializeAws_restJson1_1__listOfAddOutputRequest(
-      input.Outputs,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Outputs !== undefined && {
+      outputs: serializeAws_restJson1_1__listOfAddOutputRequest(
+        input.Outputs,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -155,34 +155,27 @@ export const serializeAws_restJson1_1CreateFlowCommand = async (
   };
   let resolvedPath = "/v1/flows";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AvailabilityZone !== undefined) {
-    bodyParams["availabilityZone"] = input.AvailabilityZone;
-  }
-  if (input.Entitlements !== undefined) {
-    bodyParams[
-      "entitlements"
-    ] = serializeAws_restJson1_1__listOfGrantEntitlementRequest(
-      input.Entitlements,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Outputs !== undefined) {
-    bodyParams["outputs"] = serializeAws_restJson1_1__listOfAddOutputRequest(
-      input.Outputs,
-      context
-    );
-  }
-  if (input.Source !== undefined) {
-    bodyParams["source"] = serializeAws_restJson1_1SetSourceRequest(
-      input.Source,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AvailabilityZone !== undefined && {
+      availabilityZone: input.AvailabilityZone
+    }),
+    ...(input.Entitlements !== undefined && {
+      entitlements: serializeAws_restJson1_1__listOfGrantEntitlementRequest(
+        input.Entitlements,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Outputs !== undefined && {
+      outputs: serializeAws_restJson1_1__listOfAddOutputRequest(
+        input.Outputs,
+        context
+      )
+    }),
+    ...(input.Source !== undefined && {
+      source: serializeAws_restJson1_1SetSourceRequest(input.Source, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -282,16 +275,14 @@ export const serializeAws_restJson1_1GrantFlowEntitlementsCommand = async (
     throw new Error("No value provided for input HTTP label: FlowArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Entitlements !== undefined) {
-    bodyParams[
-      "entitlements"
-    ] = serializeAws_restJson1_1__listOfGrantEntitlementRequest(
-      input.Entitlements,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Entitlements !== undefined && {
+      entitlements: serializeAws_restJson1_1__listOfGrantEntitlementRequest(
+        input.Entitlements,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -576,14 +567,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -672,23 +660,21 @@ export const serializeAws_restJson1_1UpdateFlowEntitlementCommand = async (
     throw new Error("No value provided for input HTTP label: FlowArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Encryption !== undefined) {
-    bodyParams["encryption"] = serializeAws_restJson1_1UpdateEncryption(
-      input.Encryption,
-      context
-    );
-  }
-  if (input.Subscribers !== undefined) {
-    bodyParams["subscribers"] = serializeAws_restJson1_1__listOf__string(
-      input.Subscribers,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Encryption !== undefined && {
+      encryption: serializeAws_restJson1_1UpdateEncryption(
+        input.Encryption,
+        context
+      )
+    }),
+    ...(input.Subscribers !== undefined && {
+      subscribers: serializeAws_restJson1_1__listOf__string(
+        input.Subscribers,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -734,44 +720,30 @@ export const serializeAws_restJson1_1UpdateFlowOutputCommand = async (
     throw new Error("No value provided for input HTTP label: OutputArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CidrAllowList !== undefined) {
-    bodyParams["cidrAllowList"] = serializeAws_restJson1_1__listOf__string(
-      input.CidrAllowList,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Destination !== undefined) {
-    bodyParams["destination"] = input.Destination;
-  }
-  if (input.Encryption !== undefined) {
-    bodyParams["encryption"] = serializeAws_restJson1_1UpdateEncryption(
-      input.Encryption,
-      context
-    );
-  }
-  if (input.MaxLatency !== undefined) {
-    bodyParams["maxLatency"] = input.MaxLatency;
-  }
-  if (input.Port !== undefined) {
-    bodyParams["port"] = input.Port;
-  }
-  if (input.Protocol !== undefined) {
-    bodyParams["protocol"] = input.Protocol;
-  }
-  if (input.RemoteId !== undefined) {
-    bodyParams["remoteId"] = input.RemoteId;
-  }
-  if (input.SmoothingLatency !== undefined) {
-    bodyParams["smoothingLatency"] = input.SmoothingLatency;
-  }
-  if (input.StreamId !== undefined) {
-    bodyParams["streamId"] = input.StreamId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CidrAllowList !== undefined && {
+      cidrAllowList: serializeAws_restJson1_1__listOf__string(
+        input.CidrAllowList,
+        context
+      )
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Destination !== undefined && { destination: input.Destination }),
+    ...(input.Encryption !== undefined && {
+      encryption: serializeAws_restJson1_1UpdateEncryption(
+        input.Encryption,
+        context
+      )
+    }),
+    ...(input.MaxLatency !== undefined && { maxLatency: input.MaxLatency }),
+    ...(input.Port !== undefined && { port: input.Port }),
+    ...(input.Protocol !== undefined && { protocol: input.Protocol }),
+    ...(input.RemoteId !== undefined && { remoteId: input.RemoteId }),
+    ...(input.SmoothingLatency !== undefined && {
+      smoothingLatency: input.SmoothingLatency
+    }),
+    ...(input.StreamId !== undefined && { streamId: input.StreamId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -817,38 +789,26 @@ export const serializeAws_restJson1_1UpdateFlowSourceCommand = async (
     throw new Error("No value provided for input HTTP label: SourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Decryption !== undefined) {
-    bodyParams["decryption"] = serializeAws_restJson1_1UpdateEncryption(
-      input.Decryption,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.EntitlementArn !== undefined) {
-    bodyParams["entitlementArn"] = input.EntitlementArn;
-  }
-  if (input.IngestPort !== undefined) {
-    bodyParams["ingestPort"] = input.IngestPort;
-  }
-  if (input.MaxBitrate !== undefined) {
-    bodyParams["maxBitrate"] = input.MaxBitrate;
-  }
-  if (input.MaxLatency !== undefined) {
-    bodyParams["maxLatency"] = input.MaxLatency;
-  }
-  if (input.Protocol !== undefined) {
-    bodyParams["protocol"] = input.Protocol;
-  }
-  if (input.StreamId !== undefined) {
-    bodyParams["streamId"] = input.StreamId;
-  }
-  if (input.WhitelistCidr !== undefined) {
-    bodyParams["whitelistCidr"] = input.WhitelistCidr;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Decryption !== undefined && {
+      decryption: serializeAws_restJson1_1UpdateEncryption(
+        input.Decryption,
+        context
+      )
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.EntitlementArn !== undefined && {
+      entitlementArn: input.EntitlementArn
+    }),
+    ...(input.IngestPort !== undefined && { ingestPort: input.IngestPort }),
+    ...(input.MaxBitrate !== undefined && { maxBitrate: input.MaxBitrate }),
+    ...(input.MaxLatency !== undefined && { maxLatency: input.MaxLatency }),
+    ...(input.Protocol !== undefined && { protocol: input.Protocol }),
+    ...(input.StreamId !== undefined && { streamId: input.StreamId }),
+    ...(input.WhitelistCidr !== undefined && {
+      whitelistCidr: input.WhitelistCidr
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
@@ -261,11 +261,9 @@ export const serializeAws_restJson1_1AssociateCertificateCommand = async (
   };
   let resolvedPath = "/2017-08-29/certificates";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["arn"] = input.Arn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { arn: input.Arn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -320,61 +318,40 @@ export const serializeAws_restJson1_1CreateJobCommand = async (
   };
   let resolvedPath = "/2017-08-29/jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccelerationSettings !== undefined) {
-    bodyParams[
-      "accelerationSettings"
-    ] = serializeAws_restJson1_1AccelerationSettings(
-      input.AccelerationSettings,
-      context
-    );
-  }
-  if (input.BillingTagsSource !== undefined) {
-    bodyParams["billingTagsSource"] = input.BillingTagsSource;
-  }
-  if (input.ClientRequestToken === undefined) {
-    input.ClientRequestToken = generateIdempotencyToken();
-  }
-  if (input.ClientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.ClientRequestToken;
-  }
-  if (input.JobTemplate !== undefined) {
-    bodyParams["jobTemplate"] = input.JobTemplate;
-  }
-  if (input.Priority !== undefined) {
-    bodyParams["priority"] = input.Priority;
-  }
-  if (input.Queue !== undefined) {
-    bodyParams["queue"] = input.Queue;
-  }
-  if (input.Role !== undefined) {
-    bodyParams["role"] = input.Role;
-  }
-  if (input.Settings !== undefined) {
-    bodyParams["settings"] = serializeAws_restJson1_1JobSettings(
-      input.Settings,
-      context
-    );
-  }
-  if (input.SimulateReservedQueue !== undefined) {
-    bodyParams["simulateReservedQueue"] = input.SimulateReservedQueue;
-  }
-  if (input.StatusUpdateInterval !== undefined) {
-    bodyParams["statusUpdateInterval"] = input.StatusUpdateInterval;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  if (input.UserMetadata !== undefined) {
-    bodyParams["userMetadata"] = serializeAws_restJson1_1__mapOf__string(
-      input.UserMetadata,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccelerationSettings !== undefined && {
+      accelerationSettings: serializeAws_restJson1_1AccelerationSettings(
+        input.AccelerationSettings,
+        context
+      )
+    }),
+    ...(input.BillingTagsSource !== undefined && {
+      billingTagsSource: input.BillingTagsSource
+    }),
+    clientRequestToken: input.ClientRequestToken ?? generateIdempotencyToken(),
+    ...(input.JobTemplate !== undefined && { jobTemplate: input.JobTemplate }),
+    ...(input.Priority !== undefined && { priority: input.Priority }),
+    ...(input.Queue !== undefined && { queue: input.Queue }),
+    ...(input.Role !== undefined && { role: input.Role }),
+    ...(input.Settings !== undefined && {
+      settings: serializeAws_restJson1_1JobSettings(input.Settings, context)
+    }),
+    ...(input.SimulateReservedQueue !== undefined && {
+      simulateReservedQueue: input.SimulateReservedQueue
+    }),
+    ...(input.StatusUpdateInterval !== undefined && {
+      statusUpdateInterval: input.StatusUpdateInterval
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    }),
+    ...(input.UserMetadata !== undefined && {
+      userMetadata: serializeAws_restJson1_1__mapOf__string(
+        input.UserMetadata,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -396,46 +373,31 @@ export const serializeAws_restJson1_1CreateJobTemplateCommand = async (
   };
   let resolvedPath = "/2017-08-29/jobTemplates";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccelerationSettings !== undefined) {
-    bodyParams[
-      "accelerationSettings"
-    ] = serializeAws_restJson1_1AccelerationSettings(
-      input.AccelerationSettings,
-      context
-    );
-  }
-  if (input.Category !== undefined) {
-    bodyParams["category"] = input.Category;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Priority !== undefined) {
-    bodyParams["priority"] = input.Priority;
-  }
-  if (input.Queue !== undefined) {
-    bodyParams["queue"] = input.Queue;
-  }
-  if (input.Settings !== undefined) {
-    bodyParams["settings"] = serializeAws_restJson1_1JobTemplateSettings(
-      input.Settings,
-      context
-    );
-  }
-  if (input.StatusUpdateInterval !== undefined) {
-    bodyParams["statusUpdateInterval"] = input.StatusUpdateInterval;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccelerationSettings !== undefined && {
+      accelerationSettings: serializeAws_restJson1_1AccelerationSettings(
+        input.AccelerationSettings,
+        context
+      )
+    }),
+    ...(input.Category !== undefined && { category: input.Category }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Priority !== undefined && { priority: input.Priority }),
+    ...(input.Queue !== undefined && { queue: input.Queue }),
+    ...(input.Settings !== undefined && {
+      settings: serializeAws_restJson1_1JobTemplateSettings(
+        input.Settings,
+        context
+      )
+    }),
+    ...(input.StatusUpdateInterval !== undefined && {
+      statusUpdateInterval: input.StatusUpdateInterval
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -457,29 +419,17 @@ export const serializeAws_restJson1_1CreatePresetCommand = async (
   };
   let resolvedPath = "/2017-08-29/presets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Category !== undefined) {
-    bodyParams["category"] = input.Category;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Settings !== undefined) {
-    bodyParams["settings"] = serializeAws_restJson1_1PresetSettings(
-      input.Settings,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Category !== undefined && { category: input.Category }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Settings !== undefined && {
+      settings: serializeAws_restJson1_1PresetSettings(input.Settings, context)
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -501,34 +451,21 @@ export const serializeAws_restJson1_1CreateQueueCommand = async (
   };
   let resolvedPath = "/2017-08-29/queues";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.PricingPlan !== undefined) {
-    bodyParams["pricingPlan"] = input.PricingPlan;
-  }
-  if (input.ReservationPlanSettings !== undefined) {
-    bodyParams[
-      "reservationPlanSettings"
-    ] = serializeAws_restJson1_1ReservationPlanSettings(
-      input.ReservationPlanSettings,
-      context
-    );
-  }
-  if (input.Status !== undefined) {
-    bodyParams["status"] = input.Status;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.PricingPlan !== undefined && { pricingPlan: input.PricingPlan }),
+    ...(input.ReservationPlanSettings !== undefined && {
+      reservationPlanSettings: serializeAws_restJson1_1ReservationPlanSettings(
+        input.ReservationPlanSettings,
+        context
+      )
+    }),
+    ...(input.Status !== undefined && { status: input.Status }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -649,17 +586,11 @@ export const serializeAws_restJson1_1DescribeEndpointsCommand = async (
   };
   let resolvedPath = "/2017-08-29/endpoints";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["maxResults"] = input.MaxResults;
-  }
-  if (input.Mode !== undefined) {
-    bodyParams["mode"] = input.Mode;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["nextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { maxResults: input.MaxResults }),
+    ...(input.Mode !== undefined && { mode: input.Mode }),
+    ...(input.NextToken !== undefined && { nextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1002,17 +933,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/2017-08-29/tags";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Arn !== undefined) {
-    bodyParams["arn"] = input.Arn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Arn !== undefined && { arn: input.Arn }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1046,14 +972,11 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: Arn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.TagKeys !== undefined) {
-    bodyParams["tagKeys"] = serializeAws_restJson1_1__listOf__string(
-      input.TagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TagKeys !== undefined && {
+      tagKeys: serializeAws_restJson1_1__listOf__string(input.TagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1087,37 +1010,27 @@ export const serializeAws_restJson1_1UpdateJobTemplateCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccelerationSettings !== undefined) {
-    bodyParams[
-      "accelerationSettings"
-    ] = serializeAws_restJson1_1AccelerationSettings(
-      input.AccelerationSettings,
-      context
-    );
-  }
-  if (input.Category !== undefined) {
-    bodyParams["category"] = input.Category;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Priority !== undefined) {
-    bodyParams["priority"] = input.Priority;
-  }
-  if (input.Queue !== undefined) {
-    bodyParams["queue"] = input.Queue;
-  }
-  if (input.Settings !== undefined) {
-    bodyParams["settings"] = serializeAws_restJson1_1JobTemplateSettings(
-      input.Settings,
-      context
-    );
-  }
-  if (input.StatusUpdateInterval !== undefined) {
-    bodyParams["statusUpdateInterval"] = input.StatusUpdateInterval;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccelerationSettings !== undefined && {
+      accelerationSettings: serializeAws_restJson1_1AccelerationSettings(
+        input.AccelerationSettings,
+        context
+      )
+    }),
+    ...(input.Category !== undefined && { category: input.Category }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Priority !== undefined && { priority: input.Priority }),
+    ...(input.Queue !== undefined && { queue: input.Queue }),
+    ...(input.Settings !== undefined && {
+      settings: serializeAws_restJson1_1JobTemplateSettings(
+        input.Settings,
+        context
+      )
+    }),
+    ...(input.StatusUpdateInterval !== undefined && {
+      statusUpdateInterval: input.StatusUpdateInterval
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1151,20 +1064,13 @@ export const serializeAws_restJson1_1UpdatePresetCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Category !== undefined) {
-    bodyParams["category"] = input.Category;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Settings !== undefined) {
-    bodyParams["settings"] = serializeAws_restJson1_1PresetSettings(
-      input.Settings,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Category !== undefined && { category: input.Category }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Settings !== undefined && {
+      settings: serializeAws_restJson1_1PresetSettings(input.Settings, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1198,22 +1104,16 @@ export const serializeAws_restJson1_1UpdateQueueCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.ReservationPlanSettings !== undefined) {
-    bodyParams[
-      "reservationPlanSettings"
-    ] = serializeAws_restJson1_1ReservationPlanSettings(
-      input.ReservationPlanSettings,
-      context
-    );
-  }
-  if (input.Status !== undefined) {
-    bodyParams["status"] = input.Status;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.ReservationPlanSettings !== undefined && {
+      reservationPlanSettings: serializeAws_restJson1_1ReservationPlanSettings(
+        input.ReservationPlanSettings,
+        context
+      )
+    }),
+    ...(input.Status !== undefined && { status: input.Status })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-medialive/protocols/Aws_restJson1_1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1_1.ts
@@ -393,24 +393,20 @@ export const serializeAws_restJson1_1BatchUpdateScheduleCommand = async (
     throw new Error("No value provided for input HTTP label: ChannelId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Creates !== undefined) {
-    bodyParams[
-      "creates"
-    ] = serializeAws_restJson1_1BatchScheduleActionCreateRequest(
-      input.Creates,
-      context
-    );
-  }
-  if (input.Deletes !== undefined) {
-    bodyParams[
-      "deletes"
-    ] = serializeAws_restJson1_1BatchScheduleActionDeleteRequest(
-      input.Deletes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Creates !== undefined && {
+      creates: serializeAws_restJson1_1BatchScheduleActionCreateRequest(
+        input.Creates,
+        context
+      )
+    }),
+    ...(input.Deletes !== undefined && {
+      deletes: serializeAws_restJson1_1BatchScheduleActionDeleteRequest(
+        input.Deletes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -432,62 +428,43 @@ export const serializeAws_restJson1_1CreateChannelCommand = async (
   };
   let resolvedPath = "/prod/channels";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelClass !== undefined) {
-    bodyParams["channelClass"] = input.ChannelClass;
-  }
-  if (input.Destinations !== undefined) {
-    bodyParams[
-      "destinations"
-    ] = serializeAws_restJson1_1__listOfOutputDestination(
-      input.Destinations,
-      context
-    );
-  }
-  if (input.EncoderSettings !== undefined) {
-    bodyParams["encoderSettings"] = serializeAws_restJson1_1EncoderSettings(
-      input.EncoderSettings,
-      context
-    );
-  }
-  if (input.InputAttachments !== undefined) {
-    bodyParams[
-      "inputAttachments"
-    ] = serializeAws_restJson1_1__listOfInputAttachment(
-      input.InputAttachments,
-      context
-    );
-  }
-  if (input.InputSpecification !== undefined) {
-    bodyParams[
-      "inputSpecification"
-    ] = serializeAws_restJson1_1InputSpecification(
-      input.InputSpecification,
-      context
-    );
-  }
-  if (input.LogLevel !== undefined) {
-    bodyParams["logLevel"] = input.LogLevel;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
-  }
-  if (input.RequestId !== undefined) {
-    bodyParams["requestId"] = input.RequestId;
-  }
-  if (input.Reserved !== undefined) {
-    bodyParams["reserved"] = input.Reserved;
-  }
-  if (input.RoleArn !== undefined) {
-    bodyParams["roleArn"] = input.RoleArn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelClass !== undefined && {
+      channelClass: input.ChannelClass
+    }),
+    ...(input.Destinations !== undefined && {
+      destinations: serializeAws_restJson1_1__listOfOutputDestination(
+        input.Destinations,
+        context
+      )
+    }),
+    ...(input.EncoderSettings !== undefined && {
+      encoderSettings: serializeAws_restJson1_1EncoderSettings(
+        input.EncoderSettings,
+        context
+      )
+    }),
+    ...(input.InputAttachments !== undefined && {
+      inputAttachments: serializeAws_restJson1_1__listOfInputAttachment(
+        input.InputAttachments,
+        context
+      )
+    }),
+    ...(input.InputSpecification !== undefined && {
+      inputSpecification: serializeAws_restJson1_1InputSpecification(
+        input.InputSpecification,
+        context
+      )
+    }),
+    ...(input.LogLevel !== undefined && { logLevel: input.LogLevel }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    requestId: input.RequestId ?? generateIdempotencyToken(),
+    ...(input.Reserved !== undefined && { reserved: input.Reserved }),
+    ...(input.RoleArn !== undefined && { roleArn: input.RoleArn }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -509,62 +486,42 @@ export const serializeAws_restJson1_1CreateInputCommand = async (
   };
   let resolvedPath = "/prod/inputs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Destinations !== undefined) {
-    bodyParams[
-      "destinations"
-    ] = serializeAws_restJson1_1__listOfInputDestinationRequest(
-      input.Destinations,
-      context
-    );
-  }
-  if (input.InputSecurityGroups !== undefined) {
-    bodyParams[
-      "inputSecurityGroups"
-    ] = serializeAws_restJson1_1__listOf__string(
-      input.InputSecurityGroups,
-      context
-    );
-  }
-  if (input.MediaConnectFlows !== undefined) {
-    bodyParams[
-      "mediaConnectFlows"
-    ] = serializeAws_restJson1_1__listOfMediaConnectFlowRequest(
-      input.MediaConnectFlows,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
-  }
-  if (input.RequestId !== undefined) {
-    bodyParams["requestId"] = input.RequestId;
-  }
-  if (input.RoleArn !== undefined) {
-    bodyParams["roleArn"] = input.RoleArn;
-  }
-  if (input.Sources !== undefined) {
-    bodyParams["sources"] = serializeAws_restJson1_1__listOfInputSourceRequest(
-      input.Sources,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.Type !== undefined) {
-    bodyParams["type"] = input.Type;
-  }
-  if (input.Vpc !== undefined) {
-    bodyParams["vpc"] = serializeAws_restJson1_1InputVpcRequest(
-      input.Vpc,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Destinations !== undefined && {
+      destinations: serializeAws_restJson1_1__listOfInputDestinationRequest(
+        input.Destinations,
+        context
+      )
+    }),
+    ...(input.InputSecurityGroups !== undefined && {
+      inputSecurityGroups: serializeAws_restJson1_1__listOf__string(
+        input.InputSecurityGroups,
+        context
+      )
+    }),
+    ...(input.MediaConnectFlows !== undefined && {
+      mediaConnectFlows: serializeAws_restJson1_1__listOfMediaConnectFlowRequest(
+        input.MediaConnectFlows,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    requestId: input.RequestId ?? generateIdempotencyToken(),
+    ...(input.RoleArn !== undefined && { roleArn: input.RoleArn }),
+    ...(input.Sources !== undefined && {
+      sources: serializeAws_restJson1_1__listOfInputSourceRequest(
+        input.Sources,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.Type !== undefined && { type: input.Type }),
+    ...(input.Vpc !== undefined && {
+      vpc: serializeAws_restJson1_1InputVpcRequest(input.Vpc, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -586,19 +543,17 @@ export const serializeAws_restJson1_1CreateInputSecurityGroupCommand = async (
   };
   let resolvedPath = "/prod/inputSecurityGroups";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.WhitelistRules !== undefined) {
-    bodyParams[
-      "whitelistRules"
-    ] = serializeAws_restJson1_1__listOfInputWhitelistRuleCidr(
-      input.WhitelistRules,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.WhitelistRules !== undefined && {
+      whitelistRules: serializeAws_restJson1_1__listOfInputWhitelistRuleCidr(
+        input.WhitelistRules,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -620,32 +575,25 @@ export const serializeAws_restJson1_1CreateMultiplexCommand = async (
   };
   let resolvedPath = "/prod/multiplexes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AvailabilityZones !== undefined) {
-    bodyParams["availabilityZones"] = serializeAws_restJson1_1__listOf__string(
-      input.AvailabilityZones,
-      context
-    );
-  }
-  if (input.MultiplexSettings !== undefined) {
-    bodyParams["multiplexSettings"] = serializeAws_restJson1_1MultiplexSettings(
-      input.MultiplexSettings,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
-  }
-  if (input.RequestId !== undefined) {
-    bodyParams["requestId"] = input.RequestId;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AvailabilityZones !== undefined && {
+      availabilityZones: serializeAws_restJson1_1__listOf__string(
+        input.AvailabilityZones,
+        context
+      )
+    }),
+    ...(input.MultiplexSettings !== undefined && {
+      multiplexSettings: serializeAws_restJson1_1MultiplexSettings(
+        input.MultiplexSettings,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    requestId: input.RequestId ?? generateIdempotencyToken(),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -681,25 +629,16 @@ export const serializeAws_restJson1_1CreateMultiplexProgramCommand = async (
     throw new Error("No value provided for input HTTP label: MultiplexId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.MultiplexProgramSettings !== undefined) {
-    bodyParams[
-      "multiplexProgramSettings"
-    ] = serializeAws_restJson1_1MultiplexProgramSettings(
-      input.MultiplexProgramSettings,
-      context
-    );
-  }
-  if (input.ProgramName !== undefined) {
-    bodyParams["programName"] = input.ProgramName;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
-  }
-  if (input.RequestId !== undefined) {
-    bodyParams["requestId"] = input.RequestId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MultiplexProgramSettings !== undefined && {
+      multiplexProgramSettings: serializeAws_restJson1_1MultiplexProgramSettings(
+        input.MultiplexProgramSettings,
+        context
+      )
+    }),
+    ...(input.ProgramName !== undefined && { programName: input.ProgramName }),
+    requestId: input.RequestId ?? generateIdempotencyToken()
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -735,11 +674,11 @@ export const serializeAws_restJson1_1CreateTagsCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1653,26 +1592,15 @@ export const serializeAws_restJson1_1PurchaseOfferingCommand = async (
     throw new Error("No value provided for input HTTP label: OfferingId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Count !== undefined) {
-    bodyParams["count"] = input.Count;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.RequestId === undefined) {
-    input.RequestId = generateIdempotencyToken();
-  }
-  if (input.RequestId !== undefined) {
-    bodyParams["requestId"] = input.RequestId;
-  }
-  if (input.Start !== undefined) {
-    bodyParams["start"] = input.Start;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Count !== undefined && { count: input.Count }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    requestId: input.RequestId ?? generateIdempotencyToken(),
+    ...(input.Start !== undefined && { start: input.Start }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1842,47 +1770,35 @@ export const serializeAws_restJson1_1UpdateChannelCommand = async (
     throw new Error("No value provided for input HTTP label: ChannelId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Destinations !== undefined) {
-    bodyParams[
-      "destinations"
-    ] = serializeAws_restJson1_1__listOfOutputDestination(
-      input.Destinations,
-      context
-    );
-  }
-  if (input.EncoderSettings !== undefined) {
-    bodyParams["encoderSettings"] = serializeAws_restJson1_1EncoderSettings(
-      input.EncoderSettings,
-      context
-    );
-  }
-  if (input.InputAttachments !== undefined) {
-    bodyParams[
-      "inputAttachments"
-    ] = serializeAws_restJson1_1__listOfInputAttachment(
-      input.InputAttachments,
-      context
-    );
-  }
-  if (input.InputSpecification !== undefined) {
-    bodyParams[
-      "inputSpecification"
-    ] = serializeAws_restJson1_1InputSpecification(
-      input.InputSpecification,
-      context
-    );
-  }
-  if (input.LogLevel !== undefined) {
-    bodyParams["logLevel"] = input.LogLevel;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.RoleArn !== undefined) {
-    bodyParams["roleArn"] = input.RoleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Destinations !== undefined && {
+      destinations: serializeAws_restJson1_1__listOfOutputDestination(
+        input.Destinations,
+        context
+      )
+    }),
+    ...(input.EncoderSettings !== undefined && {
+      encoderSettings: serializeAws_restJson1_1EncoderSettings(
+        input.EncoderSettings,
+        context
+      )
+    }),
+    ...(input.InputAttachments !== undefined && {
+      inputAttachments: serializeAws_restJson1_1__listOfInputAttachment(
+        input.InputAttachments,
+        context
+      )
+    }),
+    ...(input.InputSpecification !== undefined && {
+      inputSpecification: serializeAws_restJson1_1InputSpecification(
+        input.InputSpecification,
+        context
+      )
+    }),
+    ...(input.LogLevel !== undefined && { logLevel: input.LogLevel }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.RoleArn !== undefined && { roleArn: input.RoleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1916,19 +1832,17 @@ export const serializeAws_restJson1_1UpdateChannelClassCommand = async (
     throw new Error("No value provided for input HTTP label: ChannelId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ChannelClass !== undefined) {
-    bodyParams["channelClass"] = input.ChannelClass;
-  }
-  if (input.Destinations !== undefined) {
-    bodyParams[
-      "destinations"
-    ] = serializeAws_restJson1_1__listOfOutputDestination(
-      input.Destinations,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ChannelClass !== undefined && {
+      channelClass: input.ChannelClass
+    }),
+    ...(input.Destinations !== undefined && {
+      destinations: serializeAws_restJson1_1__listOfOutputDestination(
+        input.Destinations,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1962,44 +1876,34 @@ export const serializeAws_restJson1_1UpdateInputCommand = async (
     throw new Error("No value provided for input HTTP label: InputId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Destinations !== undefined) {
-    bodyParams[
-      "destinations"
-    ] = serializeAws_restJson1_1__listOfInputDestinationRequest(
-      input.Destinations,
-      context
-    );
-  }
-  if (input.InputSecurityGroups !== undefined) {
-    bodyParams[
-      "inputSecurityGroups"
-    ] = serializeAws_restJson1_1__listOf__string(
-      input.InputSecurityGroups,
-      context
-    );
-  }
-  if (input.MediaConnectFlows !== undefined) {
-    bodyParams[
-      "mediaConnectFlows"
-    ] = serializeAws_restJson1_1__listOfMediaConnectFlowRequest(
-      input.MediaConnectFlows,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.RoleArn !== undefined) {
-    bodyParams["roleArn"] = input.RoleArn;
-  }
-  if (input.Sources !== undefined) {
-    bodyParams["sources"] = serializeAws_restJson1_1__listOfInputSourceRequest(
-      input.Sources,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Destinations !== undefined && {
+      destinations: serializeAws_restJson1_1__listOfInputDestinationRequest(
+        input.Destinations,
+        context
+      )
+    }),
+    ...(input.InputSecurityGroups !== undefined && {
+      inputSecurityGroups: serializeAws_restJson1_1__listOf__string(
+        input.InputSecurityGroups,
+        context
+      )
+    }),
+    ...(input.MediaConnectFlows !== undefined && {
+      mediaConnectFlows: serializeAws_restJson1_1__listOfMediaConnectFlowRequest(
+        input.MediaConnectFlows,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.RoleArn !== undefined && { roleArn: input.RoleArn }),
+    ...(input.Sources !== undefined && {
+      sources: serializeAws_restJson1_1__listOfInputSourceRequest(
+        input.Sources,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2037,19 +1941,17 @@ export const serializeAws_restJson1_1UpdateInputSecurityGroupCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.WhitelistRules !== undefined) {
-    bodyParams[
-      "whitelistRules"
-    ] = serializeAws_restJson1_1__listOfInputWhitelistRuleCidr(
-      input.WhitelistRules,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.WhitelistRules !== undefined && {
+      whitelistRules: serializeAws_restJson1_1__listOfInputWhitelistRuleCidr(
+        input.WhitelistRules,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2085,17 +1987,15 @@ export const serializeAws_restJson1_1UpdateMultiplexCommand = async (
     throw new Error("No value provided for input HTTP label: MultiplexId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.MultiplexSettings !== undefined) {
-    bodyParams["multiplexSettings"] = serializeAws_restJson1_1MultiplexSettings(
-      input.MultiplexSettings,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MultiplexSettings !== undefined && {
+      multiplexSettings: serializeAws_restJson1_1MultiplexSettings(
+        input.MultiplexSettings,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2145,16 +2045,14 @@ export const serializeAws_restJson1_1UpdateMultiplexProgramCommand = async (
     throw new Error("No value provided for input HTTP label: ProgramName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.MultiplexProgramSettings !== undefined) {
-    bodyParams[
-      "multiplexProgramSettings"
-    ] = serializeAws_restJson1_1MultiplexProgramSettings(
-      input.MultiplexProgramSettings,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MultiplexProgramSettings !== undefined && {
+      multiplexProgramSettings: serializeAws_restJson1_1MultiplexProgramSettings(
+        input.MultiplexProgramSettings,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2190,11 +2088,9 @@ export const serializeAws_restJson1_1UpdateReservationCommand = async (
     throw new Error("No value provided for input HTTP label: ReservationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
@@ -95,23 +95,17 @@ export const serializeAws_restJson1_1CreateAssetCommand = async (
   };
   let resolvedPath = "/assets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Id !== undefined) {
-    bodyParams["id"] = input.Id;
-  }
-  if (input.PackagingGroupId !== undefined) {
-    bodyParams["packagingGroupId"] = input.PackagingGroupId;
-  }
-  if (input.ResourceId !== undefined) {
-    bodyParams["resourceId"] = input.ResourceId;
-  }
-  if (input.SourceArn !== undefined) {
-    bodyParams["sourceArn"] = input.SourceArn;
-  }
-  if (input.SourceRoleArn !== undefined) {
-    bodyParams["sourceRoleArn"] = input.SourceRoleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Id !== undefined && { id: input.Id }),
+    ...(input.PackagingGroupId !== undefined && {
+      packagingGroupId: input.PackagingGroupId
+    }),
+    ...(input.ResourceId !== undefined && { resourceId: input.ResourceId }),
+    ...(input.SourceArn !== undefined && { sourceArn: input.SourceArn }),
+    ...(input.SourceRoleArn !== undefined && {
+      sourceRoleArn: input.SourceRoleArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -133,38 +127,30 @@ export const serializeAws_restJson1_1CreatePackagingConfigurationCommand = async
   };
   let resolvedPath = "/packaging_configurations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.CmafPackage !== undefined) {
-    bodyParams["cmafPackage"] = serializeAws_restJson1_1CmafPackage(
-      input.CmafPackage,
-      context
-    );
-  }
-  if (input.DashPackage !== undefined) {
-    bodyParams["dashPackage"] = serializeAws_restJson1_1DashPackage(
-      input.DashPackage,
-      context
-    );
-  }
-  if (input.HlsPackage !== undefined) {
-    bodyParams["hlsPackage"] = serializeAws_restJson1_1HlsPackage(
-      input.HlsPackage,
-      context
-    );
-  }
-  if (input.Id !== undefined) {
-    bodyParams["id"] = input.Id;
-  }
-  if (input.MssPackage !== undefined) {
-    bodyParams["mssPackage"] = serializeAws_restJson1_1MssPackage(
-      input.MssPackage,
-      context
-    );
-  }
-  if (input.PackagingGroupId !== undefined) {
-    bodyParams["packagingGroupId"] = input.PackagingGroupId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CmafPackage !== undefined && {
+      cmafPackage: serializeAws_restJson1_1CmafPackage(
+        input.CmafPackage,
+        context
+      )
+    }),
+    ...(input.DashPackage !== undefined && {
+      dashPackage: serializeAws_restJson1_1DashPackage(
+        input.DashPackage,
+        context
+      )
+    }),
+    ...(input.HlsPackage !== undefined && {
+      hlsPackage: serializeAws_restJson1_1HlsPackage(input.HlsPackage, context)
+    }),
+    ...(input.Id !== undefined && { id: input.Id }),
+    ...(input.MssPackage !== undefined && {
+      mssPackage: serializeAws_restJson1_1MssPackage(input.MssPackage, context)
+    }),
+    ...(input.PackagingGroupId !== undefined && {
+      packagingGroupId: input.PackagingGroupId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -186,11 +172,9 @@ export const serializeAws_restJson1_1CreatePackagingGroupCommand = async (
   };
   let resolvedPath = "/packaging_groups";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Id !== undefined) {
-    bodyParams["id"] = input.Id;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Id !== undefined && { id: input.Id })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
@@ -124,17 +124,13 @@ export const serializeAws_restJson1_1CreateChannelCommand = async (
   };
   let resolvedPath = "/channels";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.Id !== undefined) {
-    bodyParams["id"] = input.Id;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.Id !== undefined && { id: input.Id }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -156,26 +152,20 @@ export const serializeAws_restJson1_1CreateHarvestJobCommand = async (
   };
   let resolvedPath = "/harvest_jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EndTime !== undefined) {
-    bodyParams["endTime"] = input.EndTime;
-  }
-  if (input.Id !== undefined) {
-    bodyParams["id"] = input.Id;
-  }
-  if (input.OriginEndpointId !== undefined) {
-    bodyParams["originEndpointId"] = input.OriginEndpointId;
-  }
-  if (input.S3Destination !== undefined) {
-    bodyParams["s3Destination"] = serializeAws_restJson1_1S3Destination(
-      input.S3Destination,
-      context
-    );
-  }
-  if (input.StartTime !== undefined) {
-    bodyParams["startTime"] = input.StartTime;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EndTime !== undefined && { endTime: input.EndTime }),
+    ...(input.Id !== undefined && { id: input.Id }),
+    ...(input.OriginEndpointId !== undefined && {
+      originEndpointId: input.OriginEndpointId
+    }),
+    ...(input.S3Destination !== undefined && {
+      s3Destination: serializeAws_restJson1_1S3Destination(
+        input.S3Destination,
+        context
+      )
+    }),
+    ...(input.StartTime !== undefined && { startTime: input.StartTime })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -197,70 +187,54 @@ export const serializeAws_restJson1_1CreateOriginEndpointCommand = async (
   };
   let resolvedPath = "/origin_endpoints";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Authorization !== undefined) {
-    bodyParams["authorization"] = serializeAws_restJson1_1Authorization(
-      input.Authorization,
-      context
-    );
-  }
-  if (input.ChannelId !== undefined) {
-    bodyParams["channelId"] = input.ChannelId;
-  }
-  if (input.CmafPackage !== undefined) {
-    bodyParams[
-      "cmafPackage"
-    ] = serializeAws_restJson1_1CmafPackageCreateOrUpdateParameters(
-      input.CmafPackage,
-      context
-    );
-  }
-  if (input.DashPackage !== undefined) {
-    bodyParams["dashPackage"] = serializeAws_restJson1_1DashPackage(
-      input.DashPackage,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.HlsPackage !== undefined) {
-    bodyParams["hlsPackage"] = serializeAws_restJson1_1HlsPackage(
-      input.HlsPackage,
-      context
-    );
-  }
-  if (input.Id !== undefined) {
-    bodyParams["id"] = input.Id;
-  }
-  if (input.ManifestName !== undefined) {
-    bodyParams["manifestName"] = input.ManifestName;
-  }
-  if (input.MssPackage !== undefined) {
-    bodyParams["mssPackage"] = serializeAws_restJson1_1MssPackage(
-      input.MssPackage,
-      context
-    );
-  }
-  if (input.Origination !== undefined) {
-    bodyParams["origination"] = input.Origination;
-  }
-  if (input.StartoverWindowSeconds !== undefined) {
-    bodyParams["startoverWindowSeconds"] = input.StartoverWindowSeconds;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.TimeDelaySeconds !== undefined) {
-    bodyParams["timeDelaySeconds"] = input.TimeDelaySeconds;
-  }
-  if (input.Whitelist !== undefined) {
-    bodyParams["whitelist"] = serializeAws_restJson1_1__listOf__string(
-      input.Whitelist,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Authorization !== undefined && {
+      authorization: serializeAws_restJson1_1Authorization(
+        input.Authorization,
+        context
+      )
+    }),
+    ...(input.ChannelId !== undefined && { channelId: input.ChannelId }),
+    ...(input.CmafPackage !== undefined && {
+      cmafPackage: serializeAws_restJson1_1CmafPackageCreateOrUpdateParameters(
+        input.CmafPackage,
+        context
+      )
+    }),
+    ...(input.DashPackage !== undefined && {
+      dashPackage: serializeAws_restJson1_1DashPackage(
+        input.DashPackage,
+        context
+      )
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.HlsPackage !== undefined && {
+      hlsPackage: serializeAws_restJson1_1HlsPackage(input.HlsPackage, context)
+    }),
+    ...(input.Id !== undefined && { id: input.Id }),
+    ...(input.ManifestName !== undefined && {
+      manifestName: input.ManifestName
+    }),
+    ...(input.MssPackage !== undefined && {
+      mssPackage: serializeAws_restJson1_1MssPackage(input.MssPackage, context)
+    }),
+    ...(input.Origination !== undefined && { origination: input.Origination }),
+    ...(input.StartoverWindowSeconds !== undefined && {
+      startoverWindowSeconds: input.StartoverWindowSeconds
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.TimeDelaySeconds !== undefined && {
+      timeDelaySeconds: input.TimeDelaySeconds
+    }),
+    ...(input.Whitelist !== undefined && {
+      whitelist: serializeAws_restJson1_1__listOf__string(
+        input.Whitelist,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -670,14 +644,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -752,11 +723,9 @@ export const serializeAws_restJson1_1UpdateChannelCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -790,61 +759,49 @@ export const serializeAws_restJson1_1UpdateOriginEndpointCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Authorization !== undefined) {
-    bodyParams["authorization"] = serializeAws_restJson1_1Authorization(
-      input.Authorization,
-      context
-    );
-  }
-  if (input.CmafPackage !== undefined) {
-    bodyParams[
-      "cmafPackage"
-    ] = serializeAws_restJson1_1CmafPackageCreateOrUpdateParameters(
-      input.CmafPackage,
-      context
-    );
-  }
-  if (input.DashPackage !== undefined) {
-    bodyParams["dashPackage"] = serializeAws_restJson1_1DashPackage(
-      input.DashPackage,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.HlsPackage !== undefined) {
-    bodyParams["hlsPackage"] = serializeAws_restJson1_1HlsPackage(
-      input.HlsPackage,
-      context
-    );
-  }
-  if (input.ManifestName !== undefined) {
-    bodyParams["manifestName"] = input.ManifestName;
-  }
-  if (input.MssPackage !== undefined) {
-    bodyParams["mssPackage"] = serializeAws_restJson1_1MssPackage(
-      input.MssPackage,
-      context
-    );
-  }
-  if (input.Origination !== undefined) {
-    bodyParams["origination"] = input.Origination;
-  }
-  if (input.StartoverWindowSeconds !== undefined) {
-    bodyParams["startoverWindowSeconds"] = input.StartoverWindowSeconds;
-  }
-  if (input.TimeDelaySeconds !== undefined) {
-    bodyParams["timeDelaySeconds"] = input.TimeDelaySeconds;
-  }
-  if (input.Whitelist !== undefined) {
-    bodyParams["whitelist"] = serializeAws_restJson1_1__listOf__string(
-      input.Whitelist,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Authorization !== undefined && {
+      authorization: serializeAws_restJson1_1Authorization(
+        input.Authorization,
+        context
+      )
+    }),
+    ...(input.CmafPackage !== undefined && {
+      cmafPackage: serializeAws_restJson1_1CmafPackageCreateOrUpdateParameters(
+        input.CmafPackage,
+        context
+      )
+    }),
+    ...(input.DashPackage !== undefined && {
+      dashPackage: serializeAws_restJson1_1DashPackage(
+        input.DashPackage,
+        context
+      )
+    }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.HlsPackage !== undefined && {
+      hlsPackage: serializeAws_restJson1_1HlsPackage(input.HlsPackage, context)
+    }),
+    ...(input.ManifestName !== undefined && {
+      manifestName: input.ManifestName
+    }),
+    ...(input.MssPackage !== undefined && {
+      mssPackage: serializeAws_restJson1_1MssPackage(input.MssPackage, context)
+    }),
+    ...(input.Origination !== undefined && { origination: input.Origination }),
+    ...(input.StartoverWindowSeconds !== undefined && {
+      startoverWindowSeconds: input.StartoverWindowSeconds
+    }),
+    ...(input.TimeDelaySeconds !== undefined && {
+      timeDelaySeconds: input.TimeDelaySeconds
+    }),
+    ...(input.Whitelist !== undefined && {
+      whitelist: serializeAws_restJson1_1__listOf__string(
+        input.Whitelist,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
@@ -188,51 +188,40 @@ export const serializeAws_restJson1_1PutPlaybackConfigurationCommand = async (
   };
   let resolvedPath = "/playbackConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AdDecisionServerUrl !== undefined) {
-    bodyParams["AdDecisionServerUrl"] = input.AdDecisionServerUrl;
-  }
-  if (input.CdnConfiguration !== undefined) {
-    bodyParams["CdnConfiguration"] = serializeAws_restJson1_1CdnConfiguration(
-      input.CdnConfiguration,
-      context
-    );
-  }
-  if (input.DashConfiguration !== undefined) {
-    bodyParams[
-      "DashConfiguration"
-    ] = serializeAws_restJson1_1DashConfigurationForPut(
-      input.DashConfiguration,
-      context
-    );
-  }
-  if (input.LivePreRollConfiguration !== undefined) {
-    bodyParams[
-      "LivePreRollConfiguration"
-    ] = serializeAws_restJson1_1LivePreRollConfiguration(
-      input.LivePreRollConfiguration,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.SlateAdUrl !== undefined) {
-    bodyParams["SlateAdUrl"] = input.SlateAdUrl;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  if (input.TranscodeProfileName !== undefined) {
-    bodyParams["TranscodeProfileName"] = input.TranscodeProfileName;
-  }
-  if (input.VideoContentSourceUrl !== undefined) {
-    bodyParams["VideoContentSourceUrl"] = input.VideoContentSourceUrl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AdDecisionServerUrl !== undefined && {
+      AdDecisionServerUrl: input.AdDecisionServerUrl
+    }),
+    ...(input.CdnConfiguration !== undefined && {
+      CdnConfiguration: serializeAws_restJson1_1CdnConfiguration(
+        input.CdnConfiguration,
+        context
+      )
+    }),
+    ...(input.DashConfiguration !== undefined && {
+      DashConfiguration: serializeAws_restJson1_1DashConfigurationForPut(
+        input.DashConfiguration,
+        context
+      )
+    }),
+    ...(input.LivePreRollConfiguration !== undefined && {
+      LivePreRollConfiguration: serializeAws_restJson1_1LivePreRollConfiguration(
+        input.LivePreRollConfiguration,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.SlateAdUrl !== undefined && { SlateAdUrl: input.SlateAdUrl }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    }),
+    ...(input.TranscodeProfileName !== undefined && {
+      TranscodeProfileName: input.TranscodeProfileName
+    }),
+    ...(input.VideoContentSourceUrl !== undefined && {
+      VideoContentSourceUrl: input.VideoContentSourceUrl
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -268,14 +257,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-mq/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1_1.ts
@@ -139,85 +139,66 @@ export const serializeAws_restJson1_1CreateBrokerCommand = async (
   };
   let resolvedPath = "/v1/brokers";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AutoMinorVersionUpgrade !== undefined) {
-    bodyParams["autoMinorVersionUpgrade"] = input.AutoMinorVersionUpgrade;
-  }
-  if (input.BrokerName !== undefined) {
-    bodyParams["brokerName"] = input.BrokerName;
-  }
-  if (input.Configuration !== undefined) {
-    bodyParams["configuration"] = serializeAws_restJson1_1ConfigurationId(
-      input.Configuration,
-      context
-    );
-  }
-  if (input.CreatorRequestId === undefined) {
-    input.CreatorRequestId = generateIdempotencyToken();
-  }
-  if (input.CreatorRequestId !== undefined) {
-    bodyParams["creatorRequestId"] = input.CreatorRequestId;
-  }
-  if (input.DeploymentMode !== undefined) {
-    bodyParams["deploymentMode"] = input.DeploymentMode;
-  }
-  if (input.EncryptionOptions !== undefined) {
-    bodyParams["encryptionOptions"] = serializeAws_restJson1_1EncryptionOptions(
-      input.EncryptionOptions,
-      context
-    );
-  }
-  if (input.EngineType !== undefined) {
-    bodyParams["engineType"] = input.EngineType;
-  }
-  if (input.EngineVersion !== undefined) {
-    bodyParams["engineVersion"] = input.EngineVersion;
-  }
-  if (input.HostInstanceType !== undefined) {
-    bodyParams["hostInstanceType"] = input.HostInstanceType;
-  }
-  if (input.Logs !== undefined) {
-    bodyParams["logs"] = serializeAws_restJson1_1Logs(input.Logs, context);
-  }
-  if (input.MaintenanceWindowStartTime !== undefined) {
-    bodyParams[
-      "maintenanceWindowStartTime"
-    ] = serializeAws_restJson1_1WeeklyStartTime(
-      input.MaintenanceWindowStartTime,
-      context
-    );
-  }
-  if (input.PubliclyAccessible !== undefined) {
-    bodyParams["publiclyAccessible"] = input.PubliclyAccessible;
-  }
-  if (input.SecurityGroups !== undefined) {
-    bodyParams["securityGroups"] = serializeAws_restJson1_1__listOf__string(
-      input.SecurityGroups,
-      context
-    );
-  }
-  if (input.StorageType !== undefined) {
-    bodyParams["storageType"] = input.StorageType;
-  }
-  if (input.SubnetIds !== undefined) {
-    bodyParams["subnetIds"] = serializeAws_restJson1_1__listOf__string(
-      input.SubnetIds,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  if (input.Users !== undefined) {
-    bodyParams["users"] = serializeAws_restJson1_1__listOfUser(
-      input.Users,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AutoMinorVersionUpgrade !== undefined && {
+      autoMinorVersionUpgrade: input.AutoMinorVersionUpgrade
+    }),
+    ...(input.BrokerName !== undefined && { brokerName: input.BrokerName }),
+    ...(input.Configuration !== undefined && {
+      configuration: serializeAws_restJson1_1ConfigurationId(
+        input.Configuration,
+        context
+      )
+    }),
+    creatorRequestId: input.CreatorRequestId ?? generateIdempotencyToken(),
+    ...(input.DeploymentMode !== undefined && {
+      deploymentMode: input.DeploymentMode
+    }),
+    ...(input.EncryptionOptions !== undefined && {
+      encryptionOptions: serializeAws_restJson1_1EncryptionOptions(
+        input.EncryptionOptions,
+        context
+      )
+    }),
+    ...(input.EngineType !== undefined && { engineType: input.EngineType }),
+    ...(input.EngineVersion !== undefined && {
+      engineVersion: input.EngineVersion
+    }),
+    ...(input.HostInstanceType !== undefined && {
+      hostInstanceType: input.HostInstanceType
+    }),
+    ...(input.Logs !== undefined && {
+      logs: serializeAws_restJson1_1Logs(input.Logs, context)
+    }),
+    ...(input.MaintenanceWindowStartTime !== undefined && {
+      maintenanceWindowStartTime: serializeAws_restJson1_1WeeklyStartTime(
+        input.MaintenanceWindowStartTime,
+        context
+      )
+    }),
+    ...(input.PubliclyAccessible !== undefined && {
+      publiclyAccessible: input.PubliclyAccessible
+    }),
+    ...(input.SecurityGroups !== undefined && {
+      securityGroups: serializeAws_restJson1_1__listOf__string(
+        input.SecurityGroups,
+        context
+      )
+    }),
+    ...(input.StorageType !== undefined && { storageType: input.StorageType }),
+    ...(input.SubnetIds !== undefined && {
+      subnetIds: serializeAws_restJson1_1__listOf__string(
+        input.SubnetIds,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    }),
+    ...(input.Users !== undefined && {
+      users: serializeAws_restJson1_1__listOfUser(input.Users, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -239,23 +220,16 @@ export const serializeAws_restJson1_1CreateConfigurationCommand = async (
   };
   let resolvedPath = "/v1/configurations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EngineType !== undefined) {
-    bodyParams["engineType"] = input.EngineType;
-  }
-  if (input.EngineVersion !== undefined) {
-    bodyParams["engineVersion"] = input.EngineVersion;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EngineType !== undefined && { engineType: input.EngineType }),
+    ...(input.EngineVersion !== undefined && {
+      engineVersion: input.EngineVersion
+    }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -291,14 +265,11 @@ export const serializeAws_restJson1_1CreateTagsCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__mapOf__string(
-      input.Tags,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__mapOf__string(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -344,20 +315,15 @@ export const serializeAws_restJson1_1CreateUserCommand = async (
     throw new Error("No value provided for input HTTP label: Username.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConsoleAccess !== undefined) {
-    bodyParams["consoleAccess"] = input.ConsoleAccess;
-  }
-  if (input.Groups !== undefined) {
-    bodyParams["groups"] = serializeAws_restJson1_1__listOf__string(
-      input.Groups,
-      context
-    );
-  }
-  if (input.Password !== undefined) {
-    bodyParams["password"] = input.Password;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConsoleAccess !== undefined && {
+      consoleAccess: input.ConsoleAccess
+    }),
+    ...(input.Groups !== undefined && {
+      groups: serializeAws_restJson1_1__listOf__string(input.Groups, context)
+    }),
+    ...(input.Password !== undefined && { password: input.Password })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -943,32 +909,32 @@ export const serializeAws_restJson1_1UpdateBrokerCommand = async (
     throw new Error("No value provided for input HTTP label: BrokerId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AutoMinorVersionUpgrade !== undefined) {
-    bodyParams["autoMinorVersionUpgrade"] = input.AutoMinorVersionUpgrade;
-  }
-  if (input.Configuration !== undefined) {
-    bodyParams["configuration"] = serializeAws_restJson1_1ConfigurationId(
-      input.Configuration,
-      context
-    );
-  }
-  if (input.EngineVersion !== undefined) {
-    bodyParams["engineVersion"] = input.EngineVersion;
-  }
-  if (input.HostInstanceType !== undefined) {
-    bodyParams["hostInstanceType"] = input.HostInstanceType;
-  }
-  if (input.Logs !== undefined) {
-    bodyParams["logs"] = serializeAws_restJson1_1Logs(input.Logs, context);
-  }
-  if (input.SecurityGroups !== undefined) {
-    bodyParams["securityGroups"] = serializeAws_restJson1_1__listOf__string(
-      input.SecurityGroups,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AutoMinorVersionUpgrade !== undefined && {
+      autoMinorVersionUpgrade: input.AutoMinorVersionUpgrade
+    }),
+    ...(input.Configuration !== undefined && {
+      configuration: serializeAws_restJson1_1ConfigurationId(
+        input.Configuration,
+        context
+      )
+    }),
+    ...(input.EngineVersion !== undefined && {
+      engineVersion: input.EngineVersion
+    }),
+    ...(input.HostInstanceType !== undefined && {
+      hostInstanceType: input.HostInstanceType
+    }),
+    ...(input.Logs !== undefined && {
+      logs: serializeAws_restJson1_1Logs(input.Logs, context)
+    }),
+    ...(input.SecurityGroups !== undefined && {
+      securityGroups: serializeAws_restJson1_1__listOf__string(
+        input.SecurityGroups,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1004,14 +970,10 @@ export const serializeAws_restJson1_1UpdateConfigurationCommand = async (
     throw new Error("No value provided for input HTTP label: ConfigurationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Data !== undefined) {
-    bodyParams["data"] = input.Data;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Data !== undefined && { data: input.Data }),
+    ...(input.Description !== undefined && { description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1057,20 +1019,15 @@ export const serializeAws_restJson1_1UpdateUserCommand = async (
     throw new Error("No value provided for input HTTP label: Username.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConsoleAccess !== undefined) {
-    bodyParams["consoleAccess"] = input.ConsoleAccess;
-  }
-  if (input.Groups !== undefined) {
-    bodyParams["groups"] = serializeAws_restJson1_1__listOf__string(
-      input.Groups,
-      context
-    );
-  }
-  if (input.Password !== undefined) {
-    bodyParams["password"] = input.Password;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConsoleAccess !== undefined && {
+      consoleAccess: input.ConsoleAccess
+    }),
+    ...(input.Groups !== undefined && {
+      groups: serializeAws_restJson1_1__listOf__string(input.Groups, context)
+    }),
+    ...(input.Password !== undefined && { password: input.Password })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
@@ -170,17 +170,13 @@ export const serializeAws_restJson1_1AssociateCustomerGatewayCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CustomerGatewayArn !== undefined) {
-    bodyParams["CustomerGatewayArn"] = input.CustomerGatewayArn;
-  }
-  if (input.DeviceId !== undefined) {
-    bodyParams["DeviceId"] = input.DeviceId;
-  }
-  if (input.LinkId !== undefined) {
-    bodyParams["LinkId"] = input.LinkId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CustomerGatewayArn !== undefined && {
+      CustomerGatewayArn: input.CustomerGatewayArn
+    }),
+    ...(input.DeviceId !== undefined && { DeviceId: input.DeviceId }),
+    ...(input.LinkId !== undefined && { LinkId: input.LinkId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -216,14 +212,10 @@ export const serializeAws_restJson1_1AssociateLinkCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeviceId !== undefined) {
-    bodyParams["DeviceId"] = input.DeviceId;
-  }
-  if (input.LinkId !== undefined) {
-    bodyParams["LinkId"] = input.LinkId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeviceId !== undefined && { DeviceId: input.DeviceId }),
+    ...(input.LinkId !== undefined && { LinkId: input.LinkId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -259,35 +251,22 @@ export const serializeAws_restJson1_1CreateDeviceCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["Location"] = serializeAws_restJson1_1Location(
-      input.Location,
-      context
-    );
-  }
-  if (input.Model !== undefined) {
-    bodyParams["Model"] = input.Model;
-  }
-  if (input.SerialNumber !== undefined) {
-    bodyParams["SerialNumber"] = input.SerialNumber;
-  }
-  if (input.SiteId !== undefined) {
-    bodyParams["SiteId"] = input.SiteId;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  if (input.Vendor !== undefined) {
-    bodyParams["Vendor"] = input.Vendor;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Location !== undefined && {
+      Location: serializeAws_restJson1_1Location(input.Location, context)
+    }),
+    ...(input.Model !== undefined && { Model: input.Model }),
+    ...(input.SerialNumber !== undefined && {
+      SerialNumber: input.SerialNumber
+    }),
+    ...(input.SiteId !== undefined && { SiteId: input.SiteId }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    }),
+    ...(input.Type !== undefined && { Type: input.Type }),
+    ...(input.Vendor !== undefined && { Vendor: input.Vendor })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -309,14 +288,12 @@ export const serializeAws_restJson1_1CreateGlobalNetworkCommand = async (
   };
   let resolvedPath = "/global-networks";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -352,29 +329,18 @@ export const serializeAws_restJson1_1CreateLinkCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Bandwidth !== undefined) {
-    bodyParams["Bandwidth"] = serializeAws_restJson1_1Bandwidth(
-      input.Bandwidth,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Provider !== undefined) {
-    bodyParams["Provider"] = input.Provider;
-  }
-  if (input.SiteId !== undefined) {
-    bodyParams["SiteId"] = input.SiteId;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Bandwidth !== undefined && {
+      Bandwidth: serializeAws_restJson1_1Bandwidth(input.Bandwidth, context)
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Provider !== undefined && { Provider: input.Provider }),
+    ...(input.SiteId !== undefined && { SiteId: input.SiteId }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -410,20 +376,15 @@ export const serializeAws_restJson1_1CreateSiteCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["Location"] = serializeAws_restJson1_1Location(
-      input.Location,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Location !== undefined && {
+      Location: serializeAws_restJson1_1Location(input.Location, context)
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1123,11 +1084,11 @@ export const serializeAws_restJson1_1RegisterTransitGatewayCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.TransitGatewayArn !== undefined) {
-    bodyParams["TransitGatewayArn"] = input.TransitGatewayArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TransitGatewayArn !== undefined && {
+      TransitGatewayArn: input.TransitGatewayArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1163,11 +1124,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1256,32 +1217,19 @@ export const serializeAws_restJson1_1UpdateDeviceCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["Location"] = serializeAws_restJson1_1Location(
-      input.Location,
-      context
-    );
-  }
-  if (input.Model !== undefined) {
-    bodyParams["Model"] = input.Model;
-  }
-  if (input.SerialNumber !== undefined) {
-    bodyParams["SerialNumber"] = input.SerialNumber;
-  }
-  if (input.SiteId !== undefined) {
-    bodyParams["SiteId"] = input.SiteId;
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  if (input.Vendor !== undefined) {
-    bodyParams["Vendor"] = input.Vendor;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Location !== undefined && {
+      Location: serializeAws_restJson1_1Location(input.Location, context)
+    }),
+    ...(input.Model !== undefined && { Model: input.Model }),
+    ...(input.SerialNumber !== undefined && {
+      SerialNumber: input.SerialNumber
+    }),
+    ...(input.SiteId !== undefined && { SiteId: input.SiteId }),
+    ...(input.Type !== undefined && { Type: input.Type }),
+    ...(input.Vendor !== undefined && { Vendor: input.Vendor })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1317,11 +1265,9 @@ export const serializeAws_restJson1_1UpdateGlobalNetworkCommand = async (
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1369,23 +1315,14 @@ export const serializeAws_restJson1_1UpdateLinkCommand = async (
     throw new Error("No value provided for input HTTP label: LinkId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Bandwidth !== undefined) {
-    bodyParams["Bandwidth"] = serializeAws_restJson1_1Bandwidth(
-      input.Bandwidth,
-      context
-    );
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Provider !== undefined) {
-    bodyParams["Provider"] = input.Provider;
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Bandwidth !== undefined && {
+      Bandwidth: serializeAws_restJson1_1Bandwidth(input.Bandwidth, context)
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Provider !== undefined && { Provider: input.Provider }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1433,17 +1370,12 @@ export const serializeAws_restJson1_1UpdateSiteCommand = async (
     throw new Error("No value provided for input HTTP label: SiteId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Location !== undefined) {
-    bodyParams["Location"] = serializeAws_restJson1_1Location(
-      input.Location,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Location !== undefined && {
+      Location: serializeAws_restJson1_1Location(input.Location, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-outposts/protocols/Aws_restJson1_1.ts
+++ b/clients/client-outposts/protocols/Aws_restJson1_1.ts
@@ -52,23 +52,17 @@ export const serializeAws_restJson1_1CreateOutpostCommand = async (
   };
   let resolvedPath = "/outposts";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AvailabilityZone !== undefined) {
-    bodyParams["AvailabilityZone"] = input.AvailabilityZone;
-  }
-  if (input.AvailabilityZoneId !== undefined) {
-    bodyParams["AvailabilityZoneId"] = input.AvailabilityZoneId;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.SiteId !== undefined) {
-    bodyParams["SiteId"] = input.SiteId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AvailabilityZone !== undefined && {
+      AvailabilityZone: input.AvailabilityZone
+    }),
+    ...(input.AvailabilityZoneId !== undefined && {
+      AvailabilityZoneId: input.AvailabilityZoneId
+    }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.SiteId !== undefined && { SiteId: input.SiteId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-personalize-events/protocols/Aws_restJson1_1.ts
+++ b/clients/client-personalize-events/protocols/Aws_restJson1_1.ts
@@ -27,23 +27,14 @@ export const serializeAws_restJson1_1PutEventsCommand = async (
   };
   let resolvedPath = "/events";
   let body: any;
-  const bodyParams: any = {};
-  if (input.eventList !== undefined) {
-    bodyParams["eventList"] = serializeAws_restJson1_1EventList(
-      input.eventList,
-      context
-    );
-  }
-  if (input.sessionId !== undefined) {
-    bodyParams["sessionId"] = input.sessionId;
-  }
-  if (input.trackingId !== undefined) {
-    bodyParams["trackingId"] = input.trackingId;
-  }
-  if (input.userId !== undefined) {
-    bodyParams["userId"] = input.userId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.eventList !== undefined && {
+      eventList: serializeAws_restJson1_1EventList(input.eventList, context)
+    }),
+    ...(input.sessionId !== undefined && { sessionId: input.sessionId }),
+    ...(input.trackingId !== undefined && { trackingId: input.trackingId }),
+    ...(input.userId !== undefined && { userId: input.userId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-personalize-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-personalize-runtime/protocols/Aws_restJson1_1.ts
@@ -32,26 +32,16 @@ export const serializeAws_restJson1_1GetPersonalizedRankingCommand = async (
   };
   let resolvedPath = "/personalize-ranking";
   let body: any;
-  const bodyParams: any = {};
-  if (input.campaignArn !== undefined) {
-    bodyParams["campaignArn"] = input.campaignArn;
-  }
-  if (input.context !== undefined) {
-    bodyParams["context"] = serializeAws_restJson1_1Context(
-      input.context,
-      context
-    );
-  }
-  if (input.inputList !== undefined) {
-    bodyParams["inputList"] = serializeAws_restJson1_1InputList(
-      input.inputList,
-      context
-    );
-  }
-  if (input.userId !== undefined) {
-    bodyParams["userId"] = input.userId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.campaignArn !== undefined && { campaignArn: input.campaignArn }),
+    ...(input.context !== undefined && {
+      context: serializeAws_restJson1_1Context(input.context, context)
+    }),
+    ...(input.inputList !== undefined && {
+      inputList: serializeAws_restJson1_1InputList(input.inputList, context)
+    }),
+    ...(input.userId !== undefined && { userId: input.userId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -73,26 +63,15 @@ export const serializeAws_restJson1_1GetRecommendationsCommand = async (
   };
   let resolvedPath = "/recommendations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.campaignArn !== undefined) {
-    bodyParams["campaignArn"] = input.campaignArn;
-  }
-  if (input.context !== undefined) {
-    bodyParams["context"] = serializeAws_restJson1_1Context(
-      input.context,
-      context
-    );
-  }
-  if (input.itemId !== undefined) {
-    bodyParams["itemId"] = input.itemId;
-  }
-  if (input.numResults !== undefined) {
-    bodyParams["numResults"] = input.numResults;
-  }
-  if (input.userId !== undefined) {
-    bodyParams["userId"] = input.userId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.campaignArn !== undefined && { campaignArn: input.campaignArn }),
+    ...(input.context !== undefined && {
+      context: serializeAws_restJson1_1Context(input.context, context)
+    }),
+    ...(input.itemId !== undefined && { itemId: input.itemId }),
+    ...(input.numResults !== undefined && { numResults: input.numResults }),
+    ...(input.userId !== undefined && { userId: input.userId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
@@ -239,38 +239,38 @@ export const serializeAws_restJson1_1CreateConfigurationSetCommand = async (
   };
   let resolvedPath = "/v1/email/configuration-sets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConfigurationSetName !== undefined) {
-    bodyParams["ConfigurationSetName"] = input.ConfigurationSetName;
-  }
-  if (input.DeliveryOptions !== undefined) {
-    bodyParams["DeliveryOptions"] = serializeAws_restJson1_1DeliveryOptions(
-      input.DeliveryOptions,
-      context
-    );
-  }
-  if (input.ReputationOptions !== undefined) {
-    bodyParams["ReputationOptions"] = serializeAws_restJson1_1ReputationOptions(
-      input.ReputationOptions,
-      context
-    );
-  }
-  if (input.SendingOptions !== undefined) {
-    bodyParams["SendingOptions"] = serializeAws_restJson1_1SendingOptions(
-      input.SendingOptions,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  if (input.TrackingOptions !== undefined) {
-    bodyParams["TrackingOptions"] = serializeAws_restJson1_1TrackingOptions(
-      input.TrackingOptions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConfigurationSetName !== undefined && {
+      ConfigurationSetName: input.ConfigurationSetName
+    }),
+    ...(input.DeliveryOptions !== undefined && {
+      DeliveryOptions: serializeAws_restJson1_1DeliveryOptions(
+        input.DeliveryOptions,
+        context
+      )
+    }),
+    ...(input.ReputationOptions !== undefined && {
+      ReputationOptions: serializeAws_restJson1_1ReputationOptions(
+        input.ReputationOptions,
+        context
+      )
+    }),
+    ...(input.SendingOptions !== undefined && {
+      SendingOptions: serializeAws_restJson1_1SendingOptions(
+        input.SendingOptions,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    }),
+    ...(input.TrackingOptions !== undefined && {
+      TrackingOptions: serializeAws_restJson1_1TrackingOptions(
+        input.TrackingOptions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -309,19 +309,17 @@ export const serializeAws_restJson1_1CreateConfigurationSetEventDestinationComma
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EventDestination !== undefined) {
-    bodyParams[
-      "EventDestination"
-    ] = serializeAws_restJson1_1EventDestinationDefinition(
-      input.EventDestination,
-      context
-    );
-  }
-  if (input.EventDestinationName !== undefined) {
-    bodyParams["EventDestinationName"] = input.EventDestinationName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EventDestination !== undefined && {
+      EventDestination: serializeAws_restJson1_1EventDestinationDefinition(
+        input.EventDestination,
+        context
+      )
+    }),
+    ...(input.EventDestinationName !== undefined && {
+      EventDestinationName: input.EventDestinationName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -343,14 +341,12 @@ export const serializeAws_restJson1_1CreateDedicatedIpPoolCommand = async (
   };
   let resolvedPath = "/v1/email/dedicated-ip-pools";
   let body: any;
-  const bodyParams: any = {};
-  if (input.PoolName !== undefined) {
-    bodyParams["PoolName"] = input.PoolName;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.PoolName !== undefined && { PoolName: input.PoolName }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -372,23 +368,18 @@ export const serializeAws_restJson1_1CreateDeliverabilityTestReportCommand = asy
   };
   let resolvedPath = "/v1/email/deliverability-dashboard/test";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = serializeAws_restJson1_1EmailContent(
-      input.Content,
-      context
-    );
-  }
-  if (input.FromEmailAddress !== undefined) {
-    bodyParams["FromEmailAddress"] = input.FromEmailAddress;
-  }
-  if (input.ReportName !== undefined) {
-    bodyParams["ReportName"] = input.ReportName;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Content !== undefined && {
+      Content: serializeAws_restJson1_1EmailContent(input.Content, context)
+    }),
+    ...(input.FromEmailAddress !== undefined && {
+      FromEmailAddress: input.FromEmailAddress
+    }),
+    ...(input.ReportName !== undefined && { ReportName: input.ReportName }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -410,14 +401,14 @@ export const serializeAws_restJson1_1CreateEmailIdentityCommand = async (
   };
   let resolvedPath = "/v1/email/identities";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EmailIdentity !== undefined) {
-    bodyParams["EmailIdentity"] = input.EmailIdentity;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EmailIdentity !== undefined && {
+      EmailIdentity: input.EmailIdentity
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1132,11 +1123,11 @@ export const serializeAws_restJson1_1PutAccountDedicatedIpWarmupAttributesComman
   };
   let resolvedPath = "/v1/email/account/dedicated-ips/warmup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AutoWarmupEnabled !== undefined) {
-    bodyParams["AutoWarmupEnabled"] = input.AutoWarmupEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AutoWarmupEnabled !== undefined && {
+      AutoWarmupEnabled: input.AutoWarmupEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1158,11 +1149,11 @@ export const serializeAws_restJson1_1PutAccountSendingAttributesCommand = async 
   };
   let resolvedPath = "/v1/email/account/sending";
   let body: any;
-  const bodyParams: any = {};
-  if (input.SendingEnabled !== undefined) {
-    bodyParams["SendingEnabled"] = input.SendingEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SendingEnabled !== undefined && {
+      SendingEnabled: input.SendingEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1201,14 +1192,12 @@ export const serializeAws_restJson1_1PutConfigurationSetDeliveryOptionsCommand =
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SendingPoolName !== undefined) {
-    bodyParams["SendingPoolName"] = input.SendingPoolName;
-  }
-  if (input.TlsPolicy !== undefined) {
-    bodyParams["TlsPolicy"] = input.TlsPolicy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SendingPoolName !== undefined && {
+      SendingPoolName: input.SendingPoolName
+    }),
+    ...(input.TlsPolicy !== undefined && { TlsPolicy: input.TlsPolicy })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1247,11 +1236,11 @@ export const serializeAws_restJson1_1PutConfigurationSetReputationOptionsCommand
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ReputationMetricsEnabled !== undefined) {
-    bodyParams["ReputationMetricsEnabled"] = input.ReputationMetricsEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ReputationMetricsEnabled !== undefined && {
+      ReputationMetricsEnabled: input.ReputationMetricsEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1290,11 +1279,11 @@ export const serializeAws_restJson1_1PutConfigurationSetSendingOptionsCommand = 
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SendingEnabled !== undefined) {
-    bodyParams["SendingEnabled"] = input.SendingEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SendingEnabled !== undefined && {
+      SendingEnabled: input.SendingEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1333,11 +1322,11 @@ export const serializeAws_restJson1_1PutConfigurationSetTrackingOptionsCommand =
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CustomRedirectDomain !== undefined) {
-    bodyParams["CustomRedirectDomain"] = input.CustomRedirectDomain;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CustomRedirectDomain !== undefined && {
+      CustomRedirectDomain: input.CustomRedirectDomain
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1371,11 +1360,11 @@ export const serializeAws_restJson1_1PutDedicatedIpInPoolCommand = async (
     throw new Error("No value provided for input HTTP label: Ip.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DestinationPoolName !== undefined) {
-    bodyParams["DestinationPoolName"] = input.DestinationPoolName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DestinationPoolName !== undefined && {
+      DestinationPoolName: input.DestinationPoolName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1409,11 +1398,11 @@ export const serializeAws_restJson1_1PutDedicatedIpWarmupAttributesCommand = asy
     throw new Error("No value provided for input HTTP label: Ip.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.WarmupPercentage !== undefined) {
-    bodyParams["WarmupPercentage"] = input.WarmupPercentage;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.WarmupPercentage !== undefined && {
+      WarmupPercentage: input.WarmupPercentage
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1435,19 +1424,17 @@ export const serializeAws_restJson1_1PutDeliverabilityDashboardOptionCommand = a
   };
   let resolvedPath = "/v1/email/deliverability-dashboard";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DashboardEnabled !== undefined) {
-    bodyParams["DashboardEnabled"] = input.DashboardEnabled;
-  }
-  if (input.SubscribedDomains !== undefined) {
-    bodyParams[
-      "SubscribedDomains"
-    ] = serializeAws_restJson1_1DomainDeliverabilityTrackingOptions(
-      input.SubscribedDomains,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DashboardEnabled !== undefined && {
+      DashboardEnabled: input.DashboardEnabled
+    }),
+    ...(input.SubscribedDomains !== undefined && {
+      SubscribedDomains: serializeAws_restJson1_1DomainDeliverabilityTrackingOptions(
+        input.SubscribedDomains,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1483,11 +1470,11 @@ export const serializeAws_restJson1_1PutEmailIdentityDkimAttributesCommand = asy
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SigningEnabled !== undefined) {
-    bodyParams["SigningEnabled"] = input.SigningEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SigningEnabled !== undefined && {
+      SigningEnabled: input.SigningEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1523,11 +1510,11 @@ export const serializeAws_restJson1_1PutEmailIdentityFeedbackAttributesCommand =
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EmailForwardingEnabled !== undefined) {
-    bodyParams["EmailForwardingEnabled"] = input.EmailForwardingEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EmailForwardingEnabled !== undefined && {
+      EmailForwardingEnabled: input.EmailForwardingEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1563,14 +1550,14 @@ export const serializeAws_restJson1_1PutEmailIdentityMailFromAttributesCommand =
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BehaviorOnMxFailure !== undefined) {
-    bodyParams["BehaviorOnMxFailure"] = input.BehaviorOnMxFailure;
-  }
-  if (input.MailFromDomain !== undefined) {
-    bodyParams["MailFromDomain"] = input.MailFromDomain;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BehaviorOnMxFailure !== undefined && {
+      BehaviorOnMxFailure: input.BehaviorOnMxFailure
+    }),
+    ...(input.MailFromDomain !== undefined && {
+      MailFromDomain: input.MailFromDomain
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1592,42 +1579,38 @@ export const serializeAws_restJson1_1SendEmailCommand = async (
   };
   let resolvedPath = "/v1/email/outbound-emails";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConfigurationSetName !== undefined) {
-    bodyParams["ConfigurationSetName"] = input.ConfigurationSetName;
-  }
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = serializeAws_restJson1_1EmailContent(
-      input.Content,
-      context
-    );
-  }
-  if (input.Destination !== undefined) {
-    bodyParams["Destination"] = serializeAws_restJson1_1Destination(
-      input.Destination,
-      context
-    );
-  }
-  if (input.EmailTags !== undefined) {
-    bodyParams["EmailTags"] = serializeAws_restJson1_1MessageTagList(
-      input.EmailTags,
-      context
-    );
-  }
-  if (input.FeedbackForwardingEmailAddress !== undefined) {
-    bodyParams["FeedbackForwardingEmailAddress"] =
-      input.FeedbackForwardingEmailAddress;
-  }
-  if (input.FromEmailAddress !== undefined) {
-    bodyParams["FromEmailAddress"] = input.FromEmailAddress;
-  }
-  if (input.ReplyToAddresses !== undefined) {
-    bodyParams["ReplyToAddresses"] = serializeAws_restJson1_1EmailAddressList(
-      input.ReplyToAddresses,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConfigurationSetName !== undefined && {
+      ConfigurationSetName: input.ConfigurationSetName
+    }),
+    ...(input.Content !== undefined && {
+      Content: serializeAws_restJson1_1EmailContent(input.Content, context)
+    }),
+    ...(input.Destination !== undefined && {
+      Destination: serializeAws_restJson1_1Destination(
+        input.Destination,
+        context
+      )
+    }),
+    ...(input.EmailTags !== undefined && {
+      EmailTags: serializeAws_restJson1_1MessageTagList(
+        input.EmailTags,
+        context
+      )
+    }),
+    ...(input.FeedbackForwardingEmailAddress !== undefined && {
+      FeedbackForwardingEmailAddress: input.FeedbackForwardingEmailAddress
+    }),
+    ...(input.FromEmailAddress !== undefined && {
+      FromEmailAddress: input.FromEmailAddress
+    }),
+    ...(input.ReplyToAddresses !== undefined && {
+      ReplyToAddresses: serializeAws_restJson1_1EmailAddressList(
+        input.ReplyToAddresses,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1649,14 +1632,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/v1/email/tags";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ResourceArn !== undefined) {
-    bodyParams["ResourceArn"] = input.ResourceArn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ResourceArn !== undefined && { ResourceArn: input.ResourceArn }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1739,16 +1720,14 @@ export const serializeAws_restJson1_1UpdateConfigurationSetEventDestinationComma
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EventDestination !== undefined) {
-    bodyParams[
-      "EventDestination"
-    ] = serializeAws_restJson1_1EventDestinationDefinition(
-      input.EventDestination,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EventDestination !== undefined && {
+      EventDestination: serializeAws_restJson1_1EventDestinationDefinition(
+        input.EventDestination,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
@@ -72,11 +72,11 @@ export const serializeAws_restJson1_1CreateConfigurationSetCommand = async (
   };
   let resolvedPath = "/v1/sms-voice/configuration-sets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConfigurationSetName !== undefined) {
-    bodyParams["ConfigurationSetName"] = input.ConfigurationSetName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConfigurationSetName !== undefined && {
+      ConfigurationSetName: input.ConfigurationSetName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -115,19 +115,17 @@ export const serializeAws_restJson1_1CreateConfigurationSetEventDestinationComma
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EventDestination !== undefined) {
-    bodyParams[
-      "EventDestination"
-    ] = serializeAws_restJson1_1EventDestinationDefinition(
-      input.EventDestination,
-      context
-    );
-  }
-  if (input.EventDestinationName !== undefined) {
-    bodyParams["EventDestinationName"] = input.EventDestinationName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EventDestination !== undefined && {
+      EventDestination: serializeAws_restJson1_1EventDestinationDefinition(
+        input.EventDestination,
+        context
+      )
+    }),
+    ...(input.EventDestinationName !== undefined && {
+      EventDestinationName: input.EventDestinationName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -304,26 +302,24 @@ export const serializeAws_restJson1_1SendVoiceMessageCommand = async (
   };
   let resolvedPath = "/v1/sms-voice/voice/message";
   let body: any;
-  const bodyParams: any = {};
-  if (input.CallerId !== undefined) {
-    bodyParams["CallerId"] = input.CallerId;
-  }
-  if (input.ConfigurationSetName !== undefined) {
-    bodyParams["ConfigurationSetName"] = input.ConfigurationSetName;
-  }
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = serializeAws_restJson1_1VoiceMessageContent(
-      input.Content,
-      context
-    );
-  }
-  if (input.DestinationPhoneNumber !== undefined) {
-    bodyParams["DestinationPhoneNumber"] = input.DestinationPhoneNumber;
-  }
-  if (input.OriginationPhoneNumber !== undefined) {
-    bodyParams["OriginationPhoneNumber"] = input.OriginationPhoneNumber;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CallerId !== undefined && { CallerId: input.CallerId }),
+    ...(input.ConfigurationSetName !== undefined && {
+      ConfigurationSetName: input.ConfigurationSetName
+    }),
+    ...(input.Content !== undefined && {
+      Content: serializeAws_restJson1_1VoiceMessageContent(
+        input.Content,
+        context
+      )
+    }),
+    ...(input.DestinationPhoneNumber !== undefined && {
+      DestinationPhoneNumber: input.DestinationPhoneNumber
+    }),
+    ...(input.OriginationPhoneNumber !== undefined && {
+      OriginationPhoneNumber: input.OriginationPhoneNumber
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -378,16 +374,14 @@ export const serializeAws_restJson1_1UpdateConfigurationSetEventDestinationComma
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EventDestination !== undefined) {
-    bodyParams[
-      "EventDestination"
-    ] = serializeAws_restJson1_1EventDestinationDefinition(
-      input.EventDestination,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EventDestination !== undefined && {
+      EventDestination: serializeAws_restJson1_1EventDestinationDefinition(
+        input.EventDestination,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-polly/protocols/Aws_restJson1_1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1_1.ts
@@ -286,11 +286,9 @@ export const serializeAws_restJson1_1PutLexiconCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = input.Content;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Content !== undefined && { Content: input.Content })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -312,50 +310,38 @@ export const serializeAws_restJson1_1StartSpeechSynthesisTaskCommand = async (
   };
   let resolvedPath = "/v1/synthesisTasks";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Engine !== undefined) {
-    bodyParams["Engine"] = input.Engine;
-  }
-  if (input.LanguageCode !== undefined) {
-    bodyParams["LanguageCode"] = input.LanguageCode;
-  }
-  if (input.LexiconNames !== undefined) {
-    bodyParams["LexiconNames"] = serializeAws_restJson1_1LexiconNameList(
-      input.LexiconNames,
-      context
-    );
-  }
-  if (input.OutputFormat !== undefined) {
-    bodyParams["OutputFormat"] = input.OutputFormat;
-  }
-  if (input.OutputS3BucketName !== undefined) {
-    bodyParams["OutputS3BucketName"] = input.OutputS3BucketName;
-  }
-  if (input.OutputS3KeyPrefix !== undefined) {
-    bodyParams["OutputS3KeyPrefix"] = input.OutputS3KeyPrefix;
-  }
-  if (input.SampleRate !== undefined) {
-    bodyParams["SampleRate"] = input.SampleRate;
-  }
-  if (input.SnsTopicArn !== undefined) {
-    bodyParams["SnsTopicArn"] = input.SnsTopicArn;
-  }
-  if (input.SpeechMarkTypes !== undefined) {
-    bodyParams["SpeechMarkTypes"] = serializeAws_restJson1_1SpeechMarkTypeList(
-      input.SpeechMarkTypes,
-      context
-    );
-  }
-  if (input.Text !== undefined) {
-    bodyParams["Text"] = input.Text;
-  }
-  if (input.TextType !== undefined) {
-    bodyParams["TextType"] = input.TextType;
-  }
-  if (input.VoiceId !== undefined) {
-    bodyParams["VoiceId"] = input.VoiceId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Engine !== undefined && { Engine: input.Engine }),
+    ...(input.LanguageCode !== undefined && {
+      LanguageCode: input.LanguageCode
+    }),
+    ...(input.LexiconNames !== undefined && {
+      LexiconNames: serializeAws_restJson1_1LexiconNameList(
+        input.LexiconNames,
+        context
+      )
+    }),
+    ...(input.OutputFormat !== undefined && {
+      OutputFormat: input.OutputFormat
+    }),
+    ...(input.OutputS3BucketName !== undefined && {
+      OutputS3BucketName: input.OutputS3BucketName
+    }),
+    ...(input.OutputS3KeyPrefix !== undefined && {
+      OutputS3KeyPrefix: input.OutputS3KeyPrefix
+    }),
+    ...(input.SampleRate !== undefined && { SampleRate: input.SampleRate }),
+    ...(input.SnsTopicArn !== undefined && { SnsTopicArn: input.SnsTopicArn }),
+    ...(input.SpeechMarkTypes !== undefined && {
+      SpeechMarkTypes: serializeAws_restJson1_1SpeechMarkTypeList(
+        input.SpeechMarkTypes,
+        context
+      )
+    }),
+    ...(input.Text !== undefined && { Text: input.Text }),
+    ...(input.TextType !== undefined && { TextType: input.TextType }),
+    ...(input.VoiceId !== undefined && { VoiceId: input.VoiceId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -377,41 +363,31 @@ export const serializeAws_restJson1_1SynthesizeSpeechCommand = async (
   };
   let resolvedPath = "/v1/speech";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Engine !== undefined) {
-    bodyParams["Engine"] = input.Engine;
-  }
-  if (input.LanguageCode !== undefined) {
-    bodyParams["LanguageCode"] = input.LanguageCode;
-  }
-  if (input.LexiconNames !== undefined) {
-    bodyParams["LexiconNames"] = serializeAws_restJson1_1LexiconNameList(
-      input.LexiconNames,
-      context
-    );
-  }
-  if (input.OutputFormat !== undefined) {
-    bodyParams["OutputFormat"] = input.OutputFormat;
-  }
-  if (input.SampleRate !== undefined) {
-    bodyParams["SampleRate"] = input.SampleRate;
-  }
-  if (input.SpeechMarkTypes !== undefined) {
-    bodyParams["SpeechMarkTypes"] = serializeAws_restJson1_1SpeechMarkTypeList(
-      input.SpeechMarkTypes,
-      context
-    );
-  }
-  if (input.Text !== undefined) {
-    bodyParams["Text"] = input.Text;
-  }
-  if (input.TextType !== undefined) {
-    bodyParams["TextType"] = input.TextType;
-  }
-  if (input.VoiceId !== undefined) {
-    bodyParams["VoiceId"] = input.VoiceId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Engine !== undefined && { Engine: input.Engine }),
+    ...(input.LanguageCode !== undefined && {
+      LanguageCode: input.LanguageCode
+    }),
+    ...(input.LexiconNames !== undefined && {
+      LexiconNames: serializeAws_restJson1_1LexiconNameList(
+        input.LexiconNames,
+        context
+      )
+    }),
+    ...(input.OutputFormat !== undefined && {
+      OutputFormat: input.OutputFormat
+    }),
+    ...(input.SampleRate !== undefined && { SampleRate: input.SampleRate }),
+    ...(input.SpeechMarkTypes !== undefined && {
+      SpeechMarkTypes: serializeAws_restJson1_1SpeechMarkTypeList(
+        input.SpeechMarkTypes,
+        context
+      )
+    }),
+    ...(input.Text !== undefined && { Text: input.Text }),
+    ...(input.TextType !== undefined && { TextType: input.TextType }),
+    ...(input.VoiceId !== undefined && { VoiceId: input.VoiceId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-qldb/protocols/Aws_restJson1_1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1_1.ts
@@ -95,20 +95,18 @@ export const serializeAws_restJson1_1CreateLedgerCommand = async (
   };
   let resolvedPath = "/ledgers";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeletionProtection !== undefined) {
-    bodyParams["DeletionProtection"] = input.DeletionProtection;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.PermissionsMode !== undefined) {
-    bodyParams["PermissionsMode"] = input.PermissionsMode;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeletionProtection !== undefined && {
+      DeletionProtection: input.DeletionProtection
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.PermissionsMode !== undefined && {
+      PermissionsMode: input.PermissionsMode
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -253,29 +251,21 @@ export const serializeAws_restJson1_1ExportJournalToS3Command = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ExclusiveEndTime !== undefined) {
-    bodyParams["ExclusiveEndTime"] = Math.round(
-      input.ExclusiveEndTime.getTime() / 1000
-    );
-  }
-  if (input.InclusiveStartTime !== undefined) {
-    bodyParams["InclusiveStartTime"] = Math.round(
-      input.InclusiveStartTime.getTime() / 1000
-    );
-  }
-  if (input.RoleArn !== undefined) {
-    bodyParams["RoleArn"] = input.RoleArn;
-  }
-  if (input.S3ExportConfiguration !== undefined) {
-    bodyParams[
-      "S3ExportConfiguration"
-    ] = serializeAws_restJson1_1S3ExportConfiguration(
-      input.S3ExportConfiguration,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ExclusiveEndTime !== undefined && {
+      ExclusiveEndTime: Math.round(input.ExclusiveEndTime.getTime() / 1000)
+    }),
+    ...(input.InclusiveStartTime !== undefined && {
+      InclusiveStartTime: Math.round(input.InclusiveStartTime.getTime() / 1000)
+    }),
+    ...(input.RoleArn !== undefined && { RoleArn: input.RoleArn }),
+    ...(input.S3ExportConfiguration !== undefined && {
+      S3ExportConfiguration: serializeAws_restJson1_1S3ExportConfiguration(
+        input.S3ExportConfiguration,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -309,20 +299,20 @@ export const serializeAws_restJson1_1GetBlockCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BlockAddress !== undefined) {
-    bodyParams["BlockAddress"] = serializeAws_restJson1_1ValueHolder(
-      input.BlockAddress,
-      context
-    );
-  }
-  if (input.DigestTipAddress !== undefined) {
-    bodyParams["DigestTipAddress"] = serializeAws_restJson1_1ValueHolder(
-      input.DigestTipAddress,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BlockAddress !== undefined && {
+      BlockAddress: serializeAws_restJson1_1ValueHolder(
+        input.BlockAddress,
+        context
+      )
+    }),
+    ...(input.DigestTipAddress !== undefined && {
+      DigestTipAddress: serializeAws_restJson1_1ValueHolder(
+        input.DigestTipAddress,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -389,23 +379,21 @@ export const serializeAws_restJson1_1GetRevisionCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BlockAddress !== undefined) {
-    bodyParams["BlockAddress"] = serializeAws_restJson1_1ValueHolder(
-      input.BlockAddress,
-      context
-    );
-  }
-  if (input.DigestTipAddress !== undefined) {
-    bodyParams["DigestTipAddress"] = serializeAws_restJson1_1ValueHolder(
-      input.DigestTipAddress,
-      context
-    );
-  }
-  if (input.DocumentId !== undefined) {
-    bodyParams["DocumentId"] = input.DocumentId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BlockAddress !== undefined && {
+      BlockAddress: serializeAws_restJson1_1ValueHolder(
+        input.BlockAddress,
+        context
+      )
+    }),
+    ...(input.DigestTipAddress !== undefined && {
+      DigestTipAddress: serializeAws_restJson1_1ValueHolder(
+        input.DigestTipAddress,
+        context
+      )
+    }),
+    ...(input.DocumentId !== undefined && { DocumentId: input.DocumentId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -572,11 +560,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -651,11 +639,11 @@ export const serializeAws_restJson1_1UpdateLedgerCommand = async (
     throw new Error("No value provided for input HTTP label: Name.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeletionProtection !== undefined) {
-    bodyParams["DeletionProtection"] = input.DeletionProtection;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeletionProtection !== undefined && {
+      DeletionProtection: input.DeletionProtection
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-quicksight/protocols/Aws_restJson1_1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1_1.ts
@@ -485,43 +485,36 @@ export const serializeAws_restJson1_1CreateDashboardCommand = async (
     throw new Error("No value provided for input HTTP label: DashboardId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DashboardPublishOptions !== undefined) {
-    bodyParams[
-      "DashboardPublishOptions"
-    ] = serializeAws_restJson1_1DashboardPublishOptions(
-      input.DashboardPublishOptions,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Parameters !== undefined) {
-    bodyParams["Parameters"] = serializeAws_restJson1_1_Parameters(
-      input.Parameters,
-      context
-    );
-  }
-  if (input.Permissions !== undefined) {
-    bodyParams["Permissions"] = serializeAws_restJson1_1ResourcePermissionList(
-      input.Permissions,
-      context
-    );
-  }
-  if (input.SourceEntity !== undefined) {
-    bodyParams["SourceEntity"] = serializeAws_restJson1_1DashboardSourceEntity(
-      input.SourceEntity,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  if (input.VersionDescription !== undefined) {
-    bodyParams["VersionDescription"] = input.VersionDescription;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DashboardPublishOptions !== undefined && {
+      DashboardPublishOptions: serializeAws_restJson1_1DashboardPublishOptions(
+        input.DashboardPublishOptions,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Parameters !== undefined && {
+      Parameters: serializeAws_restJson1_1_Parameters(input.Parameters, context)
+    }),
+    ...(input.Permissions !== undefined && {
+      Permissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.Permissions,
+        context
+      )
+    }),
+    ...(input.SourceEntity !== undefined && {
+      SourceEntity: serializeAws_restJson1_1DashboardSourceEntity(
+        input.SourceEntity,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    }),
+    ...(input.VersionDescription !== undefined && {
+      VersionDescription: input.VersionDescription
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -557,52 +550,44 @@ export const serializeAws_restJson1_1CreateDataSetCommand = async (
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ColumnGroups !== undefined) {
-    bodyParams["ColumnGroups"] = serializeAws_restJson1_1ColumnGroupList(
-      input.ColumnGroups,
-      context
-    );
-  }
-  if (input.DataSetId !== undefined) {
-    bodyParams["DataSetId"] = input.DataSetId;
-  }
-  if (input.ImportMode !== undefined) {
-    bodyParams["ImportMode"] = input.ImportMode;
-  }
-  if (input.LogicalTableMap !== undefined) {
-    bodyParams["LogicalTableMap"] = serializeAws_restJson1_1LogicalTableMap(
-      input.LogicalTableMap,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Permissions !== undefined) {
-    bodyParams["Permissions"] = serializeAws_restJson1_1ResourcePermissionList(
-      input.Permissions,
-      context
-    );
-  }
-  if (input.PhysicalTableMap !== undefined) {
-    bodyParams["PhysicalTableMap"] = serializeAws_restJson1_1PhysicalTableMap(
-      input.PhysicalTableMap,
-      context
-    );
-  }
-  if (input.RowLevelPermissionDataSet !== undefined) {
-    bodyParams[
-      "RowLevelPermissionDataSet"
-    ] = serializeAws_restJson1_1RowLevelPermissionDataSet(
-      input.RowLevelPermissionDataSet,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ColumnGroups !== undefined && {
+      ColumnGroups: serializeAws_restJson1_1ColumnGroupList(
+        input.ColumnGroups,
+        context
+      )
+    }),
+    ...(input.DataSetId !== undefined && { DataSetId: input.DataSetId }),
+    ...(input.ImportMode !== undefined && { ImportMode: input.ImportMode }),
+    ...(input.LogicalTableMap !== undefined && {
+      LogicalTableMap: serializeAws_restJson1_1LogicalTableMap(
+        input.LogicalTableMap,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Permissions !== undefined && {
+      Permissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.Permissions,
+        context
+      )
+    }),
+    ...(input.PhysicalTableMap !== undefined && {
+      PhysicalTableMap: serializeAws_restJson1_1PhysicalTableMap(
+        input.PhysicalTableMap,
+        context
+      )
+    }),
+    ...(input.RowLevelPermissionDataSet !== undefined && {
+      RowLevelPermissionDataSet: serializeAws_restJson1_1RowLevelPermissionDataSet(
+        input.RowLevelPermissionDataSet,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -638,54 +623,46 @@ export const serializeAws_restJson1_1CreateDataSourceCommand = async (
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Credentials !== undefined) {
-    bodyParams["Credentials"] = serializeAws_restJson1_1DataSourceCredentials(
-      input.Credentials,
-      context
-    );
-  }
-  if (input.DataSourceId !== undefined) {
-    bodyParams["DataSourceId"] = input.DataSourceId;
-  }
-  if (input.DataSourceParameters !== undefined) {
-    bodyParams[
-      "DataSourceParameters"
-    ] = serializeAws_restJson1_1DataSourceParameters(
-      input.DataSourceParameters,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Permissions !== undefined) {
-    bodyParams["Permissions"] = serializeAws_restJson1_1ResourcePermissionList(
-      input.Permissions,
-      context
-    );
-  }
-  if (input.SslProperties !== undefined) {
-    bodyParams["SslProperties"] = serializeAws_restJson1_1SslProperties(
-      input.SslProperties,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  if (input.VpcConnectionProperties !== undefined) {
-    bodyParams[
-      "VpcConnectionProperties"
-    ] = serializeAws_restJson1_1VpcConnectionProperties(
-      input.VpcConnectionProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Credentials !== undefined && {
+      Credentials: serializeAws_restJson1_1DataSourceCredentials(
+        input.Credentials,
+        context
+      )
+    }),
+    ...(input.DataSourceId !== undefined && {
+      DataSourceId: input.DataSourceId
+    }),
+    ...(input.DataSourceParameters !== undefined && {
+      DataSourceParameters: serializeAws_restJson1_1DataSourceParameters(
+        input.DataSourceParameters,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Permissions !== undefined && {
+      Permissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.Permissions,
+        context
+      )
+    }),
+    ...(input.SslProperties !== undefined && {
+      SslProperties: serializeAws_restJson1_1SslProperties(
+        input.SslProperties,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    }),
+    ...(input.Type !== undefined && { Type: input.Type }),
+    ...(input.VpcConnectionProperties !== undefined && {
+      VpcConnectionProperties: serializeAws_restJson1_1VpcConnectionProperties(
+        input.VpcConnectionProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -733,14 +710,10 @@ export const serializeAws_restJson1_1CreateGroupCommand = async (
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.GroupName !== undefined) {
-    bodyParams["GroupName"] = input.GroupName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.GroupName !== undefined && { GroupName: input.GroupName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -861,23 +834,18 @@ export const serializeAws_restJson1_1CreateIAMPolicyAssignmentCommand = async (
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AssignmentName !== undefined) {
-    bodyParams["AssignmentName"] = input.AssignmentName;
-  }
-  if (input.AssignmentStatus !== undefined) {
-    bodyParams["AssignmentStatus"] = input.AssignmentStatus;
-  }
-  if (input.Identities !== undefined) {
-    bodyParams["Identities"] = serializeAws_restJson1_1IdentityMap(
-      input.Identities,
-      context
-    );
-  }
-  if (input.PolicyArn !== undefined) {
-    bodyParams["PolicyArn"] = input.PolicyArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AssignmentName !== undefined && {
+      AssignmentName: input.AssignmentName
+    }),
+    ...(input.AssignmentStatus !== undefined && {
+      AssignmentStatus: input.AssignmentStatus
+    }),
+    ...(input.Identities !== undefined && {
+      Identities: serializeAws_restJson1_1IdentityMap(input.Identities, context)
+    }),
+    ...(input.PolicyArn !== undefined && { PolicyArn: input.PolicyArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -987,29 +955,27 @@ export const serializeAws_restJson1_1CreateTemplateCommand = async (
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Permissions !== undefined) {
-    bodyParams["Permissions"] = serializeAws_restJson1_1ResourcePermissionList(
-      input.Permissions,
-      context
-    );
-  }
-  if (input.SourceEntity !== undefined) {
-    bodyParams["SourceEntity"] = serializeAws_restJson1_1TemplateSourceEntity(
-      input.SourceEntity,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  if (input.VersionDescription !== undefined) {
-    bodyParams["VersionDescription"] = input.VersionDescription;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Permissions !== undefined && {
+      Permissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.Permissions,
+        context
+      )
+    }),
+    ...(input.SourceEntity !== undefined && {
+      SourceEntity: serializeAws_restJson1_1TemplateSourceEntity(
+        input.SourceEntity,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    }),
+    ...(input.VersionDescription !== undefined && {
+      VersionDescription: input.VersionDescription
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1070,11 +1036,11 @@ export const serializeAws_restJson1_1CreateTemplateAliasCommand = async (
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.TemplateVersionNumber !== undefined) {
-    bodyParams["TemplateVersionNumber"] = input.TemplateVersionNumber;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TemplateVersionNumber !== undefined && {
+      TemplateVersionNumber: input.TemplateVersionNumber
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2785,11 +2751,11 @@ export const serializeAws_restJson1_1ListIAMPolicyAssignmentsCommand = async (
     ...(input.NextToken !== undefined && { "next-token": input.NextToken })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.AssignmentStatus !== undefined) {
-    bodyParams["AssignmentStatus"] = input.AssignmentStatus;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AssignmentStatus !== undefined && {
+      AssignmentStatus: input.AssignmentStatus
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3266,26 +3232,16 @@ export const serializeAws_restJson1_1RegisterUserCommand = async (
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Email !== undefined) {
-    bodyParams["Email"] = input.Email;
-  }
-  if (input.IamArn !== undefined) {
-    bodyParams["IamArn"] = input.IamArn;
-  }
-  if (input.IdentityType !== undefined) {
-    bodyParams["IdentityType"] = input.IdentityType;
-  }
-  if (input.SessionName !== undefined) {
-    bodyParams["SessionName"] = input.SessionName;
-  }
-  if (input.UserName !== undefined) {
-    bodyParams["UserName"] = input.UserName;
-  }
-  if (input.UserRole !== undefined) {
-    bodyParams["UserRole"] = input.UserRole;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Email !== undefined && { Email: input.Email }),
+    ...(input.IamArn !== undefined && { IamArn: input.IamArn }),
+    ...(input.IdentityType !== undefined && {
+      IdentityType: input.IdentityType
+    }),
+    ...(input.SessionName !== undefined && { SessionName: input.SessionName }),
+    ...(input.UserName !== undefined && { UserName: input.UserName }),
+    ...(input.UserRole !== undefined && { UserRole: input.UserRole })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3321,11 +3277,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3416,34 +3372,27 @@ export const serializeAws_restJson1_1UpdateDashboardCommand = async (
     throw new Error("No value provided for input HTTP label: DashboardId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DashboardPublishOptions !== undefined) {
-    bodyParams[
-      "DashboardPublishOptions"
-    ] = serializeAws_restJson1_1DashboardPublishOptions(
-      input.DashboardPublishOptions,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.Parameters !== undefined) {
-    bodyParams["Parameters"] = serializeAws_restJson1_1_Parameters(
-      input.Parameters,
-      context
-    );
-  }
-  if (input.SourceEntity !== undefined) {
-    bodyParams["SourceEntity"] = serializeAws_restJson1_1DashboardSourceEntity(
-      input.SourceEntity,
-      context
-    );
-  }
-  if (input.VersionDescription !== undefined) {
-    bodyParams["VersionDescription"] = input.VersionDescription;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DashboardPublishOptions !== undefined && {
+      DashboardPublishOptions: serializeAws_restJson1_1DashboardPublishOptions(
+        input.DashboardPublishOptions,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Parameters !== undefined && {
+      Parameters: serializeAws_restJson1_1_Parameters(input.Parameters, context)
+    }),
+    ...(input.SourceEntity !== undefined && {
+      SourceEntity: serializeAws_restJson1_1DashboardSourceEntity(
+        input.SourceEntity,
+        context
+      )
+    }),
+    ...(input.VersionDescription !== undefined && {
+      VersionDescription: input.VersionDescription
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3494,24 +3443,20 @@ export const serializeAws_restJson1_1UpdateDashboardPermissionsCommand = async (
     throw new Error("No value provided for input HTTP label: DashboardId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.GrantPermissions !== undefined) {
-    bodyParams[
-      "GrantPermissions"
-    ] = serializeAws_restJson1_1UpdateResourcePermissionList(
-      input.GrantPermissions,
-      context
-    );
-  }
-  if (input.RevokePermissions !== undefined) {
-    bodyParams[
-      "RevokePermissions"
-    ] = serializeAws_restJson1_1UpdateResourcePermissionList(
-      input.RevokePermissions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GrantPermissions !== undefined && {
+      GrantPermissions: serializeAws_restJson1_1UpdateResourcePermissionList(
+        input.GrantPermissions,
+        context
+      )
+    }),
+    ...(input.RevokePermissions !== undefined && {
+      RevokePermissions: serializeAws_restJson1_1UpdateResourcePermissionList(
+        input.RevokePermissions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3623,40 +3568,34 @@ export const serializeAws_restJson1_1UpdateDataSetCommand = async (
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ColumnGroups !== undefined) {
-    bodyParams["ColumnGroups"] = serializeAws_restJson1_1ColumnGroupList(
-      input.ColumnGroups,
-      context
-    );
-  }
-  if (input.ImportMode !== undefined) {
-    bodyParams["ImportMode"] = input.ImportMode;
-  }
-  if (input.LogicalTableMap !== undefined) {
-    bodyParams["LogicalTableMap"] = serializeAws_restJson1_1LogicalTableMap(
-      input.LogicalTableMap,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.PhysicalTableMap !== undefined) {
-    bodyParams["PhysicalTableMap"] = serializeAws_restJson1_1PhysicalTableMap(
-      input.PhysicalTableMap,
-      context
-    );
-  }
-  if (input.RowLevelPermissionDataSet !== undefined) {
-    bodyParams[
-      "RowLevelPermissionDataSet"
-    ] = serializeAws_restJson1_1RowLevelPermissionDataSet(
-      input.RowLevelPermissionDataSet,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ColumnGroups !== undefined && {
+      ColumnGroups: serializeAws_restJson1_1ColumnGroupList(
+        input.ColumnGroups,
+        context
+      )
+    }),
+    ...(input.ImportMode !== undefined && { ImportMode: input.ImportMode }),
+    ...(input.LogicalTableMap !== undefined && {
+      LogicalTableMap: serializeAws_restJson1_1LogicalTableMap(
+        input.LogicalTableMap,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.PhysicalTableMap !== undefined && {
+      PhysicalTableMap: serializeAws_restJson1_1PhysicalTableMap(
+        input.PhysicalTableMap,
+        context
+      )
+    }),
+    ...(input.RowLevelPermissionDataSet !== undefined && {
+      RowLevelPermissionDataSet: serializeAws_restJson1_1RowLevelPermissionDataSet(
+        input.RowLevelPermissionDataSet,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3705,24 +3644,20 @@ export const serializeAws_restJson1_1UpdateDataSetPermissionsCommand = async (
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.GrantPermissions !== undefined) {
-    bodyParams[
-      "GrantPermissions"
-    ] = serializeAws_restJson1_1ResourcePermissionList(
-      input.GrantPermissions,
-      context
-    );
-  }
-  if (input.RevokePermissions !== undefined) {
-    bodyParams[
-      "RevokePermissions"
-    ] = serializeAws_restJson1_1ResourcePermissionList(
-      input.RevokePermissions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GrantPermissions !== undefined && {
+      GrantPermissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.GrantPermissions,
+        context
+      )
+    }),
+    ...(input.RevokePermissions !== undefined && {
+      RevokePermissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.RevokePermissions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3772,39 +3707,33 @@ export const serializeAws_restJson1_1UpdateDataSourceCommand = async (
     throw new Error("No value provided for input HTTP label: DataSourceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Credentials !== undefined) {
-    bodyParams["Credentials"] = serializeAws_restJson1_1DataSourceCredentials(
-      input.Credentials,
-      context
-    );
-  }
-  if (input.DataSourceParameters !== undefined) {
-    bodyParams[
-      "DataSourceParameters"
-    ] = serializeAws_restJson1_1DataSourceParameters(
-      input.DataSourceParameters,
-      context
-    );
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.SslProperties !== undefined) {
-    bodyParams["SslProperties"] = serializeAws_restJson1_1SslProperties(
-      input.SslProperties,
-      context
-    );
-  }
-  if (input.VpcConnectionProperties !== undefined) {
-    bodyParams[
-      "VpcConnectionProperties"
-    ] = serializeAws_restJson1_1VpcConnectionProperties(
-      input.VpcConnectionProperties,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Credentials !== undefined && {
+      Credentials: serializeAws_restJson1_1DataSourceCredentials(
+        input.Credentials,
+        context
+      )
+    }),
+    ...(input.DataSourceParameters !== undefined && {
+      DataSourceParameters: serializeAws_restJson1_1DataSourceParameters(
+        input.DataSourceParameters,
+        context
+      )
+    }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.SslProperties !== undefined && {
+      SslProperties: serializeAws_restJson1_1SslProperties(
+        input.SslProperties,
+        context
+      )
+    }),
+    ...(input.VpcConnectionProperties !== undefined && {
+      VpcConnectionProperties: serializeAws_restJson1_1VpcConnectionProperties(
+        input.VpcConnectionProperties,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3855,24 +3784,20 @@ export const serializeAws_restJson1_1UpdateDataSourcePermissionsCommand = async 
     throw new Error("No value provided for input HTTP label: DataSourceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.GrantPermissions !== undefined) {
-    bodyParams[
-      "GrantPermissions"
-    ] = serializeAws_restJson1_1ResourcePermissionList(
-      input.GrantPermissions,
-      context
-    );
-  }
-  if (input.RevokePermissions !== undefined) {
-    bodyParams[
-      "RevokePermissions"
-    ] = serializeAws_restJson1_1ResourcePermissionList(
-      input.RevokePermissions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GrantPermissions !== undefined && {
+      GrantPermissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.GrantPermissions,
+        context
+      )
+    }),
+    ...(input.RevokePermissions !== undefined && {
+      RevokePermissions: serializeAws_restJson1_1ResourcePermissionList(
+        input.RevokePermissions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3933,11 +3858,9 @@ export const serializeAws_restJson1_1UpdateGroupCommand = async (
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4000,20 +3923,15 @@ export const serializeAws_restJson1_1UpdateIAMPolicyAssignmentCommand = async (
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.AssignmentStatus !== undefined) {
-    bodyParams["AssignmentStatus"] = input.AssignmentStatus;
-  }
-  if (input.Identities !== undefined) {
-    bodyParams["Identities"] = serializeAws_restJson1_1IdentityMap(
-      input.Identities,
-      context
-    );
-  }
-  if (input.PolicyArn !== undefined) {
-    bodyParams["PolicyArn"] = input.PolicyArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AssignmentStatus !== undefined && {
+      AssignmentStatus: input.AssignmentStatus
+    }),
+    ...(input.Identities !== undefined && {
+      Identities: serializeAws_restJson1_1IdentityMap(input.Identities, context)
+    }),
+    ...(input.PolicyArn !== undefined && { PolicyArn: input.PolicyArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4061,20 +3979,18 @@ export const serializeAws_restJson1_1UpdateTemplateCommand = async (
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.SourceEntity !== undefined) {
-    bodyParams["SourceEntity"] = serializeAws_restJson1_1TemplateSourceEntity(
-      input.SourceEntity,
-      context
-    );
-  }
-  if (input.VersionDescription !== undefined) {
-    bodyParams["VersionDescription"] = input.VersionDescription;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.SourceEntity !== undefined && {
+      SourceEntity: serializeAws_restJson1_1TemplateSourceEntity(
+        input.SourceEntity,
+        context
+      )
+    }),
+    ...(input.VersionDescription !== undefined && {
+      VersionDescription: input.VersionDescription
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4135,11 +4051,11 @@ export const serializeAws_restJson1_1UpdateTemplateAliasCommand = async (
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.TemplateVersionNumber !== undefined) {
-    bodyParams["TemplateVersionNumber"] = input.TemplateVersionNumber;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TemplateVersionNumber !== undefined && {
+      TemplateVersionNumber: input.TemplateVersionNumber
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4188,24 +4104,20 @@ export const serializeAws_restJson1_1UpdateTemplatePermissionsCommand = async (
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.GrantPermissions !== undefined) {
-    bodyParams[
-      "GrantPermissions"
-    ] = serializeAws_restJson1_1UpdateResourcePermissionList(
-      input.GrantPermissions,
-      context
-    );
-  }
-  if (input.RevokePermissions !== undefined) {
-    bodyParams[
-      "RevokePermissions"
-    ] = serializeAws_restJson1_1UpdateResourcePermissionList(
-      input.RevokePermissions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GrantPermissions !== undefined && {
+      GrantPermissions: serializeAws_restJson1_1UpdateResourcePermissionList(
+        input.GrantPermissions,
+        context
+      )
+    }),
+    ...(input.RevokePermissions !== undefined && {
+      RevokePermissions: serializeAws_restJson1_1UpdateResourcePermissionList(
+        input.RevokePermissions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -4266,14 +4178,10 @@ export const serializeAws_restJson1_1UpdateUserCommand = async (
     throw new Error("No value provided for input HTTP label: UserName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Email !== undefined) {
-    bodyParams["Email"] = input.Email;
-  }
-  if (input.Role !== undefined) {
-    bodyParams["Role"] = input.Role;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Email !== undefined && { Email: input.Email }),
+    ...(input.Role !== undefined && { Role: input.Role })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-ram/protocols/Aws_restJson1_1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1_1.ts
@@ -146,14 +146,12 @@ export const serializeAws_restJson1_1AcceptResourceShareInvitationCommand = asyn
   };
   let resolvedPath = "/acceptresourceshareinvitation";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.resourceShareInvitationArn !== undefined) {
-    bodyParams["resourceShareInvitationArn"] = input.resourceShareInvitationArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.resourceShareInvitationArn !== undefined && {
+      resourceShareInvitationArn: input.resourceShareInvitationArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -175,26 +173,24 @@ export const serializeAws_restJson1_1AssociateResourceShareCommand = async (
   };
   let resolvedPath = "/associateresourceshare";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.principals !== undefined) {
-    bodyParams["principals"] = serializeAws_restJson1_1PrincipalArnOrIdList(
-      input.principals,
-      context
-    );
-  }
-  if (input.resourceArns !== undefined) {
-    bodyParams["resourceArns"] = serializeAws_restJson1_1ResourceArnList(
-      input.resourceArns,
-      context
-    );
-  }
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.principals !== undefined && {
+      principals: serializeAws_restJson1_1PrincipalArnOrIdList(
+        input.principals,
+        context
+      )
+    }),
+    ...(input.resourceArns !== undefined && {
+      resourceArns: serializeAws_restJson1_1ResourceArnList(
+        input.resourceArns,
+        context
+      )
+    }),
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -216,20 +212,16 @@ export const serializeAws_restJson1_1AssociateResourceSharePermissionCommand = a
   };
   let resolvedPath = "/associateresourcesharepermission";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.permissionArn !== undefined) {
-    bodyParams["permissionArn"] = input.permissionArn;
-  }
-  if (input.replace !== undefined) {
-    bodyParams["replace"] = input.replace;
-  }
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.permissionArn !== undefined && {
+      permissionArn: input.permissionArn
+    }),
+    ...(input.replace !== undefined && { replace: input.replace }),
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -251,38 +243,34 @@ export const serializeAws_restJson1_1CreateResourceShareCommand = async (
   };
   let resolvedPath = "/createresourceshare";
   let body: any;
-  const bodyParams: any = {};
-  if (input.allowExternalPrincipals !== undefined) {
-    bodyParams["allowExternalPrincipals"] = input.allowExternalPrincipals;
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.permissionArns !== undefined) {
-    bodyParams["permissionArns"] = serializeAws_restJson1_1PermissionArnList(
-      input.permissionArns,
-      context
-    );
-  }
-  if (input.principals !== undefined) {
-    bodyParams["principals"] = serializeAws_restJson1_1PrincipalArnOrIdList(
-      input.principals,
-      context
-    );
-  }
-  if (input.resourceArns !== undefined) {
-    bodyParams["resourceArns"] = serializeAws_restJson1_1ResourceArnList(
-      input.resourceArns,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.allowExternalPrincipals !== undefined && {
+      allowExternalPrincipals: input.allowExternalPrincipals
+    }),
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.permissionArns !== undefined && {
+      permissionArns: serializeAws_restJson1_1PermissionArnList(
+        input.permissionArns,
+        context
+      )
+    }),
+    ...(input.principals !== undefined && {
+      principals: serializeAws_restJson1_1PrincipalArnOrIdList(
+        input.principals,
+        context
+      )
+    }),
+    ...(input.resourceArns !== undefined && {
+      resourceArns: serializeAws_restJson1_1ResourceArnList(
+        input.resourceArns,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -332,26 +320,24 @@ export const serializeAws_restJson1_1DisassociateResourceShareCommand = async (
   };
   let resolvedPath = "/disassociateresourceshare";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.principals !== undefined) {
-    bodyParams["principals"] = serializeAws_restJson1_1PrincipalArnOrIdList(
-      input.principals,
-      context
-    );
-  }
-  if (input.resourceArns !== undefined) {
-    bodyParams["resourceArns"] = serializeAws_restJson1_1ResourceArnList(
-      input.resourceArns,
-      context
-    );
-  }
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.principals !== undefined && {
+      principals: serializeAws_restJson1_1PrincipalArnOrIdList(
+        input.principals,
+        context
+      )
+    }),
+    ...(input.resourceArns !== undefined && {
+      resourceArns: serializeAws_restJson1_1ResourceArnList(
+        input.resourceArns,
+        context
+      )
+    }),
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -373,17 +359,15 @@ export const serializeAws_restJson1_1DisassociateResourceSharePermissionCommand 
   };
   let resolvedPath = "/disassociateresourcesharepermission";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.permissionArn !== undefined) {
-    bodyParams["permissionArn"] = input.permissionArn;
-  }
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.permissionArn !== undefined && {
+      permissionArn: input.permissionArn
+    }),
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -427,14 +411,14 @@ export const serializeAws_restJson1_1GetPermissionCommand = async (
   };
   let resolvedPath = "/getpermission";
   let body: any;
-  const bodyParams: any = {};
-  if (input.permissionArn !== undefined) {
-    bodyParams["permissionArn"] = input.permissionArn;
-  }
-  if (input.permissionVersion !== undefined) {
-    bodyParams["permissionVersion"] = input.permissionVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.permissionArn !== undefined && {
+      permissionArn: input.permissionArn
+    }),
+    ...(input.permissionVersion !== undefined && {
+      permissionVersion: input.permissionVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -456,23 +440,17 @@ export const serializeAws_restJson1_1GetResourcePoliciesCommand = async (
   };
   let resolvedPath = "/getresourcepolicies";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.principal !== undefined) {
-    bodyParams["principal"] = input.principal;
-  }
-  if (input.resourceArns !== undefined) {
-    bodyParams["resourceArns"] = serializeAws_restJson1_1ResourceArnList(
-      input.resourceArns,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.principal !== undefined && { principal: input.principal }),
+    ...(input.resourceArns !== undefined && {
+      resourceArns: serializeAws_restJson1_1ResourceArnList(
+        input.resourceArns,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -494,34 +472,24 @@ export const serializeAws_restJson1_1GetResourceShareAssociationsCommand = async
   };
   let resolvedPath = "/getresourceshareassociations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.associationStatus !== undefined) {
-    bodyParams["associationStatus"] = input.associationStatus;
-  }
-  if (input.associationType !== undefined) {
-    bodyParams["associationType"] = input.associationType;
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.principal !== undefined) {
-    bodyParams["principal"] = input.principal;
-  }
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.resourceShareArns !== undefined) {
-    bodyParams[
-      "resourceShareArns"
-    ] = serializeAws_restJson1_1ResourceShareArnList(
-      input.resourceShareArns,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.associationStatus !== undefined && {
+      associationStatus: input.associationStatus
+    }),
+    ...(input.associationType !== undefined && {
+      associationType: input.associationType
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.principal !== undefined && { principal: input.principal }),
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.resourceShareArns !== undefined && {
+      resourceShareArns: serializeAws_restJson1_1ResourceShareArnList(
+        input.resourceShareArns,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -543,30 +511,22 @@ export const serializeAws_restJson1_1GetResourceShareInvitationsCommand = async 
   };
   let resolvedPath = "/getresourceshareinvitations";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.resourceShareArns !== undefined) {
-    bodyParams[
-      "resourceShareArns"
-    ] = serializeAws_restJson1_1ResourceShareArnList(
-      input.resourceShareArns,
-      context
-    );
-  }
-  if (input.resourceShareInvitationArns !== undefined) {
-    bodyParams[
-      "resourceShareInvitationArns"
-    ] = serializeAws_restJson1_1ResourceShareInvitationArnList(
-      input.resourceShareInvitationArns,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.resourceShareArns !== undefined && {
+      resourceShareArns: serializeAws_restJson1_1ResourceShareArnList(
+        input.resourceShareArns,
+        context
+      )
+    }),
+    ...(input.resourceShareInvitationArns !== undefined && {
+      resourceShareInvitationArns: serializeAws_restJson1_1ResourceShareInvitationArnList(
+        input.resourceShareInvitationArns,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -588,37 +548,26 @@ export const serializeAws_restJson1_1GetResourceSharesCommand = async (
   };
   let resolvedPath = "/getresourceshares";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.resourceOwner !== undefined) {
-    bodyParams["resourceOwner"] = input.resourceOwner;
-  }
-  if (input.resourceShareArns !== undefined) {
-    bodyParams[
-      "resourceShareArns"
-    ] = serializeAws_restJson1_1ResourceShareArnList(
-      input.resourceShareArns,
-      context
-    );
-  }
-  if (input.resourceShareStatus !== undefined) {
-    bodyParams["resourceShareStatus"] = input.resourceShareStatus;
-  }
-  if (input.tagFilters !== undefined) {
-    bodyParams["tagFilters"] = serializeAws_restJson1_1TagFilters(
-      input.tagFilters,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.resourceOwner !== undefined && {
+      resourceOwner: input.resourceOwner
+    }),
+    ...(input.resourceShareArns !== undefined && {
+      resourceShareArns: serializeAws_restJson1_1ResourceShareArnList(
+        input.resourceShareArns,
+        context
+      )
+    }),
+    ...(input.resourceShareStatus !== undefined && {
+      resourceShareStatus: input.resourceShareStatus
+    }),
+    ...(input.tagFilters !== undefined && {
+      tagFilters: serializeAws_restJson1_1TagFilters(input.tagFilters, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -640,17 +589,13 @@ export const serializeAws_restJson1_1ListPendingInvitationResourcesCommand = asy
   };
   let resolvedPath = "/listpendinginvitationresources";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.resourceShareInvitationArn !== undefined) {
-    bodyParams["resourceShareInvitationArn"] = input.resourceShareInvitationArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.resourceShareInvitationArn !== undefined && {
+      resourceShareInvitationArn: input.resourceShareInvitationArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -672,17 +617,13 @@ export const serializeAws_restJson1_1ListPermissionsCommand = async (
   };
   let resolvedPath = "/listpermissions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.resourceType !== undefined) {
-    bodyParams["resourceType"] = input.resourceType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.resourceType !== undefined && {
+      resourceType: input.resourceType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -704,37 +645,29 @@ export const serializeAws_restJson1_1ListPrincipalsCommand = async (
   };
   let resolvedPath = "/listprincipals";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.principals !== undefined) {
-    bodyParams["principals"] = serializeAws_restJson1_1PrincipalArnOrIdList(
-      input.principals,
-      context
-    );
-  }
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.resourceOwner !== undefined) {
-    bodyParams["resourceOwner"] = input.resourceOwner;
-  }
-  if (input.resourceShareArns !== undefined) {
-    bodyParams[
-      "resourceShareArns"
-    ] = serializeAws_restJson1_1ResourceShareArnList(
-      input.resourceShareArns,
-      context
-    );
-  }
-  if (input.resourceType !== undefined) {
-    bodyParams["resourceType"] = input.resourceType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.principals !== undefined && {
+      principals: serializeAws_restJson1_1PrincipalArnOrIdList(
+        input.principals,
+        context
+      )
+    }),
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.resourceOwner !== undefined && {
+      resourceOwner: input.resourceOwner
+    }),
+    ...(input.resourceShareArns !== undefined && {
+      resourceShareArns: serializeAws_restJson1_1ResourceShareArnList(
+        input.resourceShareArns,
+        context
+      )
+    }),
+    ...(input.resourceType !== undefined && {
+      resourceType: input.resourceType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -756,17 +689,13 @@ export const serializeAws_restJson1_1ListResourceSharePermissionsCommand = async
   };
   let resolvedPath = "/listresourcesharepermissions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -788,37 +717,29 @@ export const serializeAws_restJson1_1ListResourcesCommand = async (
   };
   let resolvedPath = "/listresources";
   let body: any;
-  const bodyParams: any = {};
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.principal !== undefined) {
-    bodyParams["principal"] = input.principal;
-  }
-  if (input.resourceArns !== undefined) {
-    bodyParams["resourceArns"] = serializeAws_restJson1_1ResourceArnList(
-      input.resourceArns,
-      context
-    );
-  }
-  if (input.resourceOwner !== undefined) {
-    bodyParams["resourceOwner"] = input.resourceOwner;
-  }
-  if (input.resourceShareArns !== undefined) {
-    bodyParams[
-      "resourceShareArns"
-    ] = serializeAws_restJson1_1ResourceShareArnList(
-      input.resourceShareArns,
-      context
-    );
-  }
-  if (input.resourceType !== undefined) {
-    bodyParams["resourceType"] = input.resourceType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.principal !== undefined && { principal: input.principal }),
+    ...(input.resourceArns !== undefined && {
+      resourceArns: serializeAws_restJson1_1ResourceArnList(
+        input.resourceArns,
+        context
+      )
+    }),
+    ...(input.resourceOwner !== undefined && {
+      resourceOwner: input.resourceOwner
+    }),
+    ...(input.resourceShareArns !== undefined && {
+      resourceShareArns: serializeAws_restJson1_1ResourceShareArnList(
+        input.resourceShareArns,
+        context
+      )
+    }),
+    ...(input.resourceType !== undefined && {
+      resourceType: input.resourceType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -867,14 +788,12 @@ export const serializeAws_restJson1_1RejectResourceShareInvitationCommand = asyn
   };
   let resolvedPath = "/rejectresourceshareinvitation";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.resourceShareInvitationArn !== undefined) {
-    bodyParams["resourceShareInvitationArn"] = input.resourceShareInvitationArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.resourceShareInvitationArn !== undefined && {
+      resourceShareInvitationArn: input.resourceShareInvitationArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -896,14 +815,14 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/tagresource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagList(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagList(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -925,17 +844,14 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
   };
   let resolvedPath = "/untagresource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  if (input.tagKeys !== undefined) {
-    bodyParams["tagKeys"] = serializeAws_restJson1_1TagKeyList(
-      input.tagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    }),
+    ...(input.tagKeys !== undefined && {
+      tagKeys: serializeAws_restJson1_1TagKeyList(input.tagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -957,20 +873,16 @@ export const serializeAws_restJson1_1UpdateResourceShareCommand = async (
   };
   let resolvedPath = "/updateresourceshare";
   let body: any;
-  const bodyParams: any = {};
-  if (input.allowExternalPrincipals !== undefined) {
-    bodyParams["allowExternalPrincipals"] = input.allowExternalPrincipals;
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.resourceShareArn !== undefined) {
-    bodyParams["resourceShareArn"] = input.resourceShareArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.allowExternalPrincipals !== undefined && {
+      allowExternalPrincipals: input.allowExternalPrincipals
+    }),
+    ...(input.clientToken !== undefined && { clientToken: input.clientToken }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.resourceShareArn !== undefined && {
+      resourceShareArn: input.resourceShareArn
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-rds-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1_1.ts
@@ -62,32 +62,22 @@ export const serializeAws_restJson1_1BatchExecuteStatementCommand = async (
   };
   let resolvedPath = "/BatchExecute";
   let body: any;
-  const bodyParams: any = {};
-  if (input.database !== undefined) {
-    bodyParams["database"] = input.database;
-  }
-  if (input.parameterSets !== undefined) {
-    bodyParams["parameterSets"] = serializeAws_restJson1_1SqlParameterSets(
-      input.parameterSets,
-      context
-    );
-  }
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.schema !== undefined) {
-    bodyParams["schema"] = input.schema;
-  }
-  if (input.secretArn !== undefined) {
-    bodyParams["secretArn"] = input.secretArn;
-  }
-  if (input.sql !== undefined) {
-    bodyParams["sql"] = input.sql;
-  }
-  if (input.transactionId !== undefined) {
-    bodyParams["transactionId"] = input.transactionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.database !== undefined && { database: input.database }),
+    ...(input.parameterSets !== undefined && {
+      parameterSets: serializeAws_restJson1_1SqlParameterSets(
+        input.parameterSets,
+        context
+      )
+    }),
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.schema !== undefined && { schema: input.schema }),
+    ...(input.secretArn !== undefined && { secretArn: input.secretArn }),
+    ...(input.sql !== undefined && { sql: input.sql }),
+    ...(input.transactionId !== undefined && {
+      transactionId: input.transactionId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -109,20 +99,12 @@ export const serializeAws_restJson1_1BeginTransactionCommand = async (
   };
   let resolvedPath = "/BeginTransaction";
   let body: any;
-  const bodyParams: any = {};
-  if (input.database !== undefined) {
-    bodyParams["database"] = input.database;
-  }
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.schema !== undefined) {
-    bodyParams["schema"] = input.schema;
-  }
-  if (input.secretArn !== undefined) {
-    bodyParams["secretArn"] = input.secretArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.database !== undefined && { database: input.database }),
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.schema !== undefined && { schema: input.schema }),
+    ...(input.secretArn !== undefined && { secretArn: input.secretArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -144,17 +126,13 @@ export const serializeAws_restJson1_1CommitTransactionCommand = async (
   };
   let resolvedPath = "/CommitTransaction";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.secretArn !== undefined) {
-    bodyParams["secretArn"] = input.secretArn;
-  }
-  if (input.transactionId !== undefined) {
-    bodyParams["transactionId"] = input.transactionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.secretArn !== undefined && { secretArn: input.secretArn }),
+    ...(input.transactionId !== undefined && {
+      transactionId: input.transactionId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -176,23 +154,19 @@ export const serializeAws_restJson1_1ExecuteSqlCommand = async (
   };
   let resolvedPath = "/ExecuteSql";
   let body: any;
-  const bodyParams: any = {};
-  if (input.awsSecretStoreArn !== undefined) {
-    bodyParams["awsSecretStoreArn"] = input.awsSecretStoreArn;
-  }
-  if (input.database !== undefined) {
-    bodyParams["database"] = input.database;
-  }
-  if (input.dbClusterOrInstanceArn !== undefined) {
-    bodyParams["dbClusterOrInstanceArn"] = input.dbClusterOrInstanceArn;
-  }
-  if (input.schema !== undefined) {
-    bodyParams["schema"] = input.schema;
-  }
-  if (input.sqlStatements !== undefined) {
-    bodyParams["sqlStatements"] = input.sqlStatements;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.awsSecretStoreArn !== undefined && {
+      awsSecretStoreArn: input.awsSecretStoreArn
+    }),
+    ...(input.database !== undefined && { database: input.database }),
+    ...(input.dbClusterOrInstanceArn !== undefined && {
+      dbClusterOrInstanceArn: input.dbClusterOrInstanceArn
+    }),
+    ...(input.schema !== undefined && { schema: input.schema }),
+    ...(input.sqlStatements !== undefined && {
+      sqlStatements: input.sqlStatements
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -214,38 +188,28 @@ export const serializeAws_restJson1_1ExecuteStatementCommand = async (
   };
   let resolvedPath = "/Execute";
   let body: any;
-  const bodyParams: any = {};
-  if (input.continueAfterTimeout !== undefined) {
-    bodyParams["continueAfterTimeout"] = input.continueAfterTimeout;
-  }
-  if (input.database !== undefined) {
-    bodyParams["database"] = input.database;
-  }
-  if (input.includeResultMetadata !== undefined) {
-    bodyParams["includeResultMetadata"] = input.includeResultMetadata;
-  }
-  if (input.parameters !== undefined) {
-    bodyParams["parameters"] = serializeAws_restJson1_1SqlParametersList(
-      input.parameters,
-      context
-    );
-  }
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.schema !== undefined) {
-    bodyParams["schema"] = input.schema;
-  }
-  if (input.secretArn !== undefined) {
-    bodyParams["secretArn"] = input.secretArn;
-  }
-  if (input.sql !== undefined) {
-    bodyParams["sql"] = input.sql;
-  }
-  if (input.transactionId !== undefined) {
-    bodyParams["transactionId"] = input.transactionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.continueAfterTimeout !== undefined && {
+      continueAfterTimeout: input.continueAfterTimeout
+    }),
+    ...(input.database !== undefined && { database: input.database }),
+    ...(input.includeResultMetadata !== undefined && {
+      includeResultMetadata: input.includeResultMetadata
+    }),
+    ...(input.parameters !== undefined && {
+      parameters: serializeAws_restJson1_1SqlParametersList(
+        input.parameters,
+        context
+      )
+    }),
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.schema !== undefined && { schema: input.schema }),
+    ...(input.secretArn !== undefined && { secretArn: input.secretArn }),
+    ...(input.sql !== undefined && { sql: input.sql }),
+    ...(input.transactionId !== undefined && {
+      transactionId: input.transactionId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -267,17 +231,13 @@ export const serializeAws_restJson1_1RollbackTransactionCommand = async (
   };
   let resolvedPath = "/RollbackTransaction";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.secretArn !== undefined) {
-    bodyParams["secretArn"] = input.secretArn;
-  }
-  if (input.transactionId !== undefined) {
-    bodyParams["transactionId"] = input.transactionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.secretArn !== undefined && { secretArn: input.secretArn }),
+    ...(input.transactionId !== undefined && {
+      transactionId: input.transactionId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
@@ -84,23 +84,19 @@ export const serializeAws_restJson1_1CreateGroupCommand = async (
   };
   let resolvedPath = "/groups";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ResourceQuery !== undefined) {
-    bodyParams["ResourceQuery"] = serializeAws_restJson1_1ResourceQuery(
-      input.ResourceQuery,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ResourceQuery !== undefined && {
+      ResourceQuery: serializeAws_restJson1_1ResourceQuery(
+        input.ResourceQuery,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -272,14 +268,14 @@ export const serializeAws_restJson1_1ListGroupResourcesCommand = async (
     ...(input.NextToken !== undefined && { nextToken: input.NextToken })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1ResourceFilterList(
-      input.Filters,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1ResourceFilterList(
+        input.Filters,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -308,14 +304,11 @@ export const serializeAws_restJson1_1ListGroupsCommand = async (
     ...(input.NextToken !== undefined && { nextToken: input.NextToken })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1GroupFilterList(
-      input.Filters,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1GroupFilterList(input.Filters, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -338,20 +331,16 @@ export const serializeAws_restJson1_1SearchResourcesCommand = async (
   };
   let resolvedPath = "/resources/search";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.ResourceQuery !== undefined) {
-    bodyParams["ResourceQuery"] = serializeAws_restJson1_1ResourceQuery(
-      input.ResourceQuery,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.ResourceQuery !== undefined && {
+      ResourceQuery: serializeAws_restJson1_1ResourceQuery(
+        input.ResourceQuery,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -385,11 +374,11 @@ export const serializeAws_restJson1_1TagCommand = async (
     throw new Error("No value provided for input HTTP label: Arn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -423,14 +412,11 @@ export const serializeAws_restJson1_1UntagCommand = async (
     throw new Error("No value provided for input HTTP label: Arn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Keys !== undefined) {
-    bodyParams["Keys"] = serializeAws_restJson1_1TagKeyList(
-      input.Keys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Keys !== undefined && {
+      Keys: serializeAws_restJson1_1TagKeyList(input.Keys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -464,11 +450,9 @@ export const serializeAws_restJson1_1UpdateGroupCommand = async (
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -502,14 +486,14 @@ export const serializeAws_restJson1_1UpdateGroupQueryCommand = async (
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ResourceQuery !== undefined) {
-    bodyParams["ResourceQuery"] = serializeAws_restJson1_1ResourceQuery(
-      input.ResourceQuery,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ResourceQuery !== undefined && {
+      ResourceQuery: serializeAws_restJson1_1ResourceQuery(
+        input.ResourceQuery,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-robomaker/protocols/Aws_restJson1_1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1_1.ts
@@ -210,11 +210,11 @@ export const serializeAws_restJson1_1BatchDescribeSimulationJobCommand = async (
   };
   let resolvedPath = "/batchDescribeSimulationJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.jobs !== undefined) {
-    bodyParams["jobs"] = serializeAws_restJson1_1Arns(input.jobs, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.jobs !== undefined && {
+      jobs: serializeAws_restJson1_1Arns(input.jobs, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -236,11 +236,9 @@ export const serializeAws_restJson1_1CancelDeploymentJobCommand = async (
   };
   let resolvedPath = "/cancelDeploymentJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.job !== undefined) {
-    bodyParams["job"] = input.job;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.job !== undefined && { job: input.job })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -262,11 +260,9 @@ export const serializeAws_restJson1_1CancelSimulationJobCommand = async (
   };
   let resolvedPath = "/cancelSimulationJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.job !== undefined) {
-    bodyParams["job"] = input.job;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.job !== undefined && { job: input.job })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -288,34 +284,25 @@ export const serializeAws_restJson1_1CreateDeploymentJobCommand = async (
   };
   let resolvedPath = "/createDeploymentJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.deploymentApplicationConfigs !== undefined) {
-    bodyParams[
-      "deploymentApplicationConfigs"
-    ] = serializeAws_restJson1_1DeploymentApplicationConfigs(
-      input.deploymentApplicationConfigs,
-      context
-    );
-  }
-  if (input.deploymentConfig !== undefined) {
-    bodyParams["deploymentConfig"] = serializeAws_restJson1_1DeploymentConfig(
-      input.deploymentConfig,
-      context
-    );
-  }
-  if (input.fleet !== undefined) {
-    bodyParams["fleet"] = input.fleet;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.deploymentApplicationConfigs !== undefined && {
+      deploymentApplicationConfigs: serializeAws_restJson1_1DeploymentApplicationConfigs(
+        input.deploymentApplicationConfigs,
+        context
+      )
+    }),
+    ...(input.deploymentConfig !== undefined && {
+      deploymentConfig: serializeAws_restJson1_1DeploymentConfig(
+        input.deploymentConfig,
+        context
+      )
+    }),
+    ...(input.fleet !== undefined && { fleet: input.fleet }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -337,14 +324,12 @@ export const serializeAws_restJson1_1CreateFleetCommand = async (
   };
   let resolvedPath = "/createFleet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -366,20 +351,18 @@ export const serializeAws_restJson1_1CreateRobotCommand = async (
   };
   let resolvedPath = "/createRobot";
   let body: any;
-  const bodyParams: any = {};
-  if (input.architecture !== undefined) {
-    bodyParams["architecture"] = input.architecture;
-  }
-  if (input.greengrassGroupId !== undefined) {
-    bodyParams["greengrassGroupId"] = input.greengrassGroupId;
-  }
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.architecture !== undefined && {
+      architecture: input.architecture
+    }),
+    ...(input.greengrassGroupId !== undefined && {
+      greengrassGroupId: input.greengrassGroupId
+    }),
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -401,28 +384,21 @@ export const serializeAws_restJson1_1CreateRobotApplicationCommand = async (
   };
   let resolvedPath = "/createRobotApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.robotSoftwareSuite !== undefined) {
-    bodyParams[
-      "robotSoftwareSuite"
-    ] = serializeAws_restJson1_1RobotSoftwareSuite(
-      input.robotSoftwareSuite,
-      context
-    );
-  }
-  if (input.sources !== undefined) {
-    bodyParams["sources"] = serializeAws_restJson1_1SourceConfigs(
-      input.sources,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.robotSoftwareSuite !== undefined && {
+      robotSoftwareSuite: serializeAws_restJson1_1RobotSoftwareSuite(
+        input.robotSoftwareSuite,
+        context
+      )
+    }),
+    ...(input.sources !== undefined && {
+      sources: serializeAws_restJson1_1SourceConfigs(input.sources, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -444,14 +420,12 @@ export const serializeAws_restJson1_1CreateRobotApplicationVersionCommand = asyn
   };
   let resolvedPath = "/createRobotApplicationVersion";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.currentRevisionId !== undefined) {
-    bodyParams["currentRevisionId"] = input.currentRevisionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.currentRevisionId !== undefined && {
+      currentRevisionId: input.currentRevisionId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -473,42 +447,33 @@ export const serializeAws_restJson1_1CreateSimulationApplicationCommand = async 
   };
   let resolvedPath = "/createSimulationApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.name !== undefined) {
-    bodyParams["name"] = input.name;
-  }
-  if (input.renderingEngine !== undefined) {
-    bodyParams["renderingEngine"] = serializeAws_restJson1_1RenderingEngine(
-      input.renderingEngine,
-      context
-    );
-  }
-  if (input.robotSoftwareSuite !== undefined) {
-    bodyParams[
-      "robotSoftwareSuite"
-    ] = serializeAws_restJson1_1RobotSoftwareSuite(
-      input.robotSoftwareSuite,
-      context
-    );
-  }
-  if (input.simulationSoftwareSuite !== undefined) {
-    bodyParams[
-      "simulationSoftwareSuite"
-    ] = serializeAws_restJson1_1SimulationSoftwareSuite(
-      input.simulationSoftwareSuite,
-      context
-    );
-  }
-  if (input.sources !== undefined) {
-    bodyParams["sources"] = serializeAws_restJson1_1SourceConfigs(
-      input.sources,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.renderingEngine !== undefined && {
+      renderingEngine: serializeAws_restJson1_1RenderingEngine(
+        input.renderingEngine,
+        context
+      )
+    }),
+    ...(input.robotSoftwareSuite !== undefined && {
+      robotSoftwareSuite: serializeAws_restJson1_1RobotSoftwareSuite(
+        input.robotSoftwareSuite,
+        context
+      )
+    }),
+    ...(input.simulationSoftwareSuite !== undefined && {
+      simulationSoftwareSuite: serializeAws_restJson1_1SimulationSoftwareSuite(
+        input.simulationSoftwareSuite,
+        context
+      )
+    }),
+    ...(input.sources !== undefined && {
+      sources: serializeAws_restJson1_1SourceConfigs(input.sources, context)
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -530,14 +495,12 @@ export const serializeAws_restJson1_1CreateSimulationApplicationVersionCommand =
   };
   let resolvedPath = "/createSimulationApplicationVersion";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.currentRevisionId !== undefined) {
-    bodyParams["currentRevisionId"] = input.currentRevisionId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.currentRevisionId !== undefined && {
+      currentRevisionId: input.currentRevisionId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -559,66 +522,52 @@ export const serializeAws_restJson1_1CreateSimulationJobCommand = async (
   };
   let resolvedPath = "/createSimulationJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.dataSources !== undefined) {
-    bodyParams["dataSources"] = serializeAws_restJson1_1DataSourceConfigs(
-      input.dataSources,
-      context
-    );
-  }
-  if (input.failureBehavior !== undefined) {
-    bodyParams["failureBehavior"] = input.failureBehavior;
-  }
-  if (input.iamRole !== undefined) {
-    bodyParams["iamRole"] = input.iamRole;
-  }
-  if (input.loggingConfig !== undefined) {
-    bodyParams["loggingConfig"] = serializeAws_restJson1_1LoggingConfig(
-      input.loggingConfig,
-      context
-    );
-  }
-  if (input.maxJobDurationInSeconds !== undefined) {
-    bodyParams["maxJobDurationInSeconds"] = input.maxJobDurationInSeconds;
-  }
-  if (input.outputLocation !== undefined) {
-    bodyParams["outputLocation"] = serializeAws_restJson1_1OutputLocation(
-      input.outputLocation,
-      context
-    );
-  }
-  if (input.robotApplications !== undefined) {
-    bodyParams[
-      "robotApplications"
-    ] = serializeAws_restJson1_1RobotApplicationConfigs(
-      input.robotApplications,
-      context
-    );
-  }
-  if (input.simulationApplications !== undefined) {
-    bodyParams[
-      "simulationApplications"
-    ] = serializeAws_restJson1_1SimulationApplicationConfigs(
-      input.simulationApplications,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.vpcConfig !== undefined) {
-    bodyParams["vpcConfig"] = serializeAws_restJson1_1VPCConfig(
-      input.vpcConfig,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.dataSources !== undefined && {
+      dataSources: serializeAws_restJson1_1DataSourceConfigs(
+        input.dataSources,
+        context
+      )
+    }),
+    ...(input.failureBehavior !== undefined && {
+      failureBehavior: input.failureBehavior
+    }),
+    ...(input.iamRole !== undefined && { iamRole: input.iamRole }),
+    ...(input.loggingConfig !== undefined && {
+      loggingConfig: serializeAws_restJson1_1LoggingConfig(
+        input.loggingConfig,
+        context
+      )
+    }),
+    ...(input.maxJobDurationInSeconds !== undefined && {
+      maxJobDurationInSeconds: input.maxJobDurationInSeconds
+    }),
+    ...(input.outputLocation !== undefined && {
+      outputLocation: serializeAws_restJson1_1OutputLocation(
+        input.outputLocation,
+        context
+      )
+    }),
+    ...(input.robotApplications !== undefined && {
+      robotApplications: serializeAws_restJson1_1RobotApplicationConfigs(
+        input.robotApplications,
+        context
+      )
+    }),
+    ...(input.simulationApplications !== undefined && {
+      simulationApplications: serializeAws_restJson1_1SimulationApplicationConfigs(
+        input.simulationApplications,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.vpcConfig !== undefined && {
+      vpcConfig: serializeAws_restJson1_1VPCConfig(input.vpcConfig, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -640,11 +589,9 @@ export const serializeAws_restJson1_1DeleteFleetCommand = async (
   };
   let resolvedPath = "/deleteFleet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.fleet !== undefined) {
-    bodyParams["fleet"] = input.fleet;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.fleet !== undefined && { fleet: input.fleet })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -666,11 +613,9 @@ export const serializeAws_restJson1_1DeleteRobotCommand = async (
   };
   let resolvedPath = "/deleteRobot";
   let body: any;
-  const bodyParams: any = {};
-  if (input.robot !== undefined) {
-    bodyParams["robot"] = input.robot;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.robot !== undefined && { robot: input.robot })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -692,14 +637,12 @@ export const serializeAws_restJson1_1DeleteRobotApplicationCommand = async (
   };
   let resolvedPath = "/deleteRobotApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.applicationVersion !== undefined) {
-    bodyParams["applicationVersion"] = input.applicationVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.applicationVersion !== undefined && {
+      applicationVersion: input.applicationVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -721,14 +664,12 @@ export const serializeAws_restJson1_1DeleteSimulationApplicationCommand = async 
   };
   let resolvedPath = "/deleteSimulationApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.applicationVersion !== undefined) {
-    bodyParams["applicationVersion"] = input.applicationVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.applicationVersion !== undefined && {
+      applicationVersion: input.applicationVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -750,14 +691,10 @@ export const serializeAws_restJson1_1DeregisterRobotCommand = async (
   };
   let resolvedPath = "/deregisterRobot";
   let body: any;
-  const bodyParams: any = {};
-  if (input.fleet !== undefined) {
-    bodyParams["fleet"] = input.fleet;
-  }
-  if (input.robot !== undefined) {
-    bodyParams["robot"] = input.robot;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.fleet !== undefined && { fleet: input.fleet }),
+    ...(input.robot !== undefined && { robot: input.robot })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -779,11 +716,9 @@ export const serializeAws_restJson1_1DescribeDeploymentJobCommand = async (
   };
   let resolvedPath = "/describeDeploymentJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.job !== undefined) {
-    bodyParams["job"] = input.job;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.job !== undefined && { job: input.job })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -805,11 +740,9 @@ export const serializeAws_restJson1_1DescribeFleetCommand = async (
   };
   let resolvedPath = "/describeFleet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.fleet !== undefined) {
-    bodyParams["fleet"] = input.fleet;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.fleet !== undefined && { fleet: input.fleet })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -831,11 +764,9 @@ export const serializeAws_restJson1_1DescribeRobotCommand = async (
   };
   let resolvedPath = "/describeRobot";
   let body: any;
-  const bodyParams: any = {};
-  if (input.robot !== undefined) {
-    bodyParams["robot"] = input.robot;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.robot !== undefined && { robot: input.robot })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -857,14 +788,12 @@ export const serializeAws_restJson1_1DescribeRobotApplicationCommand = async (
   };
   let resolvedPath = "/describeRobotApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.applicationVersion !== undefined) {
-    bodyParams["applicationVersion"] = input.applicationVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.applicationVersion !== undefined && {
+      applicationVersion: input.applicationVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -886,14 +815,12 @@ export const serializeAws_restJson1_1DescribeSimulationApplicationCommand = asyn
   };
   let resolvedPath = "/describeSimulationApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.applicationVersion !== undefined) {
-    bodyParams["applicationVersion"] = input.applicationVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.applicationVersion !== undefined && {
+      applicationVersion: input.applicationVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -915,11 +842,9 @@ export const serializeAws_restJson1_1DescribeSimulationJobCommand = async (
   };
   let resolvedPath = "/describeSimulationJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.job !== undefined) {
-    bodyParams["job"] = input.job;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.job !== undefined && { job: input.job })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -941,20 +866,13 @@ export const serializeAws_restJson1_1ListDeploymentJobsCommand = async (
   };
   let resolvedPath = "/listDeploymentJobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1Filters(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1Filters(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -976,20 +894,13 @@ export const serializeAws_restJson1_1ListFleetsCommand = async (
   };
   let resolvedPath = "/listFleets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1Filters(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1Filters(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1011,23 +922,16 @@ export const serializeAws_restJson1_1ListRobotApplicationsCommand = async (
   };
   let resolvedPath = "/listRobotApplications";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1Filters(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.versionQualifier !== undefined) {
-    bodyParams["versionQualifier"] = input.versionQualifier;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1Filters(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.versionQualifier !== undefined && {
+      versionQualifier: input.versionQualifier
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1049,20 +953,13 @@ export const serializeAws_restJson1_1ListRobotsCommand = async (
   };
   let resolvedPath = "/listRobots";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1Filters(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1Filters(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1084,23 +981,16 @@ export const serializeAws_restJson1_1ListSimulationApplicationsCommand = async (
   };
   let resolvedPath = "/listSimulationApplications";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1Filters(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.versionQualifier !== undefined) {
-    bodyParams["versionQualifier"] = input.versionQualifier;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1Filters(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.versionQualifier !== undefined && {
+      versionQualifier: input.versionQualifier
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1122,20 +1012,13 @@ export const serializeAws_restJson1_1ListSimulationJobsCommand = async (
   };
   let resolvedPath = "/listSimulationJobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1Filters(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1Filters(input.filters, context)
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1192,14 +1075,10 @@ export const serializeAws_restJson1_1RegisterRobotCommand = async (
   };
   let resolvedPath = "/registerRobot";
   let body: any;
-  const bodyParams: any = {};
-  if (input.fleet !== undefined) {
-    bodyParams["fleet"] = input.fleet;
-  }
-  if (input.robot !== undefined) {
-    bodyParams["robot"] = input.robot;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.fleet !== undefined && { fleet: input.fleet }),
+    ...(input.robot !== undefined && { robot: input.robot })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1221,11 +1100,9 @@ export const serializeAws_restJson1_1RestartSimulationJobCommand = async (
   };
   let resolvedPath = "/restartSimulationJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.job !== undefined) {
-    bodyParams["job"] = input.job;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.job !== undefined && { job: input.job })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1247,17 +1124,10 @@ export const serializeAws_restJson1_1SyncDeploymentJobCommand = async (
   };
   let resolvedPath = "/syncDeploymentJob";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.fleet !== undefined) {
-    bodyParams["fleet"] = input.fleet;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.fleet !== undefined && { fleet: input.fleet })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1293,11 +1163,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1360,28 +1230,21 @@ export const serializeAws_restJson1_1UpdateRobotApplicationCommand = async (
   };
   let resolvedPath = "/updateRobotApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.currentRevisionId !== undefined) {
-    bodyParams["currentRevisionId"] = input.currentRevisionId;
-  }
-  if (input.robotSoftwareSuite !== undefined) {
-    bodyParams[
-      "robotSoftwareSuite"
-    ] = serializeAws_restJson1_1RobotSoftwareSuite(
-      input.robotSoftwareSuite,
-      context
-    );
-  }
-  if (input.sources !== undefined) {
-    bodyParams["sources"] = serializeAws_restJson1_1SourceConfigs(
-      input.sources,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.currentRevisionId !== undefined && {
+      currentRevisionId: input.currentRevisionId
+    }),
+    ...(input.robotSoftwareSuite !== undefined && {
+      robotSoftwareSuite: serializeAws_restJson1_1RobotSoftwareSuite(
+        input.robotSoftwareSuite,
+        context
+      )
+    }),
+    ...(input.sources !== undefined && {
+      sources: serializeAws_restJson1_1SourceConfigs(input.sources, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1403,42 +1266,33 @@ export const serializeAws_restJson1_1UpdateSimulationApplicationCommand = async 
   };
   let resolvedPath = "/updateSimulationApplication";
   let body: any;
-  const bodyParams: any = {};
-  if (input.application !== undefined) {
-    bodyParams["application"] = input.application;
-  }
-  if (input.currentRevisionId !== undefined) {
-    bodyParams["currentRevisionId"] = input.currentRevisionId;
-  }
-  if (input.renderingEngine !== undefined) {
-    bodyParams["renderingEngine"] = serializeAws_restJson1_1RenderingEngine(
-      input.renderingEngine,
-      context
-    );
-  }
-  if (input.robotSoftwareSuite !== undefined) {
-    bodyParams[
-      "robotSoftwareSuite"
-    ] = serializeAws_restJson1_1RobotSoftwareSuite(
-      input.robotSoftwareSuite,
-      context
-    );
-  }
-  if (input.simulationSoftwareSuite !== undefined) {
-    bodyParams[
-      "simulationSoftwareSuite"
-    ] = serializeAws_restJson1_1SimulationSoftwareSuite(
-      input.simulationSoftwareSuite,
-      context
-    );
-  }
-  if (input.sources !== undefined) {
-    bodyParams["sources"] = serializeAws_restJson1_1SourceConfigs(
-      input.sources,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.application !== undefined && { application: input.application }),
+    ...(input.currentRevisionId !== undefined && {
+      currentRevisionId: input.currentRevisionId
+    }),
+    ...(input.renderingEngine !== undefined && {
+      renderingEngine: serializeAws_restJson1_1RenderingEngine(
+        input.renderingEngine,
+        context
+      )
+    }),
+    ...(input.robotSoftwareSuite !== undefined && {
+      robotSoftwareSuite: serializeAws_restJson1_1RobotSoftwareSuite(
+        input.robotSoftwareSuite,
+        context
+      )
+    }),
+    ...(input.simulationSoftwareSuite !== undefined && {
+      simulationSoftwareSuite: serializeAws_restJson1_1SimulationSoftwareSuite(
+        input.simulationSoftwareSuite,
+        context
+      )
+    }),
+    ...(input.sources !== undefined && {
+      sources: serializeAws_restJson1_1SourceConfigs(input.sources, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
@@ -165,30 +165,26 @@ export const serializeAws_restJson1_1StartHumanLoopCommand = async (
   };
   let resolvedPath = "/human-loops";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DataAttributes !== undefined) {
-    bodyParams[
-      "DataAttributes"
-    ] = serializeAws_restJson1_1HumanReviewDataAttributes(
-      input.DataAttributes,
-      context
-    );
-  }
-  if (input.FlowDefinitionArn !== undefined) {
-    bodyParams["FlowDefinitionArn"] = input.FlowDefinitionArn;
-  }
-  if (input.HumanLoopInput !== undefined) {
-    bodyParams[
-      "HumanLoopInput"
-    ] = serializeAws_restJson1_1HumanLoopInputContent(
-      input.HumanLoopInput,
-      context
-    );
-  }
-  if (input.HumanLoopName !== undefined) {
-    bodyParams["HumanLoopName"] = input.HumanLoopName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DataAttributes !== undefined && {
+      DataAttributes: serializeAws_restJson1_1HumanReviewDataAttributes(
+        input.DataAttributes,
+        context
+      )
+    }),
+    ...(input.FlowDefinitionArn !== undefined && {
+      FlowDefinitionArn: input.FlowDefinitionArn
+    }),
+    ...(input.HumanLoopInput !== undefined && {
+      HumanLoopInput: serializeAws_restJson1_1HumanLoopInputContent(
+        input.HumanLoopInput,
+        context
+      )
+    }),
+    ...(input.HumanLoopName !== undefined && {
+      HumanLoopName: input.HumanLoopName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -210,11 +206,11 @@ export const serializeAws_restJson1_1StopHumanLoopCommand = async (
   };
   let resolvedPath = "/human-loops/stop";
   let body: any;
-  const bodyParams: any = {};
-  if (input.HumanLoopName !== undefined) {
-    bodyParams["HumanLoopName"] = input.HumanLoopName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.HumanLoopName !== undefined && {
+      HumanLoopName: input.HumanLoopName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
@@ -76,74 +76,58 @@ export const serializeAws_restJson1_1DescribeSavingsPlansOfferingRatesCommand = 
   };
   let resolvedPath = "/DescribeSavingsPlansOfferingRates";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams[
-      "filters"
-    ] = serializeAws_restJson1_1SavingsPlanOfferingRateFiltersList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.operations !== undefined) {
-    bodyParams[
-      "operations"
-    ] = serializeAws_restJson1_1SavingsPlanRateOperationList(
-      input.operations,
-      context
-    );
-  }
-  if (input.products !== undefined) {
-    bodyParams["products"] = serializeAws_restJson1_1SavingsPlanProductTypeList(
-      input.products,
-      context
-    );
-  }
-  if (input.savingsPlanOfferingIds !== undefined) {
-    bodyParams["savingsPlanOfferingIds"] = serializeAws_restJson1_1UUIDs(
-      input.savingsPlanOfferingIds,
-      context
-    );
-  }
-  if (input.savingsPlanPaymentOptions !== undefined) {
-    bodyParams[
-      "savingsPlanPaymentOptions"
-    ] = serializeAws_restJson1_1SavingsPlanPaymentOptionList(
-      input.savingsPlanPaymentOptions,
-      context
-    );
-  }
-  if (input.savingsPlanTypes !== undefined) {
-    bodyParams[
-      "savingsPlanTypes"
-    ] = serializeAws_restJson1_1SavingsPlanTypeList(
-      input.savingsPlanTypes,
-      context
-    );
-  }
-  if (input.serviceCodes !== undefined) {
-    bodyParams[
-      "serviceCodes"
-    ] = serializeAws_restJson1_1SavingsPlanRateServiceCodeList(
-      input.serviceCodes,
-      context
-    );
-  }
-  if (input.usageTypes !== undefined) {
-    bodyParams[
-      "usageTypes"
-    ] = serializeAws_restJson1_1SavingsPlanRateUsageTypeList(
-      input.usageTypes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1SavingsPlanOfferingRateFiltersList(
+        input.filters,
+        context
+      )
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.operations !== undefined && {
+      operations: serializeAws_restJson1_1SavingsPlanRateOperationList(
+        input.operations,
+        context
+      )
+    }),
+    ...(input.products !== undefined && {
+      products: serializeAws_restJson1_1SavingsPlanProductTypeList(
+        input.products,
+        context
+      )
+    }),
+    ...(input.savingsPlanOfferingIds !== undefined && {
+      savingsPlanOfferingIds: serializeAws_restJson1_1UUIDs(
+        input.savingsPlanOfferingIds,
+        context
+      )
+    }),
+    ...(input.savingsPlanPaymentOptions !== undefined && {
+      savingsPlanPaymentOptions: serializeAws_restJson1_1SavingsPlanPaymentOptionList(
+        input.savingsPlanPaymentOptions,
+        context
+      )
+    }),
+    ...(input.savingsPlanTypes !== undefined && {
+      savingsPlanTypes: serializeAws_restJson1_1SavingsPlanTypeList(
+        input.savingsPlanTypes,
+        context
+      )
+    }),
+    ...(input.serviceCodes !== undefined && {
+      serviceCodes: serializeAws_restJson1_1SavingsPlanRateServiceCodeList(
+        input.serviceCodes,
+        context
+      )
+    }),
+    ...(input.usageTypes !== undefined && {
+      usageTypes: serializeAws_restJson1_1SavingsPlanRateUsageTypeList(
+        input.usageTypes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -165,85 +149,65 @@ export const serializeAws_restJson1_1DescribeSavingsPlansOfferingsCommand = asyn
   };
   let resolvedPath = "/DescribeSavingsPlansOfferings";
   let body: any;
-  const bodyParams: any = {};
-  if (input.currencies !== undefined) {
-    bodyParams["currencies"] = serializeAws_restJson1_1CurrencyList(
-      input.currencies,
-      context
-    );
-  }
-  if (input.descriptions !== undefined) {
-    bodyParams[
-      "descriptions"
-    ] = serializeAws_restJson1_1SavingsPlanDescriptionsList(
-      input.descriptions,
-      context
-    );
-  }
-  if (input.durations !== undefined) {
-    bodyParams["durations"] = serializeAws_restJson1_1DurationsList(
-      input.durations,
-      context
-    );
-  }
-  if (input.filters !== undefined) {
-    bodyParams[
-      "filters"
-    ] = serializeAws_restJson1_1SavingsPlanOfferingFiltersList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.offeringIds !== undefined) {
-    bodyParams["offeringIds"] = serializeAws_restJson1_1UUIDs(
-      input.offeringIds,
-      context
-    );
-  }
-  if (input.operations !== undefined) {
-    bodyParams["operations"] = serializeAws_restJson1_1SavingsPlanOperationList(
-      input.operations,
-      context
-    );
-  }
-  if (input.paymentOptions !== undefined) {
-    bodyParams[
-      "paymentOptions"
-    ] = serializeAws_restJson1_1SavingsPlanPaymentOptionList(
-      input.paymentOptions,
-      context
-    );
-  }
-  if (input.planTypes !== undefined) {
-    bodyParams["planTypes"] = serializeAws_restJson1_1SavingsPlanTypeList(
-      input.planTypes,
-      context
-    );
-  }
-  if (input.productType !== undefined) {
-    bodyParams["productType"] = input.productType;
-  }
-  if (input.serviceCodes !== undefined) {
-    bodyParams[
-      "serviceCodes"
-    ] = serializeAws_restJson1_1SavingsPlanServiceCodeList(
-      input.serviceCodes,
-      context
-    );
-  }
-  if (input.usageTypes !== undefined) {
-    bodyParams["usageTypes"] = serializeAws_restJson1_1SavingsPlanUsageTypeList(
-      input.usageTypes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.currencies !== undefined && {
+      currencies: serializeAws_restJson1_1CurrencyList(
+        input.currencies,
+        context
+      )
+    }),
+    ...(input.descriptions !== undefined && {
+      descriptions: serializeAws_restJson1_1SavingsPlanDescriptionsList(
+        input.descriptions,
+        context
+      )
+    }),
+    ...(input.durations !== undefined && {
+      durations: serializeAws_restJson1_1DurationsList(input.durations, context)
+    }),
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1SavingsPlanOfferingFiltersList(
+        input.filters,
+        context
+      )
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.offeringIds !== undefined && {
+      offeringIds: serializeAws_restJson1_1UUIDs(input.offeringIds, context)
+    }),
+    ...(input.operations !== undefined && {
+      operations: serializeAws_restJson1_1SavingsPlanOperationList(
+        input.operations,
+        context
+      )
+    }),
+    ...(input.paymentOptions !== undefined && {
+      paymentOptions: serializeAws_restJson1_1SavingsPlanPaymentOptionList(
+        input.paymentOptions,
+        context
+      )
+    }),
+    ...(input.planTypes !== undefined && {
+      planTypes: serializeAws_restJson1_1SavingsPlanTypeList(
+        input.planTypes,
+        context
+      )
+    }),
+    ...(input.productType !== undefined && { productType: input.productType }),
+    ...(input.serviceCodes !== undefined && {
+      serviceCodes: serializeAws_restJson1_1SavingsPlanServiceCodeList(
+        input.serviceCodes,
+        context
+      )
+    }),
+    ...(input.usageTypes !== undefined && {
+      usageTypes: serializeAws_restJson1_1SavingsPlanUsageTypeList(
+        input.usageTypes,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -265,26 +229,19 @@ export const serializeAws_restJson1_1CreateSavingsPlanCommand = async (
   };
   let resolvedPath = "/CreateSavingsPlan";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientToken === undefined) {
-    input.clientToken = generateIdempotencyToken();
-  }
-  if (input.clientToken !== undefined) {
-    bodyParams["clientToken"] = input.clientToken;
-  }
-  if (input.commitment !== undefined) {
-    bodyParams["commitment"] = input.commitment;
-  }
-  if (input.savingsPlanOfferingId !== undefined) {
-    bodyParams["savingsPlanOfferingId"] = input.savingsPlanOfferingId;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  if (input.upfrontPaymentAmount !== undefined) {
-    bodyParams["upfrontPaymentAmount"] = input.upfrontPaymentAmount;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientToken: input.clientToken ?? generateIdempotencyToken(),
+    ...(input.commitment !== undefined && { commitment: input.commitment }),
+    ...(input.savingsPlanOfferingId !== undefined && {
+      savingsPlanOfferingId: input.savingsPlanOfferingId
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    }),
+    ...(input.upfrontPaymentAmount !== undefined && {
+      upfrontPaymentAmount: input.upfrontPaymentAmount
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -306,23 +263,19 @@ export const serializeAws_restJson1_1DescribeSavingsPlanRatesCommand = async (
   };
   let resolvedPath = "/DescribeSavingsPlanRates";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1SavingsPlanRateFilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.savingsPlanId !== undefined) {
-    bodyParams["savingsPlanId"] = input.savingsPlanId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1SavingsPlanRateFilterList(
+        input.filters,
+        context
+      )
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.savingsPlanId !== undefined && {
+      savingsPlanId: input.savingsPlanId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -344,38 +297,34 @@ export const serializeAws_restJson1_1DescribeSavingsPlansCommand = async (
   };
   let resolvedPath = "/DescribeSavingsPlans";
   let body: any;
-  const bodyParams: any = {};
-  if (input.filters !== undefined) {
-    bodyParams["filters"] = serializeAws_restJson1_1SavingsPlanFilterList(
-      input.filters,
-      context
-    );
-  }
-  if (input.maxResults !== undefined) {
-    bodyParams["maxResults"] = input.maxResults;
-  }
-  if (input.nextToken !== undefined) {
-    bodyParams["nextToken"] = input.nextToken;
-  }
-  if (input.savingsPlanArns !== undefined) {
-    bodyParams["savingsPlanArns"] = serializeAws_restJson1_1SavingsPlanArnList(
-      input.savingsPlanArns,
-      context
-    );
-  }
-  if (input.savingsPlanIds !== undefined) {
-    bodyParams["savingsPlanIds"] = serializeAws_restJson1_1SavingsPlanIdList(
-      input.savingsPlanIds,
-      context
-    );
-  }
-  if (input.states !== undefined) {
-    bodyParams["states"] = serializeAws_restJson1_1SavingsPlanStateList(
-      input.states,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.filters !== undefined && {
+      filters: serializeAws_restJson1_1SavingsPlanFilterList(
+        input.filters,
+        context
+      )
+    }),
+    ...(input.maxResults !== undefined && { maxResults: input.maxResults }),
+    ...(input.nextToken !== undefined && { nextToken: input.nextToken }),
+    ...(input.savingsPlanArns !== undefined && {
+      savingsPlanArns: serializeAws_restJson1_1SavingsPlanArnList(
+        input.savingsPlanArns,
+        context
+      )
+    }),
+    ...(input.savingsPlanIds !== undefined && {
+      savingsPlanIds: serializeAws_restJson1_1SavingsPlanIdList(
+        input.savingsPlanIds,
+        context
+      )
+    }),
+    ...(input.states !== undefined && {
+      states: serializeAws_restJson1_1SavingsPlanStateList(
+        input.states,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -397,11 +346,9 @@ export const serializeAws_restJson1_1ListTagsForResourceCommand = async (
   };
   let resolvedPath = "/ListTagsForResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -423,14 +370,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/TagResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -452,17 +397,12 @@ export const serializeAws_restJson1_1UntagResourceCommand = async (
   };
   let resolvedPath = "/UntagResource";
   let body: any;
-  const bodyParams: any = {};
-  if (input.resourceArn !== undefined) {
-    bodyParams["resourceArn"] = input.resourceArn;
-  }
-  if (input.tagKeys !== undefined) {
-    bodyParams["tagKeys"] = serializeAws_restJson1_1TagKeyList(
-      input.tagKeys,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn }),
+    ...(input.tagKeys !== undefined && {
+      tagKeys: serializeAws_restJson1_1TagKeyList(input.tagKeys, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-schemas/protocols/Aws_restJson1_1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1_1.ts
@@ -156,17 +156,13 @@ export const serializeAws_restJson1_1CreateDiscovererCommand = async (
   };
   let resolvedPath = "/v1/discoverers";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.SourceArn !== undefined) {
-    bodyParams["SourceArn"] = input.SourceArn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.SourceArn !== undefined && { SourceArn: input.SourceArn }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -202,14 +198,12 @@ export const serializeAws_restJson1_1CreateRegistryCommand = async (
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -258,20 +252,14 @@ export const serializeAws_restJson1_1CreateSchemaCommand = async (
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = input.Content;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Content !== undefined && { Content: input.Content }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -729,19 +717,15 @@ export const serializeAws_restJson1_1GetDiscoveredSchemaCommand = async (
   };
   let resolvedPath = "/v1/discover";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Events !== undefined) {
-    bodyParams[
-      "Events"
-    ] = serializeAws_restJson1_1__listOfGetDiscoveredSchemaVersionItemInput(
-      input.Events,
-      context
-    );
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Events !== undefined && {
+      Events: serializeAws_restJson1_1__listOfGetDiscoveredSchemaVersionItemInput(
+        input.Events,
+        context
+      )
+    }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -956,14 +940,10 @@ export const serializeAws_restJson1_1LockServiceLinkedRoleCommand = async (
   };
   let resolvedPath = "/slr-deletion/lock";
   let body: any;
-  const bodyParams: any = {};
-  if (input.RoleArn !== undefined) {
-    bodyParams["RoleArn"] = input.RoleArn;
-  }
-  if (input.Timeout !== undefined) {
-    bodyParams["Timeout"] = input.Timeout;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.RoleArn !== undefined && { RoleArn: input.RoleArn }),
+    ...(input.Timeout !== undefined && { Timeout: input.Timeout })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1176,11 +1156,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1Tags(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1Tags(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1202,11 +1182,9 @@ export const serializeAws_restJson1_1UnlockServiceLinkedRoleCommand = async (
   };
   let resolvedPath = "/slr-deletion/unlock";
   let body: any;
-  const bodyParams: any = {};
-  if (input.RoleArn !== undefined) {
-    bodyParams["RoleArn"] = input.RoleArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.RoleArn !== undefined && { RoleArn: input.RoleArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1283,11 +1261,9 @@ export const serializeAws_restJson1_1UpdateDiscovererCommand = async (
     throw new Error("No value provided for input HTTP label: DiscovererId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1323,11 +1299,9 @@ export const serializeAws_restJson1_1UpdateRegistryCommand = async (
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1376,23 +1350,12 @@ export const serializeAws_restJson1_1UpdateSchemaCommand = async (
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ClientTokenId === undefined) {
-    input.ClientTokenId = generateIdempotencyToken();
-  }
-  if (input.ClientTokenId !== undefined) {
-    bodyParams["ClientTokenId"] = input.ClientTokenId;
-  }
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = input.Content;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ClientTokenId: input.ClientTokenId ?? generateIdempotencyToken(),
+    ...(input.Content !== undefined && { Content: input.Content }),
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-securityhub/protocols/Aws_restJson1_1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1_1.ts
@@ -251,14 +251,12 @@ export const serializeAws_restJson1_1AcceptInvitationCommand = async (
   };
   let resolvedPath = "/master";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InvitationId !== undefined) {
-    bodyParams["InvitationId"] = input.InvitationId;
-  }
-  if (input.MasterId !== undefined) {
-    bodyParams["MasterId"] = input.MasterId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InvitationId !== undefined && {
+      InvitationId: input.InvitationId
+    }),
+    ...(input.MasterId !== undefined && { MasterId: input.MasterId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -280,16 +278,14 @@ export const serializeAws_restJson1_1BatchDisableStandardsCommand = async (
   };
   let resolvedPath = "/standards/deregister";
   let body: any;
-  const bodyParams: any = {};
-  if (input.StandardsSubscriptionArns !== undefined) {
-    bodyParams[
-      "StandardsSubscriptionArns"
-    ] = serializeAws_restJson1_1StandardsSubscriptionArns(
-      input.StandardsSubscriptionArns,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.StandardsSubscriptionArns !== undefined && {
+      StandardsSubscriptionArns: serializeAws_restJson1_1StandardsSubscriptionArns(
+        input.StandardsSubscriptionArns,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -311,16 +307,14 @@ export const serializeAws_restJson1_1BatchEnableStandardsCommand = async (
   };
   let resolvedPath = "/standards/register";
   let body: any;
-  const bodyParams: any = {};
-  if (input.StandardsSubscriptionRequests !== undefined) {
-    bodyParams[
-      "StandardsSubscriptionRequests"
-    ] = serializeAws_restJson1_1StandardsSubscriptionRequests(
-      input.StandardsSubscriptionRequests,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.StandardsSubscriptionRequests !== undefined && {
+      StandardsSubscriptionRequests: serializeAws_restJson1_1StandardsSubscriptionRequests(
+        input.StandardsSubscriptionRequests,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -342,14 +336,14 @@ export const serializeAws_restJson1_1BatchImportFindingsCommand = async (
   };
   let resolvedPath = "/findings/import";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Findings !== undefined) {
-    bodyParams["Findings"] = serializeAws_restJson1_1AwsSecurityFindingList(
-      input.Findings,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Findings !== undefined && {
+      Findings: serializeAws_restJson1_1AwsSecurityFindingList(
+        input.Findings,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -371,17 +365,11 @@ export const serializeAws_restJson1_1CreateActionTargetCommand = async (
   };
   let resolvedPath = "/actionTargets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Id !== undefined) {
-    bodyParams["Id"] = input.Id;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Id !== undefined && { Id: input.Id }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -403,20 +391,18 @@ export const serializeAws_restJson1_1CreateInsightCommand = async (
   };
   let resolvedPath = "/insights";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1AwsSecurityFindingFilters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.GroupByAttribute !== undefined) {
-    bodyParams["GroupByAttribute"] = input.GroupByAttribute;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1AwsSecurityFindingFilters(
+        input.Filters,
+        context
+      )
+    }),
+    ...(input.GroupByAttribute !== undefined && {
+      GroupByAttribute: input.GroupByAttribute
+    }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -438,14 +424,14 @@ export const serializeAws_restJson1_1CreateMembersCommand = async (
   };
   let resolvedPath = "/members";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountDetails !== undefined) {
-    bodyParams["AccountDetails"] = serializeAws_restJson1_1AccountDetailsList(
-      input.AccountDetails,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountDetails !== undefined && {
+      AccountDetails: serializeAws_restJson1_1AccountDetailsList(
+        input.AccountDetails,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -467,14 +453,14 @@ export const serializeAws_restJson1_1DeclineInvitationsCommand = async (
   };
   let resolvedPath = "/invitations/decline";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -570,14 +556,14 @@ export const serializeAws_restJson1_1DeleteInvitationsCommand = async (
   };
   let resolvedPath = "/invitations/delete";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -599,14 +585,14 @@ export const serializeAws_restJson1_1DeleteMembersCommand = async (
   };
   let resolvedPath = "/members/delete";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -628,20 +614,16 @@ export const serializeAws_restJson1_1DescribeActionTargetsCommand = async (
   };
   let resolvedPath = "/actionTargets/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ActionTargetArns !== undefined) {
-    bodyParams["ActionTargetArns"] = serializeAws_restJson1_1ArnList(
-      input.ActionTargetArns,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ActionTargetArns !== undefined && {
+      ActionTargetArns: serializeAws_restJson1_1ArnList(
+        input.ActionTargetArns,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -847,14 +829,14 @@ export const serializeAws_restJson1_1DisassociateMembersCommand = async (
   };
   let resolvedPath = "/members/disassociate";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -876,11 +858,9 @@ export const serializeAws_restJson1_1EnableImportFindingsForProductCommand = asy
   };
   let resolvedPath = "/productSubscriptions";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ProductArn !== undefined) {
-    bodyParams["ProductArn"] = input.ProductArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ProductArn !== undefined && { ProductArn: input.ProductArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -902,11 +882,11 @@ export const serializeAws_restJson1_1EnableSecurityHubCommand = async (
   };
   let resolvedPath = "/accounts";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -928,22 +908,16 @@ export const serializeAws_restJson1_1GetEnabledStandardsCommand = async (
   };
   let resolvedPath = "/standards/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.StandardsSubscriptionArns !== undefined) {
-    bodyParams[
-      "StandardsSubscriptionArns"
-    ] = serializeAws_restJson1_1StandardsSubscriptionArns(
-      input.StandardsSubscriptionArns,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.StandardsSubscriptionArns !== undefined && {
+      StandardsSubscriptionArns: serializeAws_restJson1_1StandardsSubscriptionArns(
+        input.StandardsSubscriptionArns,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -965,26 +939,22 @@ export const serializeAws_restJson1_1GetFindingsCommand = async (
   };
   let resolvedPath = "/findings";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1AwsSecurityFindingFilters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.SortCriteria !== undefined) {
-    bodyParams["SortCriteria"] = serializeAws_restJson1_1SortCriteria(
-      input.SortCriteria,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1AwsSecurityFindingFilters(
+        input.Filters,
+        context
+      )
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.SortCriteria !== undefined && {
+      SortCriteria: serializeAws_restJson1_1SortCriteria(
+        input.SortCriteria,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1042,20 +1012,13 @@ export const serializeAws_restJson1_1GetInsightsCommand = async (
   };
   let resolvedPath = "/insights/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.InsightArns !== undefined) {
-    bodyParams["InsightArns"] = serializeAws_restJson1_1ArnList(
-      input.InsightArns,
-      context
-    );
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.InsightArns !== undefined && {
+      InsightArns: serializeAws_restJson1_1ArnList(input.InsightArns, context)
+    }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1121,14 +1084,14 @@ export const serializeAws_restJson1_1GetMembersCommand = async (
   };
   let resolvedPath = "/members/get";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1150,14 +1113,14 @@ export const serializeAws_restJson1_1InviteMembersCommand = async (
   };
   let resolvedPath = "/members/invite";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AccountIds !== undefined) {
-    bodyParams["AccountIds"] = serializeAws_restJson1_1AccountIdList(
-      input.AccountIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AccountIds !== undefined && {
+      AccountIds: serializeAws_restJson1_1AccountIdList(
+        input.AccountIds,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1315,11 +1278,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagMap(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagMap(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1399,14 +1362,10 @@ export const serializeAws_restJson1_1UpdateActionTargetCommand = async (
     throw new Error("No value provided for input HTTP label: ActionTargetArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Description !== undefined) {
-    bodyParams["Description"] = input.Description;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Description !== undefined && { Description: input.Description }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1428,23 +1387,18 @@ export const serializeAws_restJson1_1UpdateFindingsCommand = async (
   };
   let resolvedPath = "/findings";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1AwsSecurityFindingFilters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.Note !== undefined) {
-    bodyParams["Note"] = serializeAws_restJson1_1NoteUpdate(
-      input.Note,
-      context
-    );
-  }
-  if (input.RecordState !== undefined) {
-    bodyParams["RecordState"] = input.RecordState;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1AwsSecurityFindingFilters(
+        input.Filters,
+        context
+      )
+    }),
+    ...(input.Note !== undefined && {
+      Note: serializeAws_restJson1_1NoteUpdate(input.Note, context)
+    }),
+    ...(input.RecordState !== undefined && { RecordState: input.RecordState })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1481,20 +1435,18 @@ export const serializeAws_restJson1_1UpdateInsightCommand = async (
     throw new Error("No value provided for input HTTP label: InsightArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Filters !== undefined) {
-    bodyParams["Filters"] = serializeAws_restJson1_1AwsSecurityFindingFilters(
-      input.Filters,
-      context
-    );
-  }
-  if (input.GroupByAttribute !== undefined) {
-    bodyParams["GroupByAttribute"] = input.GroupByAttribute;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Filters !== undefined && {
+      Filters: serializeAws_restJson1_1AwsSecurityFindingFilters(
+        input.Filters,
+        context
+      )
+    }),
+    ...(input.GroupByAttribute !== undefined && {
+      GroupByAttribute: input.GroupByAttribute
+    }),
+    ...(input.Name !== undefined && { Name: input.Name })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1535,14 +1487,14 @@ export const serializeAws_restJson1_1UpdateStandardsControlCommand = async (
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ControlStatus !== undefined) {
-    bodyParams["ControlStatus"] = input.ControlStatus;
-  }
-  if (input.DisabledReason !== undefined) {
-    bodyParams["DisabledReason"] = input.DisabledReason;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ControlStatus !== undefined && {
+      ControlStatus: input.ControlStatus
+    }),
+    ...(input.DisabledReason !== undefined && {
+      DisabledReason: input.DisabledReason
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
@@ -93,56 +93,35 @@ export const serializeAws_restJson1_1CreateApplicationCommand = async (
   };
   let resolvedPath = "/applications";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Author !== undefined) {
-    bodyParams["author"] = input.Author;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.HomePageUrl !== undefined) {
-    bodyParams["homePageUrl"] = input.HomePageUrl;
-  }
-  if (input.Labels !== undefined) {
-    bodyParams["labels"] = serializeAws_restJson1_1__listOf__string(
-      input.Labels,
-      context
-    );
-  }
-  if (input.LicenseBody !== undefined) {
-    bodyParams["licenseBody"] = input.LicenseBody;
-  }
-  if (input.LicenseUrl !== undefined) {
-    bodyParams["licenseUrl"] = input.LicenseUrl;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["name"] = input.Name;
-  }
-  if (input.ReadmeBody !== undefined) {
-    bodyParams["readmeBody"] = input.ReadmeBody;
-  }
-  if (input.ReadmeUrl !== undefined) {
-    bodyParams["readmeUrl"] = input.ReadmeUrl;
-  }
-  if (input.SemanticVersion !== undefined) {
-    bodyParams["semanticVersion"] = input.SemanticVersion;
-  }
-  if (input.SourceCodeArchiveUrl !== undefined) {
-    bodyParams["sourceCodeArchiveUrl"] = input.SourceCodeArchiveUrl;
-  }
-  if (input.SourceCodeUrl !== undefined) {
-    bodyParams["sourceCodeUrl"] = input.SourceCodeUrl;
-  }
-  if (input.SpdxLicenseId !== undefined) {
-    bodyParams["spdxLicenseId"] = input.SpdxLicenseId;
-  }
-  if (input.TemplateBody !== undefined) {
-    bodyParams["templateBody"] = input.TemplateBody;
-  }
-  if (input.TemplateUrl !== undefined) {
-    bodyParams["templateUrl"] = input.TemplateUrl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Author !== undefined && { author: input.Author }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.HomePageUrl !== undefined && { homePageUrl: input.HomePageUrl }),
+    ...(input.Labels !== undefined && {
+      labels: serializeAws_restJson1_1__listOf__string(input.Labels, context)
+    }),
+    ...(input.LicenseBody !== undefined && { licenseBody: input.LicenseBody }),
+    ...(input.LicenseUrl !== undefined && { licenseUrl: input.LicenseUrl }),
+    ...(input.Name !== undefined && { name: input.Name }),
+    ...(input.ReadmeBody !== undefined && { readmeBody: input.ReadmeBody }),
+    ...(input.ReadmeUrl !== undefined && { readmeUrl: input.ReadmeUrl }),
+    ...(input.SemanticVersion !== undefined && {
+      semanticVersion: input.SemanticVersion
+    }),
+    ...(input.SourceCodeArchiveUrl !== undefined && {
+      sourceCodeArchiveUrl: input.SourceCodeArchiveUrl
+    }),
+    ...(input.SourceCodeUrl !== undefined && {
+      sourceCodeUrl: input.SourceCodeUrl
+    }),
+    ...(input.SpdxLicenseId !== undefined && {
+      spdxLicenseId: input.SpdxLicenseId
+    }),
+    ...(input.TemplateBody !== undefined && {
+      templateBody: input.TemplateBody
+    }),
+    ...(input.TemplateUrl !== undefined && { templateUrl: input.TemplateUrl })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -192,20 +171,18 @@ export const serializeAws_restJson1_1CreateApplicationVersionCommand = async (
     throw new Error("No value provided for input HTTP label: SemanticVersion.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SourceCodeArchiveUrl !== undefined) {
-    bodyParams["sourceCodeArchiveUrl"] = input.SourceCodeArchiveUrl;
-  }
-  if (input.SourceCodeUrl !== undefined) {
-    bodyParams["sourceCodeUrl"] = input.SourceCodeUrl;
-  }
-  if (input.TemplateBody !== undefined) {
-    bodyParams["templateBody"] = input.TemplateBody;
-  }
-  if (input.TemplateUrl !== undefined) {
-    bodyParams["templateUrl"] = input.TemplateUrl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SourceCodeArchiveUrl !== undefined && {
+      sourceCodeArchiveUrl: input.SourceCodeArchiveUrl
+    }),
+    ...(input.SourceCodeUrl !== undefined && {
+      sourceCodeUrl: input.SourceCodeUrl
+    }),
+    ...(input.TemplateBody !== undefined && {
+      templateBody: input.TemplateBody
+    }),
+    ...(input.TemplateUrl !== undefined && { templateUrl: input.TemplateUrl })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -241,66 +218,51 @@ export const serializeAws_restJson1_1CreateCloudFormationChangeSetCommand = asyn
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Capabilities !== undefined) {
-    bodyParams["capabilities"] = serializeAws_restJson1_1__listOf__string(
-      input.Capabilities,
-      context
-    );
-  }
-  if (input.ChangeSetName !== undefined) {
-    bodyParams["changeSetName"] = input.ChangeSetName;
-  }
-  if (input.ClientToken !== undefined) {
-    bodyParams["clientToken"] = input.ClientToken;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.NotificationArns !== undefined) {
-    bodyParams["notificationArns"] = serializeAws_restJson1_1__listOf__string(
-      input.NotificationArns,
-      context
-    );
-  }
-  if (input.ParameterOverrides !== undefined) {
-    bodyParams[
-      "parameterOverrides"
-    ] = serializeAws_restJson1_1__listOfParameterValue(
-      input.ParameterOverrides,
-      context
-    );
-  }
-  if (input.ResourceTypes !== undefined) {
-    bodyParams["resourceTypes"] = serializeAws_restJson1_1__listOf__string(
-      input.ResourceTypes,
-      context
-    );
-  }
-  if (input.RollbackConfiguration !== undefined) {
-    bodyParams[
-      "rollbackConfiguration"
-    ] = serializeAws_restJson1_1RollbackConfiguration(
-      input.RollbackConfiguration,
-      context
-    );
-  }
-  if (input.SemanticVersion !== undefined) {
-    bodyParams["semanticVersion"] = input.SemanticVersion;
-  }
-  if (input.StackName !== undefined) {
-    bodyParams["stackName"] = input.StackName;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1__listOfTag(
-      input.Tags,
-      context
-    );
-  }
-  if (input.TemplateId !== undefined) {
-    bodyParams["templateId"] = input.TemplateId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Capabilities !== undefined && {
+      capabilities: serializeAws_restJson1_1__listOf__string(
+        input.Capabilities,
+        context
+      )
+    }),
+    ...(input.ChangeSetName !== undefined && {
+      changeSetName: input.ChangeSetName
+    }),
+    ...(input.ClientToken !== undefined && { clientToken: input.ClientToken }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.NotificationArns !== undefined && {
+      notificationArns: serializeAws_restJson1_1__listOf__string(
+        input.NotificationArns,
+        context
+      )
+    }),
+    ...(input.ParameterOverrides !== undefined && {
+      parameterOverrides: serializeAws_restJson1_1__listOfParameterValue(
+        input.ParameterOverrides,
+        context
+      )
+    }),
+    ...(input.ResourceTypes !== undefined && {
+      resourceTypes: serializeAws_restJson1_1__listOf__string(
+        input.ResourceTypes,
+        context
+      )
+    }),
+    ...(input.RollbackConfiguration !== undefined && {
+      rollbackConfiguration: serializeAws_restJson1_1RollbackConfiguration(
+        input.RollbackConfiguration,
+        context
+      )
+    }),
+    ...(input.SemanticVersion !== undefined && {
+      semanticVersion: input.SemanticVersion
+    }),
+    ...(input.StackName !== undefined && { stackName: input.StackName }),
+    ...(input.Tags !== undefined && {
+      tags: serializeAws_restJson1_1__listOfTag(input.Tags, context)
+    }),
+    ...(input.TemplateId !== undefined && { templateId: input.TemplateId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -336,11 +298,11 @@ export const serializeAws_restJson1_1CreateCloudFormationTemplateCommand = async
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SemanticVersion !== undefined) {
-    bodyParams["semanticVersion"] = input.SemanticVersion;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SemanticVersion !== undefined && {
+      semanticVersion: input.SemanticVersion
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -649,16 +611,14 @@ export const serializeAws_restJson1_1PutApplicationPolicyCommand = async (
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Statements !== undefined) {
-    bodyParams[
-      "statements"
-    ] = serializeAws_restJson1_1__listOfApplicationPolicyStatement(
-      input.Statements,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Statements !== undefined && {
+      statements: serializeAws_restJson1_1__listOfApplicationPolicyStatement(
+        input.Statements,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -694,29 +654,16 @@ export const serializeAws_restJson1_1UpdateApplicationCommand = async (
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Author !== undefined) {
-    bodyParams["author"] = input.Author;
-  }
-  if (input.Description !== undefined) {
-    bodyParams["description"] = input.Description;
-  }
-  if (input.HomePageUrl !== undefined) {
-    bodyParams["homePageUrl"] = input.HomePageUrl;
-  }
-  if (input.Labels !== undefined) {
-    bodyParams["labels"] = serializeAws_restJson1_1__listOf__string(
-      input.Labels,
-      context
-    );
-  }
-  if (input.ReadmeBody !== undefined) {
-    bodyParams["readmeBody"] = input.ReadmeBody;
-  }
-  if (input.ReadmeUrl !== undefined) {
-    bodyParams["readmeUrl"] = input.ReadmeUrl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Author !== undefined && { author: input.Author }),
+    ...(input.Description !== undefined && { description: input.Description }),
+    ...(input.HomePageUrl !== undefined && { homePageUrl: input.HomePageUrl }),
+    ...(input.Labels !== undefined && {
+      labels: serializeAws_restJson1_1__listOf__string(input.Labels, context)
+    }),
+    ...(input.ReadmeBody !== undefined && { readmeBody: input.ReadmeBody }),
+    ...(input.ReadmeUrl !== undefined && { readmeUrl: input.ReadmeUrl })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-sesv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1_1.ts
@@ -275,46 +275,44 @@ export const serializeAws_restJson1_1CreateConfigurationSetCommand = async (
   };
   let resolvedPath = "/v2/email/configuration-sets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConfigurationSetName !== undefined) {
-    bodyParams["ConfigurationSetName"] = input.ConfigurationSetName;
-  }
-  if (input.DeliveryOptions !== undefined) {
-    bodyParams["DeliveryOptions"] = serializeAws_restJson1_1DeliveryOptions(
-      input.DeliveryOptions,
-      context
-    );
-  }
-  if (input.ReputationOptions !== undefined) {
-    bodyParams["ReputationOptions"] = serializeAws_restJson1_1ReputationOptions(
-      input.ReputationOptions,
-      context
-    );
-  }
-  if (input.SendingOptions !== undefined) {
-    bodyParams["SendingOptions"] = serializeAws_restJson1_1SendingOptions(
-      input.SendingOptions,
-      context
-    );
-  }
-  if (input.SuppressionOptions !== undefined) {
-    bodyParams[
-      "SuppressionOptions"
-    ] = serializeAws_restJson1_1SuppressionOptions(
-      input.SuppressionOptions,
-      context
-    );
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  if (input.TrackingOptions !== undefined) {
-    bodyParams["TrackingOptions"] = serializeAws_restJson1_1TrackingOptions(
-      input.TrackingOptions,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConfigurationSetName !== undefined && {
+      ConfigurationSetName: input.ConfigurationSetName
+    }),
+    ...(input.DeliveryOptions !== undefined && {
+      DeliveryOptions: serializeAws_restJson1_1DeliveryOptions(
+        input.DeliveryOptions,
+        context
+      )
+    }),
+    ...(input.ReputationOptions !== undefined && {
+      ReputationOptions: serializeAws_restJson1_1ReputationOptions(
+        input.ReputationOptions,
+        context
+      )
+    }),
+    ...(input.SendingOptions !== undefined && {
+      SendingOptions: serializeAws_restJson1_1SendingOptions(
+        input.SendingOptions,
+        context
+      )
+    }),
+    ...(input.SuppressionOptions !== undefined && {
+      SuppressionOptions: serializeAws_restJson1_1SuppressionOptions(
+        input.SuppressionOptions,
+        context
+      )
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    }),
+    ...(input.TrackingOptions !== undefined && {
+      TrackingOptions: serializeAws_restJson1_1TrackingOptions(
+        input.TrackingOptions,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -353,19 +351,17 @@ export const serializeAws_restJson1_1CreateConfigurationSetEventDestinationComma
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EventDestination !== undefined) {
-    bodyParams[
-      "EventDestination"
-    ] = serializeAws_restJson1_1EventDestinationDefinition(
-      input.EventDestination,
-      context
-    );
-  }
-  if (input.EventDestinationName !== undefined) {
-    bodyParams["EventDestinationName"] = input.EventDestinationName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EventDestination !== undefined && {
+      EventDestination: serializeAws_restJson1_1EventDestinationDefinition(
+        input.EventDestination,
+        context
+      )
+    }),
+    ...(input.EventDestinationName !== undefined && {
+      EventDestinationName: input.EventDestinationName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -387,14 +383,12 @@ export const serializeAws_restJson1_1CreateDedicatedIpPoolCommand = async (
   };
   let resolvedPath = "/v2/email/dedicated-ip-pools";
   let body: any;
-  const bodyParams: any = {};
-  if (input.PoolName !== undefined) {
-    bodyParams["PoolName"] = input.PoolName;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.PoolName !== undefined && { PoolName: input.PoolName }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -416,23 +410,18 @@ export const serializeAws_restJson1_1CreateDeliverabilityTestReportCommand = asy
   };
   let resolvedPath = "/v2/email/deliverability-dashboard/test";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = serializeAws_restJson1_1EmailContent(
-      input.Content,
-      context
-    );
-  }
-  if (input.FromEmailAddress !== undefined) {
-    bodyParams["FromEmailAddress"] = input.FromEmailAddress;
-  }
-  if (input.ReportName !== undefined) {
-    bodyParams["ReportName"] = input.ReportName;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Content !== undefined && {
+      Content: serializeAws_restJson1_1EmailContent(input.Content, context)
+    }),
+    ...(input.FromEmailAddress !== undefined && {
+      FromEmailAddress: input.FromEmailAddress
+    }),
+    ...(input.ReportName !== undefined && { ReportName: input.ReportName }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -454,22 +443,20 @@ export const serializeAws_restJson1_1CreateEmailIdentityCommand = async (
   };
   let resolvedPath = "/v2/email/identities";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DkimSigningAttributes !== undefined) {
-    bodyParams[
-      "DkimSigningAttributes"
-    ] = serializeAws_restJson1_1DkimSigningAttributes(
-      input.DkimSigningAttributes,
-      context
-    );
-  }
-  if (input.EmailIdentity !== undefined) {
-    bodyParams["EmailIdentity"] = input.EmailIdentity;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DkimSigningAttributes !== undefined && {
+      DkimSigningAttributes: serializeAws_restJson1_1DkimSigningAttributes(
+        input.DkimSigningAttributes,
+        context
+      )
+    }),
+    ...(input.EmailIdentity !== undefined && {
+      EmailIdentity: input.EmailIdentity
+    }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1291,11 +1278,11 @@ export const serializeAws_restJson1_1PutAccountDedicatedIpWarmupAttributesComman
   };
   let resolvedPath = "/v2/email/account/dedicated-ips/warmup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AutoWarmupEnabled !== undefined) {
-    bodyParams["AutoWarmupEnabled"] = input.AutoWarmupEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AutoWarmupEnabled !== undefined && {
+      AutoWarmupEnabled: input.AutoWarmupEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1317,11 +1304,11 @@ export const serializeAws_restJson1_1PutAccountSendingAttributesCommand = async 
   };
   let resolvedPath = "/v2/email/account/sending";
   let body: any;
-  const bodyParams: any = {};
-  if (input.SendingEnabled !== undefined) {
-    bodyParams["SendingEnabled"] = input.SendingEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SendingEnabled !== undefined && {
+      SendingEnabled: input.SendingEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1343,16 +1330,14 @@ export const serializeAws_restJson1_1PutAccountSuppressionAttributesCommand = as
   };
   let resolvedPath = "/v2/email/account/suppression";
   let body: any;
-  const bodyParams: any = {};
-  if (input.SuppressedReasons !== undefined) {
-    bodyParams[
-      "SuppressedReasons"
-    ] = serializeAws_restJson1_1SuppressionListReasons(
-      input.SuppressedReasons,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SuppressedReasons !== undefined && {
+      SuppressedReasons: serializeAws_restJson1_1SuppressionListReasons(
+        input.SuppressedReasons,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1391,14 +1376,12 @@ export const serializeAws_restJson1_1PutConfigurationSetDeliveryOptionsCommand =
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SendingPoolName !== undefined) {
-    bodyParams["SendingPoolName"] = input.SendingPoolName;
-  }
-  if (input.TlsPolicy !== undefined) {
-    bodyParams["TlsPolicy"] = input.TlsPolicy;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SendingPoolName !== undefined && {
+      SendingPoolName: input.SendingPoolName
+    }),
+    ...(input.TlsPolicy !== undefined && { TlsPolicy: input.TlsPolicy })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1437,11 +1420,11 @@ export const serializeAws_restJson1_1PutConfigurationSetReputationOptionsCommand
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.ReputationMetricsEnabled !== undefined) {
-    bodyParams["ReputationMetricsEnabled"] = input.ReputationMetricsEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ReputationMetricsEnabled !== undefined && {
+      ReputationMetricsEnabled: input.ReputationMetricsEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1480,11 +1463,11 @@ export const serializeAws_restJson1_1PutConfigurationSetSendingOptionsCommand = 
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SendingEnabled !== undefined) {
-    bodyParams["SendingEnabled"] = input.SendingEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SendingEnabled !== undefined && {
+      SendingEnabled: input.SendingEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1523,16 +1506,14 @@ export const serializeAws_restJson1_1PutConfigurationSetSuppressionOptionsComman
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SuppressedReasons !== undefined) {
-    bodyParams[
-      "SuppressedReasons"
-    ] = serializeAws_restJson1_1SuppressionListReasons(
-      input.SuppressedReasons,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SuppressedReasons !== undefined && {
+      SuppressedReasons: serializeAws_restJson1_1SuppressionListReasons(
+        input.SuppressedReasons,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1571,11 +1552,11 @@ export const serializeAws_restJson1_1PutConfigurationSetTrackingOptionsCommand =
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.CustomRedirectDomain !== undefined) {
-    bodyParams["CustomRedirectDomain"] = input.CustomRedirectDomain;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CustomRedirectDomain !== undefined && {
+      CustomRedirectDomain: input.CustomRedirectDomain
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1609,11 +1590,11 @@ export const serializeAws_restJson1_1PutDedicatedIpInPoolCommand = async (
     throw new Error("No value provided for input HTTP label: Ip.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.DestinationPoolName !== undefined) {
-    bodyParams["DestinationPoolName"] = input.DestinationPoolName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DestinationPoolName !== undefined && {
+      DestinationPoolName: input.DestinationPoolName
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1647,11 +1628,11 @@ export const serializeAws_restJson1_1PutDedicatedIpWarmupAttributesCommand = asy
     throw new Error("No value provided for input HTTP label: Ip.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.WarmupPercentage !== undefined) {
-    bodyParams["WarmupPercentage"] = input.WarmupPercentage;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.WarmupPercentage !== undefined && {
+      WarmupPercentage: input.WarmupPercentage
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1673,19 +1654,17 @@ export const serializeAws_restJson1_1PutDeliverabilityDashboardOptionCommand = a
   };
   let resolvedPath = "/v2/email/deliverability-dashboard";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DashboardEnabled !== undefined) {
-    bodyParams["DashboardEnabled"] = input.DashboardEnabled;
-  }
-  if (input.SubscribedDomains !== undefined) {
-    bodyParams[
-      "SubscribedDomains"
-    ] = serializeAws_restJson1_1DomainDeliverabilityTrackingOptions(
-      input.SubscribedDomains,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DashboardEnabled !== undefined && {
+      DashboardEnabled: input.DashboardEnabled
+    }),
+    ...(input.SubscribedDomains !== undefined && {
+      SubscribedDomains: serializeAws_restJson1_1DomainDeliverabilityTrackingOptions(
+        input.SubscribedDomains,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1721,11 +1700,11 @@ export const serializeAws_restJson1_1PutEmailIdentityDkimAttributesCommand = asy
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SigningEnabled !== undefined) {
-    bodyParams["SigningEnabled"] = input.SigningEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SigningEnabled !== undefined && {
+      SigningEnabled: input.SigningEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1761,19 +1740,17 @@ export const serializeAws_restJson1_1PutEmailIdentityDkimSigningAttributesComman
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.SigningAttributes !== undefined) {
-    bodyParams[
-      "SigningAttributes"
-    ] = serializeAws_restJson1_1DkimSigningAttributes(
-      input.SigningAttributes,
-      context
-    );
-  }
-  if (input.SigningAttributesOrigin !== undefined) {
-    bodyParams["SigningAttributesOrigin"] = input.SigningAttributesOrigin;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SigningAttributes !== undefined && {
+      SigningAttributes: serializeAws_restJson1_1DkimSigningAttributes(
+        input.SigningAttributes,
+        context
+      )
+    }),
+    ...(input.SigningAttributesOrigin !== undefined && {
+      SigningAttributesOrigin: input.SigningAttributesOrigin
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1809,11 +1786,11 @@ export const serializeAws_restJson1_1PutEmailIdentityFeedbackAttributesCommand =
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EmailForwardingEnabled !== undefined) {
-    bodyParams["EmailForwardingEnabled"] = input.EmailForwardingEnabled;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EmailForwardingEnabled !== undefined && {
+      EmailForwardingEnabled: input.EmailForwardingEnabled
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1849,14 +1826,14 @@ export const serializeAws_restJson1_1PutEmailIdentityMailFromAttributesCommand =
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.BehaviorOnMxFailure !== undefined) {
-    bodyParams["BehaviorOnMxFailure"] = input.BehaviorOnMxFailure;
-  }
-  if (input.MailFromDomain !== undefined) {
-    bodyParams["MailFromDomain"] = input.MailFromDomain;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.BehaviorOnMxFailure !== undefined && {
+      BehaviorOnMxFailure: input.BehaviorOnMxFailure
+    }),
+    ...(input.MailFromDomain !== undefined && {
+      MailFromDomain: input.MailFromDomain
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1878,14 +1855,12 @@ export const serializeAws_restJson1_1PutSuppressedDestinationCommand = async (
   };
   let resolvedPath = "/v2/email/suppression/addresses";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EmailAddress !== undefined) {
-    bodyParams["EmailAddress"] = input.EmailAddress;
-  }
-  if (input.Reason !== undefined) {
-    bodyParams["Reason"] = input.Reason;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EmailAddress !== undefined && {
+      EmailAddress: input.EmailAddress
+    }),
+    ...(input.Reason !== undefined && { Reason: input.Reason })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1907,42 +1882,38 @@ export const serializeAws_restJson1_1SendEmailCommand = async (
   };
   let resolvedPath = "/v2/email/outbound-emails";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ConfigurationSetName !== undefined) {
-    bodyParams["ConfigurationSetName"] = input.ConfigurationSetName;
-  }
-  if (input.Content !== undefined) {
-    bodyParams["Content"] = serializeAws_restJson1_1EmailContent(
-      input.Content,
-      context
-    );
-  }
-  if (input.Destination !== undefined) {
-    bodyParams["Destination"] = serializeAws_restJson1_1Destination(
-      input.Destination,
-      context
-    );
-  }
-  if (input.EmailTags !== undefined) {
-    bodyParams["EmailTags"] = serializeAws_restJson1_1MessageTagList(
-      input.EmailTags,
-      context
-    );
-  }
-  if (input.FeedbackForwardingEmailAddress !== undefined) {
-    bodyParams["FeedbackForwardingEmailAddress"] =
-      input.FeedbackForwardingEmailAddress;
-  }
-  if (input.FromEmailAddress !== undefined) {
-    bodyParams["FromEmailAddress"] = input.FromEmailAddress;
-  }
-  if (input.ReplyToAddresses !== undefined) {
-    bodyParams["ReplyToAddresses"] = serializeAws_restJson1_1EmailAddressList(
-      input.ReplyToAddresses,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ConfigurationSetName !== undefined && {
+      ConfigurationSetName: input.ConfigurationSetName
+    }),
+    ...(input.Content !== undefined && {
+      Content: serializeAws_restJson1_1EmailContent(input.Content, context)
+    }),
+    ...(input.Destination !== undefined && {
+      Destination: serializeAws_restJson1_1Destination(
+        input.Destination,
+        context
+      )
+    }),
+    ...(input.EmailTags !== undefined && {
+      EmailTags: serializeAws_restJson1_1MessageTagList(
+        input.EmailTags,
+        context
+      )
+    }),
+    ...(input.FeedbackForwardingEmailAddress !== undefined && {
+      FeedbackForwardingEmailAddress: input.FeedbackForwardingEmailAddress
+    }),
+    ...(input.FromEmailAddress !== undefined && {
+      FromEmailAddress: input.FromEmailAddress
+    }),
+    ...(input.ReplyToAddresses !== undefined && {
+      ReplyToAddresses: serializeAws_restJson1_1EmailAddressList(
+        input.ReplyToAddresses,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1964,14 +1935,12 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
   };
   let resolvedPath = "/v2/email/tags";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ResourceArn !== undefined) {
-    bodyParams["ResourceArn"] = input.ResourceArn;
-  }
-  if (input.Tags !== undefined) {
-    bodyParams["Tags"] = serializeAws_restJson1_1TagList(input.Tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ResourceArn !== undefined && { ResourceArn: input.ResourceArn }),
+    ...(input.Tags !== undefined && {
+      Tags: serializeAws_restJson1_1TagList(input.Tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2054,16 +2023,14 @@ export const serializeAws_restJson1_1UpdateConfigurationSetEventDestinationComma
     );
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.EventDestination !== undefined) {
-    bodyParams[
-      "EventDestination"
-    ] = serializeAws_restJson1_1EventDestinationDefinition(
-      input.EventDestination,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EventDestination !== undefined && {
+      EventDestination: serializeAws_restJson1_1EventDestinationDefinition(
+        input.EventDestination,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-signer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1_1.ts
@@ -377,32 +377,30 @@ export const serializeAws_restJson1_1PutSigningProfileCommand = async (
     throw new Error("No value provided for input HTTP label: profileName.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.overrides !== undefined) {
-    bodyParams["overrides"] = serializeAws_restJson1_1SigningPlatformOverrides(
-      input.overrides,
-      context
-    );
-  }
-  if (input.platformId !== undefined) {
-    bodyParams["platformId"] = input.platformId;
-  }
-  if (input.signingMaterial !== undefined) {
-    bodyParams["signingMaterial"] = serializeAws_restJson1_1SigningMaterial(
-      input.signingMaterial,
-      context
-    );
-  }
-  if (input.signingParameters !== undefined) {
-    bodyParams["signingParameters"] = serializeAws_restJson1_1SigningParameters(
-      input.signingParameters,
-      context
-    );
-  }
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.overrides !== undefined && {
+      overrides: serializeAws_restJson1_1SigningPlatformOverrides(
+        input.overrides,
+        context
+      )
+    }),
+    ...(input.platformId !== undefined && { platformId: input.platformId }),
+    ...(input.signingMaterial !== undefined && {
+      signingMaterial: serializeAws_restJson1_1SigningMaterial(
+        input.signingMaterial,
+        context
+      )
+    }),
+    ...(input.signingParameters !== undefined && {
+      signingParameters: serializeAws_restJson1_1SigningParameters(
+        input.signingParameters,
+        context
+      )
+    }),
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -424,29 +422,19 @@ export const serializeAws_restJson1_1StartSigningJobCommand = async (
   };
   let resolvedPath = "/signing-jobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientRequestToken === undefined) {
-    input.clientRequestToken = generateIdempotencyToken();
-  }
-  if (input.clientRequestToken !== undefined) {
-    bodyParams["clientRequestToken"] = input.clientRequestToken;
-  }
-  if (input.destination !== undefined) {
-    bodyParams["destination"] = serializeAws_restJson1_1Destination(
-      input.destination,
-      context
-    );
-  }
-  if (input.profileName !== undefined) {
-    bodyParams["profileName"] = input.profileName;
-  }
-  if (input.source !== undefined) {
-    bodyParams["source"] = serializeAws_restJson1_1Source(
-      input.source,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    clientRequestToken: input.clientRequestToken ?? generateIdempotencyToken(),
+    ...(input.destination !== undefined && {
+      destination: serializeAws_restJson1_1Destination(
+        input.destination,
+        context
+      )
+    }),
+    ...(input.profileName !== undefined && { profileName: input.profileName }),
+    ...(input.source !== undefined && {
+      source: serializeAws_restJson1_1Source(input.source, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -482,11 +470,11 @@ export const serializeAws_restJson1_1TagResourceCommand = async (
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.tags !== undefined) {
-    bodyParams["tags"] = serializeAws_restJson1_1TagMap(input.tags, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.tags !== undefined && {
+      tags: serializeAws_restJson1_1TagMap(input.tags, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-sso-oidc/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sso-oidc/protocols/Aws_restJson1_1.ts
@@ -45,32 +45,22 @@ export const serializeAws_restJson1_1CreateTokenCommand = async (
   };
   let resolvedPath = "/token";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientId !== undefined) {
-    bodyParams["clientId"] = input.clientId;
-  }
-  if (input.clientSecret !== undefined) {
-    bodyParams["clientSecret"] = input.clientSecret;
-  }
-  if (input.code !== undefined) {
-    bodyParams["code"] = input.code;
-  }
-  if (input.deviceCode !== undefined) {
-    bodyParams["deviceCode"] = input.deviceCode;
-  }
-  if (input.grantType !== undefined) {
-    bodyParams["grantType"] = input.grantType;
-  }
-  if (input.redirectUri !== undefined) {
-    bodyParams["redirectUri"] = input.redirectUri;
-  }
-  if (input.refreshToken !== undefined) {
-    bodyParams["refreshToken"] = input.refreshToken;
-  }
-  if (input.scope !== undefined) {
-    bodyParams["scope"] = serializeAws_restJson1_1Scopes(input.scope, context);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientId !== undefined && { clientId: input.clientId }),
+    ...(input.clientSecret !== undefined && {
+      clientSecret: input.clientSecret
+    }),
+    ...(input.code !== undefined && { code: input.code }),
+    ...(input.deviceCode !== undefined && { deviceCode: input.deviceCode }),
+    ...(input.grantType !== undefined && { grantType: input.grantType }),
+    ...(input.redirectUri !== undefined && { redirectUri: input.redirectUri }),
+    ...(input.refreshToken !== undefined && {
+      refreshToken: input.refreshToken
+    }),
+    ...(input.scope !== undefined && {
+      scope: serializeAws_restJson1_1Scopes(input.scope, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -92,20 +82,13 @@ export const serializeAws_restJson1_1RegisterClientCommand = async (
   };
   let resolvedPath = "/client/register";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientName !== undefined) {
-    bodyParams["clientName"] = input.clientName;
-  }
-  if (input.clientType !== undefined) {
-    bodyParams["clientType"] = input.clientType;
-  }
-  if (input.scopes !== undefined) {
-    bodyParams["scopes"] = serializeAws_restJson1_1Scopes(
-      input.scopes,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientName !== undefined && { clientName: input.clientName }),
+    ...(input.clientType !== undefined && { clientType: input.clientType }),
+    ...(input.scopes !== undefined && {
+      scopes: serializeAws_restJson1_1Scopes(input.scopes, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -127,17 +110,13 @@ export const serializeAws_restJson1_1StartDeviceAuthorizationCommand = async (
   };
   let resolvedPath = "/device_authorization";
   let body: any;
-  const bodyParams: any = {};
-  if (input.clientId !== undefined) {
-    bodyParams["clientId"] = input.clientId;
-  }
-  if (input.clientSecret !== undefined) {
-    bodyParams["clientSecret"] = input.clientSecret;
-  }
-  if (input.startUrl !== undefined) {
-    bodyParams["startUrl"] = input.startUrl;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.clientId !== undefined && { clientId: input.clientId }),
+    ...(input.clientSecret !== undefined && {
+      clientSecret: input.clientSecret
+    }),
+    ...(input.startUrl !== undefined && { startUrl: input.startUrl })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-workdocs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1_1.ts
@@ -334,22 +334,20 @@ export const serializeAws_restJson1_1AddResourcePermissionsCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.NotificationOptions !== undefined) {
-    bodyParams[
-      "NotificationOptions"
-    ] = serializeAws_restJson1_1NotificationOptions(
-      input.NotificationOptions,
-      context
-    );
-  }
-  if (input.Principals !== undefined) {
-    bodyParams["Principals"] = serializeAws_restJson1_1SharePrincipalList(
-      input.Principals,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NotificationOptions !== undefined && {
+      NotificationOptions: serializeAws_restJson1_1NotificationOptions(
+        input.NotificationOptions,
+        context
+      )
+    }),
+    ...(input.Principals !== undefined && {
+      Principals: serializeAws_restJson1_1SharePrincipalList(
+        input.Principals,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -399,23 +397,15 @@ export const serializeAws_restJson1_1CreateCommentCommand = async (
     throw new Error("No value provided for input HTTP label: VersionId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.NotifyCollaborators !== undefined) {
-    bodyParams["NotifyCollaborators"] = input.NotifyCollaborators;
-  }
-  if (input.ParentId !== undefined) {
-    bodyParams["ParentId"] = input.ParentId;
-  }
-  if (input.Text !== undefined) {
-    bodyParams["Text"] = input.Text;
-  }
-  if (input.ThreadId !== undefined) {
-    bodyParams["ThreadId"] = input.ThreadId;
-  }
-  if (input.Visibility !== undefined) {
-    bodyParams["Visibility"] = input.Visibility;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NotifyCollaborators !== undefined && {
+      NotifyCollaborators: input.NotifyCollaborators
+    }),
+    ...(input.ParentId !== undefined && { ParentId: input.ParentId }),
+    ...(input.Text !== undefined && { Text: input.Text }),
+    ...(input.ThreadId !== undefined && { ThreadId: input.ThreadId }),
+    ...(input.Visibility !== undefined && { Visibility: input.Visibility })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -455,14 +445,14 @@ export const serializeAws_restJson1_1CreateCustomMetadataCommand = async (
     ...(input.VersionId !== undefined && { versionid: input.VersionId })
   };
   let body: any;
-  const bodyParams: any = {};
-  if (input.CustomMetadata !== undefined) {
-    bodyParams["CustomMetadata"] = serializeAws_restJson1_1CustomMetadataMap(
-      input.CustomMetadata,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.CustomMetadata !== undefined && {
+      CustomMetadata: serializeAws_restJson1_1CustomMetadataMap(
+        input.CustomMetadata,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -488,14 +478,12 @@ export const serializeAws_restJson1_1CreateFolderCommand = async (
   };
   let resolvedPath = "/api/v1/folders";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ParentFolderId !== undefined) {
-    bodyParams["ParentFolderId"] = input.ParentFolderId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ParentFolderId !== undefined && {
+      ParentFolderId: input.ParentFolderId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -532,14 +520,11 @@ export const serializeAws_restJson1_1CreateLabelsCommand = async (
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Labels !== undefined) {
-    bodyParams["Labels"] = serializeAws_restJson1_1SharedLabels(
-      input.Labels,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Labels !== undefined && {
+      Labels: serializeAws_restJson1_1SharedLabels(input.Labels, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -575,17 +560,13 @@ export const serializeAws_restJson1_1CreateNotificationSubscriptionCommand = asy
     throw new Error("No value provided for input HTTP label: OrganizationId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Endpoint !== undefined) {
-    bodyParams["Endpoint"] = input.Endpoint;
-  }
-  if (input.Protocol !== undefined) {
-    bodyParams["Protocol"] = input.Protocol;
-  }
-  if (input.SubscriptionType !== undefined) {
-    bodyParams["SubscriptionType"] = input.SubscriptionType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Endpoint !== undefined && { Endpoint: input.Endpoint }),
+    ...(input.Protocol !== undefined && { Protocol: input.Protocol }),
+    ...(input.SubscriptionType !== undefined && {
+      SubscriptionType: input.SubscriptionType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -610,35 +591,25 @@ export const serializeAws_restJson1_1CreateUserCommand = async (
   };
   let resolvedPath = "/api/v1/users";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EmailAddress !== undefined) {
-    bodyParams["EmailAddress"] = input.EmailAddress;
-  }
-  if (input.GivenName !== undefined) {
-    bodyParams["GivenName"] = input.GivenName;
-  }
-  if (input.OrganizationId !== undefined) {
-    bodyParams["OrganizationId"] = input.OrganizationId;
-  }
-  if (input.Password !== undefined) {
-    bodyParams["Password"] = input.Password;
-  }
-  if (input.StorageRule !== undefined) {
-    bodyParams["StorageRule"] = serializeAws_restJson1_1StorageRuleType(
-      input.StorageRule,
-      context
-    );
-  }
-  if (input.Surname !== undefined) {
-    bodyParams["Surname"] = input.Surname;
-  }
-  if (input.TimeZoneId !== undefined) {
-    bodyParams["TimeZoneId"] = input.TimeZoneId;
-  }
-  if (input.Username !== undefined) {
-    bodyParams["Username"] = input.Username;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EmailAddress !== undefined && {
+      EmailAddress: input.EmailAddress
+    }),
+    ...(input.GivenName !== undefined && { GivenName: input.GivenName }),
+    ...(input.OrganizationId !== undefined && {
+      OrganizationId: input.OrganizationId
+    }),
+    ...(input.Password !== undefined && { Password: input.Password }),
+    ...(input.StorageRule !== undefined && {
+      StorageRule: serializeAws_restJson1_1StorageRuleType(
+        input.StorageRule,
+        context
+      )
+    }),
+    ...(input.Surname !== undefined && { Surname: input.Surname }),
+    ...(input.TimeZoneId !== undefined && { TimeZoneId: input.TimeZoneId }),
+    ...(input.Username !== undefined && { Username: input.Username })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1695,33 +1666,27 @@ export const serializeAws_restJson1_1InitiateDocumentVersionUploadCommand = asyn
   };
   let resolvedPath = "/api/v1/documents";
   let body: any;
-  const bodyParams: any = {};
-  if (input.ContentCreatedTimestamp !== undefined) {
-    bodyParams["ContentCreatedTimestamp"] = Math.round(
-      input.ContentCreatedTimestamp.getTime() / 1000
-    );
-  }
-  if (input.ContentModifiedTimestamp !== undefined) {
-    bodyParams["ContentModifiedTimestamp"] = Math.round(
-      input.ContentModifiedTimestamp.getTime() / 1000
-    );
-  }
-  if (input.ContentType !== undefined) {
-    bodyParams["ContentType"] = input.ContentType;
-  }
-  if (input.DocumentSizeInBytes !== undefined) {
-    bodyParams["DocumentSizeInBytes"] = input.DocumentSizeInBytes;
-  }
-  if (input.Id !== undefined) {
-    bodyParams["Id"] = input.Id;
-  }
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ParentFolderId !== undefined) {
-    bodyParams["ParentFolderId"] = input.ParentFolderId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.ContentCreatedTimestamp !== undefined && {
+      ContentCreatedTimestamp: Math.round(
+        input.ContentCreatedTimestamp.getTime() / 1000
+      )
+    }),
+    ...(input.ContentModifiedTimestamp !== undefined && {
+      ContentModifiedTimestamp: Math.round(
+        input.ContentModifiedTimestamp.getTime() / 1000
+      )
+    }),
+    ...(input.ContentType !== undefined && { ContentType: input.ContentType }),
+    ...(input.DocumentSizeInBytes !== undefined && {
+      DocumentSizeInBytes: input.DocumentSizeInBytes
+    }),
+    ...(input.Id !== undefined && { Id: input.Id }),
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ParentFolderId !== undefined && {
+      ParentFolderId: input.ParentFolderId
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1848,17 +1813,15 @@ export const serializeAws_restJson1_1UpdateDocumentCommand = async (
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ParentFolderId !== undefined) {
-    bodyParams["ParentFolderId"] = input.ParentFolderId;
-  }
-  if (input.ResourceState !== undefined) {
-    bodyParams["ResourceState"] = input.ResourceState;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ParentFolderId !== undefined && {
+      ParentFolderId: input.ParentFolderId
+    }),
+    ...(input.ResourceState !== undefined && {
+      ResourceState: input.ResourceState
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1907,11 +1870,11 @@ export const serializeAws_restJson1_1UpdateDocumentVersionCommand = async (
     throw new Error("No value provided for input HTTP label: VersionId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.VersionStatus !== undefined) {
-    bodyParams["VersionStatus"] = input.VersionStatus;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.VersionStatus !== undefined && {
+      VersionStatus: input.VersionStatus
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1948,17 +1911,15 @@ export const serializeAws_restJson1_1UpdateFolderCommand = async (
     throw new Error("No value provided for input HTTP label: FolderId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.Name !== undefined) {
-    bodyParams["Name"] = input.Name;
-  }
-  if (input.ParentFolderId !== undefined) {
-    bodyParams["ParentFolderId"] = input.ParentFolderId;
-  }
-  if (input.ResourceState !== undefined) {
-    bodyParams["ResourceState"] = input.ResourceState;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.ParentFolderId !== undefined && {
+      ParentFolderId: input.ParentFolderId
+    }),
+    ...(input.ResourceState !== undefined && {
+      ResourceState: input.ResourceState
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1995,32 +1956,22 @@ export const serializeAws_restJson1_1UpdateUserCommand = async (
     throw new Error("No value provided for input HTTP label: UserId.");
   }
   let body: any;
-  const bodyParams: any = {};
-  if (input.GivenName !== undefined) {
-    bodyParams["GivenName"] = input.GivenName;
-  }
-  if (input.GrantPoweruserPrivileges !== undefined) {
-    bodyParams["GrantPoweruserPrivileges"] = input.GrantPoweruserPrivileges;
-  }
-  if (input.Locale !== undefined) {
-    bodyParams["Locale"] = input.Locale;
-  }
-  if (input.StorageRule !== undefined) {
-    bodyParams["StorageRule"] = serializeAws_restJson1_1StorageRuleType(
-      input.StorageRule,
-      context
-    );
-  }
-  if (input.Surname !== undefined) {
-    bodyParams["Surname"] = input.Surname;
-  }
-  if (input.TimeZoneId !== undefined) {
-    bodyParams["TimeZoneId"] = input.TimeZoneId;
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GivenName !== undefined && { GivenName: input.GivenName }),
+    ...(input.GrantPoweruserPrivileges !== undefined && {
+      GrantPoweruserPrivileges: input.GrantPoweruserPrivileges
+    }),
+    ...(input.Locale !== undefined && { Locale: input.Locale }),
+    ...(input.StorageRule !== undefined && {
+      StorageRule: serializeAws_restJson1_1StorageRuleType(
+        input.StorageRule,
+        context
+      )
+    }),
+    ...(input.Surname !== undefined && { Surname: input.Surname }),
+    ...(input.TimeZoneId !== undefined && { TimeZoneId: input.TimeZoneId }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-worklink/protocols/Aws_restJson1_1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1_1.ts
@@ -152,20 +152,14 @@ export const serializeAws_restJson1_1AssociateDomainCommand = async (
   };
   let resolvedPath = "/associateDomain";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AcmCertificateArn !== undefined) {
-    bodyParams["AcmCertificateArn"] = input.AcmCertificateArn;
-  }
-  if (input.DisplayName !== undefined) {
-    bodyParams["DisplayName"] = input.DisplayName;
-  }
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AcmCertificateArn !== undefined && {
+      AcmCertificateArn: input.AcmCertificateArn
+    }),
+    ...(input.DisplayName !== undefined && { DisplayName: input.DisplayName }),
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -187,17 +181,13 @@ export const serializeAws_restJson1_1AssociateWebsiteAuthorizationProviderComman
   };
   let resolvedPath = "/associateWebsiteAuthorizationProvider";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AuthorizationProviderType !== undefined) {
-    bodyParams["AuthorizationProviderType"] = input.AuthorizationProviderType;
-  }
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AuthorizationProviderType !== undefined && {
+      AuthorizationProviderType: input.AuthorizationProviderType
+    }),
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -219,17 +209,11 @@ export const serializeAws_restJson1_1AssociateWebsiteCertificateAuthorityCommand
   };
   let resolvedPath = "/associateWebsiteCertificateAuthority";
   let body: any;
-  const bodyParams: any = {};
-  if (input.Certificate !== undefined) {
-    bodyParams["Certificate"] = input.Certificate;
-  }
-  if (input.DisplayName !== undefined) {
-    bodyParams["DisplayName"] = input.DisplayName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.Certificate !== undefined && { Certificate: input.Certificate }),
+    ...(input.DisplayName !== undefined && { DisplayName: input.DisplayName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -251,17 +235,13 @@ export const serializeAws_restJson1_1CreateFleetCommand = async (
   };
   let resolvedPath = "/createFleet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DisplayName !== undefined) {
-    bodyParams["DisplayName"] = input.DisplayName;
-  }
-  if (input.FleetName !== undefined) {
-    bodyParams["FleetName"] = input.FleetName;
-  }
-  if (input.OptimizeForEndUserLocation !== undefined) {
-    bodyParams["OptimizeForEndUserLocation"] = input.OptimizeForEndUserLocation;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DisplayName !== undefined && { DisplayName: input.DisplayName }),
+    ...(input.FleetName !== undefined && { FleetName: input.FleetName }),
+    ...(input.OptimizeForEndUserLocation !== undefined && {
+      OptimizeForEndUserLocation: input.OptimizeForEndUserLocation
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -283,11 +263,9 @@ export const serializeAws_restJson1_1DeleteFleetCommand = async (
   };
   let resolvedPath = "/deleteFleet";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -309,11 +287,9 @@ export const serializeAws_restJson1_1DescribeAuditStreamConfigurationCommand = a
   };
   let resolvedPath = "/describeAuditStreamConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -335,11 +311,9 @@ export const serializeAws_restJson1_1DescribeCompanyNetworkConfigurationCommand 
   };
   let resolvedPath = "/describeCompanyNetworkConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -361,14 +335,10 @@ export const serializeAws_restJson1_1DescribeDeviceCommand = async (
   };
   let resolvedPath = "/describeDevice";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeviceId !== undefined) {
-    bodyParams["DeviceId"] = input.DeviceId;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeviceId !== undefined && { DeviceId: input.DeviceId }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -390,11 +360,9 @@ export const serializeAws_restJson1_1DescribeDevicePolicyConfigurationCommand = 
   };
   let resolvedPath = "/describeDevicePolicyConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -416,14 +384,10 @@ export const serializeAws_restJson1_1DescribeDomainCommand = async (
   };
   let resolvedPath = "/describeDomain";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -445,11 +409,9 @@ export const serializeAws_restJson1_1DescribeFleetMetadataCommand = async (
   };
   let resolvedPath = "/describeFleetMetadata";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -471,11 +433,9 @@ export const serializeAws_restJson1_1DescribeIdentityProviderConfigurationComman
   };
   let resolvedPath = "/describeIdentityProviderConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -497,14 +457,10 @@ export const serializeAws_restJson1_1DescribeWebsiteCertificateAuthorityCommand 
   };
   let resolvedPath = "/describeWebsiteCertificateAuthority";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.WebsiteCaId !== undefined) {
-    bodyParams["WebsiteCaId"] = input.WebsiteCaId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.WebsiteCaId !== undefined && { WebsiteCaId: input.WebsiteCaId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -526,14 +482,10 @@ export const serializeAws_restJson1_1DisassociateDomainCommand = async (
   };
   let resolvedPath = "/disassociateDomain";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -555,14 +507,12 @@ export const serializeAws_restJson1_1DisassociateWebsiteAuthorizationProviderCom
   };
   let resolvedPath = "/disassociateWebsiteAuthorizationProvider";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AuthorizationProviderId !== undefined) {
-    bodyParams["AuthorizationProviderId"] = input.AuthorizationProviderId;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AuthorizationProviderId !== undefined && {
+      AuthorizationProviderId: input.AuthorizationProviderId
+    }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -584,14 +534,10 @@ export const serializeAws_restJson1_1DisassociateWebsiteCertificateAuthorityComm
   };
   let resolvedPath = "/disassociateWebsiteCertificateAuthority";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.WebsiteCaId !== undefined) {
-    bodyParams["WebsiteCaId"] = input.WebsiteCaId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.WebsiteCaId !== undefined && { WebsiteCaId: input.WebsiteCaId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -613,17 +559,11 @@ export const serializeAws_restJson1_1ListDevicesCommand = async (
   };
   let resolvedPath = "/listDevices";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -645,17 +585,11 @@ export const serializeAws_restJson1_1ListDomainsCommand = async (
   };
   let resolvedPath = "/listDomains";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -677,14 +611,10 @@ export const serializeAws_restJson1_1ListFleetsCommand = async (
   };
   let resolvedPath = "/listFleets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -706,17 +636,11 @@ export const serializeAws_restJson1_1ListWebsiteAuthorizationProvidersCommand = 
   };
   let resolvedPath = "/listWebsiteAuthorizationProviders";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -738,17 +662,11 @@ export const serializeAws_restJson1_1ListWebsiteCertificateAuthoritiesCommand = 
   };
   let resolvedPath = "/listWebsiteCertificateAuthorities";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.MaxResults !== undefined) {
-    bodyParams["MaxResults"] = input.MaxResults;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.MaxResults !== undefined && { MaxResults: input.MaxResults }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -770,14 +688,10 @@ export const serializeAws_restJson1_1RestoreDomainAccessCommand = async (
   };
   let resolvedPath = "/restoreDomainAccess";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -799,14 +713,10 @@ export const serializeAws_restJson1_1RevokeDomainAccessCommand = async (
   };
   let resolvedPath = "/revokeDomainAccess";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -828,14 +738,10 @@ export const serializeAws_restJson1_1SignOutUserCommand = async (
   };
   let resolvedPath = "/signOutUser";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.Username !== undefined) {
-    bodyParams["Username"] = input.Username;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.Username !== undefined && { Username: input.Username })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -857,14 +763,12 @@ export const serializeAws_restJson1_1UpdateAuditStreamConfigurationCommand = asy
   };
   let resolvedPath = "/updateAuditStreamConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.AuditStreamArn !== undefined) {
-    bodyParams["AuditStreamArn"] = input.AuditStreamArn;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.AuditStreamArn !== undefined && {
+      AuditStreamArn: input.AuditStreamArn
+    }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -886,26 +790,19 @@ export const serializeAws_restJson1_1UpdateCompanyNetworkConfigurationCommand = 
   };
   let resolvedPath = "/updateCompanyNetworkConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.SecurityGroupIds !== undefined) {
-    bodyParams["SecurityGroupIds"] = serializeAws_restJson1_1SecurityGroupIds(
-      input.SecurityGroupIds,
-      context
-    );
-  }
-  if (input.SubnetIds !== undefined) {
-    bodyParams["SubnetIds"] = serializeAws_restJson1_1SubnetIds(
-      input.SubnetIds,
-      context
-    );
-  }
-  if (input.VpcId !== undefined) {
-    bodyParams["VpcId"] = input.VpcId;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.SecurityGroupIds !== undefined && {
+      SecurityGroupIds: serializeAws_restJson1_1SecurityGroupIds(
+        input.SecurityGroupIds,
+        context
+      )
+    }),
+    ...(input.SubnetIds !== undefined && {
+      SubnetIds: serializeAws_restJson1_1SubnetIds(input.SubnetIds, context)
+    }),
+    ...(input.VpcId !== undefined && { VpcId: input.VpcId })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -927,14 +824,12 @@ export const serializeAws_restJson1_1UpdateDevicePolicyConfigurationCommand = as
   };
   let resolvedPath = "/updateDevicePolicyConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DeviceCaCertificate !== undefined) {
-    bodyParams["DeviceCaCertificate"] = input.DeviceCaCertificate;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DeviceCaCertificate !== undefined && {
+      DeviceCaCertificate: input.DeviceCaCertificate
+    }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -956,17 +851,11 @@ export const serializeAws_restJson1_1UpdateDomainMetadataCommand = async (
   };
   let resolvedPath = "/updateDomainMetadata";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DisplayName !== undefined) {
-    bodyParams["DisplayName"] = input.DisplayName;
-  }
-  if (input.DomainName !== undefined) {
-    bodyParams["DomainName"] = input.DomainName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DisplayName !== undefined && { DisplayName: input.DisplayName }),
+    ...(input.DomainName !== undefined && { DomainName: input.DomainName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -988,17 +877,13 @@ export const serializeAws_restJson1_1UpdateFleetMetadataCommand = async (
   };
   let resolvedPath = "/UpdateFleetMetadata";
   let body: any;
-  const bodyParams: any = {};
-  if (input.DisplayName !== undefined) {
-    bodyParams["DisplayName"] = input.DisplayName;
-  }
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.OptimizeForEndUserLocation !== undefined) {
-    bodyParams["OptimizeForEndUserLocation"] = input.OptimizeForEndUserLocation;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.DisplayName !== undefined && { DisplayName: input.DisplayName }),
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.OptimizeForEndUserLocation !== undefined && {
+      OptimizeForEndUserLocation: input.OptimizeForEndUserLocation
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1020,18 +905,15 @@ export const serializeAws_restJson1_1UpdateIdentityProviderConfigurationCommand 
   };
   let resolvedPath = "/updateIdentityProviderConfiguration";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FleetArn !== undefined) {
-    bodyParams["FleetArn"] = input.FleetArn;
-  }
-  if (input.IdentityProviderSamlMetadata !== undefined) {
-    bodyParams["IdentityProviderSamlMetadata"] =
-      input.IdentityProviderSamlMetadata;
-  }
-  if (input.IdentityProviderType !== undefined) {
-    bodyParams["IdentityProviderType"] = input.IdentityProviderType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FleetArn !== undefined && { FleetArn: input.FleetArn }),
+    ...(input.IdentityProviderSamlMetadata !== undefined && {
+      IdentityProviderSamlMetadata: input.IdentityProviderSamlMetadata
+    }),
+    ...(input.IdentityProviderType !== undefined && {
+      IdentityProviderType: input.IdentityProviderType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-xray/protocols/Aws_restJson1_1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1_1.ts
@@ -148,17 +148,12 @@ export const serializeAws_restJson1_1BatchGetTracesCommand = async (
   };
   let resolvedPath = "/Traces";
   let body: any;
-  const bodyParams: any = {};
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.TraceIds !== undefined) {
-    bodyParams["TraceIds"] = serializeAws_restJson1_1TraceIdList(
-      input.TraceIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.TraceIds !== undefined && {
+      TraceIds: serializeAws_restJson1_1TraceIdList(input.TraceIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -180,14 +175,12 @@ export const serializeAws_restJson1_1CreateGroupCommand = async (
   };
   let resolvedPath = "/CreateGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FilterExpression !== undefined) {
-    bodyParams["FilterExpression"] = input.FilterExpression;
-  }
-  if (input.GroupName !== undefined) {
-    bodyParams["GroupName"] = input.GroupName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FilterExpression !== undefined && {
+      FilterExpression: input.FilterExpression
+    }),
+    ...(input.GroupName !== undefined && { GroupName: input.GroupName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -209,14 +202,14 @@ export const serializeAws_restJson1_1CreateSamplingRuleCommand = async (
   };
   let resolvedPath = "/CreateSamplingRule";
   let body: any;
-  const bodyParams: any = {};
-  if (input.SamplingRule !== undefined) {
-    bodyParams["SamplingRule"] = serializeAws_restJson1_1SamplingRule(
-      input.SamplingRule,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SamplingRule !== undefined && {
+      SamplingRule: serializeAws_restJson1_1SamplingRule(
+        input.SamplingRule,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -238,14 +231,10 @@ export const serializeAws_restJson1_1DeleteGroupCommand = async (
   };
   let resolvedPath = "/DeleteGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.GroupARN !== undefined) {
-    bodyParams["GroupARN"] = input.GroupARN;
-  }
-  if (input.GroupName !== undefined) {
-    bodyParams["GroupName"] = input.GroupName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GroupARN !== undefined && { GroupARN: input.GroupARN }),
+    ...(input.GroupName !== undefined && { GroupName: input.GroupName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -267,14 +256,10 @@ export const serializeAws_restJson1_1DeleteSamplingRuleCommand = async (
   };
   let resolvedPath = "/DeleteSamplingRule";
   let body: any;
-  const bodyParams: any = {};
-  if (input.RuleARN !== undefined) {
-    bodyParams["RuleARN"] = input.RuleARN;
-  }
-  if (input.RuleName !== undefined) {
-    bodyParams["RuleName"] = input.RuleName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.RuleARN !== undefined && { RuleARN: input.RuleARN }),
+    ...(input.RuleName !== undefined && { RuleName: input.RuleName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -318,14 +303,10 @@ export const serializeAws_restJson1_1GetGroupCommand = async (
   };
   let resolvedPath = "/GetGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.GroupARN !== undefined) {
-    bodyParams["GroupARN"] = input.GroupARN;
-  }
-  if (input.GroupName !== undefined) {
-    bodyParams["GroupName"] = input.GroupName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.GroupARN !== undefined && { GroupARN: input.GroupARN }),
+    ...(input.GroupName !== undefined && { GroupName: input.GroupName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -347,11 +328,9 @@ export const serializeAws_restJson1_1GetGroupsCommand = async (
   };
   let resolvedPath = "/Groups";
   let body: any;
-  const bodyParams: any = {};
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -373,11 +352,9 @@ export const serializeAws_restJson1_1GetSamplingRulesCommand = async (
   };
   let resolvedPath = "/GetSamplingRules";
   let body: any;
-  const bodyParams: any = {};
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -399,11 +376,9 @@ export const serializeAws_restJson1_1GetSamplingStatisticSummariesCommand = asyn
   };
   let resolvedPath = "/SamplingStatisticSummaries";
   let body: any;
-  const bodyParams: any = {};
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -425,16 +400,14 @@ export const serializeAws_restJson1_1GetSamplingTargetsCommand = async (
   };
   let resolvedPath = "/SamplingTargets";
   let body: any;
-  const bodyParams: any = {};
-  if (input.SamplingStatisticsDocuments !== undefined) {
-    bodyParams[
-      "SamplingStatisticsDocuments"
-    ] = serializeAws_restJson1_1SamplingStatisticsDocumentList(
-      input.SamplingStatisticsDocuments,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SamplingStatisticsDocuments !== undefined && {
+      SamplingStatisticsDocuments: serializeAws_restJson1_1SamplingStatisticsDocumentList(
+        input.SamplingStatisticsDocuments,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -456,23 +429,17 @@ export const serializeAws_restJson1_1GetServiceGraphCommand = async (
   };
   let resolvedPath = "/ServiceGraph";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EndTime !== undefined) {
-    bodyParams["EndTime"] = Math.round(input.EndTime.getTime() / 1000);
-  }
-  if (input.GroupARN !== undefined) {
-    bodyParams["GroupARN"] = input.GroupARN;
-  }
-  if (input.GroupName !== undefined) {
-    bodyParams["GroupName"] = input.GroupName;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.StartTime !== undefined) {
-    bodyParams["StartTime"] = Math.round(input.StartTime.getTime() / 1000);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EndTime !== undefined && {
+      EndTime: Math.round(input.EndTime.getTime() / 1000)
+    }),
+    ...(input.GroupARN !== undefined && { GroupARN: input.GroupARN }),
+    ...(input.GroupName !== undefined && { GroupName: input.GroupName }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.StartTime !== undefined && {
+      StartTime: Math.round(input.StartTime.getTime() / 1000)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -494,29 +461,21 @@ export const serializeAws_restJson1_1GetTimeSeriesServiceStatisticsCommand = asy
   };
   let resolvedPath = "/TimeSeriesServiceStatistics";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EndTime !== undefined) {
-    bodyParams["EndTime"] = Math.round(input.EndTime.getTime() / 1000);
-  }
-  if (input.EntitySelectorExpression !== undefined) {
-    bodyParams["EntitySelectorExpression"] = input.EntitySelectorExpression;
-  }
-  if (input.GroupARN !== undefined) {
-    bodyParams["GroupARN"] = input.GroupARN;
-  }
-  if (input.GroupName !== undefined) {
-    bodyParams["GroupName"] = input.GroupName;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.Period !== undefined) {
-    bodyParams["Period"] = input.Period;
-  }
-  if (input.StartTime !== undefined) {
-    bodyParams["StartTime"] = Math.round(input.StartTime.getTime() / 1000);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EndTime !== undefined && {
+      EndTime: Math.round(input.EndTime.getTime() / 1000)
+    }),
+    ...(input.EntitySelectorExpression !== undefined && {
+      EntitySelectorExpression: input.EntitySelectorExpression
+    }),
+    ...(input.GroupARN !== undefined && { GroupARN: input.GroupARN }),
+    ...(input.GroupName !== undefined && { GroupName: input.GroupName }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.Period !== undefined && { Period: input.Period }),
+    ...(input.StartTime !== undefined && {
+      StartTime: Math.round(input.StartTime.getTime() / 1000)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -538,17 +497,12 @@ export const serializeAws_restJson1_1GetTraceGraphCommand = async (
   };
   let resolvedPath = "/TraceGraph";
   let body: any;
-  const bodyParams: any = {};
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.TraceIds !== undefined) {
-    bodyParams["TraceIds"] = serializeAws_restJson1_1TraceIdList(
-      input.TraceIds,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.TraceIds !== undefined && {
+      TraceIds: serializeAws_restJson1_1TraceIdList(input.TraceIds, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -570,32 +524,28 @@ export const serializeAws_restJson1_1GetTraceSummariesCommand = async (
   };
   let resolvedPath = "/TraceSummaries";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EndTime !== undefined) {
-    bodyParams["EndTime"] = Math.round(input.EndTime.getTime() / 1000);
-  }
-  if (input.FilterExpression !== undefined) {
-    bodyParams["FilterExpression"] = input.FilterExpression;
-  }
-  if (input.NextToken !== undefined) {
-    bodyParams["NextToken"] = input.NextToken;
-  }
-  if (input.Sampling !== undefined) {
-    bodyParams["Sampling"] = input.Sampling;
-  }
-  if (input.SamplingStrategy !== undefined) {
-    bodyParams["SamplingStrategy"] = serializeAws_restJson1_1SamplingStrategy(
-      input.SamplingStrategy,
-      context
-    );
-  }
-  if (input.StartTime !== undefined) {
-    bodyParams["StartTime"] = Math.round(input.StartTime.getTime() / 1000);
-  }
-  if (input.TimeRangeType !== undefined) {
-    bodyParams["TimeRangeType"] = input.TimeRangeType;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EndTime !== undefined && {
+      EndTime: Math.round(input.EndTime.getTime() / 1000)
+    }),
+    ...(input.FilterExpression !== undefined && {
+      FilterExpression: input.FilterExpression
+    }),
+    ...(input.NextToken !== undefined && { NextToken: input.NextToken }),
+    ...(input.Sampling !== undefined && { Sampling: input.Sampling }),
+    ...(input.SamplingStrategy !== undefined && {
+      SamplingStrategy: serializeAws_restJson1_1SamplingStrategy(
+        input.SamplingStrategy,
+        context
+      )
+    }),
+    ...(input.StartTime !== undefined && {
+      StartTime: Math.round(input.StartTime.getTime() / 1000)
+    }),
+    ...(input.TimeRangeType !== undefined && {
+      TimeRangeType: input.TimeRangeType
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -617,14 +567,10 @@ export const serializeAws_restJson1_1PutEncryptionConfigCommand = async (
   };
   let resolvedPath = "/PutEncryptionConfig";
   let body: any;
-  const bodyParams: any = {};
-  if (input.KeyId !== undefined) {
-    bodyParams["KeyId"] = input.KeyId;
-  }
-  if (input.Type !== undefined) {
-    bodyParams["Type"] = input.Type;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.KeyId !== undefined && { KeyId: input.KeyId }),
+    ...(input.Type !== undefined && { Type: input.Type })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -646,25 +592,19 @@ export const serializeAws_restJson1_1PutTelemetryRecordsCommand = async (
   };
   let resolvedPath = "/TelemetryRecords";
   let body: any;
-  const bodyParams: any = {};
-  if (input.EC2InstanceId !== undefined) {
-    bodyParams["EC2InstanceId"] = input.EC2InstanceId;
-  }
-  if (input.Hostname !== undefined) {
-    bodyParams["Hostname"] = input.Hostname;
-  }
-  if (input.ResourceARN !== undefined) {
-    bodyParams["ResourceARN"] = input.ResourceARN;
-  }
-  if (input.TelemetryRecords !== undefined) {
-    bodyParams[
-      "TelemetryRecords"
-    ] = serializeAws_restJson1_1TelemetryRecordList(
-      input.TelemetryRecords,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.EC2InstanceId !== undefined && {
+      EC2InstanceId: input.EC2InstanceId
+    }),
+    ...(input.Hostname !== undefined && { Hostname: input.Hostname }),
+    ...(input.ResourceARN !== undefined && { ResourceARN: input.ResourceARN }),
+    ...(input.TelemetryRecords !== undefined && {
+      TelemetryRecords: serializeAws_restJson1_1TelemetryRecordList(
+        input.TelemetryRecords,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -686,16 +626,14 @@ export const serializeAws_restJson1_1PutTraceSegmentsCommand = async (
   };
   let resolvedPath = "/TraceSegments";
   let body: any;
-  const bodyParams: any = {};
-  if (input.TraceSegmentDocuments !== undefined) {
-    bodyParams[
-      "TraceSegmentDocuments"
-    ] = serializeAws_restJson1_1TraceSegmentDocumentList(
-      input.TraceSegmentDocuments,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.TraceSegmentDocuments !== undefined && {
+      TraceSegmentDocuments: serializeAws_restJson1_1TraceSegmentDocumentList(
+        input.TraceSegmentDocuments,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -717,17 +655,13 @@ export const serializeAws_restJson1_1UpdateGroupCommand = async (
   };
   let resolvedPath = "/UpdateGroup";
   let body: any;
-  const bodyParams: any = {};
-  if (input.FilterExpression !== undefined) {
-    bodyParams["FilterExpression"] = input.FilterExpression;
-  }
-  if (input.GroupARN !== undefined) {
-    bodyParams["GroupARN"] = input.GroupARN;
-  }
-  if (input.GroupName !== undefined) {
-    bodyParams["GroupName"] = input.GroupName;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.FilterExpression !== undefined && {
+      FilterExpression: input.FilterExpression
+    }),
+    ...(input.GroupARN !== undefined && { GroupARN: input.GroupARN }),
+    ...(input.GroupName !== undefined && { GroupName: input.GroupName })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -749,16 +683,14 @@ export const serializeAws_restJson1_1UpdateSamplingRuleCommand = async (
   };
   let resolvedPath = "/UpdateSamplingRule";
   let body: any;
-  const bodyParams: any = {};
-  if (input.SamplingRuleUpdate !== undefined) {
-    bodyParams[
-      "SamplingRuleUpdate"
-    ] = serializeAws_restJson1_1SamplingRuleUpdate(
-      input.SamplingRuleUpdate,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.SamplingRuleUpdate !== undefined && {
+      SamplingRuleUpdate: serializeAws_restJson1_1SamplingRuleUpdate(
+        input.SamplingRuleUpdate,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1_1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1_1.ts
@@ -870,11 +870,9 @@ export const serializeAws_restJson1_1JsonBlobsCommand = async (
   };
   let resolvedPath = "/JsonBlobs";
   let body: any;
-  const bodyParams: any = {};
-  if (input.data !== undefined) {
-    bodyParams["data"] = context.base64Encoder(input.data);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.data !== undefined && { data: context.base64Encoder(input.data) })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -896,35 +894,23 @@ export const serializeAws_restJson1_1JsonEnumsCommand = async (
   };
   let resolvedPath = "/JsonEnums";
   let body: any;
-  const bodyParams: any = {};
-  if (input.fooEnum1 !== undefined) {
-    bodyParams["fooEnum1"] = input.fooEnum1;
-  }
-  if (input.fooEnum2 !== undefined) {
-    bodyParams["fooEnum2"] = input.fooEnum2;
-  }
-  if (input.fooEnum3 !== undefined) {
-    bodyParams["fooEnum3"] = input.fooEnum3;
-  }
-  if (input.fooEnumList !== undefined) {
-    bodyParams["fooEnumList"] = serializeAws_restJson1_1FooEnumList(
-      input.fooEnumList,
-      context
-    );
-  }
-  if (input.fooEnumMap !== undefined) {
-    bodyParams["fooEnumMap"] = serializeAws_restJson1_1FooEnumMap(
-      input.fooEnumMap,
-      context
-    );
-  }
-  if (input.fooEnumSet !== undefined) {
-    bodyParams["fooEnumSet"] = serializeAws_restJson1_1FooEnumSet(
-      input.fooEnumSet,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.fooEnum1 !== undefined && { fooEnum1: input.fooEnum1 }),
+    ...(input.fooEnum2 !== undefined && { fooEnum2: input.fooEnum2 }),
+    ...(input.fooEnum3 !== undefined && { fooEnum3: input.fooEnum3 }),
+    ...(input.fooEnumList !== undefined && {
+      fooEnumList: serializeAws_restJson1_1FooEnumList(
+        input.fooEnumList,
+        context
+      )
+    }),
+    ...(input.fooEnumMap !== undefined && {
+      fooEnumMap: serializeAws_restJson1_1FooEnumMap(input.fooEnumMap, context)
+    }),
+    ...(input.fooEnumSet !== undefined && {
+      fooEnumSet: serializeAws_restJson1_1FooEnumSet(input.fooEnumSet, context)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -946,56 +932,47 @@ export const serializeAws_restJson1_1JsonListsCommand = async (
   };
   let resolvedPath = "/JsonLists";
   let body: any;
-  const bodyParams: any = {};
-  if (input.booleanList !== undefined) {
-    bodyParams["booleanList"] = serializeAws_restJson1_1BooleanList(
-      input.booleanList,
-      context
-    );
-  }
-  if (input.enumList !== undefined) {
-    bodyParams["enumList"] = serializeAws_restJson1_1FooEnumList(
-      input.enumList,
-      context
-    );
-  }
-  if (input.integerList !== undefined) {
-    bodyParams["integerList"] = serializeAws_restJson1_1IntegerList(
-      input.integerList,
-      context
-    );
-  }
-  if (input.nestedStringList !== undefined) {
-    bodyParams["nestedStringList"] = serializeAws_restJson1_1NestedStringList(
-      input.nestedStringList,
-      context
-    );
-  }
-  if (input.stringList !== undefined) {
-    bodyParams["stringList"] = serializeAws_restJson1_1StringList(
-      input.stringList,
-      context
-    );
-  }
-  if (input.stringSet !== undefined) {
-    bodyParams["stringSet"] = serializeAws_restJson1_1StringSet(
-      input.stringSet,
-      context
-    );
-  }
-  if (input.structureList !== undefined) {
-    bodyParams["myStructureList"] = serializeAws_restJson1_1StructureList(
-      input.structureList,
-      context
-    );
-  }
-  if (input.timestampList !== undefined) {
-    bodyParams["timestampList"] = serializeAws_restJson1_1TimestampList(
-      input.timestampList,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.booleanList !== undefined && {
+      booleanList: serializeAws_restJson1_1BooleanList(
+        input.booleanList,
+        context
+      )
+    }),
+    ...(input.enumList !== undefined && {
+      enumList: serializeAws_restJson1_1FooEnumList(input.enumList, context)
+    }),
+    ...(input.integerList !== undefined && {
+      integerList: serializeAws_restJson1_1IntegerList(
+        input.integerList,
+        context
+      )
+    }),
+    ...(input.nestedStringList !== undefined && {
+      nestedStringList: serializeAws_restJson1_1NestedStringList(
+        input.nestedStringList,
+        context
+      )
+    }),
+    ...(input.stringList !== undefined && {
+      stringList: serializeAws_restJson1_1StringList(input.stringList, context)
+    }),
+    ...(input.stringSet !== undefined && {
+      stringSet: serializeAws_restJson1_1StringSet(input.stringSet, context)
+    }),
+    ...(input.structureList !== undefined && {
+      myStructureList: serializeAws_restJson1_1StructureList(
+        input.structureList,
+        context
+      )
+    }),
+    ...(input.timestampList !== undefined && {
+      timestampList: serializeAws_restJson1_1TimestampList(
+        input.timestampList,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1017,14 +994,14 @@ export const serializeAws_restJson1_1JsonMapsCommand = async (
   };
   let resolvedPath = "/JsonMaps";
   let body: any;
-  const bodyParams: any = {};
-  if (input.myMap !== undefined) {
-    bodyParams["myMap"] = serializeAws_restJson1_1JsonMapsInputOutputMap(
-      input.myMap,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.myMap !== undefined && {
+      myMap: serializeAws_restJson1_1JsonMapsInputOutputMap(
+        input.myMap,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1046,22 +1023,20 @@ export const serializeAws_restJson1_1JsonTimestampsCommand = async (
   };
   let resolvedPath = "/JsonTimestamps";
   let body: any;
-  const bodyParams: any = {};
-  if (input.dateTime !== undefined) {
-    bodyParams["dateTime"] = input.dateTime.toISOString().split(".")[0] + "Z";
-  }
-  if (input.epochSeconds !== undefined) {
-    bodyParams["epochSeconds"] = Math.round(
-      input.epochSeconds.getTime() / 1000
-    );
-  }
-  if (input.httpDate !== undefined) {
-    bodyParams["httpDate"] = __dateToUtcString(input.httpDate);
-  }
-  if (input.normal !== undefined) {
-    bodyParams["normal"] = Math.round(input.normal.getTime() / 1000);
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.dateTime !== undefined && {
+      dateTime: input.dateTime.toISOString().split(".")[0] + "Z"
+    }),
+    ...(input.epochSeconds !== undefined && {
+      epochSeconds: Math.round(input.epochSeconds.getTime() / 1000)
+    }),
+    ...(input.httpDate !== undefined && {
+      httpDate: __dateToUtcString(input.httpDate)
+    }),
+    ...(input.normal !== undefined && {
+      normal: Math.round(input.normal.getTime() / 1000)
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1230,16 +1205,14 @@ export const serializeAws_restJson1_1RecursiveShapesCommand = async (
   };
   let resolvedPath = "/RecursiveShapes";
   let body: any;
-  const bodyParams: any = {};
-  if (input.nested !== undefined) {
-    bodyParams[
-      "nested"
-    ] = serializeAws_restJson1_1RecursiveShapesInputOutputNested1(
-      input.nested,
-      context
-    );
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.nested !== undefined && {
+      nested: serializeAws_restJson1_1RecursiveShapesInputOutputNested1(
+        input.nested,
+        context
+      )
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -1262,35 +1235,25 @@ export const serializeAws_restJson1_1SimpleScalarPropertiesCommand = async (
   };
   let resolvedPath = "/SimpleScalarProperties";
   let body: any;
-  const bodyParams: any = {};
-  if (input.byteValue !== undefined) {
-    bodyParams["byteValue"] = input.byteValue;
-  }
-  if (input.doubleValue !== undefined) {
-    bodyParams["DoubleDribble"] = input.doubleValue;
-  }
-  if (input.falseBooleanValue !== undefined) {
-    bodyParams["falseBooleanValue"] = input.falseBooleanValue;
-  }
-  if (input.floatValue !== undefined) {
-    bodyParams["floatValue"] = input.floatValue;
-  }
-  if (input.integerValue !== undefined) {
-    bodyParams["integerValue"] = input.integerValue;
-  }
-  if (input.longValue !== undefined) {
-    bodyParams["longValue"] = input.longValue;
-  }
-  if (input.shortValue !== undefined) {
-    bodyParams["shortValue"] = input.shortValue;
-  }
-  if (input.stringValue !== undefined) {
-    bodyParams["stringValue"] = input.stringValue;
-  }
-  if (input.trueBooleanValue !== undefined) {
-    bodyParams["trueBooleanValue"] = input.trueBooleanValue;
-  }
-  body = JSON.stringify(bodyParams);
+  body = JSON.stringify({
+    ...(input.byteValue !== undefined && { byteValue: input.byteValue }),
+    ...(input.doubleValue !== undefined && {
+      DoubleDribble: input.doubleValue
+    }),
+    ...(input.falseBooleanValue !== undefined && {
+      falseBooleanValue: input.falseBooleanValue
+    }),
+    ...(input.floatValue !== undefined && { floatValue: input.floatValue }),
+    ...(input.integerValue !== undefined && {
+      integerValue: input.integerValue
+    }),
+    ...(input.longValue !== undefined && { longValue: input.longValue }),
+    ...(input.shortValue !== undefined && { shortValue: input.shortValue }),
+    ...(input.stringValue !== undefined && { stringValue: input.stringValue }),
+    ...(input.trueBooleanValue !== undefined && {
+      trueBooleanValue: input.trueBooleanValue
+    })
+  });
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,


### PR DESCRIPTION
*Issue #, if available:*
Similar to #1153

*Description of changes:*
remove bodyParams from restJson serInputDocument

* simple case
  * Before
  ```ts
  const bodyParams: any = {};
  if (input.analyzerArn !== undefined) {
    bodyParams["analyzerArn"] = input.analyzerArn;
  }
  if (input.resourceArn !== undefined) {
    bodyParams["resourceArn"] = input.resourceArn;
  }
  body = JSON.stringify(bodyParams);
  ```
  * After
  ```ts
  body = JSON.stringify({
    ...(input.analyzerArn !== undefined && { analyzerArn: input.analyzerArn }),
    ...(input.resourceArn !== undefined && { resourceArn: input.resourceArn })
  });
  ```
* with IdempotencyTokenTrait
  * Before
  ```ts
  const bodyParams: any = {};
  if (input.clientToken === undefined) {
    input.clientToken = generateIdempotencyToken();
  }
  if (input.clientToken !== undefined) {
    bodyParams["clientToken"] = input.clientToken;
  }
  if (input.filter !== undefined) {
    bodyParams["filter"] = serializeAws_restJson1_1FilterCriteriaMap(
      input.filter,
      context
    );
  }
  if (input.ruleName !== undefined) {
    bodyParams["ruleName"] = input.ruleName;
  }
  body = JSON.stringify(bodyParams);
  ```
  * After
  ```ts
  body = JSON.stringify({
    clientToken: input.clientToken ?? generateIdempotencyToken(),
    ...(input.filter !== undefined && {
      filter: serializeAws_restJson1_1FilterCriteriaMap(input.filter, context)
    }),
    ...(input.ruleName !== undefined && { ruleName: input.ruleName })
  });
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
