### PR TITLE
chore: remove entries before buildFormUrlencodedString

### DIFF
--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -367,9 +367,8 @@ export const serializeAws_queryAttachInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAttachInstancesQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAttachInstancesQuery(input, context),
     Action: "AttachInstances",
     Version: "2011-01-01"
   });
@@ -384,12 +383,8 @@ export const serializeAws_queryAttachLoadBalancerTargetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAttachLoadBalancerTargetGroupsType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAttachLoadBalancerTargetGroupsType(input, context),
     Action: "AttachLoadBalancerTargetGroups",
     Version: "2011-01-01"
   });
@@ -404,9 +399,8 @@ export const serializeAws_queryAttachLoadBalancersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAttachLoadBalancersType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAttachLoadBalancersType(input, context),
     Action: "AttachLoadBalancers",
     Version: "2011-01-01"
   });
@@ -421,12 +415,8 @@ export const serializeAws_queryBatchDeleteScheduledActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBatchDeleteScheduledActionType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBatchDeleteScheduledActionType(input, context),
     Action: "BatchDeleteScheduledAction",
     Version: "2011-01-01"
   });
@@ -441,12 +431,8 @@ export const serializeAws_queryBatchPutScheduledUpdateGroupActionCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBatchPutScheduledUpdateGroupActionType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBatchPutScheduledUpdateGroupActionType(input, context),
     Action: "BatchPutScheduledUpdateGroupAction",
     Version: "2011-01-01"
   });
@@ -461,9 +447,8 @@ export const serializeAws_queryCompleteLifecycleActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCompleteLifecycleActionType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCompleteLifecycleActionType(input, context),
     Action: "CompleteLifecycleAction",
     Version: "2011-01-01"
   });
@@ -478,9 +463,8 @@ export const serializeAws_queryCreateAutoScalingGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateAutoScalingGroupType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateAutoScalingGroupType(input, context),
     Action: "CreateAutoScalingGroup",
     Version: "2011-01-01"
   });
@@ -495,12 +479,8 @@ export const serializeAws_queryCreateLaunchConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateLaunchConfigurationType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateLaunchConfigurationType(input, context),
     Action: "CreateLaunchConfiguration",
     Version: "2011-01-01"
   });
@@ -515,9 +495,8 @@ export const serializeAws_queryCreateOrUpdateTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateOrUpdateTagsType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateOrUpdateTagsType(input, context),
     Action: "CreateOrUpdateTags",
     Version: "2011-01-01"
   });
@@ -532,9 +511,8 @@ export const serializeAws_queryDeleteAutoScalingGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteAutoScalingGroupType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteAutoScalingGroupType(input, context),
     Action: "DeleteAutoScalingGroup",
     Version: "2011-01-01"
   });
@@ -549,9 +527,8 @@ export const serializeAws_queryDeleteLaunchConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryLaunchConfigurationNameType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryLaunchConfigurationNameType(input, context),
     Action: "DeleteLaunchConfiguration",
     Version: "2011-01-01"
   });
@@ -566,9 +543,8 @@ export const serializeAws_queryDeleteLifecycleHookCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteLifecycleHookType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteLifecycleHookType(input, context),
     Action: "DeleteLifecycleHook",
     Version: "2011-01-01"
   });
@@ -583,12 +559,8 @@ export const serializeAws_queryDeleteNotificationConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteNotificationConfigurationType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteNotificationConfigurationType(input, context),
     Action: "DeleteNotificationConfiguration",
     Version: "2011-01-01"
   });
@@ -603,9 +575,8 @@ export const serializeAws_queryDeletePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeletePolicyType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeletePolicyType(input, context),
     Action: "DeletePolicy",
     Version: "2011-01-01"
   });
@@ -620,9 +591,8 @@ export const serializeAws_queryDeleteScheduledActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteScheduledActionType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteScheduledActionType(input, context),
     Action: "DeleteScheduledAction",
     Version: "2011-01-01"
   });
@@ -637,9 +607,8 @@ export const serializeAws_queryDeleteTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteTagsType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteTagsType(input, context),
     Action: "DeleteTags",
     Version: "2011-01-01"
   });
@@ -682,9 +651,8 @@ export const serializeAws_queryDescribeAutoScalingGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAutoScalingGroupNamesType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAutoScalingGroupNamesType(input, context),
     Action: "DescribeAutoScalingGroups",
     Version: "2011-01-01"
   });
@@ -699,12 +667,8 @@ export const serializeAws_queryDescribeAutoScalingInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAutoScalingInstancesType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAutoScalingInstancesType(input, context),
     Action: "DescribeAutoScalingInstances",
     Version: "2011-01-01"
   });
@@ -733,12 +697,8 @@ export const serializeAws_queryDescribeLaunchConfigurationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryLaunchConfigurationNamesType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryLaunchConfigurationNamesType(input, context),
     Action: "DescribeLaunchConfigurations",
     Version: "2011-01-01"
   });
@@ -767,9 +727,8 @@ export const serializeAws_queryDescribeLifecycleHooksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLifecycleHooksType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLifecycleHooksType(input, context),
     Action: "DescribeLifecycleHooks",
     Version: "2011-01-01"
   });
@@ -784,12 +743,11 @@ export const serializeAws_queryDescribeLoadBalancerTargetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoadBalancerTargetGroupsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoadBalancerTargetGroupsRequest(
+      input,
+      context
+    ),
     Action: "DescribeLoadBalancerTargetGroups",
     Version: "2011-01-01"
   });
@@ -804,12 +762,8 @@ export const serializeAws_queryDescribeLoadBalancersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoadBalancersRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoadBalancersRequest(input, context),
     Action: "DescribeLoadBalancers",
     Version: "2011-01-01"
   });
@@ -838,12 +792,8 @@ export const serializeAws_queryDescribeNotificationConfigurationsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeNotificationConfigurationsType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeNotificationConfigurationsType(input, context),
     Action: "DescribeNotificationConfigurations",
     Version: "2011-01-01"
   });
@@ -858,9 +808,8 @@ export const serializeAws_queryDescribePoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribePoliciesType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribePoliciesType(input, context),
     Action: "DescribePolicies",
     Version: "2011-01-01"
   });
@@ -875,12 +824,8 @@ export const serializeAws_queryDescribeScalingActivitiesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeScalingActivitiesType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeScalingActivitiesType(input, context),
     Action: "DescribeScalingActivities",
     Version: "2011-01-01"
   });
@@ -909,12 +854,8 @@ export const serializeAws_queryDescribeScheduledActionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeScheduledActionsType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeScheduledActionsType(input, context),
     Action: "DescribeScheduledActions",
     Version: "2011-01-01"
   });
@@ -929,9 +870,8 @@ export const serializeAws_queryDescribeTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTagsType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTagsType(input, context),
     Action: "DescribeTags",
     Version: "2011-01-01"
   });
@@ -960,9 +900,8 @@ export const serializeAws_queryDetachInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetachInstancesQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetachInstancesQuery(input, context),
     Action: "DetachInstances",
     Version: "2011-01-01"
   });
@@ -977,12 +916,8 @@ export const serializeAws_queryDetachLoadBalancerTargetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetachLoadBalancerTargetGroupsType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetachLoadBalancerTargetGroupsType(input, context),
     Action: "DetachLoadBalancerTargetGroups",
     Version: "2011-01-01"
   });
@@ -997,9 +932,8 @@ export const serializeAws_queryDetachLoadBalancersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetachLoadBalancersType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetachLoadBalancersType(input, context),
     Action: "DetachLoadBalancers",
     Version: "2011-01-01"
   });
@@ -1014,12 +948,8 @@ export const serializeAws_queryDisableMetricsCollectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDisableMetricsCollectionQuery(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDisableMetricsCollectionQuery(input, context),
     Action: "DisableMetricsCollection",
     Version: "2011-01-01"
   });
@@ -1034,12 +964,8 @@ export const serializeAws_queryEnableMetricsCollectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEnableMetricsCollectionQuery(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEnableMetricsCollectionQuery(input, context),
     Action: "EnableMetricsCollection",
     Version: "2011-01-01"
   });
@@ -1054,9 +980,8 @@ export const serializeAws_queryEnterStandbyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEnterStandbyQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEnterStandbyQuery(input, context),
     Action: "EnterStandby",
     Version: "2011-01-01"
   });
@@ -1071,9 +996,8 @@ export const serializeAws_queryExecutePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryExecutePolicyType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryExecutePolicyType(input, context),
     Action: "ExecutePolicy",
     Version: "2011-01-01"
   });
@@ -1088,9 +1012,8 @@ export const serializeAws_queryExitStandbyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryExitStandbyQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryExitStandbyQuery(input, context),
     Action: "ExitStandby",
     Version: "2011-01-01"
   });
@@ -1105,9 +1028,8 @@ export const serializeAws_queryPutLifecycleHookCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutLifecycleHookType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutLifecycleHookType(input, context),
     Action: "PutLifecycleHook",
     Version: "2011-01-01"
   });
@@ -1122,12 +1044,8 @@ export const serializeAws_queryPutNotificationConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutNotificationConfigurationType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutNotificationConfigurationType(input, context),
     Action: "PutNotificationConfiguration",
     Version: "2011-01-01"
   });
@@ -1142,9 +1060,8 @@ export const serializeAws_queryPutScalingPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutScalingPolicyType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutScalingPolicyType(input, context),
     Action: "PutScalingPolicy",
     Version: "2011-01-01"
   });
@@ -1159,12 +1076,8 @@ export const serializeAws_queryPutScheduledUpdateGroupActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutScheduledUpdateGroupActionType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutScheduledUpdateGroupActionType(input, context),
     Action: "PutScheduledUpdateGroupAction",
     Version: "2011-01-01"
   });
@@ -1179,12 +1092,8 @@ export const serializeAws_queryRecordLifecycleActionHeartbeatCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRecordLifecycleActionHeartbeatType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRecordLifecycleActionHeartbeatType(input, context),
     Action: "RecordLifecycleActionHeartbeat",
     Version: "2011-01-01"
   });
@@ -1199,9 +1108,8 @@ export const serializeAws_queryResumeProcessesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryScalingProcessQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryScalingProcessQuery(input, context),
     Action: "ResumeProcesses",
     Version: "2011-01-01"
   });
@@ -1216,9 +1124,8 @@ export const serializeAws_querySetDesiredCapacityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetDesiredCapacityType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetDesiredCapacityType(input, context),
     Action: "SetDesiredCapacity",
     Version: "2011-01-01"
   });
@@ -1233,9 +1140,8 @@ export const serializeAws_querySetInstanceHealthCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetInstanceHealthQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetInstanceHealthQuery(input, context),
     Action: "SetInstanceHealth",
     Version: "2011-01-01"
   });
@@ -1250,9 +1156,8 @@ export const serializeAws_querySetInstanceProtectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetInstanceProtectionQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetInstanceProtectionQuery(input, context),
     Action: "SetInstanceProtection",
     Version: "2011-01-01"
   });
@@ -1267,9 +1172,8 @@ export const serializeAws_querySuspendProcessesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryScalingProcessQuery(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryScalingProcessQuery(input, context),
     Action: "SuspendProcesses",
     Version: "2011-01-01"
   });
@@ -1284,12 +1188,11 @@ export const serializeAws_queryTerminateInstanceInAutoScalingGroupCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTerminateInstanceInAutoScalingGroupType(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTerminateInstanceInAutoScalingGroupType(
+      input,
+      context
+    ),
     Action: "TerminateInstanceInAutoScalingGroup",
     Version: "2011-01-01"
   });
@@ -1304,9 +1207,8 @@ export const serializeAws_queryUpdateAutoScalingGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateAutoScalingGroupType(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateAutoScalingGroupType(input, context),
     Action: "UpdateAutoScalingGroup",
     Version: "2011-01-01"
   });

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -422,9 +422,8 @@ export const serializeAws_queryCancelUpdateStackCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCancelUpdateStackInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCancelUpdateStackInput(input, context),
     Action: "CancelUpdateStack",
     Version: "2010-05-15"
   });
@@ -439,9 +438,8 @@ export const serializeAws_queryContinueUpdateRollbackCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryContinueUpdateRollbackInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryContinueUpdateRollbackInput(input, context),
     Action: "ContinueUpdateRollback",
     Version: "2010-05-15"
   });
@@ -456,9 +454,8 @@ export const serializeAws_queryCreateChangeSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateChangeSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateChangeSetInput(input, context),
     Action: "CreateChangeSet",
     Version: "2010-05-15"
   });
@@ -473,9 +470,8 @@ export const serializeAws_queryCreateStackCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateStackInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateStackInput(input, context),
     Action: "CreateStack",
     Version: "2010-05-15"
   });
@@ -490,9 +486,8 @@ export const serializeAws_queryDeleteChangeSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteChangeSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteChangeSetInput(input, context),
     Action: "DeleteChangeSet",
     Version: "2010-05-15"
   });
@@ -507,9 +502,8 @@ export const serializeAws_queryDeleteStackCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteStackInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteStackInput(input, context),
     Action: "DeleteStack",
     Version: "2010-05-15"
   });
@@ -524,9 +518,8 @@ export const serializeAws_queryDeregisterTypeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeregisterTypeInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeregisterTypeInput(input, context),
     Action: "DeregisterType",
     Version: "2010-05-15"
   });
@@ -541,9 +534,8 @@ export const serializeAws_queryDescribeAccountLimitsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAccountLimitsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAccountLimitsInput(input, context),
     Action: "DescribeAccountLimits",
     Version: "2010-05-15"
   });
@@ -558,9 +550,8 @@ export const serializeAws_queryDescribeChangeSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeChangeSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeChangeSetInput(input, context),
     Action: "DescribeChangeSet",
     Version: "2010-05-15"
   });
@@ -575,12 +566,8 @@ export const serializeAws_queryDescribeStackDriftDetectionStatusCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackDriftDetectionStatusInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackDriftDetectionStatusInput(input, context),
     Action: "DescribeStackDriftDetectionStatus",
     Version: "2010-05-15"
   });
@@ -595,9 +582,8 @@ export const serializeAws_queryDescribeStackEventsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackEventsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackEventsInput(input, context),
     Action: "DescribeStackEvents",
     Version: "2010-05-15"
   });
@@ -612,9 +598,8 @@ export const serializeAws_queryDescribeStackResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackResourceInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackResourceInput(input, context),
     Action: "DescribeStackResource",
     Version: "2010-05-15"
   });
@@ -629,12 +614,8 @@ export const serializeAws_queryDescribeStackResourceDriftsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackResourceDriftsInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackResourceDriftsInput(input, context),
     Action: "DescribeStackResourceDrifts",
     Version: "2010-05-15"
   });
@@ -649,9 +630,8 @@ export const serializeAws_queryDescribeStackResourcesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackResourcesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackResourcesInput(input, context),
     Action: "DescribeStackResources",
     Version: "2010-05-15"
   });
@@ -666,9 +646,8 @@ export const serializeAws_queryDescribeStacksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStacksInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStacksInput(input, context),
     Action: "DescribeStacks",
     Version: "2010-05-15"
   });
@@ -683,9 +662,8 @@ export const serializeAws_queryDescribeTypeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTypeInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTypeInput(input, context),
     Action: "DescribeType",
     Version: "2010-05-15"
   });
@@ -700,12 +678,8 @@ export const serializeAws_queryDescribeTypeRegistrationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTypeRegistrationInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTypeRegistrationInput(input, context),
     Action: "DescribeTypeRegistration",
     Version: "2010-05-15"
   });
@@ -720,9 +694,8 @@ export const serializeAws_queryDetectStackDriftCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetectStackDriftInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetectStackDriftInput(input, context),
     Action: "DetectStackDrift",
     Version: "2010-05-15"
   });
@@ -737,12 +710,8 @@ export const serializeAws_queryDetectStackResourceDriftCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetectStackResourceDriftInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetectStackResourceDriftInput(input, context),
     Action: "DetectStackResourceDrift",
     Version: "2010-05-15"
   });
@@ -757,9 +726,8 @@ export const serializeAws_queryEstimateTemplateCostCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEstimateTemplateCostInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEstimateTemplateCostInput(input, context),
     Action: "EstimateTemplateCost",
     Version: "2010-05-15"
   });
@@ -774,9 +742,8 @@ export const serializeAws_queryExecuteChangeSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryExecuteChangeSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryExecuteChangeSetInput(input, context),
     Action: "ExecuteChangeSet",
     Version: "2010-05-15"
   });
@@ -791,9 +758,8 @@ export const serializeAws_queryGetStackPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetStackPolicyInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetStackPolicyInput(input, context),
     Action: "GetStackPolicy",
     Version: "2010-05-15"
   });
@@ -808,9 +774,8 @@ export const serializeAws_queryGetTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetTemplateInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetTemplateInput(input, context),
     Action: "GetTemplate",
     Version: "2010-05-15"
   });
@@ -825,9 +790,8 @@ export const serializeAws_queryGetTemplateSummaryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetTemplateSummaryInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetTemplateSummaryInput(input, context),
     Action: "GetTemplateSummary",
     Version: "2010-05-15"
   });
@@ -842,9 +806,8 @@ export const serializeAws_queryListChangeSetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListChangeSetsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListChangeSetsInput(input, context),
     Action: "ListChangeSets",
     Version: "2010-05-15"
   });
@@ -859,9 +822,8 @@ export const serializeAws_queryListExportsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListExportsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListExportsInput(input, context),
     Action: "ListExports",
     Version: "2010-05-15"
   });
@@ -876,9 +838,8 @@ export const serializeAws_queryListImportsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListImportsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListImportsInput(input, context),
     Action: "ListImports",
     Version: "2010-05-15"
   });
@@ -893,9 +854,8 @@ export const serializeAws_queryListStackResourcesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListStackResourcesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListStackResourcesInput(input, context),
     Action: "ListStackResources",
     Version: "2010-05-15"
   });
@@ -910,9 +870,8 @@ export const serializeAws_queryListStacksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListStacksInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListStacksInput(input, context),
     Action: "ListStacks",
     Version: "2010-05-15"
   });
@@ -927,9 +886,8 @@ export const serializeAws_queryListTypeRegistrationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTypeRegistrationsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTypeRegistrationsInput(input, context),
     Action: "ListTypeRegistrations",
     Version: "2010-05-15"
   });
@@ -944,9 +902,8 @@ export const serializeAws_queryListTypeVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTypeVersionsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTypeVersionsInput(input, context),
     Action: "ListTypeVersions",
     Version: "2010-05-15"
   });
@@ -961,9 +918,8 @@ export const serializeAws_queryListTypesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTypesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTypesInput(input, context),
     Action: "ListTypes",
     Version: "2010-05-15"
   });
@@ -978,9 +934,8 @@ export const serializeAws_queryRecordHandlerProgressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRecordHandlerProgressInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRecordHandlerProgressInput(input, context),
     Action: "RecordHandlerProgress",
     Version: "2010-05-15"
   });
@@ -995,9 +950,8 @@ export const serializeAws_queryRegisterTypeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRegisterTypeInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRegisterTypeInput(input, context),
     Action: "RegisterType",
     Version: "2010-05-15"
   });
@@ -1012,9 +966,8 @@ export const serializeAws_querySetStackPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetStackPolicyInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetStackPolicyInput(input, context),
     Action: "SetStackPolicy",
     Version: "2010-05-15"
   });
@@ -1029,9 +982,8 @@ export const serializeAws_querySetTypeDefaultVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetTypeDefaultVersionInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetTypeDefaultVersionInput(input, context),
     Action: "SetTypeDefaultVersion",
     Version: "2010-05-15"
   });
@@ -1046,9 +998,8 @@ export const serializeAws_querySignalResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySignalResourceInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySignalResourceInput(input, context),
     Action: "SignalResource",
     Version: "2010-05-15"
   });
@@ -1063,9 +1014,8 @@ export const serializeAws_queryUpdateStackCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateStackInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateStackInput(input, context),
     Action: "UpdateStack",
     Version: "2010-05-15"
   });
@@ -1080,12 +1030,8 @@ export const serializeAws_queryUpdateTerminationProtectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateTerminationProtectionInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateTerminationProtectionInput(input, context),
     Action: "UpdateTerminationProtection",
     Version: "2010-05-15"
   });
@@ -1100,9 +1046,8 @@ export const serializeAws_queryValidateTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryValidateTemplateInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryValidateTemplateInput(input, context),
     Action: "ValidateTemplate",
     Version: "2010-05-15"
   });
@@ -1117,9 +1062,8 @@ export const serializeAws_queryCreateStackInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateStackInstancesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateStackInstancesInput(input, context),
     Action: "CreateStackInstances",
     Version: "2010-05-15"
   });
@@ -1134,9 +1078,8 @@ export const serializeAws_queryCreateStackSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateStackSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateStackSetInput(input, context),
     Action: "CreateStackSet",
     Version: "2010-05-15"
   });
@@ -1151,9 +1094,8 @@ export const serializeAws_queryDeleteStackInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteStackInstancesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteStackInstancesInput(input, context),
     Action: "DeleteStackInstances",
     Version: "2010-05-15"
   });
@@ -1168,9 +1110,8 @@ export const serializeAws_queryDeleteStackSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteStackSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteStackSetInput(input, context),
     Action: "DeleteStackSet",
     Version: "2010-05-15"
   });
@@ -1185,9 +1126,8 @@ export const serializeAws_queryDescribeStackInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackInstanceInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackInstanceInput(input, context),
     Action: "DescribeStackInstance",
     Version: "2010-05-15"
   });
@@ -1202,9 +1142,8 @@ export const serializeAws_queryDescribeStackSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackSetInput(input, context),
     Action: "DescribeStackSet",
     Version: "2010-05-15"
   });
@@ -1219,12 +1158,8 @@ export const serializeAws_queryDescribeStackSetOperationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeStackSetOperationInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeStackSetOperationInput(input, context),
     Action: "DescribeStackSetOperation",
     Version: "2010-05-15"
   });
@@ -1239,9 +1174,8 @@ export const serializeAws_queryDetectStackSetDriftCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetectStackSetDriftInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetectStackSetDriftInput(input, context),
     Action: "DetectStackSetDrift",
     Version: "2010-05-15"
   });
@@ -1256,9 +1190,8 @@ export const serializeAws_queryListStackInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListStackInstancesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListStackInstancesInput(input, context),
     Action: "ListStackInstances",
     Version: "2010-05-15"
   });
@@ -1273,12 +1206,8 @@ export const serializeAws_queryListStackSetOperationResultsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListStackSetOperationResultsInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListStackSetOperationResultsInput(input, context),
     Action: "ListStackSetOperationResults",
     Version: "2010-05-15"
   });
@@ -1293,9 +1222,8 @@ export const serializeAws_queryListStackSetOperationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListStackSetOperationsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListStackSetOperationsInput(input, context),
     Action: "ListStackSetOperations",
     Version: "2010-05-15"
   });
@@ -1310,9 +1238,8 @@ export const serializeAws_queryListStackSetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListStackSetsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListStackSetsInput(input, context),
     Action: "ListStackSets",
     Version: "2010-05-15"
   });
@@ -1327,9 +1254,8 @@ export const serializeAws_queryStopStackSetOperationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStopStackSetOperationInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStopStackSetOperationInput(input, context),
     Action: "StopStackSetOperation",
     Version: "2010-05-15"
   });
@@ -1344,9 +1270,8 @@ export const serializeAws_queryUpdateStackInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateStackInstancesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateStackInstancesInput(input, context),
     Action: "UpdateStackInstances",
     Version: "2010-05-15"
   });
@@ -1361,9 +1286,8 @@ export const serializeAws_queryUpdateStackSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateStackSetInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateStackSetInput(input, context),
     Action: "UpdateStackSet",
     Version: "2010-05-15"
   });

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -220,9 +220,8 @@ export const serializeAws_queryBuildSuggestersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBuildSuggestersRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBuildSuggestersRequest(input, context),
     Action: "BuildSuggesters",
     Version: "2013-01-01"
   });
@@ -237,9 +236,8 @@ export const serializeAws_queryCreateDomainCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDomainRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDomainRequest(input, context),
     Action: "CreateDomain",
     Version: "2013-01-01"
   });
@@ -254,9 +252,8 @@ export const serializeAws_queryDefineAnalysisSchemeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDefineAnalysisSchemeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDefineAnalysisSchemeRequest(input, context),
     Action: "DefineAnalysisScheme",
     Version: "2013-01-01"
   });
@@ -271,9 +268,8 @@ export const serializeAws_queryDefineExpressionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDefineExpressionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDefineExpressionRequest(input, context),
     Action: "DefineExpression",
     Version: "2013-01-01"
   });
@@ -288,9 +284,8 @@ export const serializeAws_queryDefineIndexFieldCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDefineIndexFieldRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDefineIndexFieldRequest(input, context),
     Action: "DefineIndexField",
     Version: "2013-01-01"
   });
@@ -305,9 +300,8 @@ export const serializeAws_queryDefineSuggesterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDefineSuggesterRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDefineSuggesterRequest(input, context),
     Action: "DefineSuggester",
     Version: "2013-01-01"
   });
@@ -322,9 +316,8 @@ export const serializeAws_queryDeleteAnalysisSchemeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteAnalysisSchemeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteAnalysisSchemeRequest(input, context),
     Action: "DeleteAnalysisScheme",
     Version: "2013-01-01"
   });
@@ -339,9 +332,8 @@ export const serializeAws_queryDeleteDomainCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDomainRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDomainRequest(input, context),
     Action: "DeleteDomain",
     Version: "2013-01-01"
   });
@@ -356,9 +348,8 @@ export const serializeAws_queryDeleteExpressionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteExpressionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteExpressionRequest(input, context),
     Action: "DeleteExpression",
     Version: "2013-01-01"
   });
@@ -373,9 +364,8 @@ export const serializeAws_queryDeleteIndexFieldCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteIndexFieldRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteIndexFieldRequest(input, context),
     Action: "DeleteIndexField",
     Version: "2013-01-01"
   });
@@ -390,9 +380,8 @@ export const serializeAws_queryDeleteSuggesterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteSuggesterRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteSuggesterRequest(input, context),
     Action: "DeleteSuggester",
     Version: "2013-01-01"
   });
@@ -407,12 +396,8 @@ export const serializeAws_queryDescribeAnalysisSchemesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAnalysisSchemesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAnalysisSchemesRequest(input, context),
     Action: "DescribeAnalysisSchemes",
     Version: "2013-01-01"
   });
@@ -427,12 +412,8 @@ export const serializeAws_queryDescribeAvailabilityOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAvailabilityOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAvailabilityOptionsRequest(input, context),
     Action: "DescribeAvailabilityOptions",
     Version: "2013-01-01"
   });
@@ -447,12 +428,8 @@ export const serializeAws_queryDescribeDomainEndpointOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDomainEndpointOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDomainEndpointOptionsRequest(input, context),
     Action: "DescribeDomainEndpointOptions",
     Version: "2013-01-01"
   });
@@ -467,9 +444,8 @@ export const serializeAws_queryDescribeDomainsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDomainsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDomainsRequest(input, context),
     Action: "DescribeDomains",
     Version: "2013-01-01"
   });
@@ -484,9 +460,8 @@ export const serializeAws_queryDescribeExpressionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeExpressionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeExpressionsRequest(input, context),
     Action: "DescribeExpressions",
     Version: "2013-01-01"
   });
@@ -501,9 +476,8 @@ export const serializeAws_queryDescribeIndexFieldsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeIndexFieldsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeIndexFieldsRequest(input, context),
     Action: "DescribeIndexFields",
     Version: "2013-01-01"
   });
@@ -518,12 +492,8 @@ export const serializeAws_queryDescribeScalingParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeScalingParametersRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeScalingParametersRequest(input, context),
     Action: "DescribeScalingParameters",
     Version: "2013-01-01"
   });
@@ -538,12 +508,8 @@ export const serializeAws_queryDescribeServiceAccessPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeServiceAccessPoliciesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeServiceAccessPoliciesRequest(input, context),
     Action: "DescribeServiceAccessPolicies",
     Version: "2013-01-01"
   });
@@ -558,9 +524,8 @@ export const serializeAws_queryDescribeSuggestersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeSuggestersRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeSuggestersRequest(input, context),
     Action: "DescribeSuggesters",
     Version: "2013-01-01"
   });
@@ -575,9 +540,8 @@ export const serializeAws_queryIndexDocumentsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryIndexDocumentsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryIndexDocumentsRequest(input, context),
     Action: "IndexDocuments",
     Version: "2013-01-01"
   });
@@ -606,12 +570,8 @@ export const serializeAws_queryUpdateAvailabilityOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateAvailabilityOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateAvailabilityOptionsRequest(input, context),
     Action: "UpdateAvailabilityOptions",
     Version: "2013-01-01"
   });
@@ -626,12 +586,8 @@ export const serializeAws_queryUpdateDomainEndpointOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateDomainEndpointOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateDomainEndpointOptionsRequest(input, context),
     Action: "UpdateDomainEndpointOptions",
     Version: "2013-01-01"
   });
@@ -646,12 +602,8 @@ export const serializeAws_queryUpdateScalingParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateScalingParametersRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateScalingParametersRequest(input, context),
     Action: "UpdateScalingParameters",
     Version: "2013-01-01"
   });
@@ -666,12 +618,8 @@ export const serializeAws_queryUpdateServiceAccessPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateServiceAccessPoliciesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateServiceAccessPoliciesRequest(input, context),
     Action: "UpdateServiceAccessPolicies",
     Version: "2013-01-01"
   });

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -232,9 +232,8 @@ export const serializeAws_queryDeleteAlarmsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteAlarmsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteAlarmsInput(input, context),
     Action: "DeleteAlarms",
     Version: "2010-08-01"
   });
@@ -249,9 +248,8 @@ export const serializeAws_queryDeleteAnomalyDetectorCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteAnomalyDetectorInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteAnomalyDetectorInput(input, context),
     Action: "DeleteAnomalyDetector",
     Version: "2010-08-01"
   });
@@ -266,9 +264,8 @@ export const serializeAws_queryDeleteDashboardsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDashboardsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDashboardsInput(input, context),
     Action: "DeleteDashboards",
     Version: "2010-08-01"
   });
@@ -283,9 +280,8 @@ export const serializeAws_queryDeleteInsightRulesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteInsightRulesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteInsightRulesInput(input, context),
     Action: "DeleteInsightRules",
     Version: "2010-08-01"
   });
@@ -300,9 +296,8 @@ export const serializeAws_queryDescribeAlarmHistoryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAlarmHistoryInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAlarmHistoryInput(input, context),
     Action: "DescribeAlarmHistory",
     Version: "2010-08-01"
   });
@@ -317,9 +312,8 @@ export const serializeAws_queryDescribeAlarmsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAlarmsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAlarmsInput(input, context),
     Action: "DescribeAlarms",
     Version: "2010-08-01"
   });
@@ -334,12 +328,8 @@ export const serializeAws_queryDescribeAlarmsForMetricCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAlarmsForMetricInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAlarmsForMetricInput(input, context),
     Action: "DescribeAlarmsForMetric",
     Version: "2010-08-01"
   });
@@ -354,12 +344,8 @@ export const serializeAws_queryDescribeAnomalyDetectorsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAnomalyDetectorsInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAnomalyDetectorsInput(input, context),
     Action: "DescribeAnomalyDetectors",
     Version: "2010-08-01"
   });
@@ -374,9 +360,8 @@ export const serializeAws_queryDescribeInsightRulesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeInsightRulesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeInsightRulesInput(input, context),
     Action: "DescribeInsightRules",
     Version: "2010-08-01"
   });
@@ -391,9 +376,8 @@ export const serializeAws_queryDisableAlarmActionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDisableAlarmActionsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDisableAlarmActionsInput(input, context),
     Action: "DisableAlarmActions",
     Version: "2010-08-01"
   });
@@ -408,9 +392,8 @@ export const serializeAws_queryDisableInsightRulesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDisableInsightRulesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDisableInsightRulesInput(input, context),
     Action: "DisableInsightRules",
     Version: "2010-08-01"
   });
@@ -425,9 +408,8 @@ export const serializeAws_queryEnableAlarmActionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEnableAlarmActionsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEnableAlarmActionsInput(input, context),
     Action: "EnableAlarmActions",
     Version: "2010-08-01"
   });
@@ -442,9 +424,8 @@ export const serializeAws_queryEnableInsightRulesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEnableInsightRulesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEnableInsightRulesInput(input, context),
     Action: "EnableInsightRules",
     Version: "2010-08-01"
   });
@@ -459,9 +440,8 @@ export const serializeAws_queryGetDashboardCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetDashboardInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetDashboardInput(input, context),
     Action: "GetDashboard",
     Version: "2010-08-01"
   });
@@ -476,9 +456,8 @@ export const serializeAws_queryGetInsightRuleReportCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetInsightRuleReportInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetInsightRuleReportInput(input, context),
     Action: "GetInsightRuleReport",
     Version: "2010-08-01"
   });
@@ -493,9 +472,8 @@ export const serializeAws_queryGetMetricDataCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetMetricDataInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetMetricDataInput(input, context),
     Action: "GetMetricData",
     Version: "2010-08-01"
   });
@@ -510,9 +488,8 @@ export const serializeAws_queryGetMetricStatisticsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetMetricStatisticsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetMetricStatisticsInput(input, context),
     Action: "GetMetricStatistics",
     Version: "2010-08-01"
   });
@@ -527,9 +504,8 @@ export const serializeAws_queryGetMetricWidgetImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetMetricWidgetImageInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetMetricWidgetImageInput(input, context),
     Action: "GetMetricWidgetImage",
     Version: "2010-08-01"
   });
@@ -544,9 +520,8 @@ export const serializeAws_queryListDashboardsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListDashboardsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListDashboardsInput(input, context),
     Action: "ListDashboards",
     Version: "2010-08-01"
   });
@@ -561,9 +536,8 @@ export const serializeAws_queryListMetricsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListMetricsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListMetricsInput(input, context),
     Action: "ListMetrics",
     Version: "2010-08-01"
   });
@@ -578,9 +552,8 @@ export const serializeAws_queryListTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTagsForResourceInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTagsForResourceInput(input, context),
     Action: "ListTagsForResource",
     Version: "2010-08-01"
   });
@@ -595,9 +568,8 @@ export const serializeAws_queryPutAnomalyDetectorCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutAnomalyDetectorInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutAnomalyDetectorInput(input, context),
     Action: "PutAnomalyDetector",
     Version: "2010-08-01"
   });
@@ -612,9 +584,8 @@ export const serializeAws_queryPutDashboardCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutDashboardInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutDashboardInput(input, context),
     Action: "PutDashboard",
     Version: "2010-08-01"
   });
@@ -629,9 +600,8 @@ export const serializeAws_queryPutInsightRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutInsightRuleInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutInsightRuleInput(input, context),
     Action: "PutInsightRule",
     Version: "2010-08-01"
   });
@@ -646,9 +616,8 @@ export const serializeAws_queryPutMetricAlarmCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutMetricAlarmInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutMetricAlarmInput(input, context),
     Action: "PutMetricAlarm",
     Version: "2010-08-01"
   });
@@ -663,9 +632,8 @@ export const serializeAws_queryPutMetricDataCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutMetricDataInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutMetricDataInput(input, context),
     Action: "PutMetricData",
     Version: "2010-08-01"
   });
@@ -680,9 +648,8 @@ export const serializeAws_querySetAlarmStateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetAlarmStateInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetAlarmStateInput(input, context),
     Action: "SetAlarmState",
     Version: "2010-08-01"
   });
@@ -697,9 +664,8 @@ export const serializeAws_queryTagResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTagResourceInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTagResourceInput(input, context),
     Action: "TagResource",
     Version: "2010-08-01"
   });
@@ -714,9 +680,8 @@ export const serializeAws_queryUntagResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUntagResourceInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUntagResourceInput(input, context),
     Action: "UntagResource",
     Version: "2010-08-01"
   });

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -347,9 +347,8 @@ export const serializeAws_queryAddTagsToResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddTagsToResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddTagsToResourceMessage(input, context),
     Action: "AddTagsToResource",
     Version: "2014-10-31"
   });
@@ -364,12 +363,8 @@ export const serializeAws_queryApplyPendingMaintenanceActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryApplyPendingMaintenanceActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryApplyPendingMaintenanceActionMessage(input, context),
     Action: "ApplyPendingMaintenanceAction",
     Version: "2014-10-31"
   });
@@ -384,12 +379,8 @@ export const serializeAws_queryCopyDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBClusterParameterGroupMessage(input, context),
     Action: "CopyDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -404,12 +395,8 @@ export const serializeAws_queryCopyDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBClusterSnapshotMessage(input, context),
     Action: "CopyDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -424,9 +411,8 @@ export const serializeAws_queryCreateDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterMessage(input, context),
     Action: "CreateDBCluster",
     Version: "2014-10-31"
   });
@@ -441,12 +427,8 @@ export const serializeAws_queryCreateDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterParameterGroupMessage(input, context),
     Action: "CreateDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -461,12 +443,8 @@ export const serializeAws_queryCreateDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterSnapshotMessage(input, context),
     Action: "CreateDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -481,9 +459,8 @@ export const serializeAws_queryCreateDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBInstanceMessage(input, context),
     Action: "CreateDBInstance",
     Version: "2014-10-31"
   });
@@ -498,9 +475,8 @@ export const serializeAws_queryCreateDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBSubnetGroupMessage(input, context),
     Action: "CreateDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -515,9 +491,8 @@ export const serializeAws_queryDeleteDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterMessage(input, context),
     Action: "DeleteDBCluster",
     Version: "2014-10-31"
   });
@@ -532,12 +507,8 @@ export const serializeAws_queryDeleteDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterParameterGroupMessage(input, context),
     Action: "DeleteDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -552,12 +523,8 @@ export const serializeAws_queryDeleteDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterSnapshotMessage(input, context),
     Action: "DeleteDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -572,9 +539,8 @@ export const serializeAws_queryDeleteDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBInstanceMessage(input, context),
     Action: "DeleteDBInstance",
     Version: "2014-10-31"
   });
@@ -589,9 +555,8 @@ export const serializeAws_queryDeleteDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBSubnetGroupMessage(input, context),
     Action: "DeleteDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -606,9 +571,8 @@ export const serializeAws_queryDescribeCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCertificatesMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCertificatesMessage(input, context),
     Action: "DescribeCertificates",
     Version: "2014-10-31"
   });
@@ -623,12 +587,11 @@ export const serializeAws_queryDescribeDBClusterParameterGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterParameterGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterParameterGroupsMessage(
+      input,
+      context
+    ),
     Action: "DescribeDBClusterParameterGroups",
     Version: "2014-10-31"
   });
@@ -643,12 +606,8 @@ export const serializeAws_queryDescribeDBClusterParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterParametersMessage(input, context),
     Action: "DescribeDBClusterParameters",
     Version: "2014-10-31"
   });
@@ -663,12 +622,11 @@ export const serializeAws_queryDescribeDBClusterSnapshotAttributesCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterSnapshotAttributesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterSnapshotAttributesMessage(
+      input,
+      context
+    ),
     Action: "DescribeDBClusterSnapshotAttributes",
     Version: "2014-10-31"
   });
@@ -683,12 +641,8 @@ export const serializeAws_queryDescribeDBClusterSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterSnapshotsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterSnapshotsMessage(input, context),
     Action: "DescribeDBClusterSnapshots",
     Version: "2014-10-31"
   });
@@ -703,9 +657,8 @@ export const serializeAws_queryDescribeDBClustersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClustersMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClustersMessage(input, context),
     Action: "DescribeDBClusters",
     Version: "2014-10-31"
   });
@@ -720,12 +673,8 @@ export const serializeAws_queryDescribeDBEngineVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBEngineVersionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBEngineVersionsMessage(input, context),
     Action: "DescribeDBEngineVersions",
     Version: "2014-10-31"
   });
@@ -740,9 +689,8 @@ export const serializeAws_queryDescribeDBInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBInstancesMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBInstancesMessage(input, context),
     Action: "DescribeDBInstances",
     Version: "2014-10-31"
   });
@@ -757,12 +705,8 @@ export const serializeAws_queryDescribeDBSubnetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBSubnetGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBSubnetGroupsMessage(input, context),
     Action: "DescribeDBSubnetGroups",
     Version: "2014-10-31"
   });
@@ -777,12 +721,11 @@ export const serializeAws_queryDescribeEngineDefaultClusterParametersCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEngineDefaultClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEngineDefaultClusterParametersMessage(
+      input,
+      context
+    ),
     Action: "DescribeEngineDefaultClusterParameters",
     Version: "2014-10-31"
   });
@@ -797,12 +740,8 @@ export const serializeAws_queryDescribeEventCategoriesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventCategoriesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventCategoriesMessage(input, context),
     Action: "DescribeEventCategories",
     Version: "2014-10-31"
   });
@@ -817,9 +756,8 @@ export const serializeAws_queryDescribeEventsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventsMessage(input, context),
     Action: "DescribeEvents",
     Version: "2014-10-31"
   });
@@ -834,12 +772,11 @@ export const serializeAws_queryDescribeOrderableDBInstanceOptionsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeOrderableDBInstanceOptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeOrderableDBInstanceOptionsMessage(
+      input,
+      context
+    ),
     Action: "DescribeOrderableDBInstanceOptions",
     Version: "2014-10-31"
   });
@@ -854,12 +791,11 @@ export const serializeAws_queryDescribePendingMaintenanceActionsCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribePendingMaintenanceActionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribePendingMaintenanceActionsMessage(
+      input,
+      context
+    ),
     Action: "DescribePendingMaintenanceActions",
     Version: "2014-10-31"
   });
@@ -874,9 +810,8 @@ export const serializeAws_queryFailoverDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryFailoverDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryFailoverDBClusterMessage(input, context),
     Action: "FailoverDBCluster",
     Version: "2014-10-31"
   });
@@ -891,9 +826,8 @@ export const serializeAws_queryListTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTagsForResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTagsForResourceMessage(input, context),
     Action: "ListTagsForResource",
     Version: "2014-10-31"
   });
@@ -908,9 +842,8 @@ export const serializeAws_queryModifyDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterMessage(input, context),
     Action: "ModifyDBCluster",
     Version: "2014-10-31"
   });
@@ -925,12 +858,8 @@ export const serializeAws_queryModifyDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterParameterGroupMessage(input, context),
     Action: "ModifyDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -945,12 +874,11 @@ export const serializeAws_queryModifyDBClusterSnapshotAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterSnapshotAttributeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterSnapshotAttributeMessage(
+      input,
+      context
+    ),
     Action: "ModifyDBClusterSnapshotAttribute",
     Version: "2014-10-31"
   });
@@ -965,9 +893,8 @@ export const serializeAws_queryModifyDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBInstanceMessage(input, context),
     Action: "ModifyDBInstance",
     Version: "2014-10-31"
   });
@@ -982,9 +909,8 @@ export const serializeAws_queryModifyDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBSubnetGroupMessage(input, context),
     Action: "ModifyDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -999,9 +925,8 @@ export const serializeAws_queryRebootDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRebootDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRebootDBInstanceMessage(input, context),
     Action: "RebootDBInstance",
     Version: "2014-10-31"
   });
@@ -1016,12 +941,8 @@ export const serializeAws_queryRemoveTagsFromResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveTagsFromResourceMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveTagsFromResourceMessage(input, context),
     Action: "RemoveTagsFromResource",
     Version: "2014-10-31"
   });
@@ -1036,12 +957,8 @@ export const serializeAws_queryResetDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetDBClusterParameterGroupMessage(input, context),
     Action: "ResetDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -1056,12 +973,8 @@ export const serializeAws_queryRestoreDBClusterFromSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBClusterFromSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBClusterFromSnapshotMessage(input, context),
     Action: "RestoreDBClusterFromSnapshot",
     Version: "2014-10-31"
   });
@@ -1076,12 +989,8 @@ export const serializeAws_queryRestoreDBClusterToPointInTimeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBClusterToPointInTimeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBClusterToPointInTimeMessage(input, context),
     Action: "RestoreDBClusterToPointInTime",
     Version: "2014-10-31"
   });
@@ -1096,9 +1005,8 @@ export const serializeAws_queryStartDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStartDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStartDBClusterMessage(input, context),
     Action: "StartDBCluster",
     Version: "2014-10-31"
   });
@@ -1113,9 +1021,8 @@ export const serializeAws_queryStopDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStopDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStopDBClusterMessage(input, context),
     Action: "StopDBCluster",
     Version: "2014-10-31"
   });

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -2834,12 +2834,11 @@ export const serializeAws_ec2AcceptReservedInstancesExchangeQuoteCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AcceptReservedInstancesExchangeQuoteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AcceptReservedInstancesExchangeQuoteRequest(
+      input,
+      context
+    ),
     Action: "AcceptReservedInstancesExchangeQuote",
     Version: "2016-11-15"
   });
@@ -2854,12 +2853,11 @@ export const serializeAws_ec2AcceptTransitGatewayPeeringAttachmentCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AcceptTransitGatewayPeeringAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AcceptTransitGatewayPeeringAttachmentRequest(
+      input,
+      context
+    ),
     Action: "AcceptTransitGatewayPeeringAttachment",
     Version: "2016-11-15"
   });
@@ -2874,12 +2872,8 @@ export const serializeAws_ec2AcceptTransitGatewayVpcAttachmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AcceptTransitGatewayVpcAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AcceptTransitGatewayVpcAttachmentRequest(input, context),
     Action: "AcceptTransitGatewayVpcAttachment",
     Version: "2016-11-15"
   });
@@ -2894,12 +2888,8 @@ export const serializeAws_ec2AcceptVpcEndpointConnectionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AcceptVpcEndpointConnectionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AcceptVpcEndpointConnectionsRequest(input, context),
     Action: "AcceptVpcEndpointConnections",
     Version: "2016-11-15"
   });
@@ -2914,12 +2904,8 @@ export const serializeAws_ec2AcceptVpcPeeringConnectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AcceptVpcPeeringConnectionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AcceptVpcPeeringConnectionRequest(input, context),
     Action: "AcceptVpcPeeringConnection",
     Version: "2016-11-15"
   });
@@ -2934,9 +2920,8 @@ export const serializeAws_ec2AdvertiseByoipCidrCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AdvertiseByoipCidrRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AdvertiseByoipCidrRequest(input, context),
     Action: "AdvertiseByoipCidr",
     Version: "2016-11-15"
   });
@@ -2951,9 +2936,8 @@ export const serializeAws_ec2AllocateAddressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AllocateAddressRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AllocateAddressRequest(input, context),
     Action: "AllocateAddress",
     Version: "2016-11-15"
   });
@@ -2968,9 +2952,8 @@ export const serializeAws_ec2AllocateHostsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AllocateHostsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AllocateHostsRequest(input, context),
     Action: "AllocateHosts",
     Version: "2016-11-15"
   });
@@ -2985,12 +2968,11 @@ export const serializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkCommand 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkRequest(
+      input,
+      context
+    ),
     Action: "ApplySecurityGroupsToClientVpnTargetNetwork",
     Version: "2016-11-15"
   });
@@ -3005,9 +2987,8 @@ export const serializeAws_ec2AssignIpv6AddressesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssignIpv6AddressesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssignIpv6AddressesRequest(input, context),
     Action: "AssignIpv6Addresses",
     Version: "2016-11-15"
   });
@@ -3022,12 +3003,8 @@ export const serializeAws_ec2AssignPrivateIpAddressesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssignPrivateIpAddressesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssignPrivateIpAddressesRequest(input, context),
     Action: "AssignPrivateIpAddresses",
     Version: "2016-11-15"
   });
@@ -3042,9 +3019,8 @@ export const serializeAws_ec2AssociateAddressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateAddressRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateAddressRequest(input, context),
     Action: "AssociateAddress",
     Version: "2016-11-15"
   });
@@ -3059,12 +3035,8 @@ export const serializeAws_ec2AssociateClientVpnTargetNetworkCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateClientVpnTargetNetworkRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateClientVpnTargetNetworkRequest(input, context),
     Action: "AssociateClientVpnTargetNetwork",
     Version: "2016-11-15"
   });
@@ -3079,9 +3051,8 @@ export const serializeAws_ec2AssociateDhcpOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateDhcpOptionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateDhcpOptionsRequest(input, context),
     Action: "AssociateDhcpOptions",
     Version: "2016-11-15"
   });
@@ -3096,12 +3067,8 @@ export const serializeAws_ec2AssociateIamInstanceProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateIamInstanceProfileRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateIamInstanceProfileRequest(input, context),
     Action: "AssociateIamInstanceProfile",
     Version: "2016-11-15"
   });
@@ -3116,9 +3083,8 @@ export const serializeAws_ec2AssociateRouteTableCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateRouteTableRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateRouteTableRequest(input, context),
     Action: "AssociateRouteTable",
     Version: "2016-11-15"
   });
@@ -3133,12 +3099,8 @@ export const serializeAws_ec2AssociateSubnetCidrBlockCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateSubnetCidrBlockRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateSubnetCidrBlockRequest(input, context),
     Action: "AssociateSubnetCidrBlock",
     Version: "2016-11-15"
   });
@@ -3153,12 +3115,11 @@ export const serializeAws_ec2AssociateTransitGatewayMulticastDomainCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateTransitGatewayMulticastDomainRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateTransitGatewayMulticastDomainRequest(
+      input,
+      context
+    ),
     Action: "AssociateTransitGatewayMulticastDomain",
     Version: "2016-11-15"
   });
@@ -3173,12 +3134,8 @@ export const serializeAws_ec2AssociateTransitGatewayRouteTableCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateTransitGatewayRouteTableRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateTransitGatewayRouteTableRequest(input, context),
     Action: "AssociateTransitGatewayRouteTable",
     Version: "2016-11-15"
   });
@@ -3193,9 +3150,8 @@ export const serializeAws_ec2AssociateVpcCidrBlockCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AssociateVpcCidrBlockRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AssociateVpcCidrBlockRequest(input, context),
     Action: "AssociateVpcCidrBlock",
     Version: "2016-11-15"
   });
@@ -3210,9 +3166,8 @@ export const serializeAws_ec2AttachClassicLinkVpcCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AttachClassicLinkVpcRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AttachClassicLinkVpcRequest(input, context),
     Action: "AttachClassicLinkVpc",
     Version: "2016-11-15"
   });
@@ -3227,9 +3182,8 @@ export const serializeAws_ec2AttachInternetGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AttachInternetGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AttachInternetGatewayRequest(input, context),
     Action: "AttachInternetGateway",
     Version: "2016-11-15"
   });
@@ -3244,9 +3198,8 @@ export const serializeAws_ec2AttachNetworkInterfaceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AttachNetworkInterfaceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AttachNetworkInterfaceRequest(input, context),
     Action: "AttachNetworkInterface",
     Version: "2016-11-15"
   });
@@ -3261,9 +3214,8 @@ export const serializeAws_ec2AttachVolumeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AttachVolumeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AttachVolumeRequest(input, context),
     Action: "AttachVolume",
     Version: "2016-11-15"
   });
@@ -3278,9 +3230,8 @@ export const serializeAws_ec2AttachVpnGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AttachVpnGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AttachVpnGatewayRequest(input, context),
     Action: "AttachVpnGateway",
     Version: "2016-11-15"
   });
@@ -3295,12 +3246,8 @@ export const serializeAws_ec2AuthorizeClientVpnIngressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AuthorizeClientVpnIngressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AuthorizeClientVpnIngressRequest(input, context),
     Action: "AuthorizeClientVpnIngress",
     Version: "2016-11-15"
   });
@@ -3315,12 +3262,8 @@ export const serializeAws_ec2AuthorizeSecurityGroupEgressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AuthorizeSecurityGroupEgressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AuthorizeSecurityGroupEgressRequest(input, context),
     Action: "AuthorizeSecurityGroupEgress",
     Version: "2016-11-15"
   });
@@ -3335,12 +3278,8 @@ export const serializeAws_ec2AuthorizeSecurityGroupIngressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2AuthorizeSecurityGroupIngressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2AuthorizeSecurityGroupIngressRequest(input, context),
     Action: "AuthorizeSecurityGroupIngress",
     Version: "2016-11-15"
   });
@@ -3355,9 +3294,8 @@ export const serializeAws_ec2BundleInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2BundleInstanceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2BundleInstanceRequest(input, context),
     Action: "BundleInstance",
     Version: "2016-11-15"
   });
@@ -3372,9 +3310,8 @@ export const serializeAws_ec2CancelBundleTaskCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelBundleTaskRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelBundleTaskRequest(input, context),
     Action: "CancelBundleTask",
     Version: "2016-11-15"
   });
@@ -3389,12 +3326,8 @@ export const serializeAws_ec2CancelCapacityReservationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelCapacityReservationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelCapacityReservationRequest(input, context),
     Action: "CancelCapacityReservation",
     Version: "2016-11-15"
   });
@@ -3409,9 +3342,8 @@ export const serializeAws_ec2CancelConversionTaskCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelConversionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelConversionRequest(input, context),
     Action: "CancelConversionTask",
     Version: "2016-11-15"
   });
@@ -3426,9 +3358,8 @@ export const serializeAws_ec2CancelExportTaskCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelExportTaskRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelExportTaskRequest(input, context),
     Action: "CancelExportTask",
     Version: "2016-11-15"
   });
@@ -3443,9 +3374,8 @@ export const serializeAws_ec2CancelImportTaskCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelImportTaskRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelImportTaskRequest(input, context),
     Action: "CancelImportTask",
     Version: "2016-11-15"
   });
@@ -3460,12 +3390,8 @@ export const serializeAws_ec2CancelReservedInstancesListingCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelReservedInstancesListingRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelReservedInstancesListingRequest(input, context),
     Action: "CancelReservedInstancesListing",
     Version: "2016-11-15"
   });
@@ -3480,12 +3406,8 @@ export const serializeAws_ec2CancelSpotFleetRequestsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelSpotFleetRequestsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelSpotFleetRequestsRequest(input, context),
     Action: "CancelSpotFleetRequests",
     Version: "2016-11-15"
   });
@@ -3500,12 +3422,8 @@ export const serializeAws_ec2CancelSpotInstanceRequestsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CancelSpotInstanceRequestsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CancelSpotInstanceRequestsRequest(input, context),
     Action: "CancelSpotInstanceRequests",
     Version: "2016-11-15"
   });
@@ -3520,9 +3438,8 @@ export const serializeAws_ec2ConfirmProductInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ConfirmProductInstanceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ConfirmProductInstanceRequest(input, context),
     Action: "ConfirmProductInstance",
     Version: "2016-11-15"
   });
@@ -3537,9 +3454,8 @@ export const serializeAws_ec2CopyFpgaImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CopyFpgaImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CopyFpgaImageRequest(input, context),
     Action: "CopyFpgaImage",
     Version: "2016-11-15"
   });
@@ -3554,9 +3470,8 @@ export const serializeAws_ec2CopyImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CopyImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CopyImageRequest(input, context),
     Action: "CopyImage",
     Version: "2016-11-15"
   });
@@ -3571,9 +3486,8 @@ export const serializeAws_ec2CopySnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CopySnapshotRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CopySnapshotRequest(input, context),
     Action: "CopySnapshot",
     Version: "2016-11-15"
   });
@@ -3588,12 +3502,8 @@ export const serializeAws_ec2CreateCapacityReservationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateCapacityReservationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateCapacityReservationRequest(input, context),
     Action: "CreateCapacityReservation",
     Version: "2016-11-15"
   });
@@ -3608,12 +3518,8 @@ export const serializeAws_ec2CreateClientVpnEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateClientVpnEndpointRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateClientVpnEndpointRequest(input, context),
     Action: "CreateClientVpnEndpoint",
     Version: "2016-11-15"
   });
@@ -3628,9 +3534,8 @@ export const serializeAws_ec2CreateClientVpnRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateClientVpnRouteRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateClientVpnRouteRequest(input, context),
     Action: "CreateClientVpnRoute",
     Version: "2016-11-15"
   });
@@ -3645,9 +3550,8 @@ export const serializeAws_ec2CreateCustomerGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateCustomerGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateCustomerGatewayRequest(input, context),
     Action: "CreateCustomerGateway",
     Version: "2016-11-15"
   });
@@ -3662,9 +3566,8 @@ export const serializeAws_ec2CreateDefaultSubnetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateDefaultSubnetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateDefaultSubnetRequest(input, context),
     Action: "CreateDefaultSubnet",
     Version: "2016-11-15"
   });
@@ -3679,9 +3582,8 @@ export const serializeAws_ec2CreateDefaultVpcCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateDefaultVpcRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateDefaultVpcRequest(input, context),
     Action: "CreateDefaultVpc",
     Version: "2016-11-15"
   });
@@ -3696,9 +3598,8 @@ export const serializeAws_ec2CreateDhcpOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateDhcpOptionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateDhcpOptionsRequest(input, context),
     Action: "CreateDhcpOptions",
     Version: "2016-11-15"
   });
@@ -3713,12 +3614,8 @@ export const serializeAws_ec2CreateEgressOnlyInternetGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateEgressOnlyInternetGatewayRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateEgressOnlyInternetGatewayRequest(input, context),
     Action: "CreateEgressOnlyInternetGateway",
     Version: "2016-11-15"
   });
@@ -3733,9 +3630,8 @@ export const serializeAws_ec2CreateFleetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateFleetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateFleetRequest(input, context),
     Action: "CreateFleet",
     Version: "2016-11-15"
   });
@@ -3750,9 +3646,8 @@ export const serializeAws_ec2CreateFlowLogsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateFlowLogsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateFlowLogsRequest(input, context),
     Action: "CreateFlowLogs",
     Version: "2016-11-15"
   });
@@ -3767,9 +3662,8 @@ export const serializeAws_ec2CreateFpgaImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateFpgaImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateFpgaImageRequest(input, context),
     Action: "CreateFpgaImage",
     Version: "2016-11-15"
   });
@@ -3784,9 +3678,8 @@ export const serializeAws_ec2CreateImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateImageRequest(input, context),
     Action: "CreateImage",
     Version: "2016-11-15"
   });
@@ -3801,12 +3694,8 @@ export const serializeAws_ec2CreateInstanceExportTaskCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateInstanceExportTaskRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateInstanceExportTaskRequest(input, context),
     Action: "CreateInstanceExportTask",
     Version: "2016-11-15"
   });
@@ -3821,9 +3710,8 @@ export const serializeAws_ec2CreateInternetGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateInternetGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateInternetGatewayRequest(input, context),
     Action: "CreateInternetGateway",
     Version: "2016-11-15"
   });
@@ -3838,9 +3726,8 @@ export const serializeAws_ec2CreateKeyPairCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateKeyPairRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateKeyPairRequest(input, context),
     Action: "CreateKeyPair",
     Version: "2016-11-15"
   });
@@ -3855,9 +3742,8 @@ export const serializeAws_ec2CreateLaunchTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateLaunchTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateLaunchTemplateRequest(input, context),
     Action: "CreateLaunchTemplate",
     Version: "2016-11-15"
   });
@@ -3872,12 +3758,8 @@ export const serializeAws_ec2CreateLaunchTemplateVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateLaunchTemplateVersionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateLaunchTemplateVersionRequest(input, context),
     Action: "CreateLaunchTemplateVersion",
     Version: "2016-11-15"
   });
@@ -3892,12 +3774,8 @@ export const serializeAws_ec2CreateLocalGatewayRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateLocalGatewayRouteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateLocalGatewayRouteRequest(input, context),
     Action: "CreateLocalGatewayRoute",
     Version: "2016-11-15"
   });
@@ -3912,12 +3790,11 @@ export const serializeAws_ec2CreateLocalGatewayRouteTableVpcAssociationCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateLocalGatewayRouteTableVpcAssociationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateLocalGatewayRouteTableVpcAssociationRequest(
+      input,
+      context
+    ),
     Action: "CreateLocalGatewayRouteTableVpcAssociation",
     Version: "2016-11-15"
   });
@@ -3932,9 +3809,8 @@ export const serializeAws_ec2CreateNatGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateNatGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateNatGatewayRequest(input, context),
     Action: "CreateNatGateway",
     Version: "2016-11-15"
   });
@@ -3949,9 +3825,8 @@ export const serializeAws_ec2CreateNetworkAclCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateNetworkAclRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateNetworkAclRequest(input, context),
     Action: "CreateNetworkAcl",
     Version: "2016-11-15"
   });
@@ -3966,9 +3841,8 @@ export const serializeAws_ec2CreateNetworkAclEntryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateNetworkAclEntryRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateNetworkAclEntryRequest(input, context),
     Action: "CreateNetworkAclEntry",
     Version: "2016-11-15"
   });
@@ -3983,9 +3857,8 @@ export const serializeAws_ec2CreateNetworkInterfaceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateNetworkInterfaceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateNetworkInterfaceRequest(input, context),
     Action: "CreateNetworkInterface",
     Version: "2016-11-15"
   });
@@ -4000,12 +3873,8 @@ export const serializeAws_ec2CreateNetworkInterfacePermissionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateNetworkInterfacePermissionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateNetworkInterfacePermissionRequest(input, context),
     Action: "CreateNetworkInterfacePermission",
     Version: "2016-11-15"
   });
@@ -4020,9 +3889,8 @@ export const serializeAws_ec2CreatePlacementGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreatePlacementGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreatePlacementGroupRequest(input, context),
     Action: "CreatePlacementGroup",
     Version: "2016-11-15"
   });
@@ -4037,12 +3905,8 @@ export const serializeAws_ec2CreateReservedInstancesListingCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateReservedInstancesListingRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateReservedInstancesListingRequest(input, context),
     Action: "CreateReservedInstancesListing",
     Version: "2016-11-15"
   });
@@ -4057,9 +3921,8 @@ export const serializeAws_ec2CreateRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateRouteRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateRouteRequest(input, context),
     Action: "CreateRoute",
     Version: "2016-11-15"
   });
@@ -4074,9 +3937,8 @@ export const serializeAws_ec2CreateRouteTableCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateRouteTableRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateRouteTableRequest(input, context),
     Action: "CreateRouteTable",
     Version: "2016-11-15"
   });
@@ -4091,9 +3953,8 @@ export const serializeAws_ec2CreateSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateSecurityGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateSecurityGroupRequest(input, context),
     Action: "CreateSecurityGroup",
     Version: "2016-11-15"
   });
@@ -4108,9 +3969,8 @@ export const serializeAws_ec2CreateSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateSnapshotRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateSnapshotRequest(input, context),
     Action: "CreateSnapshot",
     Version: "2016-11-15"
   });
@@ -4125,9 +3985,8 @@ export const serializeAws_ec2CreateSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateSnapshotsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateSnapshotsRequest(input, context),
     Action: "CreateSnapshots",
     Version: "2016-11-15"
   });
@@ -4142,12 +4001,8 @@ export const serializeAws_ec2CreateSpotDatafeedSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateSpotDatafeedSubscriptionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateSpotDatafeedSubscriptionRequest(input, context),
     Action: "CreateSpotDatafeedSubscription",
     Version: "2016-11-15"
   });
@@ -4162,9 +4017,8 @@ export const serializeAws_ec2CreateSubnetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateSubnetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateSubnetRequest(input, context),
     Action: "CreateSubnet",
     Version: "2016-11-15"
   });
@@ -4179,9 +4033,8 @@ export const serializeAws_ec2CreateTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTagsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTagsRequest(input, context),
     Action: "CreateTags",
     Version: "2016-11-15"
   });
@@ -4196,12 +4049,8 @@ export const serializeAws_ec2CreateTrafficMirrorFilterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTrafficMirrorFilterRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTrafficMirrorFilterRequest(input, context),
     Action: "CreateTrafficMirrorFilter",
     Version: "2016-11-15"
   });
@@ -4216,12 +4065,8 @@ export const serializeAws_ec2CreateTrafficMirrorFilterRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTrafficMirrorFilterRuleRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTrafficMirrorFilterRuleRequest(input, context),
     Action: "CreateTrafficMirrorFilterRule",
     Version: "2016-11-15"
   });
@@ -4236,12 +4081,8 @@ export const serializeAws_ec2CreateTrafficMirrorSessionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTrafficMirrorSessionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTrafficMirrorSessionRequest(input, context),
     Action: "CreateTrafficMirrorSession",
     Version: "2016-11-15"
   });
@@ -4256,12 +4097,8 @@ export const serializeAws_ec2CreateTrafficMirrorTargetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTrafficMirrorTargetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTrafficMirrorTargetRequest(input, context),
     Action: "CreateTrafficMirrorTarget",
     Version: "2016-11-15"
   });
@@ -4276,9 +4113,8 @@ export const serializeAws_ec2CreateTransitGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTransitGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTransitGatewayRequest(input, context),
     Action: "CreateTransitGateway",
     Version: "2016-11-15"
   });
@@ -4293,12 +4129,11 @@ export const serializeAws_ec2CreateTransitGatewayMulticastDomainCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTransitGatewayMulticastDomainRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTransitGatewayMulticastDomainRequest(
+      input,
+      context
+    ),
     Action: "CreateTransitGatewayMulticastDomain",
     Version: "2016-11-15"
   });
@@ -4313,12 +4148,11 @@ export const serializeAws_ec2CreateTransitGatewayPeeringAttachmentCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTransitGatewayPeeringAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTransitGatewayPeeringAttachmentRequest(
+      input,
+      context
+    ),
     Action: "CreateTransitGatewayPeeringAttachment",
     Version: "2016-11-15"
   });
@@ -4333,12 +4167,8 @@ export const serializeAws_ec2CreateTransitGatewayRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTransitGatewayRouteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTransitGatewayRouteRequest(input, context),
     Action: "CreateTransitGatewayRoute",
     Version: "2016-11-15"
   });
@@ -4353,12 +4183,8 @@ export const serializeAws_ec2CreateTransitGatewayRouteTableCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTransitGatewayRouteTableRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTransitGatewayRouteTableRequest(input, context),
     Action: "CreateTransitGatewayRouteTable",
     Version: "2016-11-15"
   });
@@ -4373,12 +4199,8 @@ export const serializeAws_ec2CreateTransitGatewayVpcAttachmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest(input, context),
     Action: "CreateTransitGatewayVpcAttachment",
     Version: "2016-11-15"
   });
@@ -4393,9 +4215,8 @@ export const serializeAws_ec2CreateVolumeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVolumeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVolumeRequest(input, context),
     Action: "CreateVolume",
     Version: "2016-11-15"
   });
@@ -4410,9 +4231,8 @@ export const serializeAws_ec2CreateVpcCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpcRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpcRequest(input, context),
     Action: "CreateVpc",
     Version: "2016-11-15"
   });
@@ -4427,9 +4247,8 @@ export const serializeAws_ec2CreateVpcEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpcEndpointRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpcEndpointRequest(input, context),
     Action: "CreateVpcEndpoint",
     Version: "2016-11-15"
   });
@@ -4444,12 +4263,11 @@ export const serializeAws_ec2CreateVpcEndpointConnectionNotificationCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpcEndpointConnectionNotificationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpcEndpointConnectionNotificationRequest(
+      input,
+      context
+    ),
     Action: "CreateVpcEndpointConnectionNotification",
     Version: "2016-11-15"
   });
@@ -4464,12 +4282,11 @@ export const serializeAws_ec2CreateVpcEndpointServiceConfigurationCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpcEndpointServiceConfigurationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpcEndpointServiceConfigurationRequest(
+      input,
+      context
+    ),
     Action: "CreateVpcEndpointServiceConfiguration",
     Version: "2016-11-15"
   });
@@ -4484,12 +4301,8 @@ export const serializeAws_ec2CreateVpcPeeringConnectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpcPeeringConnectionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpcPeeringConnectionRequest(input, context),
     Action: "CreateVpcPeeringConnection",
     Version: "2016-11-15"
   });
@@ -4504,9 +4317,8 @@ export const serializeAws_ec2CreateVpnConnectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpnConnectionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpnConnectionRequest(input, context),
     Action: "CreateVpnConnection",
     Version: "2016-11-15"
   });
@@ -4521,12 +4333,8 @@ export const serializeAws_ec2CreateVpnConnectionRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpnConnectionRouteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpnConnectionRouteRequest(input, context),
     Action: "CreateVpnConnectionRoute",
     Version: "2016-11-15"
   });
@@ -4541,9 +4349,8 @@ export const serializeAws_ec2CreateVpnGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2CreateVpnGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2CreateVpnGatewayRequest(input, context),
     Action: "CreateVpnGateway",
     Version: "2016-11-15"
   });
@@ -4558,12 +4365,8 @@ export const serializeAws_ec2DeleteClientVpnEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteClientVpnEndpointRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteClientVpnEndpointRequest(input, context),
     Action: "DeleteClientVpnEndpoint",
     Version: "2016-11-15"
   });
@@ -4578,9 +4381,8 @@ export const serializeAws_ec2DeleteClientVpnRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteClientVpnRouteRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteClientVpnRouteRequest(input, context),
     Action: "DeleteClientVpnRoute",
     Version: "2016-11-15"
   });
@@ -4595,9 +4397,8 @@ export const serializeAws_ec2DeleteCustomerGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteCustomerGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteCustomerGatewayRequest(input, context),
     Action: "DeleteCustomerGateway",
     Version: "2016-11-15"
   });
@@ -4612,9 +4413,8 @@ export const serializeAws_ec2DeleteDhcpOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteDhcpOptionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteDhcpOptionsRequest(input, context),
     Action: "DeleteDhcpOptions",
     Version: "2016-11-15"
   });
@@ -4629,12 +4429,8 @@ export const serializeAws_ec2DeleteEgressOnlyInternetGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteEgressOnlyInternetGatewayRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteEgressOnlyInternetGatewayRequest(input, context),
     Action: "DeleteEgressOnlyInternetGateway",
     Version: "2016-11-15"
   });
@@ -4649,9 +4445,8 @@ export const serializeAws_ec2DeleteFleetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteFleetsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteFleetsRequest(input, context),
     Action: "DeleteFleets",
     Version: "2016-11-15"
   });
@@ -4666,9 +4461,8 @@ export const serializeAws_ec2DeleteFlowLogsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteFlowLogsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteFlowLogsRequest(input, context),
     Action: "DeleteFlowLogs",
     Version: "2016-11-15"
   });
@@ -4683,9 +4477,8 @@ export const serializeAws_ec2DeleteFpgaImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteFpgaImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteFpgaImageRequest(input, context),
     Action: "DeleteFpgaImage",
     Version: "2016-11-15"
   });
@@ -4700,9 +4493,8 @@ export const serializeAws_ec2DeleteInternetGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteInternetGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteInternetGatewayRequest(input, context),
     Action: "DeleteInternetGateway",
     Version: "2016-11-15"
   });
@@ -4717,9 +4509,8 @@ export const serializeAws_ec2DeleteKeyPairCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteKeyPairRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteKeyPairRequest(input, context),
     Action: "DeleteKeyPair",
     Version: "2016-11-15"
   });
@@ -4734,9 +4525,8 @@ export const serializeAws_ec2DeleteLaunchTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteLaunchTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteLaunchTemplateRequest(input, context),
     Action: "DeleteLaunchTemplate",
     Version: "2016-11-15"
   });
@@ -4751,12 +4541,8 @@ export const serializeAws_ec2DeleteLaunchTemplateVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteLaunchTemplateVersionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteLaunchTemplateVersionsRequest(input, context),
     Action: "DeleteLaunchTemplateVersions",
     Version: "2016-11-15"
   });
@@ -4771,12 +4557,8 @@ export const serializeAws_ec2DeleteLocalGatewayRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteLocalGatewayRouteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteLocalGatewayRouteRequest(input, context),
     Action: "DeleteLocalGatewayRoute",
     Version: "2016-11-15"
   });
@@ -4791,12 +4573,11 @@ export const serializeAws_ec2DeleteLocalGatewayRouteTableVpcAssociationCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteLocalGatewayRouteTableVpcAssociationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteLocalGatewayRouteTableVpcAssociationRequest(
+      input,
+      context
+    ),
     Action: "DeleteLocalGatewayRouteTableVpcAssociation",
     Version: "2016-11-15"
   });
@@ -4811,9 +4592,8 @@ export const serializeAws_ec2DeleteNatGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteNatGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteNatGatewayRequest(input, context),
     Action: "DeleteNatGateway",
     Version: "2016-11-15"
   });
@@ -4828,9 +4608,8 @@ export const serializeAws_ec2DeleteNetworkAclCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteNetworkAclRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteNetworkAclRequest(input, context),
     Action: "DeleteNetworkAcl",
     Version: "2016-11-15"
   });
@@ -4845,9 +4624,8 @@ export const serializeAws_ec2DeleteNetworkAclEntryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteNetworkAclEntryRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteNetworkAclEntryRequest(input, context),
     Action: "DeleteNetworkAclEntry",
     Version: "2016-11-15"
   });
@@ -4862,9 +4640,8 @@ export const serializeAws_ec2DeleteNetworkInterfaceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteNetworkInterfaceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteNetworkInterfaceRequest(input, context),
     Action: "DeleteNetworkInterface",
     Version: "2016-11-15"
   });
@@ -4879,12 +4656,8 @@ export const serializeAws_ec2DeleteNetworkInterfacePermissionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteNetworkInterfacePermissionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteNetworkInterfacePermissionRequest(input, context),
     Action: "DeleteNetworkInterfacePermission",
     Version: "2016-11-15"
   });
@@ -4899,9 +4672,8 @@ export const serializeAws_ec2DeletePlacementGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeletePlacementGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeletePlacementGroupRequest(input, context),
     Action: "DeletePlacementGroup",
     Version: "2016-11-15"
   });
@@ -4916,12 +4688,8 @@ export const serializeAws_ec2DeleteQueuedReservedInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteQueuedReservedInstancesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteQueuedReservedInstancesRequest(input, context),
     Action: "DeleteQueuedReservedInstances",
     Version: "2016-11-15"
   });
@@ -4936,9 +4704,8 @@ export const serializeAws_ec2DeleteRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteRouteRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteRouteRequest(input, context),
     Action: "DeleteRoute",
     Version: "2016-11-15"
   });
@@ -4953,9 +4720,8 @@ export const serializeAws_ec2DeleteRouteTableCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteRouteTableRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteRouteTableRequest(input, context),
     Action: "DeleteRouteTable",
     Version: "2016-11-15"
   });
@@ -4970,9 +4736,8 @@ export const serializeAws_ec2DeleteSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteSecurityGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteSecurityGroupRequest(input, context),
     Action: "DeleteSecurityGroup",
     Version: "2016-11-15"
   });
@@ -4987,9 +4752,8 @@ export const serializeAws_ec2DeleteSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteSnapshotRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteSnapshotRequest(input, context),
     Action: "DeleteSnapshot",
     Version: "2016-11-15"
   });
@@ -5004,12 +4768,8 @@ export const serializeAws_ec2DeleteSpotDatafeedSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteSpotDatafeedSubscriptionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteSpotDatafeedSubscriptionRequest(input, context),
     Action: "DeleteSpotDatafeedSubscription",
     Version: "2016-11-15"
   });
@@ -5024,9 +4784,8 @@ export const serializeAws_ec2DeleteSubnetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteSubnetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteSubnetRequest(input, context),
     Action: "DeleteSubnet",
     Version: "2016-11-15"
   });
@@ -5041,9 +4800,8 @@ export const serializeAws_ec2DeleteTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTagsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTagsRequest(input, context),
     Action: "DeleteTags",
     Version: "2016-11-15"
   });
@@ -5058,12 +4816,8 @@ export const serializeAws_ec2DeleteTrafficMirrorFilterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTrafficMirrorFilterRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTrafficMirrorFilterRequest(input, context),
     Action: "DeleteTrafficMirrorFilter",
     Version: "2016-11-15"
   });
@@ -5078,12 +4832,8 @@ export const serializeAws_ec2DeleteTrafficMirrorFilterRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTrafficMirrorFilterRuleRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTrafficMirrorFilterRuleRequest(input, context),
     Action: "DeleteTrafficMirrorFilterRule",
     Version: "2016-11-15"
   });
@@ -5098,12 +4848,8 @@ export const serializeAws_ec2DeleteTrafficMirrorSessionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTrafficMirrorSessionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTrafficMirrorSessionRequest(input, context),
     Action: "DeleteTrafficMirrorSession",
     Version: "2016-11-15"
   });
@@ -5118,12 +4864,8 @@ export const serializeAws_ec2DeleteTrafficMirrorTargetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTrafficMirrorTargetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTrafficMirrorTargetRequest(input, context),
     Action: "DeleteTrafficMirrorTarget",
     Version: "2016-11-15"
   });
@@ -5138,9 +4880,8 @@ export const serializeAws_ec2DeleteTransitGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTransitGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTransitGatewayRequest(input, context),
     Action: "DeleteTransitGateway",
     Version: "2016-11-15"
   });
@@ -5155,12 +4896,11 @@ export const serializeAws_ec2DeleteTransitGatewayMulticastDomainCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTransitGatewayMulticastDomainRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTransitGatewayMulticastDomainRequest(
+      input,
+      context
+    ),
     Action: "DeleteTransitGatewayMulticastDomain",
     Version: "2016-11-15"
   });
@@ -5175,12 +4915,11 @@ export const serializeAws_ec2DeleteTransitGatewayPeeringAttachmentCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTransitGatewayPeeringAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTransitGatewayPeeringAttachmentRequest(
+      input,
+      context
+    ),
     Action: "DeleteTransitGatewayPeeringAttachment",
     Version: "2016-11-15"
   });
@@ -5195,12 +4934,8 @@ export const serializeAws_ec2DeleteTransitGatewayRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTransitGatewayRouteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTransitGatewayRouteRequest(input, context),
     Action: "DeleteTransitGatewayRoute",
     Version: "2016-11-15"
   });
@@ -5215,12 +4950,8 @@ export const serializeAws_ec2DeleteTransitGatewayRouteTableCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTransitGatewayRouteTableRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTransitGatewayRouteTableRequest(input, context),
     Action: "DeleteTransitGatewayRouteTable",
     Version: "2016-11-15"
   });
@@ -5235,12 +4966,8 @@ export const serializeAws_ec2DeleteTransitGatewayVpcAttachmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteTransitGatewayVpcAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteTransitGatewayVpcAttachmentRequest(input, context),
     Action: "DeleteTransitGatewayVpcAttachment",
     Version: "2016-11-15"
   });
@@ -5255,9 +4982,8 @@ export const serializeAws_ec2DeleteVolumeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVolumeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVolumeRequest(input, context),
     Action: "DeleteVolume",
     Version: "2016-11-15"
   });
@@ -5272,9 +4998,8 @@ export const serializeAws_ec2DeleteVpcCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpcRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpcRequest(input, context),
     Action: "DeleteVpc",
     Version: "2016-11-15"
   });
@@ -5289,12 +5014,11 @@ export const serializeAws_ec2DeleteVpcEndpointConnectionNotificationsCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpcEndpointConnectionNotificationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpcEndpointConnectionNotificationsRequest(
+      input,
+      context
+    ),
     Action: "DeleteVpcEndpointConnectionNotifications",
     Version: "2016-11-15"
   });
@@ -5309,12 +5033,11 @@ export const serializeAws_ec2DeleteVpcEndpointServiceConfigurationsCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpcEndpointServiceConfigurationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpcEndpointServiceConfigurationsRequest(
+      input,
+      context
+    ),
     Action: "DeleteVpcEndpointServiceConfigurations",
     Version: "2016-11-15"
   });
@@ -5329,9 +5052,8 @@ export const serializeAws_ec2DeleteVpcEndpointsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpcEndpointsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpcEndpointsRequest(input, context),
     Action: "DeleteVpcEndpoints",
     Version: "2016-11-15"
   });
@@ -5346,12 +5068,8 @@ export const serializeAws_ec2DeleteVpcPeeringConnectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpcPeeringConnectionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpcPeeringConnectionRequest(input, context),
     Action: "DeleteVpcPeeringConnection",
     Version: "2016-11-15"
   });
@@ -5366,9 +5084,8 @@ export const serializeAws_ec2DeleteVpnConnectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpnConnectionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpnConnectionRequest(input, context),
     Action: "DeleteVpnConnection",
     Version: "2016-11-15"
   });
@@ -5383,12 +5100,8 @@ export const serializeAws_ec2DeleteVpnConnectionRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpnConnectionRouteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpnConnectionRouteRequest(input, context),
     Action: "DeleteVpnConnectionRoute",
     Version: "2016-11-15"
   });
@@ -5403,9 +5116,8 @@ export const serializeAws_ec2DeleteVpnGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeleteVpnGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeleteVpnGatewayRequest(input, context),
     Action: "DeleteVpnGateway",
     Version: "2016-11-15"
   });
@@ -5420,9 +5132,8 @@ export const serializeAws_ec2DeprovisionByoipCidrCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeprovisionByoipCidrRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeprovisionByoipCidrRequest(input, context),
     Action: "DeprovisionByoipCidr",
     Version: "2016-11-15"
   });
@@ -5437,9 +5148,8 @@ export const serializeAws_ec2DeregisterImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeregisterImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeregisterImageRequest(input, context),
     Action: "DeregisterImage",
     Version: "2016-11-15"
   });
@@ -5454,12 +5164,11 @@ export const serializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersComman
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersRequest(
+      input,
+      context
+    ),
     Action: "DeregisterTransitGatewayMulticastGroupMembers",
     Version: "2016-11-15"
   });
@@ -5474,12 +5183,11 @@ export const serializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesComman
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesRequest(
+      input,
+      context
+    ),
     Action: "DeregisterTransitGatewayMulticastGroupSources",
     Version: "2016-11-15"
   });
@@ -5494,12 +5202,8 @@ export const serializeAws_ec2DescribeAccountAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeAccountAttributesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeAccountAttributesRequest(input, context),
     Action: "DescribeAccountAttributes",
     Version: "2016-11-15"
   });
@@ -5514,9 +5218,8 @@ export const serializeAws_ec2DescribeAddressesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeAddressesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeAddressesRequest(input, context),
     Action: "DescribeAddresses",
     Version: "2016-11-15"
   });
@@ -5531,12 +5234,8 @@ export const serializeAws_ec2DescribeAggregateIdFormatCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeAggregateIdFormatRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeAggregateIdFormatRequest(input, context),
     Action: "DescribeAggregateIdFormat",
     Version: "2016-11-15"
   });
@@ -5551,12 +5250,8 @@ export const serializeAws_ec2DescribeAvailabilityZonesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeAvailabilityZonesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeAvailabilityZonesRequest(input, context),
     Action: "DescribeAvailabilityZones",
     Version: "2016-11-15"
   });
@@ -5571,9 +5266,8 @@ export const serializeAws_ec2DescribeBundleTasksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeBundleTasksRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeBundleTasksRequest(input, context),
     Action: "DescribeBundleTasks",
     Version: "2016-11-15"
   });
@@ -5588,9 +5282,8 @@ export const serializeAws_ec2DescribeByoipCidrsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeByoipCidrsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeByoipCidrsRequest(input, context),
     Action: "DescribeByoipCidrs",
     Version: "2016-11-15"
   });
@@ -5605,12 +5298,8 @@ export const serializeAws_ec2DescribeCapacityReservationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeCapacityReservationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeCapacityReservationsRequest(input, context),
     Action: "DescribeCapacityReservations",
     Version: "2016-11-15"
   });
@@ -5625,12 +5314,8 @@ export const serializeAws_ec2DescribeClassicLinkInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeClassicLinkInstancesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeClassicLinkInstancesRequest(input, context),
     Action: "DescribeClassicLinkInstances",
     Version: "2016-11-15"
   });
@@ -5645,12 +5330,11 @@ export const serializeAws_ec2DescribeClientVpnAuthorizationRulesCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeClientVpnAuthorizationRulesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeClientVpnAuthorizationRulesRequest(
+      input,
+      context
+    ),
     Action: "DescribeClientVpnAuthorizationRules",
     Version: "2016-11-15"
   });
@@ -5665,12 +5349,8 @@ export const serializeAws_ec2DescribeClientVpnConnectionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeClientVpnConnectionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeClientVpnConnectionsRequest(input, context),
     Action: "DescribeClientVpnConnections",
     Version: "2016-11-15"
   });
@@ -5685,12 +5365,8 @@ export const serializeAws_ec2DescribeClientVpnEndpointsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeClientVpnEndpointsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeClientVpnEndpointsRequest(input, context),
     Action: "DescribeClientVpnEndpoints",
     Version: "2016-11-15"
   });
@@ -5705,12 +5381,8 @@ export const serializeAws_ec2DescribeClientVpnRoutesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeClientVpnRoutesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeClientVpnRoutesRequest(input, context),
     Action: "DescribeClientVpnRoutes",
     Version: "2016-11-15"
   });
@@ -5725,12 +5397,8 @@ export const serializeAws_ec2DescribeClientVpnTargetNetworksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeClientVpnTargetNetworksRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeClientVpnTargetNetworksRequest(input, context),
     Action: "DescribeClientVpnTargetNetworks",
     Version: "2016-11-15"
   });
@@ -5745,9 +5413,8 @@ export const serializeAws_ec2DescribeCoipPoolsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeCoipPoolsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeCoipPoolsRequest(input, context),
     Action: "DescribeCoipPools",
     Version: "2016-11-15"
   });
@@ -5762,12 +5429,8 @@ export const serializeAws_ec2DescribeConversionTasksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeConversionTasksRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeConversionTasksRequest(input, context),
     Action: "DescribeConversionTasks",
     Version: "2016-11-15"
   });
@@ -5782,12 +5445,8 @@ export const serializeAws_ec2DescribeCustomerGatewaysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeCustomerGatewaysRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeCustomerGatewaysRequest(input, context),
     Action: "DescribeCustomerGateways",
     Version: "2016-11-15"
   });
@@ -5802,9 +5461,8 @@ export const serializeAws_ec2DescribeDhcpOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeDhcpOptionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeDhcpOptionsRequest(input, context),
     Action: "DescribeDhcpOptions",
     Version: "2016-11-15"
   });
@@ -5819,12 +5477,11 @@ export const serializeAws_ec2DescribeEgressOnlyInternetGatewaysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeEgressOnlyInternetGatewaysRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeEgressOnlyInternetGatewaysRequest(
+      input,
+      context
+    ),
     Action: "DescribeEgressOnlyInternetGateways",
     Version: "2016-11-15"
   });
@@ -5839,9 +5496,8 @@ export const serializeAws_ec2DescribeElasticGpusCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeElasticGpusRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeElasticGpusRequest(input, context),
     Action: "DescribeElasticGpus",
     Version: "2016-11-15"
   });
@@ -5856,12 +5512,8 @@ export const serializeAws_ec2DescribeExportImageTasksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeExportImageTasksRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeExportImageTasksRequest(input, context),
     Action: "DescribeExportImageTasks",
     Version: "2016-11-15"
   });
@@ -5876,9 +5528,8 @@ export const serializeAws_ec2DescribeExportTasksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeExportTasksRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeExportTasksRequest(input, context),
     Action: "DescribeExportTasks",
     Version: "2016-11-15"
   });
@@ -5893,12 +5544,8 @@ export const serializeAws_ec2DescribeFastSnapshotRestoresCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeFastSnapshotRestoresRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeFastSnapshotRestoresRequest(input, context),
     Action: "DescribeFastSnapshotRestores",
     Version: "2016-11-15"
   });
@@ -5913,9 +5560,8 @@ export const serializeAws_ec2DescribeFleetHistoryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeFleetHistoryRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeFleetHistoryRequest(input, context),
     Action: "DescribeFleetHistory",
     Version: "2016-11-15"
   });
@@ -5930,9 +5576,8 @@ export const serializeAws_ec2DescribeFleetInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeFleetInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeFleetInstancesRequest(input, context),
     Action: "DescribeFleetInstances",
     Version: "2016-11-15"
   });
@@ -5947,9 +5592,8 @@ export const serializeAws_ec2DescribeFleetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeFleetsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeFleetsRequest(input, context),
     Action: "DescribeFleets",
     Version: "2016-11-15"
   });
@@ -5964,9 +5608,8 @@ export const serializeAws_ec2DescribeFlowLogsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeFlowLogsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeFlowLogsRequest(input, context),
     Action: "DescribeFlowLogs",
     Version: "2016-11-15"
   });
@@ -5981,12 +5624,8 @@ export const serializeAws_ec2DescribeFpgaImageAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeFpgaImageAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeFpgaImageAttributeRequest(input, context),
     Action: "DescribeFpgaImageAttribute",
     Version: "2016-11-15"
   });
@@ -6001,9 +5640,8 @@ export const serializeAws_ec2DescribeFpgaImagesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeFpgaImagesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeFpgaImagesRequest(input, context),
     Action: "DescribeFpgaImages",
     Version: "2016-11-15"
   });
@@ -6018,12 +5656,8 @@ export const serializeAws_ec2DescribeHostReservationOfferingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeHostReservationOfferingsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeHostReservationOfferingsRequest(input, context),
     Action: "DescribeHostReservationOfferings",
     Version: "2016-11-15"
   });
@@ -6038,12 +5672,8 @@ export const serializeAws_ec2DescribeHostReservationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeHostReservationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeHostReservationsRequest(input, context),
     Action: "DescribeHostReservations",
     Version: "2016-11-15"
   });
@@ -6058,9 +5688,8 @@ export const serializeAws_ec2DescribeHostsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeHostsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeHostsRequest(input, context),
     Action: "DescribeHosts",
     Version: "2016-11-15"
   });
@@ -6075,12 +5704,11 @@ export const serializeAws_ec2DescribeIamInstanceProfileAssociationsCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeIamInstanceProfileAssociationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeIamInstanceProfileAssociationsRequest(
+      input,
+      context
+    ),
     Action: "DescribeIamInstanceProfileAssociations",
     Version: "2016-11-15"
   });
@@ -6095,9 +5723,8 @@ export const serializeAws_ec2DescribeIdFormatCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeIdFormatRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeIdFormatRequest(input, context),
     Action: "DescribeIdFormat",
     Version: "2016-11-15"
   });
@@ -6112,12 +5739,8 @@ export const serializeAws_ec2DescribeIdentityIdFormatCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeIdentityIdFormatRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeIdentityIdFormatRequest(input, context),
     Action: "DescribeIdentityIdFormat",
     Version: "2016-11-15"
   });
@@ -6132,9 +5755,8 @@ export const serializeAws_ec2DescribeImageAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeImageAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeImageAttributeRequest(input, context),
     Action: "DescribeImageAttribute",
     Version: "2016-11-15"
   });
@@ -6149,9 +5771,8 @@ export const serializeAws_ec2DescribeImagesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeImagesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeImagesRequest(input, context),
     Action: "DescribeImages",
     Version: "2016-11-15"
   });
@@ -6166,12 +5787,8 @@ export const serializeAws_ec2DescribeImportImageTasksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeImportImageTasksRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeImportImageTasksRequest(input, context),
     Action: "DescribeImportImageTasks",
     Version: "2016-11-15"
   });
@@ -6186,12 +5803,8 @@ export const serializeAws_ec2DescribeImportSnapshotTasksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeImportSnapshotTasksRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeImportSnapshotTasksRequest(input, context),
     Action: "DescribeImportSnapshotTasks",
     Version: "2016-11-15"
   });
@@ -6206,12 +5819,8 @@ export const serializeAws_ec2DescribeInstanceAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeInstanceAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeInstanceAttributeRequest(input, context),
     Action: "DescribeInstanceAttribute",
     Version: "2016-11-15"
   });
@@ -6226,12 +5835,11 @@ export const serializeAws_ec2DescribeInstanceCreditSpecificationsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeInstanceCreditSpecificationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeInstanceCreditSpecificationsRequest(
+      input,
+      context
+    ),
     Action: "DescribeInstanceCreditSpecifications",
     Version: "2016-11-15"
   });
@@ -6246,9 +5854,8 @@ export const serializeAws_ec2DescribeInstanceStatusCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeInstanceStatusRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeInstanceStatusRequest(input, context),
     Action: "DescribeInstanceStatus",
     Version: "2016-11-15"
   });
@@ -6263,12 +5870,8 @@ export const serializeAws_ec2DescribeInstanceTypeOfferingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeInstanceTypeOfferingsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeInstanceTypeOfferingsRequest(input, context),
     Action: "DescribeInstanceTypeOfferings",
     Version: "2016-11-15"
   });
@@ -6283,9 +5886,8 @@ export const serializeAws_ec2DescribeInstanceTypesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeInstanceTypesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeInstanceTypesRequest(input, context),
     Action: "DescribeInstanceTypes",
     Version: "2016-11-15"
   });
@@ -6300,9 +5902,8 @@ export const serializeAws_ec2DescribeInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeInstancesRequest(input, context),
     Action: "DescribeInstances",
     Version: "2016-11-15"
   });
@@ -6317,12 +5918,8 @@ export const serializeAws_ec2DescribeInternetGatewaysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeInternetGatewaysRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeInternetGatewaysRequest(input, context),
     Action: "DescribeInternetGateways",
     Version: "2016-11-15"
   });
@@ -6337,9 +5934,8 @@ export const serializeAws_ec2DescribeIpv6PoolsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeIpv6PoolsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeIpv6PoolsRequest(input, context),
     Action: "DescribeIpv6Pools",
     Version: "2016-11-15"
   });
@@ -6354,9 +5950,8 @@ export const serializeAws_ec2DescribeKeyPairsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeKeyPairsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeKeyPairsRequest(input, context),
     Action: "DescribeKeyPairs",
     Version: "2016-11-15"
   });
@@ -6371,12 +5966,8 @@ export const serializeAws_ec2DescribeLaunchTemplateVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLaunchTemplateVersionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLaunchTemplateVersionsRequest(input, context),
     Action: "DescribeLaunchTemplateVersions",
     Version: "2016-11-15"
   });
@@ -6391,12 +5982,8 @@ export const serializeAws_ec2DescribeLaunchTemplatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLaunchTemplatesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLaunchTemplatesRequest(input, context),
     Action: "DescribeLaunchTemplates",
     Version: "2016-11-15"
   });
@@ -6411,12 +5998,11 @@ export const serializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroup
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(
+      input,
+      context
+    ),
     Action: "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations",
     Version: "2016-11-15"
   });
@@ -6431,12 +6017,11 @@ export const serializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsComman
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsRequest(
+      input,
+      context
+    ),
     Action: "DescribeLocalGatewayRouteTableVpcAssociations",
     Version: "2016-11-15"
   });
@@ -6451,12 +6036,8 @@ export const serializeAws_ec2DescribeLocalGatewayRouteTablesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLocalGatewayRouteTablesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLocalGatewayRouteTablesRequest(input, context),
     Action: "DescribeLocalGatewayRouteTables",
     Version: "2016-11-15"
   });
@@ -6471,12 +6052,11 @@ export const serializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsRequest(
+      input,
+      context
+    ),
     Action: "DescribeLocalGatewayVirtualInterfaceGroups",
     Version: "2016-11-15"
   });
@@ -6491,12 +6071,11 @@ export const serializeAws_ec2DescribeLocalGatewayVirtualInterfacesCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLocalGatewayVirtualInterfacesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLocalGatewayVirtualInterfacesRequest(
+      input,
+      context
+    ),
     Action: "DescribeLocalGatewayVirtualInterfaces",
     Version: "2016-11-15"
   });
@@ -6511,9 +6090,8 @@ export const serializeAws_ec2DescribeLocalGatewaysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeLocalGatewaysRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeLocalGatewaysRequest(input, context),
     Action: "DescribeLocalGateways",
     Version: "2016-11-15"
   });
@@ -6528,12 +6106,8 @@ export const serializeAws_ec2DescribeMovingAddressesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeMovingAddressesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeMovingAddressesRequest(input, context),
     Action: "DescribeMovingAddresses",
     Version: "2016-11-15"
   });
@@ -6548,9 +6122,8 @@ export const serializeAws_ec2DescribeNatGatewaysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeNatGatewaysRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeNatGatewaysRequest(input, context),
     Action: "DescribeNatGateways",
     Version: "2016-11-15"
   });
@@ -6565,9 +6138,8 @@ export const serializeAws_ec2DescribeNetworkAclsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeNetworkAclsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeNetworkAclsRequest(input, context),
     Action: "DescribeNetworkAcls",
     Version: "2016-11-15"
   });
@@ -6582,12 +6154,8 @@ export const serializeAws_ec2DescribeNetworkInterfaceAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeNetworkInterfaceAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeNetworkInterfaceAttributeRequest(input, context),
     Action: "DescribeNetworkInterfaceAttribute",
     Version: "2016-11-15"
   });
@@ -6602,12 +6170,11 @@ export const serializeAws_ec2DescribeNetworkInterfacePermissionsCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeNetworkInterfacePermissionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeNetworkInterfacePermissionsRequest(
+      input,
+      context
+    ),
     Action: "DescribeNetworkInterfacePermissions",
     Version: "2016-11-15"
   });
@@ -6622,12 +6189,8 @@ export const serializeAws_ec2DescribeNetworkInterfacesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeNetworkInterfacesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeNetworkInterfacesRequest(input, context),
     Action: "DescribeNetworkInterfaces",
     Version: "2016-11-15"
   });
@@ -6642,12 +6205,8 @@ export const serializeAws_ec2DescribePlacementGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribePlacementGroupsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribePlacementGroupsRequest(input, context),
     Action: "DescribePlacementGroups",
     Version: "2016-11-15"
   });
@@ -6662,9 +6221,8 @@ export const serializeAws_ec2DescribePrefixListsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribePrefixListsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribePrefixListsRequest(input, context),
     Action: "DescribePrefixLists",
     Version: "2016-11-15"
   });
@@ -6679,12 +6237,8 @@ export const serializeAws_ec2DescribePrincipalIdFormatCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribePrincipalIdFormatRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribePrincipalIdFormatRequest(input, context),
     Action: "DescribePrincipalIdFormat",
     Version: "2016-11-15"
   });
@@ -6699,12 +6253,8 @@ export const serializeAws_ec2DescribePublicIpv4PoolsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribePublicIpv4PoolsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribePublicIpv4PoolsRequest(input, context),
     Action: "DescribePublicIpv4Pools",
     Version: "2016-11-15"
   });
@@ -6719,9 +6269,8 @@ export const serializeAws_ec2DescribeRegionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeRegionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeRegionsRequest(input, context),
     Action: "DescribeRegions",
     Version: "2016-11-15"
   });
@@ -6736,12 +6285,8 @@ export const serializeAws_ec2DescribeReservedInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeReservedInstancesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeReservedInstancesRequest(input, context),
     Action: "DescribeReservedInstances",
     Version: "2016-11-15"
   });
@@ -6756,12 +6301,8 @@ export const serializeAws_ec2DescribeReservedInstancesListingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeReservedInstancesListingsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeReservedInstancesListingsRequest(input, context),
     Action: "DescribeReservedInstancesListings",
     Version: "2016-11-15"
   });
@@ -6776,12 +6317,11 @@ export const serializeAws_ec2DescribeReservedInstancesModificationsCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeReservedInstancesModificationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeReservedInstancesModificationsRequest(
+      input,
+      context
+    ),
     Action: "DescribeReservedInstancesModifications",
     Version: "2016-11-15"
   });
@@ -6796,12 +6336,11 @@ export const serializeAws_ec2DescribeReservedInstancesOfferingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeReservedInstancesOfferingsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeReservedInstancesOfferingsRequest(
+      input,
+      context
+    ),
     Action: "DescribeReservedInstancesOfferings",
     Version: "2016-11-15"
   });
@@ -6816,9 +6355,8 @@ export const serializeAws_ec2DescribeRouteTablesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeRouteTablesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeRouteTablesRequest(input, context),
     Action: "DescribeRouteTables",
     Version: "2016-11-15"
   });
@@ -6833,12 +6371,11 @@ export const serializeAws_ec2DescribeScheduledInstanceAvailabilityCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest(
+      input,
+      context
+    ),
     Action: "DescribeScheduledInstanceAvailability",
     Version: "2016-11-15"
   });
@@ -6853,12 +6390,8 @@ export const serializeAws_ec2DescribeScheduledInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeScheduledInstancesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeScheduledInstancesRequest(input, context),
     Action: "DescribeScheduledInstances",
     Version: "2016-11-15"
   });
@@ -6873,12 +6406,8 @@ export const serializeAws_ec2DescribeSecurityGroupReferencesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSecurityGroupReferencesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSecurityGroupReferencesRequest(input, context),
     Action: "DescribeSecurityGroupReferences",
     Version: "2016-11-15"
   });
@@ -6893,9 +6422,8 @@ export const serializeAws_ec2DescribeSecurityGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSecurityGroupsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSecurityGroupsRequest(input, context),
     Action: "DescribeSecurityGroups",
     Version: "2016-11-15"
   });
@@ -6910,12 +6438,8 @@ export const serializeAws_ec2DescribeSnapshotAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSnapshotAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSnapshotAttributeRequest(input, context),
     Action: "DescribeSnapshotAttribute",
     Version: "2016-11-15"
   });
@@ -6930,9 +6454,8 @@ export const serializeAws_ec2DescribeSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSnapshotsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSnapshotsRequest(input, context),
     Action: "DescribeSnapshots",
     Version: "2016-11-15"
   });
@@ -6947,12 +6470,8 @@ export const serializeAws_ec2DescribeSpotDatafeedSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSpotDatafeedSubscriptionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSpotDatafeedSubscriptionRequest(input, context),
     Action: "DescribeSpotDatafeedSubscription",
     Version: "2016-11-15"
   });
@@ -6967,12 +6486,8 @@ export const serializeAws_ec2DescribeSpotFleetInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSpotFleetInstancesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSpotFleetInstancesRequest(input, context),
     Action: "DescribeSpotFleetInstances",
     Version: "2016-11-15"
   });
@@ -6987,12 +6502,8 @@ export const serializeAws_ec2DescribeSpotFleetRequestHistoryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSpotFleetRequestHistoryRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSpotFleetRequestHistoryRequest(input, context),
     Action: "DescribeSpotFleetRequestHistory",
     Version: "2016-11-15"
   });
@@ -7007,12 +6518,8 @@ export const serializeAws_ec2DescribeSpotFleetRequestsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSpotFleetRequestsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSpotFleetRequestsRequest(input, context),
     Action: "DescribeSpotFleetRequests",
     Version: "2016-11-15"
   });
@@ -7027,12 +6534,8 @@ export const serializeAws_ec2DescribeSpotInstanceRequestsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSpotInstanceRequestsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSpotInstanceRequestsRequest(input, context),
     Action: "DescribeSpotInstanceRequests",
     Version: "2016-11-15"
   });
@@ -7047,12 +6550,8 @@ export const serializeAws_ec2DescribeSpotPriceHistoryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSpotPriceHistoryRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSpotPriceHistoryRequest(input, context),
     Action: "DescribeSpotPriceHistory",
     Version: "2016-11-15"
   });
@@ -7067,12 +6566,8 @@ export const serializeAws_ec2DescribeStaleSecurityGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeStaleSecurityGroupsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeStaleSecurityGroupsRequest(input, context),
     Action: "DescribeStaleSecurityGroups",
     Version: "2016-11-15"
   });
@@ -7087,9 +6582,8 @@ export const serializeAws_ec2DescribeSubnetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeSubnetsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeSubnetsRequest(input, context),
     Action: "DescribeSubnets",
     Version: "2016-11-15"
   });
@@ -7104,9 +6598,8 @@ export const serializeAws_ec2DescribeTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTagsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTagsRequest(input, context),
     Action: "DescribeTags",
     Version: "2016-11-15"
   });
@@ -7121,12 +6614,8 @@ export const serializeAws_ec2DescribeTrafficMirrorFiltersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTrafficMirrorFiltersRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTrafficMirrorFiltersRequest(input, context),
     Action: "DescribeTrafficMirrorFilters",
     Version: "2016-11-15"
   });
@@ -7141,12 +6630,8 @@ export const serializeAws_ec2DescribeTrafficMirrorSessionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTrafficMirrorSessionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTrafficMirrorSessionsRequest(input, context),
     Action: "DescribeTrafficMirrorSessions",
     Version: "2016-11-15"
   });
@@ -7161,12 +6646,8 @@ export const serializeAws_ec2DescribeTrafficMirrorTargetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTrafficMirrorTargetsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTrafficMirrorTargetsRequest(input, context),
     Action: "DescribeTrafficMirrorTargets",
     Version: "2016-11-15"
   });
@@ -7181,12 +6662,8 @@ export const serializeAws_ec2DescribeTransitGatewayAttachmentsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTransitGatewayAttachmentsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTransitGatewayAttachmentsRequest(input, context),
     Action: "DescribeTransitGatewayAttachments",
     Version: "2016-11-15"
   });
@@ -7201,12 +6678,11 @@ export const serializeAws_ec2DescribeTransitGatewayMulticastDomainsCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTransitGatewayMulticastDomainsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTransitGatewayMulticastDomainsRequest(
+      input,
+      context
+    ),
     Action: "DescribeTransitGatewayMulticastDomains",
     Version: "2016-11-15"
   });
@@ -7221,12 +6697,11 @@ export const serializeAws_ec2DescribeTransitGatewayPeeringAttachmentsCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTransitGatewayPeeringAttachmentsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTransitGatewayPeeringAttachmentsRequest(
+      input,
+      context
+    ),
     Action: "DescribeTransitGatewayPeeringAttachments",
     Version: "2016-11-15"
   });
@@ -7241,12 +6716,8 @@ export const serializeAws_ec2DescribeTransitGatewayRouteTablesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTransitGatewayRouteTablesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTransitGatewayRouteTablesRequest(input, context),
     Action: "DescribeTransitGatewayRouteTables",
     Version: "2016-11-15"
   });
@@ -7261,12 +6732,11 @@ export const serializeAws_ec2DescribeTransitGatewayVpcAttachmentsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTransitGatewayVpcAttachmentsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTransitGatewayVpcAttachmentsRequest(
+      input,
+      context
+    ),
     Action: "DescribeTransitGatewayVpcAttachments",
     Version: "2016-11-15"
   });
@@ -7281,12 +6751,8 @@ export const serializeAws_ec2DescribeTransitGatewaysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeTransitGatewaysRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeTransitGatewaysRequest(input, context),
     Action: "DescribeTransitGateways",
     Version: "2016-11-15"
   });
@@ -7301,12 +6767,8 @@ export const serializeAws_ec2DescribeVolumeAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVolumeAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVolumeAttributeRequest(input, context),
     Action: "DescribeVolumeAttribute",
     Version: "2016-11-15"
   });
@@ -7321,9 +6783,8 @@ export const serializeAws_ec2DescribeVolumeStatusCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVolumeStatusRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVolumeStatusRequest(input, context),
     Action: "DescribeVolumeStatus",
     Version: "2016-11-15"
   });
@@ -7338,9 +6799,8 @@ export const serializeAws_ec2DescribeVolumesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVolumesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVolumesRequest(input, context),
     Action: "DescribeVolumes",
     Version: "2016-11-15"
   });
@@ -7355,12 +6815,8 @@ export const serializeAws_ec2DescribeVolumesModificationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVolumesModificationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVolumesModificationsRequest(input, context),
     Action: "DescribeVolumesModifications",
     Version: "2016-11-15"
   });
@@ -7375,9 +6831,8 @@ export const serializeAws_ec2DescribeVpcAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcAttributeRequest(input, context),
     Action: "DescribeVpcAttribute",
     Version: "2016-11-15"
   });
@@ -7392,9 +6847,8 @@ export const serializeAws_ec2DescribeVpcClassicLinkCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcClassicLinkRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcClassicLinkRequest(input, context),
     Action: "DescribeVpcClassicLink",
     Version: "2016-11-15"
   });
@@ -7409,12 +6863,8 @@ export const serializeAws_ec2DescribeVpcClassicLinkDnsSupportCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcClassicLinkDnsSupportRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcClassicLinkDnsSupportRequest(input, context),
     Action: "DescribeVpcClassicLinkDnsSupport",
     Version: "2016-11-15"
   });
@@ -7429,12 +6879,11 @@ export const serializeAws_ec2DescribeVpcEndpointConnectionNotificationsCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcEndpointConnectionNotificationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcEndpointConnectionNotificationsRequest(
+      input,
+      context
+    ),
     Action: "DescribeVpcEndpointConnectionNotifications",
     Version: "2016-11-15"
   });
@@ -7449,12 +6898,8 @@ export const serializeAws_ec2DescribeVpcEndpointConnectionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcEndpointConnectionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcEndpointConnectionsRequest(input, context),
     Action: "DescribeVpcEndpointConnections",
     Version: "2016-11-15"
   });
@@ -7469,12 +6914,11 @@ export const serializeAws_ec2DescribeVpcEndpointServiceConfigurationsCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcEndpointServiceConfigurationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcEndpointServiceConfigurationsRequest(
+      input,
+      context
+    ),
     Action: "DescribeVpcEndpointServiceConfigurations",
     Version: "2016-11-15"
   });
@@ -7489,12 +6933,11 @@ export const serializeAws_ec2DescribeVpcEndpointServicePermissionsCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcEndpointServicePermissionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcEndpointServicePermissionsRequest(
+      input,
+      context
+    ),
     Action: "DescribeVpcEndpointServicePermissions",
     Version: "2016-11-15"
   });
@@ -7509,12 +6952,8 @@ export const serializeAws_ec2DescribeVpcEndpointServicesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcEndpointServicesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcEndpointServicesRequest(input, context),
     Action: "DescribeVpcEndpointServices",
     Version: "2016-11-15"
   });
@@ -7529,9 +6968,8 @@ export const serializeAws_ec2DescribeVpcEndpointsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcEndpointsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcEndpointsRequest(input, context),
     Action: "DescribeVpcEndpoints",
     Version: "2016-11-15"
   });
@@ -7546,12 +6984,8 @@ export const serializeAws_ec2DescribeVpcPeeringConnectionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcPeeringConnectionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcPeeringConnectionsRequest(input, context),
     Action: "DescribeVpcPeeringConnections",
     Version: "2016-11-15"
   });
@@ -7566,9 +7000,8 @@ export const serializeAws_ec2DescribeVpcsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpcsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpcsRequest(input, context),
     Action: "DescribeVpcs",
     Version: "2016-11-15"
   });
@@ -7583,9 +7016,8 @@ export const serializeAws_ec2DescribeVpnConnectionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpnConnectionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpnConnectionsRequest(input, context),
     Action: "DescribeVpnConnections",
     Version: "2016-11-15"
   });
@@ -7600,9 +7032,8 @@ export const serializeAws_ec2DescribeVpnGatewaysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DescribeVpnGatewaysRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DescribeVpnGatewaysRequest(input, context),
     Action: "DescribeVpnGateways",
     Version: "2016-11-15"
   });
@@ -7617,9 +7048,8 @@ export const serializeAws_ec2DetachClassicLinkVpcCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DetachClassicLinkVpcRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DetachClassicLinkVpcRequest(input, context),
     Action: "DetachClassicLinkVpc",
     Version: "2016-11-15"
   });
@@ -7634,9 +7064,8 @@ export const serializeAws_ec2DetachInternetGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DetachInternetGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DetachInternetGatewayRequest(input, context),
     Action: "DetachInternetGateway",
     Version: "2016-11-15"
   });
@@ -7651,9 +7080,8 @@ export const serializeAws_ec2DetachNetworkInterfaceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DetachNetworkInterfaceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DetachNetworkInterfaceRequest(input, context),
     Action: "DetachNetworkInterface",
     Version: "2016-11-15"
   });
@@ -7668,9 +7096,8 @@ export const serializeAws_ec2DetachVolumeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DetachVolumeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DetachVolumeRequest(input, context),
     Action: "DetachVolume",
     Version: "2016-11-15"
   });
@@ -7685,9 +7112,8 @@ export const serializeAws_ec2DetachVpnGatewayCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DetachVpnGatewayRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DetachVpnGatewayRequest(input, context),
     Action: "DetachVpnGateway",
     Version: "2016-11-15"
   });
@@ -7702,12 +7128,8 @@ export const serializeAws_ec2DisableEbsEncryptionByDefaultCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisableEbsEncryptionByDefaultRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisableEbsEncryptionByDefaultRequest(input, context),
     Action: "DisableEbsEncryptionByDefault",
     Version: "2016-11-15"
   });
@@ -7722,12 +7144,8 @@ export const serializeAws_ec2DisableFastSnapshotRestoresCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisableFastSnapshotRestoresRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisableFastSnapshotRestoresRequest(input, context),
     Action: "DisableFastSnapshotRestores",
     Version: "2016-11-15"
   });
@@ -7742,12 +7160,11 @@ export const serializeAws_ec2DisableTransitGatewayRouteTablePropagationCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisableTransitGatewayRouteTablePropagationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisableTransitGatewayRouteTablePropagationRequest(
+      input,
+      context
+    ),
     Action: "DisableTransitGatewayRouteTablePropagation",
     Version: "2016-11-15"
   });
@@ -7762,12 +7179,8 @@ export const serializeAws_ec2DisableVgwRoutePropagationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisableVgwRoutePropagationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisableVgwRoutePropagationRequest(input, context),
     Action: "DisableVgwRoutePropagation",
     Version: "2016-11-15"
   });
@@ -7782,9 +7195,8 @@ export const serializeAws_ec2DisableVpcClassicLinkCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisableVpcClassicLinkRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisableVpcClassicLinkRequest(input, context),
     Action: "DisableVpcClassicLink",
     Version: "2016-11-15"
   });
@@ -7799,12 +7211,8 @@ export const serializeAws_ec2DisableVpcClassicLinkDnsSupportCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisableVpcClassicLinkDnsSupportRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisableVpcClassicLinkDnsSupportRequest(input, context),
     Action: "DisableVpcClassicLinkDnsSupport",
     Version: "2016-11-15"
   });
@@ -7819,9 +7227,8 @@ export const serializeAws_ec2DisassociateAddressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateAddressRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateAddressRequest(input, context),
     Action: "DisassociateAddress",
     Version: "2016-11-15"
   });
@@ -7836,12 +7243,11 @@ export const serializeAws_ec2DisassociateClientVpnTargetNetworkCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateClientVpnTargetNetworkRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateClientVpnTargetNetworkRequest(
+      input,
+      context
+    ),
     Action: "DisassociateClientVpnTargetNetwork",
     Version: "2016-11-15"
   });
@@ -7856,12 +7262,8 @@ export const serializeAws_ec2DisassociateIamInstanceProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateIamInstanceProfileRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateIamInstanceProfileRequest(input, context),
     Action: "DisassociateIamInstanceProfile",
     Version: "2016-11-15"
   });
@@ -7876,9 +7278,8 @@ export const serializeAws_ec2DisassociateRouteTableCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateRouteTableRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateRouteTableRequest(input, context),
     Action: "DisassociateRouteTable",
     Version: "2016-11-15"
   });
@@ -7893,12 +7294,8 @@ export const serializeAws_ec2DisassociateSubnetCidrBlockCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateSubnetCidrBlockRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateSubnetCidrBlockRequest(input, context),
     Action: "DisassociateSubnetCidrBlock",
     Version: "2016-11-15"
   });
@@ -7913,12 +7310,11 @@ export const serializeAws_ec2DisassociateTransitGatewayMulticastDomainCommand = 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateTransitGatewayMulticastDomainRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateTransitGatewayMulticastDomainRequest(
+      input,
+      context
+    ),
     Action: "DisassociateTransitGatewayMulticastDomain",
     Version: "2016-11-15"
   });
@@ -7933,12 +7329,11 @@ export const serializeAws_ec2DisassociateTransitGatewayRouteTableCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateTransitGatewayRouteTableRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateTransitGatewayRouteTableRequest(
+      input,
+      context
+    ),
     Action: "DisassociateTransitGatewayRouteTable",
     Version: "2016-11-15"
   });
@@ -7953,12 +7348,8 @@ export const serializeAws_ec2DisassociateVpcCidrBlockCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2DisassociateVpcCidrBlockRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2DisassociateVpcCidrBlockRequest(input, context),
     Action: "DisassociateVpcCidrBlock",
     Version: "2016-11-15"
   });
@@ -7973,12 +7364,8 @@ export const serializeAws_ec2EnableEbsEncryptionByDefaultCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EnableEbsEncryptionByDefaultRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EnableEbsEncryptionByDefaultRequest(input, context),
     Action: "EnableEbsEncryptionByDefault",
     Version: "2016-11-15"
   });
@@ -7993,12 +7380,8 @@ export const serializeAws_ec2EnableFastSnapshotRestoresCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EnableFastSnapshotRestoresRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EnableFastSnapshotRestoresRequest(input, context),
     Action: "EnableFastSnapshotRestores",
     Version: "2016-11-15"
   });
@@ -8013,12 +7396,11 @@ export const serializeAws_ec2EnableTransitGatewayRouteTablePropagationCommand = 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EnableTransitGatewayRouteTablePropagationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EnableTransitGatewayRouteTablePropagationRequest(
+      input,
+      context
+    ),
     Action: "EnableTransitGatewayRouteTablePropagation",
     Version: "2016-11-15"
   });
@@ -8033,12 +7415,8 @@ export const serializeAws_ec2EnableVgwRoutePropagationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EnableVgwRoutePropagationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EnableVgwRoutePropagationRequest(input, context),
     Action: "EnableVgwRoutePropagation",
     Version: "2016-11-15"
   });
@@ -8053,9 +7431,8 @@ export const serializeAws_ec2EnableVolumeIOCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EnableVolumeIORequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EnableVolumeIORequest(input, context),
     Action: "EnableVolumeIO",
     Version: "2016-11-15"
   });
@@ -8070,9 +7447,8 @@ export const serializeAws_ec2EnableVpcClassicLinkCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EnableVpcClassicLinkRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EnableVpcClassicLinkRequest(input, context),
     Action: "EnableVpcClassicLink",
     Version: "2016-11-15"
   });
@@ -8087,12 +7463,8 @@ export const serializeAws_ec2EnableVpcClassicLinkDnsSupportCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EnableVpcClassicLinkDnsSupportRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EnableVpcClassicLinkDnsSupportRequest(input, context),
     Action: "EnableVpcClassicLinkDnsSupport",
     Version: "2016-11-15"
   });
@@ -8107,12 +7479,11 @@ export const serializeAws_ec2ExportClientVpnClientCertificateRevocationListComma
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ExportClientVpnClientCertificateRevocationListRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ExportClientVpnClientCertificateRevocationListRequest(
+      input,
+      context
+    ),
     Action: "ExportClientVpnClientCertificateRevocationList",
     Version: "2016-11-15"
   });
@@ -8127,12 +7498,11 @@ export const serializeAws_ec2ExportClientVpnClientConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ExportClientVpnClientConfigurationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ExportClientVpnClientConfigurationRequest(
+      input,
+      context
+    ),
     Action: "ExportClientVpnClientConfiguration",
     Version: "2016-11-15"
   });
@@ -8147,9 +7517,8 @@ export const serializeAws_ec2ExportImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ExportImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ExportImageRequest(input, context),
     Action: "ExportImage",
     Version: "2016-11-15"
   });
@@ -8164,12 +7533,8 @@ export const serializeAws_ec2ExportTransitGatewayRoutesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ExportTransitGatewayRoutesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ExportTransitGatewayRoutesRequest(input, context),
     Action: "ExportTransitGatewayRoutes",
     Version: "2016-11-15"
   });
@@ -8184,12 +7549,8 @@ export const serializeAws_ec2GetAssociatedIpv6PoolCidrsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetAssociatedIpv6PoolCidrsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetAssociatedIpv6PoolCidrsRequest(input, context),
     Action: "GetAssociatedIpv6PoolCidrs",
     Version: "2016-11-15"
   });
@@ -8204,12 +7565,8 @@ export const serializeAws_ec2GetCapacityReservationUsageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetCapacityReservationUsageRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetCapacityReservationUsageRequest(input, context),
     Action: "GetCapacityReservationUsage",
     Version: "2016-11-15"
   });
@@ -8224,9 +7581,8 @@ export const serializeAws_ec2GetCoipPoolUsageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetCoipPoolUsageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetCoipPoolUsageRequest(input, context),
     Action: "GetCoipPoolUsage",
     Version: "2016-11-15"
   });
@@ -8241,9 +7597,8 @@ export const serializeAws_ec2GetConsoleOutputCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetConsoleOutputRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetConsoleOutputRequest(input, context),
     Action: "GetConsoleOutput",
     Version: "2016-11-15"
   });
@@ -8258,9 +7613,8 @@ export const serializeAws_ec2GetConsoleScreenshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetConsoleScreenshotRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetConsoleScreenshotRequest(input, context),
     Action: "GetConsoleScreenshot",
     Version: "2016-11-15"
   });
@@ -8275,12 +7629,8 @@ export const serializeAws_ec2GetDefaultCreditSpecificationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetDefaultCreditSpecificationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetDefaultCreditSpecificationRequest(input, context),
     Action: "GetDefaultCreditSpecification",
     Version: "2016-11-15"
   });
@@ -8295,9 +7645,8 @@ export const serializeAws_ec2GetEbsDefaultKmsKeyIdCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetEbsDefaultKmsKeyIdRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetEbsDefaultKmsKeyIdRequest(input, context),
     Action: "GetEbsDefaultKmsKeyId",
     Version: "2016-11-15"
   });
@@ -8312,12 +7661,8 @@ export const serializeAws_ec2GetEbsEncryptionByDefaultCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetEbsEncryptionByDefaultRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetEbsEncryptionByDefaultRequest(input, context),
     Action: "GetEbsEncryptionByDefault",
     Version: "2016-11-15"
   });
@@ -8332,12 +7677,8 @@ export const serializeAws_ec2GetHostReservationPurchasePreviewCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetHostReservationPurchasePreviewRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetHostReservationPurchasePreviewRequest(input, context),
     Action: "GetHostReservationPurchasePreview",
     Version: "2016-11-15"
   });
@@ -8352,9 +7693,8 @@ export const serializeAws_ec2GetLaunchTemplateDataCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetLaunchTemplateDataRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetLaunchTemplateDataRequest(input, context),
     Action: "GetLaunchTemplateData",
     Version: "2016-11-15"
   });
@@ -8369,9 +7709,8 @@ export const serializeAws_ec2GetPasswordDataCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetPasswordDataRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetPasswordDataRequest(input, context),
     Action: "GetPasswordData",
     Version: "2016-11-15"
   });
@@ -8386,12 +7725,8 @@ export const serializeAws_ec2GetReservedInstancesExchangeQuoteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetReservedInstancesExchangeQuoteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetReservedInstancesExchangeQuoteRequest(input, context),
     Action: "GetReservedInstancesExchangeQuote",
     Version: "2016-11-15"
   });
@@ -8406,12 +7741,11 @@ export const serializeAws_ec2GetTransitGatewayAttachmentPropagationsCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetTransitGatewayAttachmentPropagationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetTransitGatewayAttachmentPropagationsRequest(
+      input,
+      context
+    ),
     Action: "GetTransitGatewayAttachmentPropagations",
     Version: "2016-11-15"
   });
@@ -8426,12 +7760,11 @@ export const serializeAws_ec2GetTransitGatewayMulticastDomainAssociationsCommand
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetTransitGatewayMulticastDomainAssociationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetTransitGatewayMulticastDomainAssociationsRequest(
+      input,
+      context
+    ),
     Action: "GetTransitGatewayMulticastDomainAssociations",
     Version: "2016-11-15"
   });
@@ -8446,12 +7779,11 @@ export const serializeAws_ec2GetTransitGatewayRouteTableAssociationsCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetTransitGatewayRouteTableAssociationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetTransitGatewayRouteTableAssociationsRequest(
+      input,
+      context
+    ),
     Action: "GetTransitGatewayRouteTableAssociations",
     Version: "2016-11-15"
   });
@@ -8466,12 +7798,11 @@ export const serializeAws_ec2GetTransitGatewayRouteTablePropagationsCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2GetTransitGatewayRouteTablePropagationsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2GetTransitGatewayRouteTablePropagationsRequest(
+      input,
+      context
+    ),
     Action: "GetTransitGatewayRouteTablePropagations",
     Version: "2016-11-15"
   });
@@ -8486,12 +7817,11 @@ export const serializeAws_ec2ImportClientVpnClientCertificateRevocationListComma
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ImportClientVpnClientCertificateRevocationListRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ImportClientVpnClientCertificateRevocationListRequest(
+      input,
+      context
+    ),
     Action: "ImportClientVpnClientCertificateRevocationList",
     Version: "2016-11-15"
   });
@@ -8506,9 +7836,8 @@ export const serializeAws_ec2ImportImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ImportImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ImportImageRequest(input, context),
     Action: "ImportImage",
     Version: "2016-11-15"
   });
@@ -8523,9 +7852,8 @@ export const serializeAws_ec2ImportInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ImportInstanceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ImportInstanceRequest(input, context),
     Action: "ImportInstance",
     Version: "2016-11-15"
   });
@@ -8540,9 +7868,8 @@ export const serializeAws_ec2ImportKeyPairCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ImportKeyPairRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ImportKeyPairRequest(input, context),
     Action: "ImportKeyPair",
     Version: "2016-11-15"
   });
@@ -8557,9 +7884,8 @@ export const serializeAws_ec2ImportSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ImportSnapshotRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ImportSnapshotRequest(input, context),
     Action: "ImportSnapshot",
     Version: "2016-11-15"
   });
@@ -8574,9 +7900,8 @@ export const serializeAws_ec2ImportVolumeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ImportVolumeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ImportVolumeRequest(input, context),
     Action: "ImportVolume",
     Version: "2016-11-15"
   });
@@ -8591,12 +7916,8 @@ export const serializeAws_ec2ModifyCapacityReservationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyCapacityReservationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyCapacityReservationRequest(input, context),
     Action: "ModifyCapacityReservation",
     Version: "2016-11-15"
   });
@@ -8611,12 +7932,8 @@ export const serializeAws_ec2ModifyClientVpnEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyClientVpnEndpointRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyClientVpnEndpointRequest(input, context),
     Action: "ModifyClientVpnEndpoint",
     Version: "2016-11-15"
   });
@@ -8631,12 +7948,8 @@ export const serializeAws_ec2ModifyDefaultCreditSpecificationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyDefaultCreditSpecificationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyDefaultCreditSpecificationRequest(input, context),
     Action: "ModifyDefaultCreditSpecification",
     Version: "2016-11-15"
   });
@@ -8651,12 +7964,8 @@ export const serializeAws_ec2ModifyEbsDefaultKmsKeyIdCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyEbsDefaultKmsKeyIdRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyEbsDefaultKmsKeyIdRequest(input, context),
     Action: "ModifyEbsDefaultKmsKeyId",
     Version: "2016-11-15"
   });
@@ -8671,9 +7980,8 @@ export const serializeAws_ec2ModifyFleetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyFleetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyFleetRequest(input, context),
     Action: "ModifyFleet",
     Version: "2016-11-15"
   });
@@ -8688,12 +7996,8 @@ export const serializeAws_ec2ModifyFpgaImageAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyFpgaImageAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyFpgaImageAttributeRequest(input, context),
     Action: "ModifyFpgaImageAttribute",
     Version: "2016-11-15"
   });
@@ -8708,9 +8012,8 @@ export const serializeAws_ec2ModifyHostsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyHostsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyHostsRequest(input, context),
     Action: "ModifyHosts",
     Version: "2016-11-15"
   });
@@ -8725,9 +8028,8 @@ export const serializeAws_ec2ModifyIdFormatCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyIdFormatRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyIdFormatRequest(input, context),
     Action: "ModifyIdFormat",
     Version: "2016-11-15"
   });
@@ -8742,9 +8044,8 @@ export const serializeAws_ec2ModifyIdentityIdFormatCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyIdentityIdFormatRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyIdentityIdFormatRequest(input, context),
     Action: "ModifyIdentityIdFormat",
     Version: "2016-11-15"
   });
@@ -8759,9 +8060,8 @@ export const serializeAws_ec2ModifyImageAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyImageAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyImageAttributeRequest(input, context),
     Action: "ModifyImageAttribute",
     Version: "2016-11-15"
   });
@@ -8776,12 +8076,8 @@ export const serializeAws_ec2ModifyInstanceAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyInstanceAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyInstanceAttributeRequest(input, context),
     Action: "ModifyInstanceAttribute",
     Version: "2016-11-15"
   });
@@ -8796,12 +8092,11 @@ export const serializeAws_ec2ModifyInstanceCapacityReservationAttributesCommand 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyInstanceCapacityReservationAttributesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyInstanceCapacityReservationAttributesRequest(
+      input,
+      context
+    ),
     Action: "ModifyInstanceCapacityReservationAttributes",
     Version: "2016-11-15"
   });
@@ -8816,12 +8111,8 @@ export const serializeAws_ec2ModifyInstanceCreditSpecificationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyInstanceCreditSpecificationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyInstanceCreditSpecificationRequest(input, context),
     Action: "ModifyInstanceCreditSpecification",
     Version: "2016-11-15"
   });
@@ -8836,12 +8127,8 @@ export const serializeAws_ec2ModifyInstanceEventStartTimeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyInstanceEventStartTimeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyInstanceEventStartTimeRequest(input, context),
     Action: "ModifyInstanceEventStartTime",
     Version: "2016-11-15"
   });
@@ -8856,12 +8143,8 @@ export const serializeAws_ec2ModifyInstanceMetadataOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyInstanceMetadataOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyInstanceMetadataOptionsRequest(input, context),
     Action: "ModifyInstanceMetadataOptions",
     Version: "2016-11-15"
   });
@@ -8876,12 +8159,8 @@ export const serializeAws_ec2ModifyInstancePlacementCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyInstancePlacementRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyInstancePlacementRequest(input, context),
     Action: "ModifyInstancePlacement",
     Version: "2016-11-15"
   });
@@ -8896,9 +8175,8 @@ export const serializeAws_ec2ModifyLaunchTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyLaunchTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyLaunchTemplateRequest(input, context),
     Action: "ModifyLaunchTemplate",
     Version: "2016-11-15"
   });
@@ -8913,12 +8191,8 @@ export const serializeAws_ec2ModifyNetworkInterfaceAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyNetworkInterfaceAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyNetworkInterfaceAttributeRequest(input, context),
     Action: "ModifyNetworkInterfaceAttribute",
     Version: "2016-11-15"
   });
@@ -8933,12 +8207,8 @@ export const serializeAws_ec2ModifyReservedInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyReservedInstancesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyReservedInstancesRequest(input, context),
     Action: "ModifyReservedInstances",
     Version: "2016-11-15"
   });
@@ -8953,12 +8223,8 @@ export const serializeAws_ec2ModifySnapshotAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifySnapshotAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifySnapshotAttributeRequest(input, context),
     Action: "ModifySnapshotAttribute",
     Version: "2016-11-15"
   });
@@ -8973,9 +8239,8 @@ export const serializeAws_ec2ModifySpotFleetRequestCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifySpotFleetRequestRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifySpotFleetRequestRequest(input, context),
     Action: "ModifySpotFleetRequest",
     Version: "2016-11-15"
   });
@@ -8990,9 +8255,8 @@ export const serializeAws_ec2ModifySubnetAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifySubnetAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifySubnetAttributeRequest(input, context),
     Action: "ModifySubnetAttribute",
     Version: "2016-11-15"
   });
@@ -9007,12 +8271,11 @@ export const serializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesRequest(
+      input,
+      context
+    ),
     Action: "ModifyTrafficMirrorFilterNetworkServices",
     Version: "2016-11-15"
   });
@@ -9027,12 +8290,8 @@ export const serializeAws_ec2ModifyTrafficMirrorFilterRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest(input, context),
     Action: "ModifyTrafficMirrorFilterRule",
     Version: "2016-11-15"
   });
@@ -9047,12 +8306,8 @@ export const serializeAws_ec2ModifyTrafficMirrorSessionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyTrafficMirrorSessionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyTrafficMirrorSessionRequest(input, context),
     Action: "ModifyTrafficMirrorSession",
     Version: "2016-11-15"
   });
@@ -9067,12 +8322,8 @@ export const serializeAws_ec2ModifyTransitGatewayVpcAttachmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest(input, context),
     Action: "ModifyTransitGatewayVpcAttachment",
     Version: "2016-11-15"
   });
@@ -9087,9 +8338,8 @@ export const serializeAws_ec2ModifyVolumeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVolumeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVolumeRequest(input, context),
     Action: "ModifyVolume",
     Version: "2016-11-15"
   });
@@ -9104,9 +8354,8 @@ export const serializeAws_ec2ModifyVolumeAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVolumeAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVolumeAttributeRequest(input, context),
     Action: "ModifyVolumeAttribute",
     Version: "2016-11-15"
   });
@@ -9121,9 +8370,8 @@ export const serializeAws_ec2ModifyVpcAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpcAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpcAttributeRequest(input, context),
     Action: "ModifyVpcAttribute",
     Version: "2016-11-15"
   });
@@ -9138,9 +8386,8 @@ export const serializeAws_ec2ModifyVpcEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpcEndpointRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpcEndpointRequest(input, context),
     Action: "ModifyVpcEndpoint",
     Version: "2016-11-15"
   });
@@ -9155,12 +8402,11 @@ export const serializeAws_ec2ModifyVpcEndpointConnectionNotificationCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpcEndpointConnectionNotificationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpcEndpointConnectionNotificationRequest(
+      input,
+      context
+    ),
     Action: "ModifyVpcEndpointConnectionNotification",
     Version: "2016-11-15"
   });
@@ -9175,12 +8421,11 @@ export const serializeAws_ec2ModifyVpcEndpointServiceConfigurationCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest(
+      input,
+      context
+    ),
     Action: "ModifyVpcEndpointServiceConfiguration",
     Version: "2016-11-15"
   });
@@ -9195,12 +8440,11 @@ export const serializeAws_ec2ModifyVpcEndpointServicePermissionsCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpcEndpointServicePermissionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpcEndpointServicePermissionsRequest(
+      input,
+      context
+    ),
     Action: "ModifyVpcEndpointServicePermissions",
     Version: "2016-11-15"
   });
@@ -9215,12 +8459,8 @@ export const serializeAws_ec2ModifyVpcPeeringConnectionOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpcPeeringConnectionOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpcPeeringConnectionOptionsRequest(input, context),
     Action: "ModifyVpcPeeringConnectionOptions",
     Version: "2016-11-15"
   });
@@ -9235,9 +8475,8 @@ export const serializeAws_ec2ModifyVpcTenancyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpcTenancyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpcTenancyRequest(input, context),
     Action: "ModifyVpcTenancy",
     Version: "2016-11-15"
   });
@@ -9252,9 +8491,8 @@ export const serializeAws_ec2ModifyVpnConnectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpnConnectionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpnConnectionRequest(input, context),
     Action: "ModifyVpnConnection",
     Version: "2016-11-15"
   });
@@ -9269,12 +8507,8 @@ export const serializeAws_ec2ModifyVpnTunnelCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpnTunnelCertificateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpnTunnelCertificateRequest(input, context),
     Action: "ModifyVpnTunnelCertificate",
     Version: "2016-11-15"
   });
@@ -9289,9 +8523,8 @@ export const serializeAws_ec2ModifyVpnTunnelOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ModifyVpnTunnelOptionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ModifyVpnTunnelOptionsRequest(input, context),
     Action: "ModifyVpnTunnelOptions",
     Version: "2016-11-15"
   });
@@ -9306,9 +8539,8 @@ export const serializeAws_ec2MonitorInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2MonitorInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2MonitorInstancesRequest(input, context),
     Action: "MonitorInstances",
     Version: "2016-11-15"
   });
@@ -9323,9 +8555,8 @@ export const serializeAws_ec2MoveAddressToVpcCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2MoveAddressToVpcRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2MoveAddressToVpcRequest(input, context),
     Action: "MoveAddressToVpc",
     Version: "2016-11-15"
   });
@@ -9340,9 +8571,8 @@ export const serializeAws_ec2ProvisionByoipCidrCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ProvisionByoipCidrRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ProvisionByoipCidrRequest(input, context),
     Action: "ProvisionByoipCidr",
     Version: "2016-11-15"
   });
@@ -9357,12 +8587,8 @@ export const serializeAws_ec2PurchaseHostReservationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2PurchaseHostReservationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2PurchaseHostReservationRequest(input, context),
     Action: "PurchaseHostReservation",
     Version: "2016-11-15"
   });
@@ -9377,12 +8603,8 @@ export const serializeAws_ec2PurchaseReservedInstancesOfferingCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2PurchaseReservedInstancesOfferingRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2PurchaseReservedInstancesOfferingRequest(input, context),
     Action: "PurchaseReservedInstancesOffering",
     Version: "2016-11-15"
   });
@@ -9397,12 +8619,8 @@ export const serializeAws_ec2PurchaseScheduledInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2PurchaseScheduledInstancesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2PurchaseScheduledInstancesRequest(input, context),
     Action: "PurchaseScheduledInstances",
     Version: "2016-11-15"
   });
@@ -9417,9 +8635,8 @@ export const serializeAws_ec2RebootInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RebootInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RebootInstancesRequest(input, context),
     Action: "RebootInstances",
     Version: "2016-11-15"
   });
@@ -9434,9 +8651,8 @@ export const serializeAws_ec2RegisterImageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RegisterImageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RegisterImageRequest(input, context),
     Action: "RegisterImage",
     Version: "2016-11-15"
   });
@@ -9451,12 +8667,11 @@ export const serializeAws_ec2RegisterTransitGatewayMulticastGroupMembersCommand 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RegisterTransitGatewayMulticastGroupMembersRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RegisterTransitGatewayMulticastGroupMembersRequest(
+      input,
+      context
+    ),
     Action: "RegisterTransitGatewayMulticastGroupMembers",
     Version: "2016-11-15"
   });
@@ -9471,12 +8686,11 @@ export const serializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesCommand 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesRequest(
+      input,
+      context
+    ),
     Action: "RegisterTransitGatewayMulticastGroupSources",
     Version: "2016-11-15"
   });
@@ -9491,12 +8705,11 @@ export const serializeAws_ec2RejectTransitGatewayPeeringAttachmentCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RejectTransitGatewayPeeringAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RejectTransitGatewayPeeringAttachmentRequest(
+      input,
+      context
+    ),
     Action: "RejectTransitGatewayPeeringAttachment",
     Version: "2016-11-15"
   });
@@ -9511,12 +8724,8 @@ export const serializeAws_ec2RejectTransitGatewayVpcAttachmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RejectTransitGatewayVpcAttachmentRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RejectTransitGatewayVpcAttachmentRequest(input, context),
     Action: "RejectTransitGatewayVpcAttachment",
     Version: "2016-11-15"
   });
@@ -9531,12 +8740,8 @@ export const serializeAws_ec2RejectVpcEndpointConnectionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RejectVpcEndpointConnectionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RejectVpcEndpointConnectionsRequest(input, context),
     Action: "RejectVpcEndpointConnections",
     Version: "2016-11-15"
   });
@@ -9551,12 +8756,8 @@ export const serializeAws_ec2RejectVpcPeeringConnectionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RejectVpcPeeringConnectionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RejectVpcPeeringConnectionRequest(input, context),
     Action: "RejectVpcPeeringConnection",
     Version: "2016-11-15"
   });
@@ -9571,9 +8772,8 @@ export const serializeAws_ec2ReleaseAddressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReleaseAddressRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReleaseAddressRequest(input, context),
     Action: "ReleaseAddress",
     Version: "2016-11-15"
   });
@@ -9588,9 +8788,8 @@ export const serializeAws_ec2ReleaseHostsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReleaseHostsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReleaseHostsRequest(input, context),
     Action: "ReleaseHosts",
     Version: "2016-11-15"
   });
@@ -9605,12 +8804,11 @@ export const serializeAws_ec2ReplaceIamInstanceProfileAssociationCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReplaceIamInstanceProfileAssociationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReplaceIamInstanceProfileAssociationRequest(
+      input,
+      context
+    ),
     Action: "ReplaceIamInstanceProfileAssociation",
     Version: "2016-11-15"
   });
@@ -9625,12 +8823,8 @@ export const serializeAws_ec2ReplaceNetworkAclAssociationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReplaceNetworkAclAssociationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReplaceNetworkAclAssociationRequest(input, context),
     Action: "ReplaceNetworkAclAssociation",
     Version: "2016-11-15"
   });
@@ -9645,9 +8839,8 @@ export const serializeAws_ec2ReplaceNetworkAclEntryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReplaceNetworkAclEntryRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReplaceNetworkAclEntryRequest(input, context),
     Action: "ReplaceNetworkAclEntry",
     Version: "2016-11-15"
   });
@@ -9662,9 +8855,8 @@ export const serializeAws_ec2ReplaceRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReplaceRouteRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReplaceRouteRequest(input, context),
     Action: "ReplaceRoute",
     Version: "2016-11-15"
   });
@@ -9679,12 +8871,8 @@ export const serializeAws_ec2ReplaceRouteTableAssociationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReplaceRouteTableAssociationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReplaceRouteTableAssociationRequest(input, context),
     Action: "ReplaceRouteTableAssociation",
     Version: "2016-11-15"
   });
@@ -9699,12 +8887,8 @@ export const serializeAws_ec2ReplaceTransitGatewayRouteCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReplaceTransitGatewayRouteRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReplaceTransitGatewayRouteRequest(input, context),
     Action: "ReplaceTransitGatewayRoute",
     Version: "2016-11-15"
   });
@@ -9719,9 +8903,8 @@ export const serializeAws_ec2ReportInstanceStatusCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ReportInstanceStatusRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ReportInstanceStatusRequest(input, context),
     Action: "ReportInstanceStatus",
     Version: "2016-11-15"
   });
@@ -9736,9 +8919,8 @@ export const serializeAws_ec2RequestSpotFleetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RequestSpotFleetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RequestSpotFleetRequest(input, context),
     Action: "RequestSpotFleet",
     Version: "2016-11-15"
   });
@@ -9753,9 +8935,8 @@ export const serializeAws_ec2RequestSpotInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RequestSpotInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RequestSpotInstancesRequest(input, context),
     Action: "RequestSpotInstances",
     Version: "2016-11-15"
   });
@@ -9770,12 +8951,8 @@ export const serializeAws_ec2ResetEbsDefaultKmsKeyIdCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ResetEbsDefaultKmsKeyIdRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ResetEbsDefaultKmsKeyIdRequest(input, context),
     Action: "ResetEbsDefaultKmsKeyId",
     Version: "2016-11-15"
   });
@@ -9790,12 +8967,8 @@ export const serializeAws_ec2ResetFpgaImageAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ResetFpgaImageAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ResetFpgaImageAttributeRequest(input, context),
     Action: "ResetFpgaImageAttribute",
     Version: "2016-11-15"
   });
@@ -9810,9 +8983,8 @@ export const serializeAws_ec2ResetImageAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ResetImageAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ResetImageAttributeRequest(input, context),
     Action: "ResetImageAttribute",
     Version: "2016-11-15"
   });
@@ -9827,9 +8999,8 @@ export const serializeAws_ec2ResetInstanceAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ResetInstanceAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ResetInstanceAttributeRequest(input, context),
     Action: "ResetInstanceAttribute",
     Version: "2016-11-15"
   });
@@ -9844,12 +9015,8 @@ export const serializeAws_ec2ResetNetworkInterfaceAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ResetNetworkInterfaceAttributeRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ResetNetworkInterfaceAttributeRequest(input, context),
     Action: "ResetNetworkInterfaceAttribute",
     Version: "2016-11-15"
   });
@@ -9864,9 +9031,8 @@ export const serializeAws_ec2ResetSnapshotAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2ResetSnapshotAttributeRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2ResetSnapshotAttributeRequest(input, context),
     Action: "ResetSnapshotAttribute",
     Version: "2016-11-15"
   });
@@ -9881,12 +9047,8 @@ export const serializeAws_ec2RestoreAddressToClassicCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RestoreAddressToClassicRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RestoreAddressToClassicRequest(input, context),
     Action: "RestoreAddressToClassic",
     Version: "2016-11-15"
   });
@@ -9901,9 +9063,8 @@ export const serializeAws_ec2RevokeClientVpnIngressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RevokeClientVpnIngressRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RevokeClientVpnIngressRequest(input, context),
     Action: "RevokeClientVpnIngress",
     Version: "2016-11-15"
   });
@@ -9918,12 +9079,8 @@ export const serializeAws_ec2RevokeSecurityGroupEgressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RevokeSecurityGroupEgressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RevokeSecurityGroupEgressRequest(input, context),
     Action: "RevokeSecurityGroupEgress",
     Version: "2016-11-15"
   });
@@ -9938,12 +9095,8 @@ export const serializeAws_ec2RevokeSecurityGroupIngressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RevokeSecurityGroupIngressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RevokeSecurityGroupIngressRequest(input, context),
     Action: "RevokeSecurityGroupIngress",
     Version: "2016-11-15"
   });
@@ -9958,9 +9111,8 @@ export const serializeAws_ec2RunInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RunInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RunInstancesRequest(input, context),
     Action: "RunInstances",
     Version: "2016-11-15"
   });
@@ -9975,9 +9127,8 @@ export const serializeAws_ec2RunScheduledInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2RunScheduledInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2RunScheduledInstancesRequest(input, context),
     Action: "RunScheduledInstances",
     Version: "2016-11-15"
   });
@@ -9992,12 +9143,8 @@ export const serializeAws_ec2SearchLocalGatewayRoutesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2SearchLocalGatewayRoutesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2SearchLocalGatewayRoutesRequest(input, context),
     Action: "SearchLocalGatewayRoutes",
     Version: "2016-11-15"
   });
@@ -10012,12 +9159,11 @@ export const serializeAws_ec2SearchTransitGatewayMulticastGroupsCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2SearchTransitGatewayMulticastGroupsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2SearchTransitGatewayMulticastGroupsRequest(
+      input,
+      context
+    ),
     Action: "SearchTransitGatewayMulticastGroups",
     Version: "2016-11-15"
   });
@@ -10032,12 +9178,8 @@ export const serializeAws_ec2SearchTransitGatewayRoutesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2SearchTransitGatewayRoutesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2SearchTransitGatewayRoutesRequest(input, context),
     Action: "SearchTransitGatewayRoutes",
     Version: "2016-11-15"
   });
@@ -10052,12 +9194,8 @@ export const serializeAws_ec2SendDiagnosticInterruptCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2SendDiagnosticInterruptRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2SendDiagnosticInterruptRequest(input, context),
     Action: "SendDiagnosticInterrupt",
     Version: "2016-11-15"
   });
@@ -10072,9 +9210,8 @@ export const serializeAws_ec2StartInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2StartInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2StartInstancesRequest(input, context),
     Action: "StartInstances",
     Version: "2016-11-15"
   });
@@ -10089,12 +9226,11 @@ export const serializeAws_ec2StartVpcEndpointServicePrivateDnsVerificationComman
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2StartVpcEndpointServicePrivateDnsVerificationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2StartVpcEndpointServicePrivateDnsVerificationRequest(
+      input,
+      context
+    ),
     Action: "StartVpcEndpointServicePrivateDnsVerification",
     Version: "2016-11-15"
   });
@@ -10109,9 +9245,8 @@ export const serializeAws_ec2StopInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2StopInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2StopInstancesRequest(input, context),
     Action: "StopInstances",
     Version: "2016-11-15"
   });
@@ -10126,12 +9261,8 @@ export const serializeAws_ec2TerminateClientVpnConnectionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2TerminateClientVpnConnectionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2TerminateClientVpnConnectionsRequest(input, context),
     Action: "TerminateClientVpnConnections",
     Version: "2016-11-15"
   });
@@ -10146,9 +9277,8 @@ export const serializeAws_ec2TerminateInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2TerminateInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2TerminateInstancesRequest(input, context),
     Action: "TerminateInstances",
     Version: "2016-11-15"
   });
@@ -10163,9 +9293,8 @@ export const serializeAws_ec2UnassignIpv6AddressesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2UnassignIpv6AddressesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2UnassignIpv6AddressesRequest(input, context),
     Action: "UnassignIpv6Addresses",
     Version: "2016-11-15"
   });
@@ -10180,12 +9309,8 @@ export const serializeAws_ec2UnassignPrivateIpAddressesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2UnassignPrivateIpAddressesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2UnassignPrivateIpAddressesRequest(input, context),
     Action: "UnassignPrivateIpAddresses",
     Version: "2016-11-15"
   });
@@ -10200,9 +9325,8 @@ export const serializeAws_ec2UnmonitorInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2UnmonitorInstancesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2UnmonitorInstancesRequest(input, context),
     Action: "UnmonitorInstances",
     Version: "2016-11-15"
   });
@@ -10217,12 +9341,11 @@ export const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressCommand = 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressRequest(
+      input,
+      context
+    ),
     Action: "UpdateSecurityGroupRuleDescriptionsEgress",
     Version: "2016-11-15"
   });
@@ -10237,12 +9360,11 @@ export const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressRequest(
+      input,
+      context
+    ),
     Action: "UpdateSecurityGroupRuleDescriptionsIngress",
     Version: "2016-11-15"
   });
@@ -10257,9 +9379,8 @@ export const serializeAws_ec2WithdrawByoipCidrCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2WithdrawByoipCidrRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2WithdrawByoipCidrRequest(input, context),
     Action: "WithdrawByoipCidr",
     Version: "2016-11-15"
   });

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -344,12 +344,8 @@ export const serializeAws_queryAbortEnvironmentUpdateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAbortEnvironmentUpdateMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAbortEnvironmentUpdateMessage(input, context),
     Action: "AbortEnvironmentUpdate",
     Version: "2010-12-01"
   });
@@ -364,12 +360,8 @@ export const serializeAws_queryApplyEnvironmentManagedActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryApplyEnvironmentManagedActionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryApplyEnvironmentManagedActionRequest(input, context),
     Action: "ApplyEnvironmentManagedAction",
     Version: "2010-12-01"
   });
@@ -384,9 +376,8 @@ export const serializeAws_queryCheckDNSAvailabilityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCheckDNSAvailabilityMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCheckDNSAvailabilityMessage(input, context),
     Action: "CheckDNSAvailability",
     Version: "2010-12-01"
   });
@@ -401,9 +392,8 @@ export const serializeAws_queryComposeEnvironmentsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryComposeEnvironmentsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryComposeEnvironmentsMessage(input, context),
     Action: "ComposeEnvironments",
     Version: "2010-12-01"
   });
@@ -418,9 +408,8 @@ export const serializeAws_queryCreateApplicationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateApplicationMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateApplicationMessage(input, context),
     Action: "CreateApplication",
     Version: "2010-12-01"
   });
@@ -435,12 +424,8 @@ export const serializeAws_queryCreateApplicationVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateApplicationVersionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateApplicationVersionMessage(input, context),
     Action: "CreateApplicationVersion",
     Version: "2010-12-01"
   });
@@ -455,12 +440,8 @@ export const serializeAws_queryCreateConfigurationTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateConfigurationTemplateMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateConfigurationTemplateMessage(input, context),
     Action: "CreateConfigurationTemplate",
     Version: "2010-12-01"
   });
@@ -475,9 +456,8 @@ export const serializeAws_queryCreateEnvironmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateEnvironmentMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateEnvironmentMessage(input, context),
     Action: "CreateEnvironment",
     Version: "2010-12-01"
   });
@@ -492,12 +472,8 @@ export const serializeAws_queryCreatePlatformVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreatePlatformVersionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreatePlatformVersionRequest(input, context),
     Action: "CreatePlatformVersion",
     Version: "2010-12-01"
   });
@@ -526,9 +502,8 @@ export const serializeAws_queryDeleteApplicationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteApplicationMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteApplicationMessage(input, context),
     Action: "DeleteApplication",
     Version: "2010-12-01"
   });
@@ -543,12 +518,8 @@ export const serializeAws_queryDeleteApplicationVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteApplicationVersionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteApplicationVersionMessage(input, context),
     Action: "DeleteApplicationVersion",
     Version: "2010-12-01"
   });
@@ -563,12 +534,8 @@ export const serializeAws_queryDeleteConfigurationTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteConfigurationTemplateMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteConfigurationTemplateMessage(input, context),
     Action: "DeleteConfigurationTemplate",
     Version: "2010-12-01"
   });
@@ -583,12 +550,8 @@ export const serializeAws_queryDeleteEnvironmentConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteEnvironmentConfigurationMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteEnvironmentConfigurationMessage(input, context),
     Action: "DeleteEnvironmentConfiguration",
     Version: "2010-12-01"
   });
@@ -603,12 +566,8 @@ export const serializeAws_queryDeletePlatformVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeletePlatformVersionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeletePlatformVersionRequest(input, context),
     Action: "DeletePlatformVersion",
     Version: "2010-12-01"
   });
@@ -637,12 +596,8 @@ export const serializeAws_queryDescribeApplicationVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeApplicationVersionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeApplicationVersionsMessage(input, context),
     Action: "DescribeApplicationVersions",
     Version: "2010-12-01"
   });
@@ -657,9 +612,8 @@ export const serializeAws_queryDescribeApplicationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeApplicationsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeApplicationsMessage(input, context),
     Action: "DescribeApplications",
     Version: "2010-12-01"
   });
@@ -674,12 +628,8 @@ export const serializeAws_queryDescribeConfigurationOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeConfigurationOptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeConfigurationOptionsMessage(input, context),
     Action: "DescribeConfigurationOptions",
     Version: "2010-12-01"
   });
@@ -694,12 +644,8 @@ export const serializeAws_queryDescribeConfigurationSettingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeConfigurationSettingsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeConfigurationSettingsMessage(input, context),
     Action: "DescribeConfigurationSettings",
     Version: "2010-12-01"
   });
@@ -714,12 +660,8 @@ export const serializeAws_queryDescribeEnvironmentHealthCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEnvironmentHealthRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEnvironmentHealthRequest(input, context),
     Action: "DescribeEnvironmentHealth",
     Version: "2010-12-01"
   });
@@ -734,12 +676,11 @@ export const serializeAws_queryDescribeEnvironmentManagedActionHistoryCommand = 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEnvironmentManagedActionHistoryRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEnvironmentManagedActionHistoryRequest(
+      input,
+      context
+    ),
     Action: "DescribeEnvironmentManagedActionHistory",
     Version: "2010-12-01"
   });
@@ -754,12 +695,11 @@ export const serializeAws_queryDescribeEnvironmentManagedActionsCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEnvironmentManagedActionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEnvironmentManagedActionsRequest(
+      input,
+      context
+    ),
     Action: "DescribeEnvironmentManagedActions",
     Version: "2010-12-01"
   });
@@ -774,12 +714,8 @@ export const serializeAws_queryDescribeEnvironmentResourcesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEnvironmentResourcesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEnvironmentResourcesMessage(input, context),
     Action: "DescribeEnvironmentResources",
     Version: "2010-12-01"
   });
@@ -794,9 +730,8 @@ export const serializeAws_queryDescribeEnvironmentsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEnvironmentsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEnvironmentsMessage(input, context),
     Action: "DescribeEnvironments",
     Version: "2010-12-01"
   });
@@ -811,9 +746,8 @@ export const serializeAws_queryDescribeEventsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventsMessage(input, context),
     Action: "DescribeEvents",
     Version: "2010-12-01"
   });
@@ -828,12 +762,8 @@ export const serializeAws_queryDescribeInstancesHealthCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeInstancesHealthRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeInstancesHealthRequest(input, context),
     Action: "DescribeInstancesHealth",
     Version: "2010-12-01"
   });
@@ -848,12 +778,8 @@ export const serializeAws_queryDescribePlatformVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribePlatformVersionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribePlatformVersionRequest(input, context),
     Action: "DescribePlatformVersion",
     Version: "2010-12-01"
   });
@@ -882,9 +808,8 @@ export const serializeAws_queryListPlatformVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListPlatformVersionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListPlatformVersionsRequest(input, context),
     Action: "ListPlatformVersions",
     Version: "2010-12-01"
   });
@@ -899,9 +824,8 @@ export const serializeAws_queryListTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTagsForResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTagsForResourceMessage(input, context),
     Action: "ListTagsForResource",
     Version: "2010-12-01"
   });
@@ -916,9 +840,8 @@ export const serializeAws_queryRebuildEnvironmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRebuildEnvironmentMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRebuildEnvironmentMessage(input, context),
     Action: "RebuildEnvironment",
     Version: "2010-12-01"
   });
@@ -933,12 +856,8 @@ export const serializeAws_queryRequestEnvironmentInfoCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRequestEnvironmentInfoMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRequestEnvironmentInfoMessage(input, context),
     Action: "RequestEnvironmentInfo",
     Version: "2010-12-01"
   });
@@ -953,9 +872,8 @@ export const serializeAws_queryRestartAppServerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestartAppServerMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestartAppServerMessage(input, context),
     Action: "RestartAppServer",
     Version: "2010-12-01"
   });
@@ -970,12 +888,8 @@ export const serializeAws_queryRetrieveEnvironmentInfoCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRetrieveEnvironmentInfoMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRetrieveEnvironmentInfoMessage(input, context),
     Action: "RetrieveEnvironmentInfo",
     Version: "2010-12-01"
   });
@@ -990,12 +904,8 @@ export const serializeAws_querySwapEnvironmentCNAMEsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySwapEnvironmentCNAMEsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySwapEnvironmentCNAMEsMessage(input, context),
     Action: "SwapEnvironmentCNAMEs",
     Version: "2010-12-01"
   });
@@ -1010,9 +920,8 @@ export const serializeAws_queryTerminateEnvironmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTerminateEnvironmentMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTerminateEnvironmentMessage(input, context),
     Action: "TerminateEnvironment",
     Version: "2010-12-01"
   });
@@ -1027,9 +936,8 @@ export const serializeAws_queryUpdateApplicationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateApplicationMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateApplicationMessage(input, context),
     Action: "UpdateApplication",
     Version: "2010-12-01"
   });
@@ -1044,12 +952,11 @@ export const serializeAws_queryUpdateApplicationResourceLifecycleCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateApplicationResourceLifecycleMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateApplicationResourceLifecycleMessage(
+      input,
+      context
+    ),
     Action: "UpdateApplicationResourceLifecycle",
     Version: "2010-12-01"
   });
@@ -1064,12 +971,8 @@ export const serializeAws_queryUpdateApplicationVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateApplicationVersionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateApplicationVersionMessage(input, context),
     Action: "UpdateApplicationVersion",
     Version: "2010-12-01"
   });
@@ -1084,12 +987,8 @@ export const serializeAws_queryUpdateConfigurationTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateConfigurationTemplateMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateConfigurationTemplateMessage(input, context),
     Action: "UpdateConfigurationTemplate",
     Version: "2010-12-01"
   });
@@ -1104,9 +1003,8 @@ export const serializeAws_queryUpdateEnvironmentCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateEnvironmentMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateEnvironmentMessage(input, context),
     Action: "UpdateEnvironment",
     Version: "2010-12-01"
   });
@@ -1121,12 +1019,8 @@ export const serializeAws_queryUpdateTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateTagsForResourceMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateTagsForResourceMessage(input, context),
     Action: "UpdateTagsForResource",
     Version: "2010-12-01"
   });
@@ -1141,12 +1035,8 @@ export const serializeAws_queryValidateConfigurationSettingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryValidateConfigurationSettingsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryValidateConfigurationSettingsMessage(input, context),
     Action: "ValidateConfigurationSettings",
     Version: "2010-12-01"
   });

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -304,12 +304,8 @@ export const serializeAws_queryAddListenerCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddListenerCertificatesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddListenerCertificatesInput(input, context),
     Action: "AddListenerCertificates",
     Version: "2015-12-01"
   });
@@ -324,9 +320,8 @@ export const serializeAws_queryAddTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddTagsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddTagsInput(input, context),
     Action: "AddTags",
     Version: "2015-12-01"
   });
@@ -341,9 +336,8 @@ export const serializeAws_queryCreateListenerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateListenerInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateListenerInput(input, context),
     Action: "CreateListener",
     Version: "2015-12-01"
   });
@@ -358,9 +352,8 @@ export const serializeAws_queryCreateLoadBalancerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateLoadBalancerInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateLoadBalancerInput(input, context),
     Action: "CreateLoadBalancer",
     Version: "2015-12-01"
   });
@@ -375,9 +368,8 @@ export const serializeAws_queryCreateRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateRuleInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateRuleInput(input, context),
     Action: "CreateRule",
     Version: "2015-12-01"
   });
@@ -392,9 +384,8 @@ export const serializeAws_queryCreateTargetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateTargetGroupInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateTargetGroupInput(input, context),
     Action: "CreateTargetGroup",
     Version: "2015-12-01"
   });
@@ -409,9 +400,8 @@ export const serializeAws_queryDeleteListenerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteListenerInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteListenerInput(input, context),
     Action: "DeleteListener",
     Version: "2015-12-01"
   });
@@ -426,9 +416,8 @@ export const serializeAws_queryDeleteLoadBalancerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteLoadBalancerInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteLoadBalancerInput(input, context),
     Action: "DeleteLoadBalancer",
     Version: "2015-12-01"
   });
@@ -443,9 +432,8 @@ export const serializeAws_queryDeleteRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteRuleInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteRuleInput(input, context),
     Action: "DeleteRule",
     Version: "2015-12-01"
   });
@@ -460,9 +448,8 @@ export const serializeAws_queryDeleteTargetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteTargetGroupInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteTargetGroupInput(input, context),
     Action: "DeleteTargetGroup",
     Version: "2015-12-01"
   });
@@ -477,9 +464,8 @@ export const serializeAws_queryDeregisterTargetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeregisterTargetsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeregisterTargetsInput(input, context),
     Action: "DeregisterTargets",
     Version: "2015-12-01"
   });
@@ -494,9 +480,8 @@ export const serializeAws_queryDescribeAccountLimitsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAccountLimitsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAccountLimitsInput(input, context),
     Action: "DescribeAccountLimits",
     Version: "2015-12-01"
   });
@@ -511,12 +496,8 @@ export const serializeAws_queryDescribeListenerCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeListenerCertificatesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeListenerCertificatesInput(input, context),
     Action: "DescribeListenerCertificates",
     Version: "2015-12-01"
   });
@@ -531,9 +512,8 @@ export const serializeAws_queryDescribeListenersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeListenersInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeListenersInput(input, context),
     Action: "DescribeListeners",
     Version: "2015-12-01"
   });
@@ -548,12 +528,8 @@ export const serializeAws_queryDescribeLoadBalancerAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoadBalancerAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoadBalancerAttributesInput(input, context),
     Action: "DescribeLoadBalancerAttributes",
     Version: "2015-12-01"
   });
@@ -568,9 +544,8 @@ export const serializeAws_queryDescribeLoadBalancersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoadBalancersInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoadBalancersInput(input, context),
     Action: "DescribeLoadBalancers",
     Version: "2015-12-01"
   });
@@ -585,9 +560,8 @@ export const serializeAws_queryDescribeRulesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeRulesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeRulesInput(input, context),
     Action: "DescribeRules",
     Version: "2015-12-01"
   });
@@ -602,9 +576,8 @@ export const serializeAws_queryDescribeSSLPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeSSLPoliciesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeSSLPoliciesInput(input, context),
     Action: "DescribeSSLPolicies",
     Version: "2015-12-01"
   });
@@ -619,9 +592,8 @@ export const serializeAws_queryDescribeTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTagsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTagsInput(input, context),
     Action: "DescribeTags",
     Version: "2015-12-01"
   });
@@ -636,12 +608,8 @@ export const serializeAws_queryDescribeTargetGroupAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTargetGroupAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTargetGroupAttributesInput(input, context),
     Action: "DescribeTargetGroupAttributes",
     Version: "2015-12-01"
   });
@@ -656,9 +624,8 @@ export const serializeAws_queryDescribeTargetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTargetGroupsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTargetGroupsInput(input, context),
     Action: "DescribeTargetGroups",
     Version: "2015-12-01"
   });
@@ -673,9 +640,8 @@ export const serializeAws_queryDescribeTargetHealthCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTargetHealthInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTargetHealthInput(input, context),
     Action: "DescribeTargetHealth",
     Version: "2015-12-01"
   });
@@ -690,9 +656,8 @@ export const serializeAws_queryModifyListenerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyListenerInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyListenerInput(input, context),
     Action: "ModifyListener",
     Version: "2015-12-01"
   });
@@ -707,12 +672,8 @@ export const serializeAws_queryModifyLoadBalancerAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyLoadBalancerAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyLoadBalancerAttributesInput(input, context),
     Action: "ModifyLoadBalancerAttributes",
     Version: "2015-12-01"
   });
@@ -727,9 +688,8 @@ export const serializeAws_queryModifyRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyRuleInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyRuleInput(input, context),
     Action: "ModifyRule",
     Version: "2015-12-01"
   });
@@ -744,9 +704,8 @@ export const serializeAws_queryModifyTargetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyTargetGroupInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyTargetGroupInput(input, context),
     Action: "ModifyTargetGroup",
     Version: "2015-12-01"
   });
@@ -761,12 +720,8 @@ export const serializeAws_queryModifyTargetGroupAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyTargetGroupAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyTargetGroupAttributesInput(input, context),
     Action: "ModifyTargetGroupAttributes",
     Version: "2015-12-01"
   });
@@ -781,9 +736,8 @@ export const serializeAws_queryRegisterTargetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRegisterTargetsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRegisterTargetsInput(input, context),
     Action: "RegisterTargets",
     Version: "2015-12-01"
   });
@@ -798,12 +752,8 @@ export const serializeAws_queryRemoveListenerCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveListenerCertificatesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveListenerCertificatesInput(input, context),
     Action: "RemoveListenerCertificates",
     Version: "2015-12-01"
   });
@@ -818,9 +768,8 @@ export const serializeAws_queryRemoveTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveTagsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveTagsInput(input, context),
     Action: "RemoveTags",
     Version: "2015-12-01"
   });
@@ -835,9 +784,8 @@ export const serializeAws_querySetIpAddressTypeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetIpAddressTypeInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetIpAddressTypeInput(input, context),
     Action: "SetIpAddressType",
     Version: "2015-12-01"
   });
@@ -852,9 +800,8 @@ export const serializeAws_querySetRulePrioritiesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetRulePrioritiesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetRulePrioritiesInput(input, context),
     Action: "SetRulePriorities",
     Version: "2015-12-01"
   });
@@ -869,9 +816,8 @@ export const serializeAws_querySetSecurityGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetSecurityGroupsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetSecurityGroupsInput(input, context),
     Action: "SetSecurityGroups",
     Version: "2015-12-01"
   });
@@ -886,9 +832,8 @@ export const serializeAws_querySetSubnetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetSubnetsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetSubnetsInput(input, context),
     Action: "SetSubnets",
     Version: "2015-12-01"
   });

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -249,9 +249,8 @@ export const serializeAws_queryAddTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddTagsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddTagsInput(input, context),
     Action: "AddTags",
     Version: "2012-06-01"
   });
@@ -266,12 +265,8 @@ export const serializeAws_queryApplySecurityGroupsToLoadBalancerCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryApplySecurityGroupsToLoadBalancerInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryApplySecurityGroupsToLoadBalancerInput(input, context),
     Action: "ApplySecurityGroupsToLoadBalancer",
     Version: "2012-06-01"
   });
@@ -286,12 +281,8 @@ export const serializeAws_queryAttachLoadBalancerToSubnetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAttachLoadBalancerToSubnetsInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAttachLoadBalancerToSubnetsInput(input, context),
     Action: "AttachLoadBalancerToSubnets",
     Version: "2012-06-01"
   });
@@ -306,9 +297,8 @@ export const serializeAws_queryConfigureHealthCheckCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryConfigureHealthCheckInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryConfigureHealthCheckInput(input, context),
     Action: "ConfigureHealthCheck",
     Version: "2012-06-01"
   });
@@ -323,12 +313,8 @@ export const serializeAws_queryCreateAppCookieStickinessPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateAppCookieStickinessPolicyInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateAppCookieStickinessPolicyInput(input, context),
     Action: "CreateAppCookieStickinessPolicy",
     Version: "2012-06-01"
   });
@@ -343,12 +329,8 @@ export const serializeAws_queryCreateLBCookieStickinessPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateLBCookieStickinessPolicyInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateLBCookieStickinessPolicyInput(input, context),
     Action: "CreateLBCookieStickinessPolicy",
     Version: "2012-06-01"
   });
@@ -363,9 +345,8 @@ export const serializeAws_queryCreateLoadBalancerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateAccessPointInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateAccessPointInput(input, context),
     Action: "CreateLoadBalancer",
     Version: "2012-06-01"
   });
@@ -380,12 +361,8 @@ export const serializeAws_queryCreateLoadBalancerListenersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateLoadBalancerListenerInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateLoadBalancerListenerInput(input, context),
     Action: "CreateLoadBalancerListeners",
     Version: "2012-06-01"
   });
@@ -400,12 +377,8 @@ export const serializeAws_queryCreateLoadBalancerPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateLoadBalancerPolicyInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateLoadBalancerPolicyInput(input, context),
     Action: "CreateLoadBalancerPolicy",
     Version: "2012-06-01"
   });
@@ -420,9 +393,8 @@ export const serializeAws_queryDeleteLoadBalancerCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteAccessPointInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteAccessPointInput(input, context),
     Action: "DeleteLoadBalancer",
     Version: "2012-06-01"
   });
@@ -437,12 +409,8 @@ export const serializeAws_queryDeleteLoadBalancerListenersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteLoadBalancerListenerInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteLoadBalancerListenerInput(input, context),
     Action: "DeleteLoadBalancerListeners",
     Version: "2012-06-01"
   });
@@ -457,12 +425,8 @@ export const serializeAws_queryDeleteLoadBalancerPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteLoadBalancerPolicyInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteLoadBalancerPolicyInput(input, context),
     Action: "DeleteLoadBalancerPolicy",
     Version: "2012-06-01"
   });
@@ -477,9 +441,8 @@ export const serializeAws_queryDeregisterInstancesFromLoadBalancerCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeregisterEndPointsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeregisterEndPointsInput(input, context),
     Action: "DeregisterInstancesFromLoadBalancer",
     Version: "2012-06-01"
   });
@@ -494,9 +457,8 @@ export const serializeAws_queryDescribeAccountLimitsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAccountLimitsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAccountLimitsInput(input, context),
     Action: "DescribeAccountLimits",
     Version: "2012-06-01"
   });
@@ -511,9 +473,8 @@ export const serializeAws_queryDescribeInstanceHealthCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEndPointStateInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEndPointStateInput(input, context),
     Action: "DescribeInstanceHealth",
     Version: "2012-06-01"
   });
@@ -528,12 +489,8 @@ export const serializeAws_queryDescribeLoadBalancerAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoadBalancerAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoadBalancerAttributesInput(input, context),
     Action: "DescribeLoadBalancerAttributes",
     Version: "2012-06-01"
   });
@@ -548,12 +505,8 @@ export const serializeAws_queryDescribeLoadBalancerPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoadBalancerPoliciesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoadBalancerPoliciesInput(input, context),
     Action: "DescribeLoadBalancerPolicies",
     Version: "2012-06-01"
   });
@@ -568,12 +521,8 @@ export const serializeAws_queryDescribeLoadBalancerPolicyTypesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoadBalancerPolicyTypesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoadBalancerPolicyTypesInput(input, context),
     Action: "DescribeLoadBalancerPolicyTypes",
     Version: "2012-06-01"
   });
@@ -588,9 +537,8 @@ export const serializeAws_queryDescribeLoadBalancersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAccessPointsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAccessPointsInput(input, context),
     Action: "DescribeLoadBalancers",
     Version: "2012-06-01"
   });
@@ -605,9 +553,8 @@ export const serializeAws_queryDescribeTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTagsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTagsInput(input, context),
     Action: "DescribeTags",
     Version: "2012-06-01"
   });
@@ -622,12 +569,8 @@ export const serializeAws_queryDetachLoadBalancerFromSubnetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetachLoadBalancerFromSubnetsInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetachLoadBalancerFromSubnetsInput(input, context),
     Action: "DetachLoadBalancerFromSubnets",
     Version: "2012-06-01"
   });
@@ -642,12 +585,8 @@ export const serializeAws_queryDisableAvailabilityZonesForLoadBalancerCommand = 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveAvailabilityZonesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveAvailabilityZonesInput(input, context),
     Action: "DisableAvailabilityZonesForLoadBalancer",
     Version: "2012-06-01"
   });
@@ -662,9 +601,8 @@ export const serializeAws_queryEnableAvailabilityZonesForLoadBalancerCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddAvailabilityZonesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddAvailabilityZonesInput(input, context),
     Action: "EnableAvailabilityZonesForLoadBalancer",
     Version: "2012-06-01"
   });
@@ -679,12 +617,8 @@ export const serializeAws_queryModifyLoadBalancerAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyLoadBalancerAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyLoadBalancerAttributesInput(input, context),
     Action: "ModifyLoadBalancerAttributes",
     Version: "2012-06-01"
   });
@@ -699,9 +633,8 @@ export const serializeAws_queryRegisterInstancesWithLoadBalancerCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRegisterEndPointsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRegisterEndPointsInput(input, context),
     Action: "RegisterInstancesWithLoadBalancer",
     Version: "2012-06-01"
   });
@@ -716,9 +649,8 @@ export const serializeAws_queryRemoveTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveTagsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveTagsInput(input, context),
     Action: "RemoveTags",
     Version: "2012-06-01"
   });
@@ -733,12 +665,11 @@ export const serializeAws_querySetLoadBalancerListenerSSLCertificateCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetLoadBalancerListenerSSLCertificateInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetLoadBalancerListenerSSLCertificateInput(
+      input,
+      context
+    ),
     Action: "SetLoadBalancerListenerSSLCertificate",
     Version: "2012-06-01"
   });
@@ -753,12 +684,11 @@ export const serializeAws_querySetLoadBalancerPoliciesForBackendServerCommand = 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetLoadBalancerPoliciesForBackendServerInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetLoadBalancerPoliciesForBackendServerInput(
+      input,
+      context
+    ),
     Action: "SetLoadBalancerPoliciesForBackendServer",
     Version: "2012-06-01"
   });
@@ -773,12 +703,8 @@ export const serializeAws_querySetLoadBalancerPoliciesOfListenerCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetLoadBalancerPoliciesOfListenerInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetLoadBalancerPoliciesOfListenerInput(input, context),
     Action: "SetLoadBalancerPoliciesOfListener",
     Version: "2012-06-01"
   });

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -407,9 +407,8 @@ export const serializeAws_queryAddTagsToResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddTagsToResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddTagsToResourceMessage(input, context),
     Action: "AddTagsToResource",
     Version: "2015-02-02"
   });
@@ -424,12 +423,11 @@ export const serializeAws_queryAuthorizeCacheSecurityGroupIngressCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAuthorizeCacheSecurityGroupIngressMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAuthorizeCacheSecurityGroupIngressMessage(
+      input,
+      context
+    ),
     Action: "AuthorizeCacheSecurityGroupIngress",
     Version: "2015-02-02"
   });
@@ -444,12 +442,8 @@ export const serializeAws_queryBatchApplyUpdateActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBatchApplyUpdateActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBatchApplyUpdateActionMessage(input, context),
     Action: "BatchApplyUpdateAction",
     Version: "2015-02-02"
   });
@@ -464,12 +458,8 @@ export const serializeAws_queryBatchStopUpdateActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBatchStopUpdateActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBatchStopUpdateActionMessage(input, context),
     Action: "BatchStopUpdateAction",
     Version: "2015-02-02"
   });
@@ -484,9 +474,8 @@ export const serializeAws_queryCompleteMigrationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCompleteMigrationMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCompleteMigrationMessage(input, context),
     Action: "CompleteMigration",
     Version: "2015-02-02"
   });
@@ -501,9 +490,8 @@ export const serializeAws_queryCopySnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopySnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopySnapshotMessage(input, context),
     Action: "CopySnapshot",
     Version: "2015-02-02"
   });
@@ -518,9 +506,8 @@ export const serializeAws_queryCreateCacheClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateCacheClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateCacheClusterMessage(input, context),
     Action: "CreateCacheCluster",
     Version: "2015-02-02"
   });
@@ -535,12 +522,8 @@ export const serializeAws_queryCreateCacheParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateCacheParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateCacheParameterGroupMessage(input, context),
     Action: "CreateCacheParameterGroup",
     Version: "2015-02-02"
   });
@@ -555,12 +538,8 @@ export const serializeAws_queryCreateCacheSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateCacheSecurityGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateCacheSecurityGroupMessage(input, context),
     Action: "CreateCacheSecurityGroup",
     Version: "2015-02-02"
   });
@@ -575,12 +554,8 @@ export const serializeAws_queryCreateCacheSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateCacheSubnetGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateCacheSubnetGroupMessage(input, context),
     Action: "CreateCacheSubnetGroup",
     Version: "2015-02-02"
   });
@@ -595,12 +570,8 @@ export const serializeAws_queryCreateReplicationGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateReplicationGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateReplicationGroupMessage(input, context),
     Action: "CreateReplicationGroup",
     Version: "2015-02-02"
   });
@@ -615,9 +586,8 @@ export const serializeAws_queryCreateSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateSnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateSnapshotMessage(input, context),
     Action: "CreateSnapshot",
     Version: "2015-02-02"
   });
@@ -632,9 +602,8 @@ export const serializeAws_queryDecreaseReplicaCountCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDecreaseReplicaCountMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDecreaseReplicaCountMessage(input, context),
     Action: "DecreaseReplicaCount",
     Version: "2015-02-02"
   });
@@ -649,9 +618,8 @@ export const serializeAws_queryDeleteCacheClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteCacheClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteCacheClusterMessage(input, context),
     Action: "DeleteCacheCluster",
     Version: "2015-02-02"
   });
@@ -666,12 +634,8 @@ export const serializeAws_queryDeleteCacheParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteCacheParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteCacheParameterGroupMessage(input, context),
     Action: "DeleteCacheParameterGroup",
     Version: "2015-02-02"
   });
@@ -686,12 +650,8 @@ export const serializeAws_queryDeleteCacheSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteCacheSecurityGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteCacheSecurityGroupMessage(input, context),
     Action: "DeleteCacheSecurityGroup",
     Version: "2015-02-02"
   });
@@ -706,12 +666,8 @@ export const serializeAws_queryDeleteCacheSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteCacheSubnetGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteCacheSubnetGroupMessage(input, context),
     Action: "DeleteCacheSubnetGroup",
     Version: "2015-02-02"
   });
@@ -726,12 +682,8 @@ export const serializeAws_queryDeleteReplicationGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteReplicationGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteReplicationGroupMessage(input, context),
     Action: "DeleteReplicationGroup",
     Version: "2015-02-02"
   });
@@ -746,9 +698,8 @@ export const serializeAws_queryDeleteSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteSnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteSnapshotMessage(input, context),
     Action: "DeleteSnapshot",
     Version: "2015-02-02"
   });
@@ -763,12 +714,8 @@ export const serializeAws_queryDescribeCacheClustersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCacheClustersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCacheClustersMessage(input, context),
     Action: "DescribeCacheClusters",
     Version: "2015-02-02"
   });
@@ -783,12 +730,8 @@ export const serializeAws_queryDescribeCacheEngineVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCacheEngineVersionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCacheEngineVersionsMessage(input, context),
     Action: "DescribeCacheEngineVersions",
     Version: "2015-02-02"
   });
@@ -803,12 +746,8 @@ export const serializeAws_queryDescribeCacheParameterGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCacheParameterGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCacheParameterGroupsMessage(input, context),
     Action: "DescribeCacheParameterGroups",
     Version: "2015-02-02"
   });
@@ -823,12 +762,8 @@ export const serializeAws_queryDescribeCacheParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCacheParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCacheParametersMessage(input, context),
     Action: "DescribeCacheParameters",
     Version: "2015-02-02"
   });
@@ -843,12 +778,8 @@ export const serializeAws_queryDescribeCacheSecurityGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCacheSecurityGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCacheSecurityGroupsMessage(input, context),
     Action: "DescribeCacheSecurityGroups",
     Version: "2015-02-02"
   });
@@ -863,12 +794,8 @@ export const serializeAws_queryDescribeCacheSubnetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCacheSubnetGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCacheSubnetGroupsMessage(input, context),
     Action: "DescribeCacheSubnetGroups",
     Version: "2015-02-02"
   });
@@ -883,12 +810,8 @@ export const serializeAws_queryDescribeEngineDefaultParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEngineDefaultParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEngineDefaultParametersMessage(input, context),
     Action: "DescribeEngineDefaultParameters",
     Version: "2015-02-02"
   });
@@ -903,9 +826,8 @@ export const serializeAws_queryDescribeEventsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventsMessage(input, context),
     Action: "DescribeEvents",
     Version: "2015-02-02"
   });
@@ -920,12 +842,8 @@ export const serializeAws_queryDescribeReplicationGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReplicationGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReplicationGroupsMessage(input, context),
     Action: "DescribeReplicationGroups",
     Version: "2015-02-02"
   });
@@ -940,12 +858,8 @@ export const serializeAws_queryDescribeReservedCacheNodesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReservedCacheNodesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReservedCacheNodesMessage(input, context),
     Action: "DescribeReservedCacheNodes",
     Version: "2015-02-02"
   });
@@ -960,12 +874,11 @@ export const serializeAws_queryDescribeReservedCacheNodesOfferingsCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReservedCacheNodesOfferingsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReservedCacheNodesOfferingsMessage(
+      input,
+      context
+    ),
     Action: "DescribeReservedCacheNodesOfferings",
     Version: "2015-02-02"
   });
@@ -980,12 +893,8 @@ export const serializeAws_queryDescribeServiceUpdatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeServiceUpdatesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeServiceUpdatesMessage(input, context),
     Action: "DescribeServiceUpdates",
     Version: "2015-02-02"
   });
@@ -1000,9 +909,8 @@ export const serializeAws_queryDescribeSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeSnapshotsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeSnapshotsMessage(input, context),
     Action: "DescribeSnapshots",
     Version: "2015-02-02"
   });
@@ -1017,12 +925,8 @@ export const serializeAws_queryDescribeUpdateActionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeUpdateActionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeUpdateActionsMessage(input, context),
     Action: "DescribeUpdateActions",
     Version: "2015-02-02"
   });
@@ -1037,9 +941,8 @@ export const serializeAws_queryIncreaseReplicaCountCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryIncreaseReplicaCountMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryIncreaseReplicaCountMessage(input, context),
     Action: "IncreaseReplicaCount",
     Version: "2015-02-02"
   });
@@ -1054,12 +957,11 @@ export const serializeAws_queryListAllowedNodeTypeModificationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListAllowedNodeTypeModificationsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListAllowedNodeTypeModificationsMessage(
+      input,
+      context
+    ),
     Action: "ListAllowedNodeTypeModifications",
     Version: "2015-02-02"
   });
@@ -1074,9 +976,8 @@ export const serializeAws_queryListTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTagsForResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTagsForResourceMessage(input, context),
     Action: "ListTagsForResource",
     Version: "2015-02-02"
   });
@@ -1091,9 +992,8 @@ export const serializeAws_queryModifyCacheClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyCacheClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyCacheClusterMessage(input, context),
     Action: "ModifyCacheCluster",
     Version: "2015-02-02"
   });
@@ -1108,12 +1008,8 @@ export const serializeAws_queryModifyCacheParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyCacheParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyCacheParameterGroupMessage(input, context),
     Action: "ModifyCacheParameterGroup",
     Version: "2015-02-02"
   });
@@ -1128,12 +1024,8 @@ export const serializeAws_queryModifyCacheSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyCacheSubnetGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyCacheSubnetGroupMessage(input, context),
     Action: "ModifyCacheSubnetGroup",
     Version: "2015-02-02"
   });
@@ -1148,12 +1040,8 @@ export const serializeAws_queryModifyReplicationGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyReplicationGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyReplicationGroupMessage(input, context),
     Action: "ModifyReplicationGroup",
     Version: "2015-02-02"
   });
@@ -1168,12 +1056,11 @@ export const serializeAws_queryModifyReplicationGroupShardConfigurationCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyReplicationGroupShardConfigurationMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyReplicationGroupShardConfigurationMessage(
+      input,
+      context
+    ),
     Action: "ModifyReplicationGroupShardConfiguration",
     Version: "2015-02-02"
   });
@@ -1188,12 +1075,11 @@ export const serializeAws_queryPurchaseReservedCacheNodesOfferingCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPurchaseReservedCacheNodesOfferingMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPurchaseReservedCacheNodesOfferingMessage(
+      input,
+      context
+    ),
     Action: "PurchaseReservedCacheNodesOffering",
     Version: "2015-02-02"
   });
@@ -1208,9 +1094,8 @@ export const serializeAws_queryRebootCacheClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRebootCacheClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRebootCacheClusterMessage(input, context),
     Action: "RebootCacheCluster",
     Version: "2015-02-02"
   });
@@ -1225,12 +1110,8 @@ export const serializeAws_queryRemoveTagsFromResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveTagsFromResourceMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveTagsFromResourceMessage(input, context),
     Action: "RemoveTagsFromResource",
     Version: "2015-02-02"
   });
@@ -1245,12 +1126,8 @@ export const serializeAws_queryResetCacheParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetCacheParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetCacheParameterGroupMessage(input, context),
     Action: "ResetCacheParameterGroup",
     Version: "2015-02-02"
   });
@@ -1265,12 +1142,8 @@ export const serializeAws_queryRevokeCacheSecurityGroupIngressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRevokeCacheSecurityGroupIngressMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRevokeCacheSecurityGroupIngressMessage(input, context),
     Action: "RevokeCacheSecurityGroupIngress",
     Version: "2015-02-02"
   });
@@ -1285,9 +1158,8 @@ export const serializeAws_queryStartMigrationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStartMigrationMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStartMigrationMessage(input, context),
     Action: "StartMigration",
     Version: "2015-02-02"
   });
@@ -1302,9 +1174,8 @@ export const serializeAws_queryTestFailoverCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTestFailoverMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTestFailoverMessage(input, context),
     Action: "TestFailover",
     Version: "2015-02-02"
   });

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -877,12 +877,11 @@ export const serializeAws_queryAddClientIDToOpenIDConnectProviderCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddClientIDToOpenIDConnectProviderRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddClientIDToOpenIDConnectProviderRequest(
+      input,
+      context
+    ),
     Action: "AddClientIDToOpenIDConnectProvider",
     Version: "2010-05-08"
   });
@@ -897,12 +896,8 @@ export const serializeAws_queryAddRoleToInstanceProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddRoleToInstanceProfileRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddRoleToInstanceProfileRequest(input, context),
     Action: "AddRoleToInstanceProfile",
     Version: "2010-05-08"
   });
@@ -917,9 +912,8 @@ export const serializeAws_queryAddUserToGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddUserToGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddUserToGroupRequest(input, context),
     Action: "AddUserToGroup",
     Version: "2010-05-08"
   });
@@ -934,9 +928,8 @@ export const serializeAws_queryAttachGroupPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAttachGroupPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAttachGroupPolicyRequest(input, context),
     Action: "AttachGroupPolicy",
     Version: "2010-05-08"
   });
@@ -951,9 +944,8 @@ export const serializeAws_queryAttachRolePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAttachRolePolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAttachRolePolicyRequest(input, context),
     Action: "AttachRolePolicy",
     Version: "2010-05-08"
   });
@@ -968,9 +960,8 @@ export const serializeAws_queryAttachUserPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAttachUserPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAttachUserPolicyRequest(input, context),
     Action: "AttachUserPolicy",
     Version: "2010-05-08"
   });
@@ -985,9 +976,8 @@ export const serializeAws_queryChangePasswordCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryChangePasswordRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryChangePasswordRequest(input, context),
     Action: "ChangePassword",
     Version: "2010-05-08"
   });
@@ -1002,9 +992,8 @@ export const serializeAws_queryCreateAccessKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateAccessKeyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateAccessKeyRequest(input, context),
     Action: "CreateAccessKey",
     Version: "2010-05-08"
   });
@@ -1019,9 +1008,8 @@ export const serializeAws_queryCreateAccountAliasCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateAccountAliasRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateAccountAliasRequest(input, context),
     Action: "CreateAccountAlias",
     Version: "2010-05-08"
   });
@@ -1036,9 +1024,8 @@ export const serializeAws_queryCreateGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateGroupRequest(input, context),
     Action: "CreateGroup",
     Version: "2010-05-08"
   });
@@ -1053,12 +1040,8 @@ export const serializeAws_queryCreateInstanceProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateInstanceProfileRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateInstanceProfileRequest(input, context),
     Action: "CreateInstanceProfile",
     Version: "2010-05-08"
   });
@@ -1073,9 +1056,8 @@ export const serializeAws_queryCreateLoginProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateLoginProfileRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateLoginProfileRequest(input, context),
     Action: "CreateLoginProfile",
     Version: "2010-05-08"
   });
@@ -1090,12 +1072,8 @@ export const serializeAws_queryCreateOpenIDConnectProviderCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateOpenIDConnectProviderRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateOpenIDConnectProviderRequest(input, context),
     Action: "CreateOpenIDConnectProvider",
     Version: "2010-05-08"
   });
@@ -1110,9 +1088,8 @@ export const serializeAws_queryCreatePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreatePolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreatePolicyRequest(input, context),
     Action: "CreatePolicy",
     Version: "2010-05-08"
   });
@@ -1127,9 +1104,8 @@ export const serializeAws_queryCreatePolicyVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreatePolicyVersionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreatePolicyVersionRequest(input, context),
     Action: "CreatePolicyVersion",
     Version: "2010-05-08"
   });
@@ -1144,9 +1120,8 @@ export const serializeAws_queryCreateRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateRoleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateRoleRequest(input, context),
     Action: "CreateRole",
     Version: "2010-05-08"
   });
@@ -1161,9 +1136,8 @@ export const serializeAws_queryCreateSAMLProviderCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateSAMLProviderRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateSAMLProviderRequest(input, context),
     Action: "CreateSAMLProvider",
     Version: "2010-05-08"
   });
@@ -1178,12 +1152,8 @@ export const serializeAws_queryCreateServiceLinkedRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateServiceLinkedRoleRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateServiceLinkedRoleRequest(input, context),
     Action: "CreateServiceLinkedRole",
     Version: "2010-05-08"
   });
@@ -1198,12 +1168,8 @@ export const serializeAws_queryCreateServiceSpecificCredentialCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateServiceSpecificCredentialRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateServiceSpecificCredentialRequest(input, context),
     Action: "CreateServiceSpecificCredential",
     Version: "2010-05-08"
   });
@@ -1218,9 +1184,8 @@ export const serializeAws_queryCreateUserCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateUserRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateUserRequest(input, context),
     Action: "CreateUser",
     Version: "2010-05-08"
   });
@@ -1235,12 +1200,8 @@ export const serializeAws_queryCreateVirtualMFADeviceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateVirtualMFADeviceRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateVirtualMFADeviceRequest(input, context),
     Action: "CreateVirtualMFADevice",
     Version: "2010-05-08"
   });
@@ -1255,9 +1216,8 @@ export const serializeAws_queryDeactivateMFADeviceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeactivateMFADeviceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeactivateMFADeviceRequest(input, context),
     Action: "DeactivateMFADevice",
     Version: "2010-05-08"
   });
@@ -1272,9 +1232,8 @@ export const serializeAws_queryDeleteAccessKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteAccessKeyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteAccessKeyRequest(input, context),
     Action: "DeleteAccessKey",
     Version: "2010-05-08"
   });
@@ -1289,9 +1248,8 @@ export const serializeAws_queryDeleteAccountAliasCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteAccountAliasRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteAccountAliasRequest(input, context),
     Action: "DeleteAccountAlias",
     Version: "2010-05-08"
   });
@@ -1320,9 +1278,8 @@ export const serializeAws_queryDeleteGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteGroupRequest(input, context),
     Action: "DeleteGroup",
     Version: "2010-05-08"
   });
@@ -1337,9 +1294,8 @@ export const serializeAws_queryDeleteGroupPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteGroupPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteGroupPolicyRequest(input, context),
     Action: "DeleteGroupPolicy",
     Version: "2010-05-08"
   });
@@ -1354,12 +1310,8 @@ export const serializeAws_queryDeleteInstanceProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteInstanceProfileRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteInstanceProfileRequest(input, context),
     Action: "DeleteInstanceProfile",
     Version: "2010-05-08"
   });
@@ -1374,9 +1326,8 @@ export const serializeAws_queryDeleteLoginProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteLoginProfileRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteLoginProfileRequest(input, context),
     Action: "DeleteLoginProfile",
     Version: "2010-05-08"
   });
@@ -1391,12 +1342,8 @@ export const serializeAws_queryDeleteOpenIDConnectProviderCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteOpenIDConnectProviderRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteOpenIDConnectProviderRequest(input, context),
     Action: "DeleteOpenIDConnectProvider",
     Version: "2010-05-08"
   });
@@ -1411,9 +1358,8 @@ export const serializeAws_queryDeletePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeletePolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeletePolicyRequest(input, context),
     Action: "DeletePolicy",
     Version: "2010-05-08"
   });
@@ -1428,9 +1374,8 @@ export const serializeAws_queryDeletePolicyVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeletePolicyVersionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeletePolicyVersionRequest(input, context),
     Action: "DeletePolicyVersion",
     Version: "2010-05-08"
   });
@@ -1445,9 +1390,8 @@ export const serializeAws_queryDeleteRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteRoleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteRoleRequest(input, context),
     Action: "DeleteRole",
     Version: "2010-05-08"
   });
@@ -1462,12 +1406,8 @@ export const serializeAws_queryDeleteRolePermissionsBoundaryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteRolePermissionsBoundaryRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteRolePermissionsBoundaryRequest(input, context),
     Action: "DeleteRolePermissionsBoundary",
     Version: "2010-05-08"
   });
@@ -1482,9 +1422,8 @@ export const serializeAws_queryDeleteRolePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteRolePolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteRolePolicyRequest(input, context),
     Action: "DeleteRolePolicy",
     Version: "2010-05-08"
   });
@@ -1499,9 +1438,8 @@ export const serializeAws_queryDeleteSAMLProviderCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteSAMLProviderRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteSAMLProviderRequest(input, context),
     Action: "DeleteSAMLProvider",
     Version: "2010-05-08"
   });
@@ -1516,9 +1454,8 @@ export const serializeAws_queryDeleteSSHPublicKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteSSHPublicKeyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteSSHPublicKeyRequest(input, context),
     Action: "DeleteSSHPublicKey",
     Version: "2010-05-08"
   });
@@ -1533,12 +1470,8 @@ export const serializeAws_queryDeleteServerCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteServerCertificateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteServerCertificateRequest(input, context),
     Action: "DeleteServerCertificate",
     Version: "2010-05-08"
   });
@@ -1553,12 +1486,8 @@ export const serializeAws_queryDeleteServiceLinkedRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteServiceLinkedRoleRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteServiceLinkedRoleRequest(input, context),
     Action: "DeleteServiceLinkedRole",
     Version: "2010-05-08"
   });
@@ -1573,12 +1502,8 @@ export const serializeAws_queryDeleteServiceSpecificCredentialCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteServiceSpecificCredentialRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteServiceSpecificCredentialRequest(input, context),
     Action: "DeleteServiceSpecificCredential",
     Version: "2010-05-08"
   });
@@ -1593,12 +1518,8 @@ export const serializeAws_queryDeleteSigningCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteSigningCertificateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteSigningCertificateRequest(input, context),
     Action: "DeleteSigningCertificate",
     Version: "2010-05-08"
   });
@@ -1613,9 +1534,8 @@ export const serializeAws_queryDeleteUserCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteUserRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteUserRequest(input, context),
     Action: "DeleteUser",
     Version: "2010-05-08"
   });
@@ -1630,12 +1550,8 @@ export const serializeAws_queryDeleteUserPermissionsBoundaryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteUserPermissionsBoundaryRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteUserPermissionsBoundaryRequest(input, context),
     Action: "DeleteUserPermissionsBoundary",
     Version: "2010-05-08"
   });
@@ -1650,9 +1566,8 @@ export const serializeAws_queryDeleteUserPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteUserPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteUserPolicyRequest(input, context),
     Action: "DeleteUserPolicy",
     Version: "2010-05-08"
   });
@@ -1667,12 +1582,8 @@ export const serializeAws_queryDeleteVirtualMFADeviceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteVirtualMFADeviceRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteVirtualMFADeviceRequest(input, context),
     Action: "DeleteVirtualMFADevice",
     Version: "2010-05-08"
   });
@@ -1687,9 +1598,8 @@ export const serializeAws_queryDetachGroupPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetachGroupPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetachGroupPolicyRequest(input, context),
     Action: "DetachGroupPolicy",
     Version: "2010-05-08"
   });
@@ -1704,9 +1614,8 @@ export const serializeAws_queryDetachRolePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetachRolePolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetachRolePolicyRequest(input, context),
     Action: "DetachRolePolicy",
     Version: "2010-05-08"
   });
@@ -1721,9 +1630,8 @@ export const serializeAws_queryDetachUserPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDetachUserPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDetachUserPolicyRequest(input, context),
     Action: "DetachUserPolicy",
     Version: "2010-05-08"
   });
@@ -1738,9 +1646,8 @@ export const serializeAws_queryEnableMFADeviceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEnableMFADeviceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEnableMFADeviceRequest(input, context),
     Action: "EnableMFADevice",
     Version: "2010-05-08"
   });
@@ -1769,12 +1676,11 @@ export const serializeAws_queryGenerateOrganizationsAccessReportCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGenerateOrganizationsAccessReportRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGenerateOrganizationsAccessReportRequest(
+      input,
+      context
+    ),
     Action: "GenerateOrganizationsAccessReport",
     Version: "2010-05-08"
   });
@@ -1789,12 +1695,11 @@ export const serializeAws_queryGenerateServiceLastAccessedDetailsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGenerateServiceLastAccessedDetailsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGenerateServiceLastAccessedDetailsRequest(
+      input,
+      context
+    ),
     Action: "GenerateServiceLastAccessedDetails",
     Version: "2010-05-08"
   });
@@ -1809,9 +1714,8 @@ export const serializeAws_queryGetAccessKeyLastUsedCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetAccessKeyLastUsedRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetAccessKeyLastUsedRequest(input, context),
     Action: "GetAccessKeyLastUsed",
     Version: "2010-05-08"
   });
@@ -1826,12 +1730,8 @@ export const serializeAws_queryGetAccountAuthorizationDetailsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetAccountAuthorizationDetailsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetAccountAuthorizationDetailsRequest(input, context),
     Action: "GetAccountAuthorizationDetails",
     Version: "2010-05-08"
   });
@@ -1874,12 +1774,8 @@ export const serializeAws_queryGetContextKeysForCustomPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetContextKeysForCustomPolicyRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetContextKeysForCustomPolicyRequest(input, context),
     Action: "GetContextKeysForCustomPolicy",
     Version: "2010-05-08"
   });
@@ -1894,12 +1790,11 @@ export const serializeAws_queryGetContextKeysForPrincipalPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetContextKeysForPrincipalPolicyRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetContextKeysForPrincipalPolicyRequest(
+      input,
+      context
+    ),
     Action: "GetContextKeysForPrincipalPolicy",
     Version: "2010-05-08"
   });
@@ -1928,9 +1823,8 @@ export const serializeAws_queryGetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetGroupRequest(input, context),
     Action: "GetGroup",
     Version: "2010-05-08"
   });
@@ -1945,9 +1839,8 @@ export const serializeAws_queryGetGroupPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetGroupPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetGroupPolicyRequest(input, context),
     Action: "GetGroupPolicy",
     Version: "2010-05-08"
   });
@@ -1962,9 +1855,8 @@ export const serializeAws_queryGetInstanceProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetInstanceProfileRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetInstanceProfileRequest(input, context),
     Action: "GetInstanceProfile",
     Version: "2010-05-08"
   });
@@ -1979,9 +1871,8 @@ export const serializeAws_queryGetLoginProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetLoginProfileRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetLoginProfileRequest(input, context),
     Action: "GetLoginProfile",
     Version: "2010-05-08"
   });
@@ -1996,12 +1887,8 @@ export const serializeAws_queryGetOpenIDConnectProviderCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetOpenIDConnectProviderRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetOpenIDConnectProviderRequest(input, context),
     Action: "GetOpenIDConnectProvider",
     Version: "2010-05-08"
   });
@@ -2016,12 +1903,8 @@ export const serializeAws_queryGetOrganizationsAccessReportCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetOrganizationsAccessReportRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetOrganizationsAccessReportRequest(input, context),
     Action: "GetOrganizationsAccessReport",
     Version: "2010-05-08"
   });
@@ -2036,9 +1919,8 @@ export const serializeAws_queryGetPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetPolicyRequest(input, context),
     Action: "GetPolicy",
     Version: "2010-05-08"
   });
@@ -2053,9 +1935,8 @@ export const serializeAws_queryGetPolicyVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetPolicyVersionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetPolicyVersionRequest(input, context),
     Action: "GetPolicyVersion",
     Version: "2010-05-08"
   });
@@ -2070,9 +1951,8 @@ export const serializeAws_queryGetRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetRoleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetRoleRequest(input, context),
     Action: "GetRole",
     Version: "2010-05-08"
   });
@@ -2087,9 +1967,8 @@ export const serializeAws_queryGetRolePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetRolePolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetRolePolicyRequest(input, context),
     Action: "GetRolePolicy",
     Version: "2010-05-08"
   });
@@ -2104,9 +1983,8 @@ export const serializeAws_queryGetSAMLProviderCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetSAMLProviderRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetSAMLProviderRequest(input, context),
     Action: "GetSAMLProvider",
     Version: "2010-05-08"
   });
@@ -2121,9 +1999,8 @@ export const serializeAws_queryGetSSHPublicKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetSSHPublicKeyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetSSHPublicKeyRequest(input, context),
     Action: "GetSSHPublicKey",
     Version: "2010-05-08"
   });
@@ -2138,9 +2015,8 @@ export const serializeAws_queryGetServerCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetServerCertificateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetServerCertificateRequest(input, context),
     Action: "GetServerCertificate",
     Version: "2010-05-08"
   });
@@ -2155,12 +2031,8 @@ export const serializeAws_queryGetServiceLastAccessedDetailsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetServiceLastAccessedDetailsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetServiceLastAccessedDetailsRequest(input, context),
     Action: "GetServiceLastAccessedDetails",
     Version: "2010-05-08"
   });
@@ -2175,12 +2047,11 @@ export const serializeAws_queryGetServiceLastAccessedDetailsWithEntitiesCommand 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetServiceLastAccessedDetailsWithEntitiesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetServiceLastAccessedDetailsWithEntitiesRequest(
+      input,
+      context
+    ),
     Action: "GetServiceLastAccessedDetailsWithEntities",
     Version: "2010-05-08"
   });
@@ -2195,12 +2066,11 @@ export const serializeAws_queryGetServiceLinkedRoleDeletionStatusCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetServiceLinkedRoleDeletionStatusRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetServiceLinkedRoleDeletionStatusRequest(
+      input,
+      context
+    ),
     Action: "GetServiceLinkedRoleDeletionStatus",
     Version: "2010-05-08"
   });
@@ -2215,9 +2085,8 @@ export const serializeAws_queryGetUserCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetUserRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetUserRequest(input, context),
     Action: "GetUser",
     Version: "2010-05-08"
   });
@@ -2232,9 +2101,8 @@ export const serializeAws_queryGetUserPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetUserPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetUserPolicyRequest(input, context),
     Action: "GetUserPolicy",
     Version: "2010-05-08"
   });
@@ -2249,9 +2117,8 @@ export const serializeAws_queryListAccessKeysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListAccessKeysRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListAccessKeysRequest(input, context),
     Action: "ListAccessKeys",
     Version: "2010-05-08"
   });
@@ -2266,9 +2133,8 @@ export const serializeAws_queryListAccountAliasesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListAccountAliasesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListAccountAliasesRequest(input, context),
     Action: "ListAccountAliases",
     Version: "2010-05-08"
   });
@@ -2283,12 +2149,8 @@ export const serializeAws_queryListAttachedGroupPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListAttachedGroupPoliciesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListAttachedGroupPoliciesRequest(input, context),
     Action: "ListAttachedGroupPolicies",
     Version: "2010-05-08"
   });
@@ -2303,12 +2165,8 @@ export const serializeAws_queryListAttachedRolePoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListAttachedRolePoliciesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListAttachedRolePoliciesRequest(input, context),
     Action: "ListAttachedRolePolicies",
     Version: "2010-05-08"
   });
@@ -2323,12 +2181,8 @@ export const serializeAws_queryListAttachedUserPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListAttachedUserPoliciesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListAttachedUserPoliciesRequest(input, context),
     Action: "ListAttachedUserPolicies",
     Version: "2010-05-08"
   });
@@ -2343,12 +2197,8 @@ export const serializeAws_queryListEntitiesForPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListEntitiesForPolicyRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListEntitiesForPolicyRequest(input, context),
     Action: "ListEntitiesForPolicy",
     Version: "2010-05-08"
   });
@@ -2363,9 +2213,8 @@ export const serializeAws_queryListGroupPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListGroupPoliciesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListGroupPoliciesRequest(input, context),
     Action: "ListGroupPolicies",
     Version: "2010-05-08"
   });
@@ -2380,9 +2229,8 @@ export const serializeAws_queryListGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListGroupsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListGroupsRequest(input, context),
     Action: "ListGroups",
     Version: "2010-05-08"
   });
@@ -2397,9 +2245,8 @@ export const serializeAws_queryListGroupsForUserCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListGroupsForUserRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListGroupsForUserRequest(input, context),
     Action: "ListGroupsForUser",
     Version: "2010-05-08"
   });
@@ -2414,9 +2261,8 @@ export const serializeAws_queryListInstanceProfilesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListInstanceProfilesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListInstanceProfilesRequest(input, context),
     Action: "ListInstanceProfiles",
     Version: "2010-05-08"
   });
@@ -2431,12 +2277,8 @@ export const serializeAws_queryListInstanceProfilesForRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListInstanceProfilesForRoleRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListInstanceProfilesForRoleRequest(input, context),
     Action: "ListInstanceProfilesForRole",
     Version: "2010-05-08"
   });
@@ -2451,9 +2293,8 @@ export const serializeAws_queryListMFADevicesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListMFADevicesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListMFADevicesRequest(input, context),
     Action: "ListMFADevices",
     Version: "2010-05-08"
   });
@@ -2468,12 +2309,8 @@ export const serializeAws_queryListOpenIDConnectProvidersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListOpenIDConnectProvidersRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListOpenIDConnectProvidersRequest(input, context),
     Action: "ListOpenIDConnectProviders",
     Version: "2010-05-08"
   });
@@ -2488,9 +2325,8 @@ export const serializeAws_queryListPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListPoliciesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListPoliciesRequest(input, context),
     Action: "ListPolicies",
     Version: "2010-05-08"
   });
@@ -2505,12 +2341,11 @@ export const serializeAws_queryListPoliciesGrantingServiceAccessCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListPoliciesGrantingServiceAccessRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListPoliciesGrantingServiceAccessRequest(
+      input,
+      context
+    ),
     Action: "ListPoliciesGrantingServiceAccess",
     Version: "2010-05-08"
   });
@@ -2525,9 +2360,8 @@ export const serializeAws_queryListPolicyVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListPolicyVersionsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListPolicyVersionsRequest(input, context),
     Action: "ListPolicyVersions",
     Version: "2010-05-08"
   });
@@ -2542,9 +2376,8 @@ export const serializeAws_queryListRolePoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListRolePoliciesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListRolePoliciesRequest(input, context),
     Action: "ListRolePolicies",
     Version: "2010-05-08"
   });
@@ -2559,9 +2392,8 @@ export const serializeAws_queryListRoleTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListRoleTagsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListRoleTagsRequest(input, context),
     Action: "ListRoleTags",
     Version: "2010-05-08"
   });
@@ -2576,9 +2408,8 @@ export const serializeAws_queryListRolesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListRolesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListRolesRequest(input, context),
     Action: "ListRoles",
     Version: "2010-05-08"
   });
@@ -2593,9 +2424,8 @@ export const serializeAws_queryListSAMLProvidersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListSAMLProvidersRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListSAMLProvidersRequest(input, context),
     Action: "ListSAMLProviders",
     Version: "2010-05-08"
   });
@@ -2610,9 +2440,8 @@ export const serializeAws_queryListSSHPublicKeysCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListSSHPublicKeysRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListSSHPublicKeysRequest(input, context),
     Action: "ListSSHPublicKeys",
     Version: "2010-05-08"
   });
@@ -2627,12 +2456,8 @@ export const serializeAws_queryListServerCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListServerCertificatesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListServerCertificatesRequest(input, context),
     Action: "ListServerCertificates",
     Version: "2010-05-08"
   });
@@ -2647,12 +2472,8 @@ export const serializeAws_queryListServiceSpecificCredentialsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListServiceSpecificCredentialsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListServiceSpecificCredentialsRequest(input, context),
     Action: "ListServiceSpecificCredentials",
     Version: "2010-05-08"
   });
@@ -2667,12 +2488,8 @@ export const serializeAws_queryListSigningCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListSigningCertificatesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListSigningCertificatesRequest(input, context),
     Action: "ListSigningCertificates",
     Version: "2010-05-08"
   });
@@ -2687,9 +2504,8 @@ export const serializeAws_queryListUserPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListUserPoliciesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListUserPoliciesRequest(input, context),
     Action: "ListUserPolicies",
     Version: "2010-05-08"
   });
@@ -2704,9 +2520,8 @@ export const serializeAws_queryListUserTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListUserTagsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListUserTagsRequest(input, context),
     Action: "ListUserTags",
     Version: "2010-05-08"
   });
@@ -2721,9 +2536,8 @@ export const serializeAws_queryListUsersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListUsersRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListUsersRequest(input, context),
     Action: "ListUsers",
     Version: "2010-05-08"
   });
@@ -2738,12 +2552,8 @@ export const serializeAws_queryListVirtualMFADevicesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListVirtualMFADevicesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListVirtualMFADevicesRequest(input, context),
     Action: "ListVirtualMFADevices",
     Version: "2010-05-08"
   });
@@ -2758,9 +2568,8 @@ export const serializeAws_queryPutGroupPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutGroupPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutGroupPolicyRequest(input, context),
     Action: "PutGroupPolicy",
     Version: "2010-05-08"
   });
@@ -2775,12 +2584,8 @@ export const serializeAws_queryPutRolePermissionsBoundaryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutRolePermissionsBoundaryRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutRolePermissionsBoundaryRequest(input, context),
     Action: "PutRolePermissionsBoundary",
     Version: "2010-05-08"
   });
@@ -2795,9 +2600,8 @@ export const serializeAws_queryPutRolePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutRolePolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutRolePolicyRequest(input, context),
     Action: "PutRolePolicy",
     Version: "2010-05-08"
   });
@@ -2812,12 +2616,8 @@ export const serializeAws_queryPutUserPermissionsBoundaryCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutUserPermissionsBoundaryRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutUserPermissionsBoundaryRequest(input, context),
     Action: "PutUserPermissionsBoundary",
     Version: "2010-05-08"
   });
@@ -2832,9 +2632,8 @@ export const serializeAws_queryPutUserPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutUserPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutUserPolicyRequest(input, context),
     Action: "PutUserPolicy",
     Version: "2010-05-08"
   });
@@ -2849,12 +2648,11 @@ export const serializeAws_queryRemoveClientIDFromOpenIDConnectProviderCommand = 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveClientIDFromOpenIDConnectProviderRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveClientIDFromOpenIDConnectProviderRequest(
+      input,
+      context
+    ),
     Action: "RemoveClientIDFromOpenIDConnectProvider",
     Version: "2010-05-08"
   });
@@ -2869,12 +2667,8 @@ export const serializeAws_queryRemoveRoleFromInstanceProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveRoleFromInstanceProfileRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveRoleFromInstanceProfileRequest(input, context),
     Action: "RemoveRoleFromInstanceProfile",
     Version: "2010-05-08"
   });
@@ -2889,9 +2683,8 @@ export const serializeAws_queryRemoveUserFromGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveUserFromGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveUserFromGroupRequest(input, context),
     Action: "RemoveUserFromGroup",
     Version: "2010-05-08"
   });
@@ -2906,12 +2699,8 @@ export const serializeAws_queryResetServiceSpecificCredentialCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetServiceSpecificCredentialRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetServiceSpecificCredentialRequest(input, context),
     Action: "ResetServiceSpecificCredential",
     Version: "2010-05-08"
   });
@@ -2926,9 +2715,8 @@ export const serializeAws_queryResyncMFADeviceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResyncMFADeviceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResyncMFADeviceRequest(input, context),
     Action: "ResyncMFADevice",
     Version: "2010-05-08"
   });
@@ -2943,12 +2731,8 @@ export const serializeAws_querySetDefaultPolicyVersionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetDefaultPolicyVersionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetDefaultPolicyVersionRequest(input, context),
     Action: "SetDefaultPolicyVersion",
     Version: "2010-05-08"
   });
@@ -2963,12 +2747,11 @@ export const serializeAws_querySetSecurityTokenServicePreferencesCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetSecurityTokenServicePreferencesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetSecurityTokenServicePreferencesRequest(
+      input,
+      context
+    ),
     Action: "SetSecurityTokenServicePreferences",
     Version: "2010-05-08"
   });
@@ -2983,9 +2766,8 @@ export const serializeAws_querySimulateCustomPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySimulateCustomPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySimulateCustomPolicyRequest(input, context),
     Action: "SimulateCustomPolicy",
     Version: "2010-05-08"
   });
@@ -3000,12 +2782,8 @@ export const serializeAws_querySimulatePrincipalPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySimulatePrincipalPolicyRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySimulatePrincipalPolicyRequest(input, context),
     Action: "SimulatePrincipalPolicy",
     Version: "2010-05-08"
   });
@@ -3020,9 +2798,8 @@ export const serializeAws_queryTagRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTagRoleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTagRoleRequest(input, context),
     Action: "TagRole",
     Version: "2010-05-08"
   });
@@ -3037,9 +2814,8 @@ export const serializeAws_queryTagUserCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTagUserRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTagUserRequest(input, context),
     Action: "TagUser",
     Version: "2010-05-08"
   });
@@ -3054,9 +2830,8 @@ export const serializeAws_queryUntagRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUntagRoleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUntagRoleRequest(input, context),
     Action: "UntagRole",
     Version: "2010-05-08"
   });
@@ -3071,9 +2846,8 @@ export const serializeAws_queryUntagUserCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUntagUserRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUntagUserRequest(input, context),
     Action: "UntagUser",
     Version: "2010-05-08"
   });
@@ -3088,9 +2862,8 @@ export const serializeAws_queryUpdateAccessKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateAccessKeyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateAccessKeyRequest(input, context),
     Action: "UpdateAccessKey",
     Version: "2010-05-08"
   });
@@ -3105,12 +2878,8 @@ export const serializeAws_queryUpdateAccountPasswordPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateAccountPasswordPolicyRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateAccountPasswordPolicyRequest(input, context),
     Action: "UpdateAccountPasswordPolicy",
     Version: "2010-05-08"
   });
@@ -3125,12 +2894,8 @@ export const serializeAws_queryUpdateAssumeRolePolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateAssumeRolePolicyRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateAssumeRolePolicyRequest(input, context),
     Action: "UpdateAssumeRolePolicy",
     Version: "2010-05-08"
   });
@@ -3145,9 +2910,8 @@ export const serializeAws_queryUpdateGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateGroupRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateGroupRequest(input, context),
     Action: "UpdateGroup",
     Version: "2010-05-08"
   });
@@ -3162,9 +2926,8 @@ export const serializeAws_queryUpdateLoginProfileCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateLoginProfileRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateLoginProfileRequest(input, context),
     Action: "UpdateLoginProfile",
     Version: "2010-05-08"
   });
@@ -3179,12 +2942,11 @@ export const serializeAws_queryUpdateOpenIDConnectProviderThumbprintCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateOpenIDConnectProviderThumbprintRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateOpenIDConnectProviderThumbprintRequest(
+      input,
+      context
+    ),
     Action: "UpdateOpenIDConnectProviderThumbprint",
     Version: "2010-05-08"
   });
@@ -3199,9 +2961,8 @@ export const serializeAws_queryUpdateRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateRoleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateRoleRequest(input, context),
     Action: "UpdateRole",
     Version: "2010-05-08"
   });
@@ -3216,12 +2977,8 @@ export const serializeAws_queryUpdateRoleDescriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateRoleDescriptionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateRoleDescriptionRequest(input, context),
     Action: "UpdateRoleDescription",
     Version: "2010-05-08"
   });
@@ -3236,9 +2993,8 @@ export const serializeAws_queryUpdateSAMLProviderCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateSAMLProviderRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateSAMLProviderRequest(input, context),
     Action: "UpdateSAMLProvider",
     Version: "2010-05-08"
   });
@@ -3253,9 +3009,8 @@ export const serializeAws_queryUpdateSSHPublicKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateSSHPublicKeyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateSSHPublicKeyRequest(input, context),
     Action: "UpdateSSHPublicKey",
     Version: "2010-05-08"
   });
@@ -3270,12 +3025,8 @@ export const serializeAws_queryUpdateServerCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateServerCertificateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateServerCertificateRequest(input, context),
     Action: "UpdateServerCertificate",
     Version: "2010-05-08"
   });
@@ -3290,12 +3041,8 @@ export const serializeAws_queryUpdateServiceSpecificCredentialCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateServiceSpecificCredentialRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateServiceSpecificCredentialRequest(input, context),
     Action: "UpdateServiceSpecificCredential",
     Version: "2010-05-08"
   });
@@ -3310,12 +3057,8 @@ export const serializeAws_queryUpdateSigningCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateSigningCertificateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateSigningCertificateRequest(input, context),
     Action: "UpdateSigningCertificate",
     Version: "2010-05-08"
   });
@@ -3330,9 +3073,8 @@ export const serializeAws_queryUpdateUserCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateUserRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateUserRequest(input, context),
     Action: "UpdateUser",
     Version: "2010-05-08"
   });
@@ -3347,9 +3089,8 @@ export const serializeAws_queryUploadSSHPublicKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUploadSSHPublicKeyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUploadSSHPublicKeyRequest(input, context),
     Action: "UploadSSHPublicKey",
     Version: "2010-05-08"
   });
@@ -3364,12 +3105,8 @@ export const serializeAws_queryUploadServerCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUploadServerCertificateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUploadServerCertificateRequest(input, context),
     Action: "UploadServerCertificate",
     Version: "2010-05-08"
   });
@@ -3384,12 +3121,8 @@ export const serializeAws_queryUploadSigningCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUploadSigningCertificateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUploadSigningCertificateRequest(input, context),
     Action: "UploadSigningCertificate",
     Version: "2010-05-08"
   });

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -460,9 +460,8 @@ export const serializeAws_queryAddRoleToDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddRoleToDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddRoleToDBClusterMessage(input, context),
     Action: "AddRoleToDBCluster",
     Version: "2014-10-31"
   });
@@ -477,12 +476,11 @@ export const serializeAws_queryAddSourceIdentifierToSubscriptionCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddSourceIdentifierToSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddSourceIdentifierToSubscriptionMessage(
+      input,
+      context
+    ),
     Action: "AddSourceIdentifierToSubscription",
     Version: "2014-10-31"
   });
@@ -497,9 +495,8 @@ export const serializeAws_queryAddTagsToResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddTagsToResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddTagsToResourceMessage(input, context),
     Action: "AddTagsToResource",
     Version: "2014-10-31"
   });
@@ -514,12 +511,8 @@ export const serializeAws_queryApplyPendingMaintenanceActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryApplyPendingMaintenanceActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryApplyPendingMaintenanceActionMessage(input, context),
     Action: "ApplyPendingMaintenanceAction",
     Version: "2014-10-31"
   });
@@ -534,12 +527,8 @@ export const serializeAws_queryCopyDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBClusterParameterGroupMessage(input, context),
     Action: "CopyDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -554,12 +543,8 @@ export const serializeAws_queryCopyDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBClusterSnapshotMessage(input, context),
     Action: "CopyDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -574,9 +559,8 @@ export const serializeAws_queryCopyDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBParameterGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBParameterGroupMessage(input, context),
     Action: "CopyDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -591,9 +575,8 @@ export const serializeAws_queryCreateDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterMessage(input, context),
     Action: "CreateDBCluster",
     Version: "2014-10-31"
   });
@@ -608,12 +591,8 @@ export const serializeAws_queryCreateDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterParameterGroupMessage(input, context),
     Action: "CreateDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -628,12 +607,8 @@ export const serializeAws_queryCreateDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterSnapshotMessage(input, context),
     Action: "CreateDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -648,9 +623,8 @@ export const serializeAws_queryCreateDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBInstanceMessage(input, context),
     Action: "CreateDBInstance",
     Version: "2014-10-31"
   });
@@ -665,12 +639,8 @@ export const serializeAws_queryCreateDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBParameterGroupMessage(input, context),
     Action: "CreateDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -685,9 +655,8 @@ export const serializeAws_queryCreateDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBSubnetGroupMessage(input, context),
     Action: "CreateDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -702,12 +671,8 @@ export const serializeAws_queryCreateEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateEventSubscriptionMessage(input, context),
     Action: "CreateEventSubscription",
     Version: "2014-10-31"
   });
@@ -722,9 +687,8 @@ export const serializeAws_queryDeleteDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterMessage(input, context),
     Action: "DeleteDBCluster",
     Version: "2014-10-31"
   });
@@ -739,12 +703,8 @@ export const serializeAws_queryDeleteDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterParameterGroupMessage(input, context),
     Action: "DeleteDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -759,12 +719,8 @@ export const serializeAws_queryDeleteDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterSnapshotMessage(input, context),
     Action: "DeleteDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -779,9 +735,8 @@ export const serializeAws_queryDeleteDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBInstanceMessage(input, context),
     Action: "DeleteDBInstance",
     Version: "2014-10-31"
   });
@@ -796,12 +751,8 @@ export const serializeAws_queryDeleteDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBParameterGroupMessage(input, context),
     Action: "DeleteDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -816,9 +767,8 @@ export const serializeAws_queryDeleteDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBSubnetGroupMessage(input, context),
     Action: "DeleteDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -833,12 +783,8 @@ export const serializeAws_queryDeleteEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteEventSubscriptionMessage(input, context),
     Action: "DeleteEventSubscription",
     Version: "2014-10-31"
   });
@@ -853,12 +799,11 @@ export const serializeAws_queryDescribeDBClusterParameterGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterParameterGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterParameterGroupsMessage(
+      input,
+      context
+    ),
     Action: "DescribeDBClusterParameterGroups",
     Version: "2014-10-31"
   });
@@ -873,12 +818,8 @@ export const serializeAws_queryDescribeDBClusterParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterParametersMessage(input, context),
     Action: "DescribeDBClusterParameters",
     Version: "2014-10-31"
   });
@@ -893,12 +834,11 @@ export const serializeAws_queryDescribeDBClusterSnapshotAttributesCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterSnapshotAttributesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterSnapshotAttributesMessage(
+      input,
+      context
+    ),
     Action: "DescribeDBClusterSnapshotAttributes",
     Version: "2014-10-31"
   });
@@ -913,12 +853,8 @@ export const serializeAws_queryDescribeDBClusterSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterSnapshotsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterSnapshotsMessage(input, context),
     Action: "DescribeDBClusterSnapshots",
     Version: "2014-10-31"
   });
@@ -933,9 +869,8 @@ export const serializeAws_queryDescribeDBClustersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClustersMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClustersMessage(input, context),
     Action: "DescribeDBClusters",
     Version: "2014-10-31"
   });
@@ -950,12 +885,8 @@ export const serializeAws_queryDescribeDBEngineVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBEngineVersionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBEngineVersionsMessage(input, context),
     Action: "DescribeDBEngineVersions",
     Version: "2014-10-31"
   });
@@ -970,9 +901,8 @@ export const serializeAws_queryDescribeDBInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBInstancesMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBInstancesMessage(input, context),
     Action: "DescribeDBInstances",
     Version: "2014-10-31"
   });
@@ -987,12 +917,8 @@ export const serializeAws_queryDescribeDBParameterGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBParameterGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBParameterGroupsMessage(input, context),
     Action: "DescribeDBParameterGroups",
     Version: "2014-10-31"
   });
@@ -1007,9 +933,8 @@ export const serializeAws_queryDescribeDBParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBParametersMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBParametersMessage(input, context),
     Action: "DescribeDBParameters",
     Version: "2014-10-31"
   });
@@ -1024,12 +949,8 @@ export const serializeAws_queryDescribeDBSubnetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBSubnetGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBSubnetGroupsMessage(input, context),
     Action: "DescribeDBSubnetGroups",
     Version: "2014-10-31"
   });
@@ -1044,12 +965,11 @@ export const serializeAws_queryDescribeEngineDefaultClusterParametersCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEngineDefaultClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEngineDefaultClusterParametersMessage(
+      input,
+      context
+    ),
     Action: "DescribeEngineDefaultClusterParameters",
     Version: "2014-10-31"
   });
@@ -1064,12 +984,8 @@ export const serializeAws_queryDescribeEngineDefaultParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEngineDefaultParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEngineDefaultParametersMessage(input, context),
     Action: "DescribeEngineDefaultParameters",
     Version: "2014-10-31"
   });
@@ -1084,12 +1000,8 @@ export const serializeAws_queryDescribeEventCategoriesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventCategoriesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventCategoriesMessage(input, context),
     Action: "DescribeEventCategories",
     Version: "2014-10-31"
   });
@@ -1104,12 +1016,8 @@ export const serializeAws_queryDescribeEventSubscriptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventSubscriptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventSubscriptionsMessage(input, context),
     Action: "DescribeEventSubscriptions",
     Version: "2014-10-31"
   });
@@ -1124,9 +1032,8 @@ export const serializeAws_queryDescribeEventsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventsMessage(input, context),
     Action: "DescribeEvents",
     Version: "2014-10-31"
   });
@@ -1141,12 +1048,11 @@ export const serializeAws_queryDescribeOrderableDBInstanceOptionsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeOrderableDBInstanceOptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeOrderableDBInstanceOptionsMessage(
+      input,
+      context
+    ),
     Action: "DescribeOrderableDBInstanceOptions",
     Version: "2014-10-31"
   });
@@ -1161,12 +1067,11 @@ export const serializeAws_queryDescribePendingMaintenanceActionsCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribePendingMaintenanceActionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribePendingMaintenanceActionsMessage(
+      input,
+      context
+    ),
     Action: "DescribePendingMaintenanceActions",
     Version: "2014-10-31"
   });
@@ -1181,12 +1086,11 @@ export const serializeAws_queryDescribeValidDBInstanceModificationsCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeValidDBInstanceModificationsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeValidDBInstanceModificationsMessage(
+      input,
+      context
+    ),
     Action: "DescribeValidDBInstanceModifications",
     Version: "2014-10-31"
   });
@@ -1201,9 +1105,8 @@ export const serializeAws_queryFailoverDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryFailoverDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryFailoverDBClusterMessage(input, context),
     Action: "FailoverDBCluster",
     Version: "2014-10-31"
   });
@@ -1218,9 +1121,8 @@ export const serializeAws_queryListTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTagsForResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTagsForResourceMessage(input, context),
     Action: "ListTagsForResource",
     Version: "2014-10-31"
   });
@@ -1235,9 +1137,8 @@ export const serializeAws_queryModifyDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterMessage(input, context),
     Action: "ModifyDBCluster",
     Version: "2014-10-31"
   });
@@ -1252,12 +1153,8 @@ export const serializeAws_queryModifyDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterParameterGroupMessage(input, context),
     Action: "ModifyDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -1272,12 +1169,11 @@ export const serializeAws_queryModifyDBClusterSnapshotAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterSnapshotAttributeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterSnapshotAttributeMessage(
+      input,
+      context
+    ),
     Action: "ModifyDBClusterSnapshotAttribute",
     Version: "2014-10-31"
   });
@@ -1292,9 +1188,8 @@ export const serializeAws_queryModifyDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBInstanceMessage(input, context),
     Action: "ModifyDBInstance",
     Version: "2014-10-31"
   });
@@ -1309,12 +1204,8 @@ export const serializeAws_queryModifyDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBParameterGroupMessage(input, context),
     Action: "ModifyDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -1329,9 +1220,8 @@ export const serializeAws_queryModifyDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBSubnetGroupMessage(input, context),
     Action: "ModifyDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -1346,12 +1236,8 @@ export const serializeAws_queryModifyEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyEventSubscriptionMessage(input, context),
     Action: "ModifyEventSubscription",
     Version: "2014-10-31"
   });
@@ -1366,12 +1252,8 @@ export const serializeAws_queryPromoteReadReplicaDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPromoteReadReplicaDBClusterMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPromoteReadReplicaDBClusterMessage(input, context),
     Action: "PromoteReadReplicaDBCluster",
     Version: "2014-10-31"
   });
@@ -1386,9 +1268,8 @@ export const serializeAws_queryRebootDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRebootDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRebootDBInstanceMessage(input, context),
     Action: "RebootDBInstance",
     Version: "2014-10-31"
   });
@@ -1403,12 +1284,8 @@ export const serializeAws_queryRemoveRoleFromDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveRoleFromDBClusterMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveRoleFromDBClusterMessage(input, context),
     Action: "RemoveRoleFromDBCluster",
     Version: "2014-10-31"
   });
@@ -1423,12 +1300,11 @@ export const serializeAws_queryRemoveSourceIdentifierFromSubscriptionCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveSourceIdentifierFromSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveSourceIdentifierFromSubscriptionMessage(
+      input,
+      context
+    ),
     Action: "RemoveSourceIdentifierFromSubscription",
     Version: "2014-10-31"
   });
@@ -1443,12 +1319,8 @@ export const serializeAws_queryRemoveTagsFromResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveTagsFromResourceMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveTagsFromResourceMessage(input, context),
     Action: "RemoveTagsFromResource",
     Version: "2014-10-31"
   });
@@ -1463,12 +1335,8 @@ export const serializeAws_queryResetDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetDBClusterParameterGroupMessage(input, context),
     Action: "ResetDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -1483,12 +1351,8 @@ export const serializeAws_queryResetDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetDBParameterGroupMessage(input, context),
     Action: "ResetDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -1503,12 +1367,8 @@ export const serializeAws_queryRestoreDBClusterFromSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBClusterFromSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBClusterFromSnapshotMessage(input, context),
     Action: "RestoreDBClusterFromSnapshot",
     Version: "2014-10-31"
   });
@@ -1523,12 +1383,8 @@ export const serializeAws_queryRestoreDBClusterToPointInTimeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBClusterToPointInTimeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBClusterToPointInTimeMessage(input, context),
     Action: "RestoreDBClusterToPointInTime",
     Version: "2014-10-31"
   });

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -959,9 +959,8 @@ export const serializeAws_queryAddRoleToDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddRoleToDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddRoleToDBClusterMessage(input, context),
     Action: "AddRoleToDBCluster",
     Version: "2014-10-31"
   });
@@ -976,9 +975,8 @@ export const serializeAws_queryAddRoleToDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddRoleToDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddRoleToDBInstanceMessage(input, context),
     Action: "AddRoleToDBInstance",
     Version: "2014-10-31"
   });
@@ -993,12 +991,11 @@ export const serializeAws_queryAddSourceIdentifierToSubscriptionCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddSourceIdentifierToSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddSourceIdentifierToSubscriptionMessage(
+      input,
+      context
+    ),
     Action: "AddSourceIdentifierToSubscription",
     Version: "2014-10-31"
   });
@@ -1013,9 +1010,8 @@ export const serializeAws_queryAddTagsToResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddTagsToResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddTagsToResourceMessage(input, context),
     Action: "AddTagsToResource",
     Version: "2014-10-31"
   });
@@ -1030,12 +1026,8 @@ export const serializeAws_queryApplyPendingMaintenanceActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryApplyPendingMaintenanceActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryApplyPendingMaintenanceActionMessage(input, context),
     Action: "ApplyPendingMaintenanceAction",
     Version: "2014-10-31"
   });
@@ -1050,12 +1042,8 @@ export const serializeAws_queryAuthorizeDBSecurityGroupIngressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAuthorizeDBSecurityGroupIngressMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAuthorizeDBSecurityGroupIngressMessage(input, context),
     Action: "AuthorizeDBSecurityGroupIngress",
     Version: "2014-10-31"
   });
@@ -1070,9 +1058,8 @@ export const serializeAws_queryBacktrackDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBacktrackDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBacktrackDBClusterMessage(input, context),
     Action: "BacktrackDBCluster",
     Version: "2014-10-31"
   });
@@ -1087,12 +1074,8 @@ export const serializeAws_queryCopyDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBClusterParameterGroupMessage(input, context),
     Action: "CopyDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -1107,12 +1090,8 @@ export const serializeAws_queryCopyDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBClusterSnapshotMessage(input, context),
     Action: "CopyDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -1127,9 +1106,8 @@ export const serializeAws_queryCopyDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBParameterGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBParameterGroupMessage(input, context),
     Action: "CopyDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -1144,9 +1122,8 @@ export const serializeAws_queryCopyDBSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyDBSnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyDBSnapshotMessage(input, context),
     Action: "CopyDBSnapshot",
     Version: "2014-10-31"
   });
@@ -1161,9 +1138,8 @@ export const serializeAws_queryCopyOptionGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyOptionGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyOptionGroupMessage(input, context),
     Action: "CopyOptionGroup",
     Version: "2014-10-31"
   });
@@ -1178,12 +1154,8 @@ export const serializeAws_queryCreateCustomAvailabilityZoneCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateCustomAvailabilityZoneMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateCustomAvailabilityZoneMessage(input, context),
     Action: "CreateCustomAvailabilityZone",
     Version: "2014-10-31"
   });
@@ -1198,9 +1170,8 @@ export const serializeAws_queryCreateDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterMessage(input, context),
     Action: "CreateDBCluster",
     Version: "2014-10-31"
   });
@@ -1215,12 +1186,8 @@ export const serializeAws_queryCreateDBClusterEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterEndpointMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterEndpointMessage(input, context),
     Action: "CreateDBClusterEndpoint",
     Version: "2014-10-31"
   });
@@ -1235,12 +1202,8 @@ export const serializeAws_queryCreateDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterParameterGroupMessage(input, context),
     Action: "CreateDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -1255,12 +1218,8 @@ export const serializeAws_queryCreateDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBClusterSnapshotMessage(input, context),
     Action: "CreateDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -1275,9 +1234,8 @@ export const serializeAws_queryCreateDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBInstanceMessage(input, context),
     Action: "CreateDBInstance",
     Version: "2014-10-31"
   });
@@ -1292,12 +1250,8 @@ export const serializeAws_queryCreateDBInstanceReadReplicaCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBInstanceReadReplicaMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBInstanceReadReplicaMessage(input, context),
     Action: "CreateDBInstanceReadReplica",
     Version: "2014-10-31"
   });
@@ -1312,12 +1266,8 @@ export const serializeAws_queryCreateDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBParameterGroupMessage(input, context),
     Action: "CreateDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -1332,9 +1282,8 @@ export const serializeAws_queryCreateDBProxyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBProxyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBProxyRequest(input, context),
     Action: "CreateDBProxy",
     Version: "2014-10-31"
   });
@@ -1349,12 +1298,8 @@ export const serializeAws_queryCreateDBSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBSecurityGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBSecurityGroupMessage(input, context),
     Action: "CreateDBSecurityGroup",
     Version: "2014-10-31"
   });
@@ -1369,9 +1314,8 @@ export const serializeAws_queryCreateDBSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBSnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBSnapshotMessage(input, context),
     Action: "CreateDBSnapshot",
     Version: "2014-10-31"
   });
@@ -1386,9 +1330,8 @@ export const serializeAws_queryCreateDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateDBSubnetGroupMessage(input, context),
     Action: "CreateDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -1403,12 +1346,8 @@ export const serializeAws_queryCreateEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateEventSubscriptionMessage(input, context),
     Action: "CreateEventSubscription",
     Version: "2014-10-31"
   });
@@ -1423,9 +1362,8 @@ export const serializeAws_queryCreateGlobalClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateGlobalClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateGlobalClusterMessage(input, context),
     Action: "CreateGlobalCluster",
     Version: "2014-10-31"
   });
@@ -1440,9 +1378,8 @@ export const serializeAws_queryCreateOptionGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateOptionGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateOptionGroupMessage(input, context),
     Action: "CreateOptionGroup",
     Version: "2014-10-31"
   });
@@ -1457,12 +1394,8 @@ export const serializeAws_queryDeleteCustomAvailabilityZoneCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteCustomAvailabilityZoneMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteCustomAvailabilityZoneMessage(input, context),
     Action: "DeleteCustomAvailabilityZone",
     Version: "2014-10-31"
   });
@@ -1477,9 +1410,8 @@ export const serializeAws_queryDeleteDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterMessage(input, context),
     Action: "DeleteDBCluster",
     Version: "2014-10-31"
   });
@@ -1494,12 +1426,8 @@ export const serializeAws_queryDeleteDBClusterEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterEndpointMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterEndpointMessage(input, context),
     Action: "DeleteDBClusterEndpoint",
     Version: "2014-10-31"
   });
@@ -1514,12 +1442,8 @@ export const serializeAws_queryDeleteDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterParameterGroupMessage(input, context),
     Action: "DeleteDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -1534,12 +1458,8 @@ export const serializeAws_queryDeleteDBClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBClusterSnapshotMessage(input, context),
     Action: "DeleteDBClusterSnapshot",
     Version: "2014-10-31"
   });
@@ -1554,9 +1474,8 @@ export const serializeAws_queryDeleteDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBInstanceMessage(input, context),
     Action: "DeleteDBInstance",
     Version: "2014-10-31"
   });
@@ -1571,12 +1490,8 @@ export const serializeAws_queryDeleteDBInstanceAutomatedBackupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBInstanceAutomatedBackupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBInstanceAutomatedBackupMessage(input, context),
     Action: "DeleteDBInstanceAutomatedBackup",
     Version: "2014-10-31"
   });
@@ -1591,12 +1506,8 @@ export const serializeAws_queryDeleteDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBParameterGroupMessage(input, context),
     Action: "DeleteDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -1611,9 +1522,8 @@ export const serializeAws_queryDeleteDBProxyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBProxyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBProxyRequest(input, context),
     Action: "DeleteDBProxy",
     Version: "2014-10-31"
   });
@@ -1628,12 +1538,8 @@ export const serializeAws_queryDeleteDBSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBSecurityGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBSecurityGroupMessage(input, context),
     Action: "DeleteDBSecurityGroup",
     Version: "2014-10-31"
   });
@@ -1648,9 +1554,8 @@ export const serializeAws_queryDeleteDBSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBSnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBSnapshotMessage(input, context),
     Action: "DeleteDBSnapshot",
     Version: "2014-10-31"
   });
@@ -1665,9 +1570,8 @@ export const serializeAws_queryDeleteDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteDBSubnetGroupMessage(input, context),
     Action: "DeleteDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -1682,12 +1586,8 @@ export const serializeAws_queryDeleteEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteEventSubscriptionMessage(input, context),
     Action: "DeleteEventSubscription",
     Version: "2014-10-31"
   });
@@ -1702,9 +1602,8 @@ export const serializeAws_queryDeleteGlobalClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteGlobalClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteGlobalClusterMessage(input, context),
     Action: "DeleteGlobalCluster",
     Version: "2014-10-31"
   });
@@ -1719,12 +1618,8 @@ export const serializeAws_queryDeleteInstallationMediaCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteInstallationMediaMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteInstallationMediaMessage(input, context),
     Action: "DeleteInstallationMedia",
     Version: "2014-10-31"
   });
@@ -1739,9 +1634,8 @@ export const serializeAws_queryDeleteOptionGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteOptionGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteOptionGroupMessage(input, context),
     Action: "DeleteOptionGroup",
     Version: "2014-10-31"
   });
@@ -1756,12 +1650,8 @@ export const serializeAws_queryDeregisterDBProxyTargetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeregisterDBProxyTargetsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeregisterDBProxyTargetsRequest(input, context),
     Action: "DeregisterDBProxyTargets",
     Version: "2014-10-31"
   });
@@ -1776,12 +1666,8 @@ export const serializeAws_queryDescribeAccountAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAccountAttributesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAccountAttributesMessage(input, context),
     Action: "DescribeAccountAttributes",
     Version: "2014-10-31"
   });
@@ -1796,9 +1682,8 @@ export const serializeAws_queryDescribeCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCertificatesMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCertificatesMessage(input, context),
     Action: "DescribeCertificates",
     Version: "2014-10-31"
   });
@@ -1813,12 +1698,8 @@ export const serializeAws_queryDescribeCustomAvailabilityZonesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeCustomAvailabilityZonesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeCustomAvailabilityZonesMessage(input, context),
     Action: "DescribeCustomAvailabilityZones",
     Version: "2014-10-31"
   });
@@ -1833,12 +1714,8 @@ export const serializeAws_queryDescribeDBClusterBacktracksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterBacktracksMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterBacktracksMessage(input, context),
     Action: "DescribeDBClusterBacktracks",
     Version: "2014-10-31"
   });
@@ -1853,12 +1730,8 @@ export const serializeAws_queryDescribeDBClusterEndpointsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterEndpointsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterEndpointsMessage(input, context),
     Action: "DescribeDBClusterEndpoints",
     Version: "2014-10-31"
   });
@@ -1873,12 +1746,11 @@ export const serializeAws_queryDescribeDBClusterParameterGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterParameterGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterParameterGroupsMessage(
+      input,
+      context
+    ),
     Action: "DescribeDBClusterParameterGroups",
     Version: "2014-10-31"
   });
@@ -1893,12 +1765,8 @@ export const serializeAws_queryDescribeDBClusterParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterParametersMessage(input, context),
     Action: "DescribeDBClusterParameters",
     Version: "2014-10-31"
   });
@@ -1913,12 +1781,11 @@ export const serializeAws_queryDescribeDBClusterSnapshotAttributesCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterSnapshotAttributesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterSnapshotAttributesMessage(
+      input,
+      context
+    ),
     Action: "DescribeDBClusterSnapshotAttributes",
     Version: "2014-10-31"
   });
@@ -1933,12 +1800,8 @@ export const serializeAws_queryDescribeDBClusterSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClusterSnapshotsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClusterSnapshotsMessage(input, context),
     Action: "DescribeDBClusterSnapshots",
     Version: "2014-10-31"
   });
@@ -1953,9 +1816,8 @@ export const serializeAws_queryDescribeDBClustersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBClustersMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBClustersMessage(input, context),
     Action: "DescribeDBClusters",
     Version: "2014-10-31"
   });
@@ -1970,12 +1832,8 @@ export const serializeAws_queryDescribeDBEngineVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBEngineVersionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBEngineVersionsMessage(input, context),
     Action: "DescribeDBEngineVersions",
     Version: "2014-10-31"
   });
@@ -1990,12 +1848,11 @@ export const serializeAws_queryDescribeDBInstanceAutomatedBackupsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBInstanceAutomatedBackupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBInstanceAutomatedBackupsMessage(
+      input,
+      context
+    ),
     Action: "DescribeDBInstanceAutomatedBackups",
     Version: "2014-10-31"
   });
@@ -2010,9 +1867,8 @@ export const serializeAws_queryDescribeDBInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBInstancesMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBInstancesMessage(input, context),
     Action: "DescribeDBInstances",
     Version: "2014-10-31"
   });
@@ -2027,9 +1883,8 @@ export const serializeAws_queryDescribeDBLogFilesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBLogFilesMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBLogFilesMessage(input, context),
     Action: "DescribeDBLogFiles",
     Version: "2014-10-31"
   });
@@ -2044,12 +1899,8 @@ export const serializeAws_queryDescribeDBParameterGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBParameterGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBParameterGroupsMessage(input, context),
     Action: "DescribeDBParameterGroups",
     Version: "2014-10-31"
   });
@@ -2064,9 +1915,8 @@ export const serializeAws_queryDescribeDBParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBParametersMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBParametersMessage(input, context),
     Action: "DescribeDBParameters",
     Version: "2014-10-31"
   });
@@ -2081,9 +1931,8 @@ export const serializeAws_queryDescribeDBProxiesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBProxiesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBProxiesRequest(input, context),
     Action: "DescribeDBProxies",
     Version: "2014-10-31"
   });
@@ -2098,12 +1947,8 @@ export const serializeAws_queryDescribeDBProxyTargetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBProxyTargetGroupsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBProxyTargetGroupsRequest(input, context),
     Action: "DescribeDBProxyTargetGroups",
     Version: "2014-10-31"
   });
@@ -2118,12 +1963,8 @@ export const serializeAws_queryDescribeDBProxyTargetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBProxyTargetsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBProxyTargetsRequest(input, context),
     Action: "DescribeDBProxyTargets",
     Version: "2014-10-31"
   });
@@ -2138,12 +1979,8 @@ export const serializeAws_queryDescribeDBSecurityGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBSecurityGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBSecurityGroupsMessage(input, context),
     Action: "DescribeDBSecurityGroups",
     Version: "2014-10-31"
   });
@@ -2158,12 +1995,8 @@ export const serializeAws_queryDescribeDBSnapshotAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBSnapshotAttributesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBSnapshotAttributesMessage(input, context),
     Action: "DescribeDBSnapshotAttributes",
     Version: "2014-10-31"
   });
@@ -2178,9 +2011,8 @@ export const serializeAws_queryDescribeDBSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBSnapshotsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBSnapshotsMessage(input, context),
     Action: "DescribeDBSnapshots",
     Version: "2014-10-31"
   });
@@ -2195,12 +2027,8 @@ export const serializeAws_queryDescribeDBSubnetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDBSubnetGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDBSubnetGroupsMessage(input, context),
     Action: "DescribeDBSubnetGroups",
     Version: "2014-10-31"
   });
@@ -2215,12 +2043,11 @@ export const serializeAws_queryDescribeEngineDefaultClusterParametersCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEngineDefaultClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEngineDefaultClusterParametersMessage(
+      input,
+      context
+    ),
     Action: "DescribeEngineDefaultClusterParameters",
     Version: "2014-10-31"
   });
@@ -2235,12 +2062,8 @@ export const serializeAws_queryDescribeEngineDefaultParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEngineDefaultParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEngineDefaultParametersMessage(input, context),
     Action: "DescribeEngineDefaultParameters",
     Version: "2014-10-31"
   });
@@ -2255,12 +2078,8 @@ export const serializeAws_queryDescribeEventCategoriesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventCategoriesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventCategoriesMessage(input, context),
     Action: "DescribeEventCategories",
     Version: "2014-10-31"
   });
@@ -2275,12 +2094,8 @@ export const serializeAws_queryDescribeEventSubscriptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventSubscriptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventSubscriptionsMessage(input, context),
     Action: "DescribeEventSubscriptions",
     Version: "2014-10-31"
   });
@@ -2295,9 +2110,8 @@ export const serializeAws_queryDescribeEventsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventsMessage(input, context),
     Action: "DescribeEvents",
     Version: "2014-10-31"
   });
@@ -2312,12 +2126,8 @@ export const serializeAws_queryDescribeGlobalClustersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeGlobalClustersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeGlobalClustersMessage(input, context),
     Action: "DescribeGlobalClusters",
     Version: "2014-10-31"
   });
@@ -2332,12 +2142,8 @@ export const serializeAws_queryDescribeInstallationMediaCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeInstallationMediaMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeInstallationMediaMessage(input, context),
     Action: "DescribeInstallationMedia",
     Version: "2014-10-31"
   });
@@ -2352,12 +2158,8 @@ export const serializeAws_queryDescribeOptionGroupOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeOptionGroupOptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeOptionGroupOptionsMessage(input, context),
     Action: "DescribeOptionGroupOptions",
     Version: "2014-10-31"
   });
@@ -2372,9 +2174,8 @@ export const serializeAws_queryDescribeOptionGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeOptionGroupsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeOptionGroupsMessage(input, context),
     Action: "DescribeOptionGroups",
     Version: "2014-10-31"
   });
@@ -2389,12 +2190,11 @@ export const serializeAws_queryDescribeOrderableDBInstanceOptionsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeOrderableDBInstanceOptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeOrderableDBInstanceOptionsMessage(
+      input,
+      context
+    ),
     Action: "DescribeOrderableDBInstanceOptions",
     Version: "2014-10-31"
   });
@@ -2409,12 +2209,11 @@ export const serializeAws_queryDescribePendingMaintenanceActionsCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribePendingMaintenanceActionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribePendingMaintenanceActionsMessage(
+      input,
+      context
+    ),
     Action: "DescribePendingMaintenanceActions",
     Version: "2014-10-31"
   });
@@ -2429,12 +2228,8 @@ export const serializeAws_queryDescribeReservedDBInstancesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReservedDBInstancesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReservedDBInstancesMessage(input, context),
     Action: "DescribeReservedDBInstances",
     Version: "2014-10-31"
   });
@@ -2449,12 +2244,11 @@ export const serializeAws_queryDescribeReservedDBInstancesOfferingsCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReservedDBInstancesOfferingsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReservedDBInstancesOfferingsMessage(
+      input,
+      context
+    ),
     Action: "DescribeReservedDBInstancesOfferings",
     Version: "2014-10-31"
   });
@@ -2469,12 +2263,8 @@ export const serializeAws_queryDescribeSourceRegionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeSourceRegionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeSourceRegionsMessage(input, context),
     Action: "DescribeSourceRegions",
     Version: "2014-10-31"
   });
@@ -2489,12 +2279,11 @@ export const serializeAws_queryDescribeValidDBInstanceModificationsCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeValidDBInstanceModificationsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeValidDBInstanceModificationsMessage(
+      input,
+      context
+    ),
     Action: "DescribeValidDBInstanceModifications",
     Version: "2014-10-31"
   });
@@ -2509,12 +2298,8 @@ export const serializeAws_queryDownloadDBLogFilePortionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDownloadDBLogFilePortionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDownloadDBLogFilePortionMessage(input, context),
     Action: "DownloadDBLogFilePortion",
     Version: "2014-10-31"
   });
@@ -2529,9 +2314,8 @@ export const serializeAws_queryFailoverDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryFailoverDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryFailoverDBClusterMessage(input, context),
     Action: "FailoverDBCluster",
     Version: "2014-10-31"
   });
@@ -2546,12 +2330,8 @@ export const serializeAws_queryImportInstallationMediaCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryImportInstallationMediaMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryImportInstallationMediaMessage(input, context),
     Action: "ImportInstallationMedia",
     Version: "2014-10-31"
   });
@@ -2566,9 +2346,8 @@ export const serializeAws_queryListTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTagsForResourceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTagsForResourceMessage(input, context),
     Action: "ListTagsForResource",
     Version: "2014-10-31"
   });
@@ -2583,9 +2362,8 @@ export const serializeAws_queryModifyCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyCertificatesMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyCertificatesMessage(input, context),
     Action: "ModifyCertificates",
     Version: "2014-10-31"
   });
@@ -2600,12 +2378,8 @@ export const serializeAws_queryModifyCurrentDBClusterCapacityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyCurrentDBClusterCapacityMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyCurrentDBClusterCapacityMessage(input, context),
     Action: "ModifyCurrentDBClusterCapacity",
     Version: "2014-10-31"
   });
@@ -2620,9 +2394,8 @@ export const serializeAws_queryModifyDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterMessage(input, context),
     Action: "ModifyDBCluster",
     Version: "2014-10-31"
   });
@@ -2637,12 +2410,8 @@ export const serializeAws_queryModifyDBClusterEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterEndpointMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterEndpointMessage(input, context),
     Action: "ModifyDBClusterEndpoint",
     Version: "2014-10-31"
   });
@@ -2657,12 +2426,8 @@ export const serializeAws_queryModifyDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterParameterGroupMessage(input, context),
     Action: "ModifyDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -2677,12 +2442,11 @@ export const serializeAws_queryModifyDBClusterSnapshotAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBClusterSnapshotAttributeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBClusterSnapshotAttributeMessage(
+      input,
+      context
+    ),
     Action: "ModifyDBClusterSnapshotAttribute",
     Version: "2014-10-31"
   });
@@ -2697,9 +2461,8 @@ export const serializeAws_queryModifyDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBInstanceMessage(input, context),
     Action: "ModifyDBInstance",
     Version: "2014-10-31"
   });
@@ -2714,12 +2477,8 @@ export const serializeAws_queryModifyDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBParameterGroupMessage(input, context),
     Action: "ModifyDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -2734,9 +2493,8 @@ export const serializeAws_queryModifyDBProxyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBProxyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBProxyRequest(input, context),
     Action: "ModifyDBProxy",
     Version: "2014-10-31"
   });
@@ -2751,12 +2509,8 @@ export const serializeAws_queryModifyDBProxyTargetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBProxyTargetGroupRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBProxyTargetGroupRequest(input, context),
     Action: "ModifyDBProxyTargetGroup",
     Version: "2014-10-31"
   });
@@ -2771,9 +2525,8 @@ export const serializeAws_queryModifyDBSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBSnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBSnapshotMessage(input, context),
     Action: "ModifyDBSnapshot",
     Version: "2014-10-31"
   });
@@ -2788,12 +2541,8 @@ export const serializeAws_queryModifyDBSnapshotAttributeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBSnapshotAttributeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBSnapshotAttributeMessage(input, context),
     Action: "ModifyDBSnapshotAttribute",
     Version: "2014-10-31"
   });
@@ -2808,9 +2557,8 @@ export const serializeAws_queryModifyDBSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyDBSubnetGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyDBSubnetGroupMessage(input, context),
     Action: "ModifyDBSubnetGroup",
     Version: "2014-10-31"
   });
@@ -2825,12 +2573,8 @@ export const serializeAws_queryModifyEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyEventSubscriptionMessage(input, context),
     Action: "ModifyEventSubscription",
     Version: "2014-10-31"
   });
@@ -2845,9 +2589,8 @@ export const serializeAws_queryModifyGlobalClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyGlobalClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyGlobalClusterMessage(input, context),
     Action: "ModifyGlobalCluster",
     Version: "2014-10-31"
   });
@@ -2862,9 +2605,8 @@ export const serializeAws_queryModifyOptionGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyOptionGroupMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyOptionGroupMessage(input, context),
     Action: "ModifyOptionGroup",
     Version: "2014-10-31"
   });
@@ -2879,9 +2621,8 @@ export const serializeAws_queryPromoteReadReplicaCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPromoteReadReplicaMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPromoteReadReplicaMessage(input, context),
     Action: "PromoteReadReplica",
     Version: "2014-10-31"
   });
@@ -2896,12 +2637,8 @@ export const serializeAws_queryPromoteReadReplicaDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPromoteReadReplicaDBClusterMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPromoteReadReplicaDBClusterMessage(input, context),
     Action: "PromoteReadReplicaDBCluster",
     Version: "2014-10-31"
   });
@@ -2916,12 +2653,11 @@ export const serializeAws_queryPurchaseReservedDBInstancesOfferingCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPurchaseReservedDBInstancesOfferingMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPurchaseReservedDBInstancesOfferingMessage(
+      input,
+      context
+    ),
     Action: "PurchaseReservedDBInstancesOffering",
     Version: "2014-10-31"
   });
@@ -2936,9 +2672,8 @@ export const serializeAws_queryRebootDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRebootDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRebootDBInstanceMessage(input, context),
     Action: "RebootDBInstance",
     Version: "2014-10-31"
   });
@@ -2953,12 +2688,8 @@ export const serializeAws_queryRegisterDBProxyTargetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRegisterDBProxyTargetsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRegisterDBProxyTargetsRequest(input, context),
     Action: "RegisterDBProxyTargets",
     Version: "2014-10-31"
   });
@@ -2973,12 +2704,8 @@ export const serializeAws_queryRemoveFromGlobalClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveFromGlobalClusterMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveFromGlobalClusterMessage(input, context),
     Action: "RemoveFromGlobalCluster",
     Version: "2014-10-31"
   });
@@ -2993,12 +2720,8 @@ export const serializeAws_queryRemoveRoleFromDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveRoleFromDBClusterMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveRoleFromDBClusterMessage(input, context),
     Action: "RemoveRoleFromDBCluster",
     Version: "2014-10-31"
   });
@@ -3013,12 +2736,8 @@ export const serializeAws_queryRemoveRoleFromDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveRoleFromDBInstanceMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveRoleFromDBInstanceMessage(input, context),
     Action: "RemoveRoleFromDBInstance",
     Version: "2014-10-31"
   });
@@ -3033,12 +2752,11 @@ export const serializeAws_queryRemoveSourceIdentifierFromSubscriptionCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveSourceIdentifierFromSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveSourceIdentifierFromSubscriptionMessage(
+      input,
+      context
+    ),
     Action: "RemoveSourceIdentifierFromSubscription",
     Version: "2014-10-31"
   });
@@ -3053,12 +2771,8 @@ export const serializeAws_queryRemoveTagsFromResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemoveTagsFromResourceMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemoveTagsFromResourceMessage(input, context),
     Action: "RemoveTagsFromResource",
     Version: "2014-10-31"
   });
@@ -3073,12 +2787,8 @@ export const serializeAws_queryResetDBClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetDBClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetDBClusterParameterGroupMessage(input, context),
     Action: "ResetDBClusterParameterGroup",
     Version: "2014-10-31"
   });
@@ -3093,12 +2803,8 @@ export const serializeAws_queryResetDBParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetDBParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetDBParameterGroupMessage(input, context),
     Action: "ResetDBParameterGroup",
     Version: "2014-10-31"
   });
@@ -3113,12 +2819,8 @@ export const serializeAws_queryRestoreDBClusterFromS3Command = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBClusterFromS3Message(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBClusterFromS3Message(input, context),
     Action: "RestoreDBClusterFromS3",
     Version: "2014-10-31"
   });
@@ -3133,12 +2835,8 @@ export const serializeAws_queryRestoreDBClusterFromSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBClusterFromSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBClusterFromSnapshotMessage(input, context),
     Action: "RestoreDBClusterFromSnapshot",
     Version: "2014-10-31"
   });
@@ -3153,12 +2851,8 @@ export const serializeAws_queryRestoreDBClusterToPointInTimeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBClusterToPointInTimeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBClusterToPointInTimeMessage(input, context),
     Action: "RestoreDBClusterToPointInTime",
     Version: "2014-10-31"
   });
@@ -3173,12 +2867,8 @@ export const serializeAws_queryRestoreDBInstanceFromDBSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage(input, context),
     Action: "RestoreDBInstanceFromDBSnapshot",
     Version: "2014-10-31"
   });
@@ -3193,12 +2883,8 @@ export const serializeAws_queryRestoreDBInstanceFromS3Command = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBInstanceFromS3Message(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBInstanceFromS3Message(input, context),
     Action: "RestoreDBInstanceFromS3",
     Version: "2014-10-31"
   });
@@ -3213,12 +2899,8 @@ export const serializeAws_queryRestoreDBInstanceToPointInTimeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreDBInstanceToPointInTimeMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreDBInstanceToPointInTimeMessage(input, context),
     Action: "RestoreDBInstanceToPointInTime",
     Version: "2014-10-31"
   });
@@ -3233,12 +2915,8 @@ export const serializeAws_queryRevokeDBSecurityGroupIngressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRevokeDBSecurityGroupIngressMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRevokeDBSecurityGroupIngressMessage(input, context),
     Action: "RevokeDBSecurityGroupIngress",
     Version: "2014-10-31"
   });
@@ -3253,9 +2931,8 @@ export const serializeAws_queryStartActivityStreamCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStartActivityStreamRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStartActivityStreamRequest(input, context),
     Action: "StartActivityStream",
     Version: "2014-10-31"
   });
@@ -3270,9 +2947,8 @@ export const serializeAws_queryStartDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStartDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStartDBClusterMessage(input, context),
     Action: "StartDBCluster",
     Version: "2014-10-31"
   });
@@ -3287,9 +2963,8 @@ export const serializeAws_queryStartDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStartDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStartDBInstanceMessage(input, context),
     Action: "StartDBInstance",
     Version: "2014-10-31"
   });
@@ -3304,9 +2979,8 @@ export const serializeAws_queryStopActivityStreamCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStopActivityStreamRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStopActivityStreamRequest(input, context),
     Action: "StopActivityStream",
     Version: "2014-10-31"
   });
@@ -3321,9 +2995,8 @@ export const serializeAws_queryStopDBClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStopDBClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStopDBClusterMessage(input, context),
     Action: "StopDBCluster",
     Version: "2014-10-31"
   });
@@ -3338,9 +3011,8 @@ export const serializeAws_queryStopDBInstanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryStopDBInstanceMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryStopDBInstanceMessage(input, context),
     Action: "StopDBInstance",
     Version: "2014-10-31"
   });

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -685,12 +685,8 @@ export const serializeAws_queryAcceptReservedNodeExchangeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAcceptReservedNodeExchangeInputMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAcceptReservedNodeExchangeInputMessage(input, context),
     Action: "AcceptReservedNodeExchange",
     Version: "2012-12-01"
   });
@@ -705,12 +701,11 @@ export const serializeAws_queryAuthorizeClusterSecurityGroupIngressCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAuthorizeClusterSecurityGroupIngressMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAuthorizeClusterSecurityGroupIngressMessage(
+      input,
+      context
+    ),
     Action: "AuthorizeClusterSecurityGroupIngress",
     Version: "2012-12-01"
   });
@@ -725,12 +720,8 @@ export const serializeAws_queryAuthorizeSnapshotAccessCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAuthorizeSnapshotAccessMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAuthorizeSnapshotAccessMessage(input, context),
     Action: "AuthorizeSnapshotAccess",
     Version: "2012-12-01"
   });
@@ -745,12 +736,8 @@ export const serializeAws_queryBatchDeleteClusterSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBatchDeleteClusterSnapshotsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBatchDeleteClusterSnapshotsRequest(input, context),
     Action: "BatchDeleteClusterSnapshots",
     Version: "2012-12-01"
   });
@@ -765,12 +752,8 @@ export const serializeAws_queryBatchModifyClusterSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryBatchModifyClusterSnapshotsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryBatchModifyClusterSnapshotsMessage(input, context),
     Action: "BatchModifyClusterSnapshots",
     Version: "2012-12-01"
   });
@@ -785,9 +768,8 @@ export const serializeAws_queryCancelResizeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCancelResizeMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCancelResizeMessage(input, context),
     Action: "CancelResize",
     Version: "2012-12-01"
   });
@@ -802,9 +784,8 @@ export const serializeAws_queryCopyClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCopyClusterSnapshotMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCopyClusterSnapshotMessage(input, context),
     Action: "CopyClusterSnapshot",
     Version: "2012-12-01"
   });
@@ -819,9 +800,8 @@ export const serializeAws_queryCreateClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateClusterMessage(input, context),
     Action: "CreateCluster",
     Version: "2012-12-01"
   });
@@ -836,12 +816,8 @@ export const serializeAws_queryCreateClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateClusterParameterGroupMessage(input, context),
     Action: "CreateClusterParameterGroup",
     Version: "2012-12-01"
   });
@@ -856,12 +832,8 @@ export const serializeAws_queryCreateClusterSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateClusterSecurityGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateClusterSecurityGroupMessage(input, context),
     Action: "CreateClusterSecurityGroup",
     Version: "2012-12-01"
   });
@@ -876,12 +848,8 @@ export const serializeAws_queryCreateClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateClusterSnapshotMessage(input, context),
     Action: "CreateClusterSnapshot",
     Version: "2012-12-01"
   });
@@ -896,12 +864,8 @@ export const serializeAws_queryCreateClusterSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateClusterSubnetGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateClusterSubnetGroupMessage(input, context),
     Action: "CreateClusterSubnetGroup",
     Version: "2012-12-01"
   });
@@ -916,12 +880,8 @@ export const serializeAws_queryCreateEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateEventSubscriptionMessage(input, context),
     Action: "CreateEventSubscription",
     Version: "2012-12-01"
   });
@@ -936,12 +896,8 @@ export const serializeAws_queryCreateHsmClientCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateHsmClientCertificateMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateHsmClientCertificateMessage(input, context),
     Action: "CreateHsmClientCertificate",
     Version: "2012-12-01"
   });
@@ -956,12 +912,8 @@ export const serializeAws_queryCreateHsmConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateHsmConfigurationMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateHsmConfigurationMessage(input, context),
     Action: "CreateHsmConfiguration",
     Version: "2012-12-01"
   });
@@ -976,12 +928,8 @@ export const serializeAws_queryCreateScheduledActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateScheduledActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateScheduledActionMessage(input, context),
     Action: "CreateScheduledAction",
     Version: "2012-12-01"
   });
@@ -996,12 +944,8 @@ export const serializeAws_queryCreateSnapshotCopyGrantCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateSnapshotCopyGrantMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateSnapshotCopyGrantMessage(input, context),
     Action: "CreateSnapshotCopyGrant",
     Version: "2012-12-01"
   });
@@ -1016,12 +960,8 @@ export const serializeAws_queryCreateSnapshotScheduleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateSnapshotScheduleMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateSnapshotScheduleMessage(input, context),
     Action: "CreateSnapshotSchedule",
     Version: "2012-12-01"
   });
@@ -1036,9 +976,8 @@ export const serializeAws_queryCreateTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateTagsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateTagsMessage(input, context),
     Action: "CreateTags",
     Version: "2012-12-01"
   });
@@ -1053,9 +992,8 @@ export const serializeAws_queryDeleteClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteClusterMessage(input, context),
     Action: "DeleteCluster",
     Version: "2012-12-01"
   });
@@ -1070,12 +1008,8 @@ export const serializeAws_queryDeleteClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteClusterParameterGroupMessage(input, context),
     Action: "DeleteClusterParameterGroup",
     Version: "2012-12-01"
   });
@@ -1090,12 +1024,8 @@ export const serializeAws_queryDeleteClusterSecurityGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteClusterSecurityGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteClusterSecurityGroupMessage(input, context),
     Action: "DeleteClusterSecurityGroup",
     Version: "2012-12-01"
   });
@@ -1110,12 +1040,8 @@ export const serializeAws_queryDeleteClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteClusterSnapshotMessage(input, context),
     Action: "DeleteClusterSnapshot",
     Version: "2012-12-01"
   });
@@ -1130,12 +1056,8 @@ export const serializeAws_queryDeleteClusterSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteClusterSubnetGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteClusterSubnetGroupMessage(input, context),
     Action: "DeleteClusterSubnetGroup",
     Version: "2012-12-01"
   });
@@ -1150,12 +1072,8 @@ export const serializeAws_queryDeleteEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteEventSubscriptionMessage(input, context),
     Action: "DeleteEventSubscription",
     Version: "2012-12-01"
   });
@@ -1170,12 +1088,8 @@ export const serializeAws_queryDeleteHsmClientCertificateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteHsmClientCertificateMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteHsmClientCertificateMessage(input, context),
     Action: "DeleteHsmClientCertificate",
     Version: "2012-12-01"
   });
@@ -1190,12 +1104,8 @@ export const serializeAws_queryDeleteHsmConfigurationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteHsmConfigurationMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteHsmConfigurationMessage(input, context),
     Action: "DeleteHsmConfiguration",
     Version: "2012-12-01"
   });
@@ -1210,12 +1120,8 @@ export const serializeAws_queryDeleteScheduledActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteScheduledActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteScheduledActionMessage(input, context),
     Action: "DeleteScheduledAction",
     Version: "2012-12-01"
   });
@@ -1230,12 +1136,8 @@ export const serializeAws_queryDeleteSnapshotCopyGrantCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteSnapshotCopyGrantMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteSnapshotCopyGrantMessage(input, context),
     Action: "DeleteSnapshotCopyGrant",
     Version: "2012-12-01"
   });
@@ -1250,12 +1152,8 @@ export const serializeAws_queryDeleteSnapshotScheduleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteSnapshotScheduleMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteSnapshotScheduleMessage(input, context),
     Action: "DeleteSnapshotSchedule",
     Version: "2012-12-01"
   });
@@ -1270,9 +1168,8 @@ export const serializeAws_queryDeleteTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteTagsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteTagsMessage(input, context),
     Action: "DeleteTags",
     Version: "2012-12-01"
   });
@@ -1287,12 +1184,8 @@ export const serializeAws_queryDescribeAccountAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeAccountAttributesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeAccountAttributesMessage(input, context),
     Action: "DescribeAccountAttributes",
     Version: "2012-12-01"
   });
@@ -1307,12 +1200,8 @@ export const serializeAws_queryDescribeClusterDbRevisionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterDbRevisionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterDbRevisionsMessage(input, context),
     Action: "DescribeClusterDbRevisions",
     Version: "2012-12-01"
   });
@@ -1327,12 +1216,8 @@ export const serializeAws_queryDescribeClusterParameterGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterParameterGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterParameterGroupsMessage(input, context),
     Action: "DescribeClusterParameterGroups",
     Version: "2012-12-01"
   });
@@ -1347,12 +1232,8 @@ export const serializeAws_queryDescribeClusterParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterParametersMessage(input, context),
     Action: "DescribeClusterParameters",
     Version: "2012-12-01"
   });
@@ -1367,12 +1248,8 @@ export const serializeAws_queryDescribeClusterSecurityGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterSecurityGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterSecurityGroupsMessage(input, context),
     Action: "DescribeClusterSecurityGroups",
     Version: "2012-12-01"
   });
@@ -1387,12 +1264,8 @@ export const serializeAws_queryDescribeClusterSnapshotsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterSnapshotsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterSnapshotsMessage(input, context),
     Action: "DescribeClusterSnapshots",
     Version: "2012-12-01"
   });
@@ -1407,12 +1280,8 @@ export const serializeAws_queryDescribeClusterSubnetGroupsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterSubnetGroupsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterSubnetGroupsMessage(input, context),
     Action: "DescribeClusterSubnetGroups",
     Version: "2012-12-01"
   });
@@ -1427,12 +1296,8 @@ export const serializeAws_queryDescribeClusterTracksCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterTracksMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterTracksMessage(input, context),
     Action: "DescribeClusterTracks",
     Version: "2012-12-01"
   });
@@ -1447,12 +1312,8 @@ export const serializeAws_queryDescribeClusterVersionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClusterVersionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClusterVersionsMessage(input, context),
     Action: "DescribeClusterVersions",
     Version: "2012-12-01"
   });
@@ -1467,9 +1328,8 @@ export const serializeAws_queryDescribeClustersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeClustersMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeClustersMessage(input, context),
     Action: "DescribeClusters",
     Version: "2012-12-01"
   });
@@ -1484,12 +1344,11 @@ export const serializeAws_queryDescribeDefaultClusterParametersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeDefaultClusterParametersMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeDefaultClusterParametersMessage(
+      input,
+      context
+    ),
     Action: "DescribeDefaultClusterParameters",
     Version: "2012-12-01"
   });
@@ -1504,12 +1363,8 @@ export const serializeAws_queryDescribeEventCategoriesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventCategoriesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventCategoriesMessage(input, context),
     Action: "DescribeEventCategories",
     Version: "2012-12-01"
   });
@@ -1524,12 +1379,8 @@ export const serializeAws_queryDescribeEventSubscriptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventSubscriptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventSubscriptionsMessage(input, context),
     Action: "DescribeEventSubscriptions",
     Version: "2012-12-01"
   });
@@ -1544,9 +1395,8 @@ export const serializeAws_queryDescribeEventsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeEventsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeEventsMessage(input, context),
     Action: "DescribeEvents",
     Version: "2012-12-01"
   });
@@ -1561,12 +1411,8 @@ export const serializeAws_queryDescribeHsmClientCertificatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeHsmClientCertificatesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeHsmClientCertificatesMessage(input, context),
     Action: "DescribeHsmClientCertificates",
     Version: "2012-12-01"
   });
@@ -1581,12 +1427,8 @@ export const serializeAws_queryDescribeHsmConfigurationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeHsmConfigurationsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeHsmConfigurationsMessage(input, context),
     Action: "DescribeHsmConfigurations",
     Version: "2012-12-01"
   });
@@ -1601,12 +1443,8 @@ export const serializeAws_queryDescribeLoggingStatusCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeLoggingStatusMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeLoggingStatusMessage(input, context),
     Action: "DescribeLoggingStatus",
     Version: "2012-12-01"
   });
@@ -1621,12 +1459,11 @@ export const serializeAws_queryDescribeNodeConfigurationOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeNodeConfigurationOptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeNodeConfigurationOptionsMessage(
+      input,
+      context
+    ),
     Action: "DescribeNodeConfigurationOptions",
     Version: "2012-12-01"
   });
@@ -1641,12 +1478,8 @@ export const serializeAws_queryDescribeOrderableClusterOptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeOrderableClusterOptionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeOrderableClusterOptionsMessage(input, context),
     Action: "DescribeOrderableClusterOptions",
     Version: "2012-12-01"
   });
@@ -1661,12 +1494,8 @@ export const serializeAws_queryDescribeReservedNodeOfferingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReservedNodeOfferingsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReservedNodeOfferingsMessage(input, context),
     Action: "DescribeReservedNodeOfferings",
     Version: "2012-12-01"
   });
@@ -1681,12 +1510,8 @@ export const serializeAws_queryDescribeReservedNodesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReservedNodesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReservedNodesMessage(input, context),
     Action: "DescribeReservedNodes",
     Version: "2012-12-01"
   });
@@ -1701,9 +1526,8 @@ export const serializeAws_queryDescribeResizeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeResizeMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeResizeMessage(input, context),
     Action: "DescribeResize",
     Version: "2012-12-01"
   });
@@ -1718,12 +1542,8 @@ export const serializeAws_queryDescribeScheduledActionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeScheduledActionsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeScheduledActionsMessage(input, context),
     Action: "DescribeScheduledActions",
     Version: "2012-12-01"
   });
@@ -1738,12 +1558,8 @@ export const serializeAws_queryDescribeSnapshotCopyGrantsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeSnapshotCopyGrantsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeSnapshotCopyGrantsMessage(input, context),
     Action: "DescribeSnapshotCopyGrants",
     Version: "2012-12-01"
   });
@@ -1758,12 +1574,8 @@ export const serializeAws_queryDescribeSnapshotSchedulesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeSnapshotSchedulesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeSnapshotSchedulesMessage(input, context),
     Action: "DescribeSnapshotSchedules",
     Version: "2012-12-01"
   });
@@ -1792,12 +1604,8 @@ export const serializeAws_queryDescribeTableRestoreStatusCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTableRestoreStatusMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTableRestoreStatusMessage(input, context),
     Action: "DescribeTableRestoreStatus",
     Version: "2012-12-01"
   });
@@ -1812,9 +1620,8 @@ export const serializeAws_queryDescribeTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeTagsMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeTagsMessage(input, context),
     Action: "DescribeTags",
     Version: "2012-12-01"
   });
@@ -1829,9 +1636,8 @@ export const serializeAws_queryDisableLoggingCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDisableLoggingMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDisableLoggingMessage(input, context),
     Action: "DisableLogging",
     Version: "2012-12-01"
   });
@@ -1846,9 +1652,8 @@ export const serializeAws_queryDisableSnapshotCopyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDisableSnapshotCopyMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDisableSnapshotCopyMessage(input, context),
     Action: "DisableSnapshotCopy",
     Version: "2012-12-01"
   });
@@ -1863,9 +1668,8 @@ export const serializeAws_queryEnableLoggingCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEnableLoggingMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEnableLoggingMessage(input, context),
     Action: "EnableLogging",
     Version: "2012-12-01"
   });
@@ -1880,9 +1684,8 @@ export const serializeAws_queryEnableSnapshotCopyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEnableSnapshotCopyMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEnableSnapshotCopyMessage(input, context),
     Action: "EnableSnapshotCopy",
     Version: "2012-12-01"
   });
@@ -1897,12 +1700,8 @@ export const serializeAws_queryGetClusterCredentialsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetClusterCredentialsMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetClusterCredentialsMessage(input, context),
     Action: "GetClusterCredentials",
     Version: "2012-12-01"
   });
@@ -1917,12 +1716,11 @@ export const serializeAws_queryGetReservedNodeExchangeOfferingsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetReservedNodeExchangeOfferingsInputMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetReservedNodeExchangeOfferingsInputMessage(
+      input,
+      context
+    ),
     Action: "GetReservedNodeExchangeOfferings",
     Version: "2012-12-01"
   });
@@ -1937,9 +1735,8 @@ export const serializeAws_queryModifyClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterMessage(input, context),
     Action: "ModifyCluster",
     Version: "2012-12-01"
   });
@@ -1954,12 +1751,8 @@ export const serializeAws_queryModifyClusterDbRevisionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterDbRevisionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterDbRevisionMessage(input, context),
     Action: "ModifyClusterDbRevision",
     Version: "2012-12-01"
   });
@@ -1974,12 +1767,8 @@ export const serializeAws_queryModifyClusterIamRolesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterIamRolesMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterIamRolesMessage(input, context),
     Action: "ModifyClusterIamRoles",
     Version: "2012-12-01"
   });
@@ -1994,12 +1783,8 @@ export const serializeAws_queryModifyClusterMaintenanceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterMaintenanceMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterMaintenanceMessage(input, context),
     Action: "ModifyClusterMaintenance",
     Version: "2012-12-01"
   });
@@ -2014,12 +1799,8 @@ export const serializeAws_queryModifyClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterParameterGroupMessage(input, context),
     Action: "ModifyClusterParameterGroup",
     Version: "2012-12-01"
   });
@@ -2034,12 +1815,8 @@ export const serializeAws_queryModifyClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterSnapshotMessage(input, context),
     Action: "ModifyClusterSnapshot",
     Version: "2012-12-01"
   });
@@ -2054,12 +1831,8 @@ export const serializeAws_queryModifyClusterSnapshotScheduleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterSnapshotScheduleMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterSnapshotScheduleMessage(input, context),
     Action: "ModifyClusterSnapshotSchedule",
     Version: "2012-12-01"
   });
@@ -2074,12 +1847,8 @@ export const serializeAws_queryModifyClusterSubnetGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyClusterSubnetGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyClusterSubnetGroupMessage(input, context),
     Action: "ModifyClusterSubnetGroup",
     Version: "2012-12-01"
   });
@@ -2094,12 +1863,8 @@ export const serializeAws_queryModifyEventSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyEventSubscriptionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyEventSubscriptionMessage(input, context),
     Action: "ModifyEventSubscription",
     Version: "2012-12-01"
   });
@@ -2114,12 +1879,8 @@ export const serializeAws_queryModifyScheduledActionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifyScheduledActionMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifyScheduledActionMessage(input, context),
     Action: "ModifyScheduledAction",
     Version: "2012-12-01"
   });
@@ -2134,12 +1895,11 @@ export const serializeAws_queryModifySnapshotCopyRetentionPeriodCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifySnapshotCopyRetentionPeriodMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifySnapshotCopyRetentionPeriodMessage(
+      input,
+      context
+    ),
     Action: "ModifySnapshotCopyRetentionPeriod",
     Version: "2012-12-01"
   });
@@ -2154,12 +1914,8 @@ export const serializeAws_queryModifySnapshotScheduleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryModifySnapshotScheduleMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryModifySnapshotScheduleMessage(input, context),
     Action: "ModifySnapshotSchedule",
     Version: "2012-12-01"
   });
@@ -2174,12 +1930,8 @@ export const serializeAws_queryPurchaseReservedNodeOfferingCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPurchaseReservedNodeOfferingMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPurchaseReservedNodeOfferingMessage(input, context),
     Action: "PurchaseReservedNodeOffering",
     Version: "2012-12-01"
   });
@@ -2194,9 +1946,8 @@ export const serializeAws_queryRebootClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRebootClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRebootClusterMessage(input, context),
     Action: "RebootCluster",
     Version: "2012-12-01"
   });
@@ -2211,12 +1962,8 @@ export const serializeAws_queryResetClusterParameterGroupCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResetClusterParameterGroupMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResetClusterParameterGroupMessage(input, context),
     Action: "ResetClusterParameterGroup",
     Version: "2012-12-01"
   });
@@ -2231,9 +1978,8 @@ export const serializeAws_queryResizeClusterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryResizeClusterMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryResizeClusterMessage(input, context),
     Action: "ResizeCluster",
     Version: "2012-12-01"
   });
@@ -2248,12 +1994,8 @@ export const serializeAws_queryRestoreFromClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreFromClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreFromClusterSnapshotMessage(input, context),
     Action: "RestoreFromClusterSnapshot",
     Version: "2012-12-01"
   });
@@ -2268,12 +2010,8 @@ export const serializeAws_queryRestoreTableFromClusterSnapshotCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRestoreTableFromClusterSnapshotMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRestoreTableFromClusterSnapshotMessage(input, context),
     Action: "RestoreTableFromClusterSnapshot",
     Version: "2012-12-01"
   });
@@ -2288,12 +2026,11 @@ export const serializeAws_queryRevokeClusterSecurityGroupIngressCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRevokeClusterSecurityGroupIngressMessage(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRevokeClusterSecurityGroupIngressMessage(
+      input,
+      context
+    ),
     Action: "RevokeClusterSecurityGroupIngress",
     Version: "2012-12-01"
   });
@@ -2308,9 +2045,8 @@ export const serializeAws_queryRevokeSnapshotAccessCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRevokeSnapshotAccessMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRevokeSnapshotAccessMessage(input, context),
     Action: "RevokeSnapshotAccess",
     Version: "2012-12-01"
   });
@@ -2325,9 +2061,8 @@ export const serializeAws_queryRotateEncryptionKeyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRotateEncryptionKeyMessage(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRotateEncryptionKeyMessage(input, context),
     Action: "RotateEncryptionKey",
     Version: "2012-12-01"
   });

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -518,9 +518,8 @@ export const serializeAws_queryCloneReceiptRuleSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCloneReceiptRuleSetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCloneReceiptRuleSetRequest(input, context),
     Action: "CloneReceiptRuleSet",
     Version: "2010-12-01"
   });
@@ -535,12 +534,8 @@ export const serializeAws_queryCreateConfigurationSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateConfigurationSetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateConfigurationSetRequest(input, context),
     Action: "CreateConfigurationSet",
     Version: "2010-12-01"
   });
@@ -555,12 +550,11 @@ export const serializeAws_queryCreateConfigurationSetEventDestinationCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateConfigurationSetEventDestinationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateConfigurationSetEventDestinationRequest(
+      input,
+      context
+    ),
     Action: "CreateConfigurationSetEventDestination",
     Version: "2010-12-01"
   });
@@ -575,12 +569,11 @@ export const serializeAws_queryCreateConfigurationSetTrackingOptionsCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateConfigurationSetTrackingOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateConfigurationSetTrackingOptionsRequest(
+      input,
+      context
+    ),
     Action: "CreateConfigurationSetTrackingOptions",
     Version: "2010-12-01"
   });
@@ -595,12 +588,11 @@ export const serializeAws_queryCreateCustomVerificationEmailTemplateCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateCustomVerificationEmailTemplateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateCustomVerificationEmailTemplateRequest(
+      input,
+      context
+    ),
     Action: "CreateCustomVerificationEmailTemplate",
     Version: "2010-12-01"
   });
@@ -615,9 +607,8 @@ export const serializeAws_queryCreateReceiptFilterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateReceiptFilterRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateReceiptFilterRequest(input, context),
     Action: "CreateReceiptFilter",
     Version: "2010-12-01"
   });
@@ -632,9 +623,8 @@ export const serializeAws_queryCreateReceiptRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateReceiptRuleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateReceiptRuleRequest(input, context),
     Action: "CreateReceiptRule",
     Version: "2010-12-01"
   });
@@ -649,9 +639,8 @@ export const serializeAws_queryCreateReceiptRuleSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateReceiptRuleSetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateReceiptRuleSetRequest(input, context),
     Action: "CreateReceiptRuleSet",
     Version: "2010-12-01"
   });
@@ -666,9 +655,8 @@ export const serializeAws_queryCreateTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateTemplateRequest(input, context),
     Action: "CreateTemplate",
     Version: "2010-12-01"
   });
@@ -683,12 +671,8 @@ export const serializeAws_queryDeleteConfigurationSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteConfigurationSetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteConfigurationSetRequest(input, context),
     Action: "DeleteConfigurationSet",
     Version: "2010-12-01"
   });
@@ -703,12 +687,11 @@ export const serializeAws_queryDeleteConfigurationSetEventDestinationCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteConfigurationSetEventDestinationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteConfigurationSetEventDestinationRequest(
+      input,
+      context
+    ),
     Action: "DeleteConfigurationSetEventDestination",
     Version: "2010-12-01"
   });
@@ -723,12 +706,11 @@ export const serializeAws_queryDeleteConfigurationSetTrackingOptionsCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteConfigurationSetTrackingOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteConfigurationSetTrackingOptionsRequest(
+      input,
+      context
+    ),
     Action: "DeleteConfigurationSetTrackingOptions",
     Version: "2010-12-01"
   });
@@ -743,12 +725,11 @@ export const serializeAws_queryDeleteCustomVerificationEmailTemplateCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteCustomVerificationEmailTemplateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteCustomVerificationEmailTemplateRequest(
+      input,
+      context
+    ),
     Action: "DeleteCustomVerificationEmailTemplate",
     Version: "2010-12-01"
   });
@@ -763,9 +744,8 @@ export const serializeAws_queryDeleteIdentityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteIdentityRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteIdentityRequest(input, context),
     Action: "DeleteIdentity",
     Version: "2010-12-01"
   });
@@ -780,9 +760,8 @@ export const serializeAws_queryDeleteIdentityPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteIdentityPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteIdentityPolicyRequest(input, context),
     Action: "DeleteIdentityPolicy",
     Version: "2010-12-01"
   });
@@ -797,9 +776,8 @@ export const serializeAws_queryDeleteReceiptFilterCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteReceiptFilterRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteReceiptFilterRequest(input, context),
     Action: "DeleteReceiptFilter",
     Version: "2010-12-01"
   });
@@ -814,9 +792,8 @@ export const serializeAws_queryDeleteReceiptRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteReceiptRuleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteReceiptRuleRequest(input, context),
     Action: "DeleteReceiptRule",
     Version: "2010-12-01"
   });
@@ -831,9 +808,8 @@ export const serializeAws_queryDeleteReceiptRuleSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteReceiptRuleSetRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteReceiptRuleSetRequest(input, context),
     Action: "DeleteReceiptRuleSet",
     Version: "2010-12-01"
   });
@@ -848,9 +824,8 @@ export const serializeAws_queryDeleteTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteTemplateRequest(input, context),
     Action: "DeleteTemplate",
     Version: "2010-12-01"
   });
@@ -865,12 +840,8 @@ export const serializeAws_queryDeleteVerifiedEmailAddressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteVerifiedEmailAddressRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteVerifiedEmailAddressRequest(input, context),
     Action: "DeleteVerifiedEmailAddress",
     Version: "2010-12-01"
   });
@@ -885,12 +856,8 @@ export const serializeAws_queryDescribeActiveReceiptRuleSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeActiveReceiptRuleSetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeActiveReceiptRuleSetRequest(input, context),
     Action: "DescribeActiveReceiptRuleSet",
     Version: "2010-12-01"
   });
@@ -905,12 +872,8 @@ export const serializeAws_queryDescribeConfigurationSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeConfigurationSetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeConfigurationSetRequest(input, context),
     Action: "DescribeConfigurationSet",
     Version: "2010-12-01"
   });
@@ -925,9 +888,8 @@ export const serializeAws_queryDescribeReceiptRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReceiptRuleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReceiptRuleRequest(input, context),
     Action: "DescribeReceiptRule",
     Version: "2010-12-01"
   });
@@ -942,12 +904,8 @@ export const serializeAws_queryDescribeReceiptRuleSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDescribeReceiptRuleSetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDescribeReceiptRuleSetRequest(input, context),
     Action: "DescribeReceiptRuleSet",
     Version: "2010-12-01"
   });
@@ -976,12 +934,11 @@ export const serializeAws_queryGetCustomVerificationEmailTemplateCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetCustomVerificationEmailTemplateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetCustomVerificationEmailTemplateRequest(
+      input,
+      context
+    ),
     Action: "GetCustomVerificationEmailTemplate",
     Version: "2010-12-01"
   });
@@ -996,12 +953,8 @@ export const serializeAws_queryGetIdentityDkimAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetIdentityDkimAttributesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetIdentityDkimAttributesRequest(input, context),
     Action: "GetIdentityDkimAttributes",
     Version: "2010-12-01"
   });
@@ -1016,12 +969,11 @@ export const serializeAws_queryGetIdentityMailFromDomainAttributesCommand = asyn
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetIdentityMailFromDomainAttributesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetIdentityMailFromDomainAttributesRequest(
+      input,
+      context
+    ),
     Action: "GetIdentityMailFromDomainAttributes",
     Version: "2010-12-01"
   });
@@ -1036,12 +988,11 @@ export const serializeAws_queryGetIdentityNotificationAttributesCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetIdentityNotificationAttributesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetIdentityNotificationAttributesRequest(
+      input,
+      context
+    ),
     Action: "GetIdentityNotificationAttributes",
     Version: "2010-12-01"
   });
@@ -1056,9 +1007,8 @@ export const serializeAws_queryGetIdentityPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetIdentityPoliciesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetIdentityPoliciesRequest(input, context),
     Action: "GetIdentityPolicies",
     Version: "2010-12-01"
   });
@@ -1073,12 +1023,11 @@ export const serializeAws_queryGetIdentityVerificationAttributesCommand = async 
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetIdentityVerificationAttributesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetIdentityVerificationAttributesRequest(
+      input,
+      context
+    ),
     Action: "GetIdentityVerificationAttributes",
     Version: "2010-12-01"
   });
@@ -1121,9 +1070,8 @@ export const serializeAws_queryGetTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetTemplateRequest(input, context),
     Action: "GetTemplate",
     Version: "2010-12-01"
   });
@@ -1138,12 +1086,8 @@ export const serializeAws_queryListConfigurationSetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListConfigurationSetsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListConfigurationSetsRequest(input, context),
     Action: "ListConfigurationSets",
     Version: "2010-12-01"
   });
@@ -1158,12 +1102,11 @@ export const serializeAws_queryListCustomVerificationEmailTemplatesCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListCustomVerificationEmailTemplatesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListCustomVerificationEmailTemplatesRequest(
+      input,
+      context
+    ),
     Action: "ListCustomVerificationEmailTemplates",
     Version: "2010-12-01"
   });
@@ -1178,9 +1121,8 @@ export const serializeAws_queryListIdentitiesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListIdentitiesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListIdentitiesRequest(input, context),
     Action: "ListIdentities",
     Version: "2010-12-01"
   });
@@ -1195,9 +1137,8 @@ export const serializeAws_queryListIdentityPoliciesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListIdentityPoliciesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListIdentityPoliciesRequest(input, context),
     Action: "ListIdentityPolicies",
     Version: "2010-12-01"
   });
@@ -1212,9 +1153,8 @@ export const serializeAws_queryListReceiptFiltersCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListReceiptFiltersRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListReceiptFiltersRequest(input, context),
     Action: "ListReceiptFilters",
     Version: "2010-12-01"
   });
@@ -1229,9 +1169,8 @@ export const serializeAws_queryListReceiptRuleSetsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListReceiptRuleSetsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListReceiptRuleSetsRequest(input, context),
     Action: "ListReceiptRuleSets",
     Version: "2010-12-01"
   });
@@ -1246,9 +1185,8 @@ export const serializeAws_queryListTemplatesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTemplatesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTemplatesRequest(input, context),
     Action: "ListTemplates",
     Version: "2010-12-01"
   });
@@ -1277,12 +1215,11 @@ export const serializeAws_queryPutConfigurationSetDeliveryOptionsCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutConfigurationSetDeliveryOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutConfigurationSetDeliveryOptionsRequest(
+      input,
+      context
+    ),
     Action: "PutConfigurationSetDeliveryOptions",
     Version: "2010-12-01"
   });
@@ -1297,9 +1234,8 @@ export const serializeAws_queryPutIdentityPolicyCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPutIdentityPolicyRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPutIdentityPolicyRequest(input, context),
     Action: "PutIdentityPolicy",
     Version: "2010-12-01"
   });
@@ -1314,12 +1250,8 @@ export const serializeAws_queryReorderReceiptRuleSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryReorderReceiptRuleSetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryReorderReceiptRuleSetRequest(input, context),
     Action: "ReorderReceiptRuleSet",
     Version: "2010-12-01"
   });
@@ -1334,9 +1266,8 @@ export const serializeAws_querySendBounceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendBounceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendBounceRequest(input, context),
     Action: "SendBounce",
     Version: "2010-12-01"
   });
@@ -1351,12 +1282,8 @@ export const serializeAws_querySendBulkTemplatedEmailCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendBulkTemplatedEmailRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendBulkTemplatedEmailRequest(input, context),
     Action: "SendBulkTemplatedEmail",
     Version: "2010-12-01"
   });
@@ -1371,12 +1298,8 @@ export const serializeAws_querySendCustomVerificationEmailCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendCustomVerificationEmailRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendCustomVerificationEmailRequest(input, context),
     Action: "SendCustomVerificationEmail",
     Version: "2010-12-01"
   });
@@ -1391,9 +1314,8 @@ export const serializeAws_querySendEmailCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendEmailRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendEmailRequest(input, context),
     Action: "SendEmail",
     Version: "2010-12-01"
   });
@@ -1408,9 +1330,8 @@ export const serializeAws_querySendRawEmailCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendRawEmailRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendRawEmailRequest(input, context),
     Action: "SendRawEmail",
     Version: "2010-12-01"
   });
@@ -1425,9 +1346,8 @@ export const serializeAws_querySendTemplatedEmailCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendTemplatedEmailRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendTemplatedEmailRequest(input, context),
     Action: "SendTemplatedEmail",
     Version: "2010-12-01"
   });
@@ -1442,12 +1362,8 @@ export const serializeAws_querySetActiveReceiptRuleSetCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetActiveReceiptRuleSetRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetActiveReceiptRuleSetRequest(input, context),
     Action: "SetActiveReceiptRuleSet",
     Version: "2010-12-01"
   });
@@ -1462,12 +1378,8 @@ export const serializeAws_querySetIdentityDkimEnabledCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetIdentityDkimEnabledRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetIdentityDkimEnabledRequest(input, context),
     Action: "SetIdentityDkimEnabled",
     Version: "2010-12-01"
   });
@@ -1482,12 +1394,11 @@ export const serializeAws_querySetIdentityFeedbackForwardingEnabledCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetIdentityFeedbackForwardingEnabledRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetIdentityFeedbackForwardingEnabledRequest(
+      input,
+      context
+    ),
     Action: "SetIdentityFeedbackForwardingEnabled",
     Version: "2010-12-01"
   });
@@ -1502,12 +1413,11 @@ export const serializeAws_querySetIdentityHeadersInNotificationsEnabledCommand =
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetIdentityHeadersInNotificationsEnabledRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetIdentityHeadersInNotificationsEnabledRequest(
+      input,
+      context
+    ),
     Action: "SetIdentityHeadersInNotificationsEnabled",
     Version: "2010-12-01"
   });
@@ -1522,12 +1432,8 @@ export const serializeAws_querySetIdentityMailFromDomainCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetIdentityMailFromDomainRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetIdentityMailFromDomainRequest(input, context),
     Action: "SetIdentityMailFromDomain",
     Version: "2010-12-01"
   });
@@ -1542,12 +1448,8 @@ export const serializeAws_querySetIdentityNotificationTopicCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetIdentityNotificationTopicRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetIdentityNotificationTopicRequest(input, context),
     Action: "SetIdentityNotificationTopic",
     Version: "2010-12-01"
   });
@@ -1562,12 +1464,8 @@ export const serializeAws_querySetReceiptRulePositionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetReceiptRulePositionRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetReceiptRulePositionRequest(input, context),
     Action: "SetReceiptRulePosition",
     Version: "2010-12-01"
   });
@@ -1582,9 +1480,8 @@ export const serializeAws_queryTestRenderTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTestRenderTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTestRenderTemplateRequest(input, context),
     Action: "TestRenderTemplate",
     Version: "2010-12-01"
   });
@@ -1599,12 +1496,8 @@ export const serializeAws_queryUpdateAccountSendingEnabledCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateAccountSendingEnabledRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateAccountSendingEnabledRequest(input, context),
     Action: "UpdateAccountSendingEnabled",
     Version: "2010-12-01"
   });
@@ -1619,12 +1512,11 @@ export const serializeAws_queryUpdateConfigurationSetEventDestinationCommand = a
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateConfigurationSetEventDestinationRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateConfigurationSetEventDestinationRequest(
+      input,
+      context
+    ),
     Action: "UpdateConfigurationSetEventDestination",
     Version: "2010-12-01"
   });
@@ -1639,12 +1531,11 @@ export const serializeAws_queryUpdateConfigurationSetReputationMetricsEnabledCom
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateConfigurationSetReputationMetricsEnabledRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateConfigurationSetReputationMetricsEnabledRequest(
+      input,
+      context
+    ),
     Action: "UpdateConfigurationSetReputationMetricsEnabled",
     Version: "2010-12-01"
   });
@@ -1659,12 +1550,11 @@ export const serializeAws_queryUpdateConfigurationSetSendingEnabledCommand = asy
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateConfigurationSetSendingEnabledRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateConfigurationSetSendingEnabledRequest(
+      input,
+      context
+    ),
     Action: "UpdateConfigurationSetSendingEnabled",
     Version: "2010-12-01"
   });
@@ -1679,12 +1569,11 @@ export const serializeAws_queryUpdateConfigurationSetTrackingOptionsCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateConfigurationSetTrackingOptionsRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateConfigurationSetTrackingOptionsRequest(
+      input,
+      context
+    ),
     Action: "UpdateConfigurationSetTrackingOptions",
     Version: "2010-12-01"
   });
@@ -1699,12 +1588,11 @@ export const serializeAws_queryUpdateCustomVerificationEmailTemplateCommand = as
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateCustomVerificationEmailTemplateRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateCustomVerificationEmailTemplateRequest(
+      input,
+      context
+    ),
     Action: "UpdateCustomVerificationEmailTemplate",
     Version: "2010-12-01"
   });
@@ -1719,9 +1607,8 @@ export const serializeAws_queryUpdateReceiptRuleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateReceiptRuleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateReceiptRuleRequest(input, context),
     Action: "UpdateReceiptRule",
     Version: "2010-12-01"
   });
@@ -1736,9 +1623,8 @@ export const serializeAws_queryUpdateTemplateCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUpdateTemplateRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUpdateTemplateRequest(input, context),
     Action: "UpdateTemplate",
     Version: "2010-12-01"
   });
@@ -1753,9 +1639,8 @@ export const serializeAws_queryVerifyDomainDkimCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryVerifyDomainDkimRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryVerifyDomainDkimRequest(input, context),
     Action: "VerifyDomainDkim",
     Version: "2010-12-01"
   });
@@ -1770,9 +1655,8 @@ export const serializeAws_queryVerifyDomainIdentityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryVerifyDomainIdentityRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryVerifyDomainIdentityRequest(input, context),
     Action: "VerifyDomainIdentity",
     Version: "2010-12-01"
   });
@@ -1787,9 +1671,8 @@ export const serializeAws_queryVerifyEmailAddressCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryVerifyEmailAddressRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryVerifyEmailAddressRequest(input, context),
     Action: "VerifyEmailAddress",
     Version: "2010-12-01"
   });
@@ -1804,9 +1687,8 @@ export const serializeAws_queryVerifyEmailIdentityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryVerifyEmailIdentityRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryVerifyEmailIdentityRequest(input, context),
     Action: "VerifyEmailIdentity",
     Version: "2010-12-01"
   });

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -244,9 +244,8 @@ export const serializeAws_queryAddPermissionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddPermissionInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddPermissionInput(input, context),
     Action: "AddPermission",
     Version: "2010-03-31"
   });
@@ -261,12 +260,8 @@ export const serializeAws_queryCheckIfPhoneNumberIsOptedOutCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCheckIfPhoneNumberIsOptedOutInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCheckIfPhoneNumberIsOptedOutInput(input, context),
     Action: "CheckIfPhoneNumberIsOptedOut",
     Version: "2010-03-31"
   });
@@ -281,9 +276,8 @@ export const serializeAws_queryConfirmSubscriptionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryConfirmSubscriptionInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryConfirmSubscriptionInput(input, context),
     Action: "ConfirmSubscription",
     Version: "2010-03-31"
   });
@@ -298,12 +292,8 @@ export const serializeAws_queryCreatePlatformApplicationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreatePlatformApplicationInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreatePlatformApplicationInput(input, context),
     Action: "CreatePlatformApplication",
     Version: "2010-03-31"
   });
@@ -318,9 +308,8 @@ export const serializeAws_queryCreatePlatformEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreatePlatformEndpointInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreatePlatformEndpointInput(input, context),
     Action: "CreatePlatformEndpoint",
     Version: "2010-03-31"
   });
@@ -335,9 +324,8 @@ export const serializeAws_queryCreateTopicCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateTopicInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateTopicInput(input, context),
     Action: "CreateTopic",
     Version: "2010-03-31"
   });
@@ -352,9 +340,8 @@ export const serializeAws_queryDeleteEndpointCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteEndpointInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteEndpointInput(input, context),
     Action: "DeleteEndpoint",
     Version: "2010-03-31"
   });
@@ -369,12 +356,8 @@ export const serializeAws_queryDeletePlatformApplicationCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeletePlatformApplicationInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeletePlatformApplicationInput(input, context),
     Action: "DeletePlatformApplication",
     Version: "2010-03-31"
   });
@@ -389,9 +372,8 @@ export const serializeAws_queryDeleteTopicCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteTopicInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteTopicInput(input, context),
     Action: "DeleteTopic",
     Version: "2010-03-31"
   });
@@ -406,9 +388,8 @@ export const serializeAws_queryGetEndpointAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetEndpointAttributesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetEndpointAttributesInput(input, context),
     Action: "GetEndpointAttributes",
     Version: "2010-03-31"
   });
@@ -423,12 +404,8 @@ export const serializeAws_queryGetPlatformApplicationAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetPlatformApplicationAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetPlatformApplicationAttributesInput(input, context),
     Action: "GetPlatformApplicationAttributes",
     Version: "2010-03-31"
   });
@@ -443,9 +420,8 @@ export const serializeAws_queryGetSMSAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetSMSAttributesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetSMSAttributesInput(input, context),
     Action: "GetSMSAttributes",
     Version: "2010-03-31"
   });
@@ -460,12 +436,8 @@ export const serializeAws_queryGetSubscriptionAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetSubscriptionAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetSubscriptionAttributesInput(input, context),
     Action: "GetSubscriptionAttributes",
     Version: "2010-03-31"
   });
@@ -480,9 +452,8 @@ export const serializeAws_queryGetTopicAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetTopicAttributesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetTopicAttributesInput(input, context),
     Action: "GetTopicAttributes",
     Version: "2010-03-31"
   });
@@ -497,12 +468,11 @@ export const serializeAws_queryListEndpointsByPlatformApplicationCommand = async
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListEndpointsByPlatformApplicationInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListEndpointsByPlatformApplicationInput(
+      input,
+      context
+    ),
     Action: "ListEndpointsByPlatformApplication",
     Version: "2010-03-31"
   });
@@ -517,12 +487,8 @@ export const serializeAws_queryListPhoneNumbersOptedOutCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListPhoneNumbersOptedOutInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListPhoneNumbersOptedOutInput(input, context),
     Action: "ListPhoneNumbersOptedOut",
     Version: "2010-03-31"
   });
@@ -537,12 +503,8 @@ export const serializeAws_queryListPlatformApplicationsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListPlatformApplicationsInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListPlatformApplicationsInput(input, context),
     Action: "ListPlatformApplications",
     Version: "2010-03-31"
   });
@@ -557,9 +519,8 @@ export const serializeAws_queryListSubscriptionsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListSubscriptionsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListSubscriptionsInput(input, context),
     Action: "ListSubscriptions",
     Version: "2010-03-31"
   });
@@ -574,12 +535,8 @@ export const serializeAws_queryListSubscriptionsByTopicCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListSubscriptionsByTopicInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListSubscriptionsByTopicInput(input, context),
     Action: "ListSubscriptionsByTopic",
     Version: "2010-03-31"
   });
@@ -594,9 +551,8 @@ export const serializeAws_queryListTagsForResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTagsForResourceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTagsForResourceRequest(input, context),
     Action: "ListTagsForResource",
     Version: "2010-03-31"
   });
@@ -611,9 +567,8 @@ export const serializeAws_queryListTopicsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListTopicsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListTopicsInput(input, context),
     Action: "ListTopics",
     Version: "2010-03-31"
   });
@@ -628,9 +583,8 @@ export const serializeAws_queryOptInPhoneNumberCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryOptInPhoneNumberInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryOptInPhoneNumberInput(input, context),
     Action: "OptInPhoneNumber",
     Version: "2010-03-31"
   });
@@ -645,9 +599,8 @@ export const serializeAws_queryPublishCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPublishInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPublishInput(input, context),
     Action: "Publish",
     Version: "2010-03-31"
   });
@@ -662,9 +615,8 @@ export const serializeAws_queryRemovePermissionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemovePermissionInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemovePermissionInput(input, context),
     Action: "RemovePermission",
     Version: "2010-03-31"
   });
@@ -679,9 +631,8 @@ export const serializeAws_querySetEndpointAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetEndpointAttributesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetEndpointAttributesInput(input, context),
     Action: "SetEndpointAttributes",
     Version: "2010-03-31"
   });
@@ -696,12 +647,8 @@ export const serializeAws_querySetPlatformApplicationAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetPlatformApplicationAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetPlatformApplicationAttributesInput(input, context),
     Action: "SetPlatformApplicationAttributes",
     Version: "2010-03-31"
   });
@@ -716,9 +663,8 @@ export const serializeAws_querySetSMSAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetSMSAttributesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetSMSAttributesInput(input, context),
     Action: "SetSMSAttributes",
     Version: "2010-03-31"
   });
@@ -733,12 +679,8 @@ export const serializeAws_querySetSubscriptionAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetSubscriptionAttributesInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetSubscriptionAttributesInput(input, context),
     Action: "SetSubscriptionAttributes",
     Version: "2010-03-31"
   });
@@ -753,9 +695,8 @@ export const serializeAws_querySetTopicAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetTopicAttributesInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetTopicAttributesInput(input, context),
     Action: "SetTopicAttributes",
     Version: "2010-03-31"
   });
@@ -770,9 +711,8 @@ export const serializeAws_querySubscribeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySubscribeInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySubscribeInput(input, context),
     Action: "Subscribe",
     Version: "2010-03-31"
   });
@@ -787,9 +727,8 @@ export const serializeAws_queryTagResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTagResourceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTagResourceRequest(input, context),
     Action: "TagResource",
     Version: "2010-03-31"
   });
@@ -804,9 +743,8 @@ export const serializeAws_queryUnsubscribeCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUnsubscribeInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUnsubscribeInput(input, context),
     Action: "Unsubscribe",
     Version: "2010-03-31"
   });
@@ -821,9 +759,8 @@ export const serializeAws_queryUntagResourceCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUntagResourceRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUntagResourceRequest(input, context),
     Action: "UntagResource",
     Version: "2010-03-31"
   });

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -165,9 +165,8 @@ export const serializeAws_queryAddPermissionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAddPermissionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAddPermissionRequest(input, context),
     Action: "AddPermission",
     Version: "2012-11-05"
   });
@@ -182,12 +181,8 @@ export const serializeAws_queryChangeMessageVisibilityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryChangeMessageVisibilityRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryChangeMessageVisibilityRequest(input, context),
     Action: "ChangeMessageVisibility",
     Version: "2012-11-05"
   });
@@ -202,12 +197,8 @@ export const serializeAws_queryChangeMessageVisibilityBatchCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryChangeMessageVisibilityBatchRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryChangeMessageVisibilityBatchRequest(input, context),
     Action: "ChangeMessageVisibilityBatch",
     Version: "2012-11-05"
   });
@@ -222,9 +213,8 @@ export const serializeAws_queryCreateQueueCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryCreateQueueRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryCreateQueueRequest(input, context),
     Action: "CreateQueue",
     Version: "2012-11-05"
   });
@@ -239,9 +229,8 @@ export const serializeAws_queryDeleteMessageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteMessageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteMessageRequest(input, context),
     Action: "DeleteMessage",
     Version: "2012-11-05"
   });
@@ -256,9 +245,8 @@ export const serializeAws_queryDeleteMessageBatchCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteMessageBatchRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteMessageBatchRequest(input, context),
     Action: "DeleteMessageBatch",
     Version: "2012-11-05"
   });
@@ -273,9 +261,8 @@ export const serializeAws_queryDeleteQueueCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDeleteQueueRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDeleteQueueRequest(input, context),
     Action: "DeleteQueue",
     Version: "2012-11-05"
   });
@@ -290,9 +277,8 @@ export const serializeAws_queryGetQueueAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetQueueAttributesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetQueueAttributesRequest(input, context),
     Action: "GetQueueAttributes",
     Version: "2012-11-05"
   });
@@ -307,9 +293,8 @@ export const serializeAws_queryGetQueueUrlCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetQueueUrlRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetQueueUrlRequest(input, context),
     Action: "GetQueueUrl",
     Version: "2012-11-05"
   });
@@ -324,12 +309,8 @@ export const serializeAws_queryListDeadLetterSourceQueuesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListDeadLetterSourceQueuesRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListDeadLetterSourceQueuesRequest(input, context),
     Action: "ListDeadLetterSourceQueues",
     Version: "2012-11-05"
   });
@@ -344,9 +325,8 @@ export const serializeAws_queryListQueueTagsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListQueueTagsRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListQueueTagsRequest(input, context),
     Action: "ListQueueTags",
     Version: "2012-11-05"
   });
@@ -361,9 +341,8 @@ export const serializeAws_queryListQueuesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryListQueuesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryListQueuesRequest(input, context),
     Action: "ListQueues",
     Version: "2012-11-05"
   });
@@ -378,9 +357,8 @@ export const serializeAws_queryPurgeQueueCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryPurgeQueueRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryPurgeQueueRequest(input, context),
     Action: "PurgeQueue",
     Version: "2012-11-05"
   });
@@ -395,9 +373,8 @@ export const serializeAws_queryReceiveMessageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryReceiveMessageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryReceiveMessageRequest(input, context),
     Action: "ReceiveMessage",
     Version: "2012-11-05"
   });
@@ -412,9 +389,8 @@ export const serializeAws_queryRemovePermissionCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryRemovePermissionRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryRemovePermissionRequest(input, context),
     Action: "RemovePermission",
     Version: "2012-11-05"
   });
@@ -429,9 +405,8 @@ export const serializeAws_querySendMessageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendMessageRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendMessageRequest(input, context),
     Action: "SendMessage",
     Version: "2012-11-05"
   });
@@ -446,9 +421,8 @@ export const serializeAws_querySendMessageBatchCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySendMessageBatchRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySendMessageBatchRequest(input, context),
     Action: "SendMessageBatch",
     Version: "2012-11-05"
   });
@@ -463,9 +437,8 @@ export const serializeAws_querySetQueueAttributesCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySetQueueAttributesRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySetQueueAttributesRequest(input, context),
     Action: "SetQueueAttributes",
     Version: "2012-11-05"
   });
@@ -480,9 +453,8 @@ export const serializeAws_queryTagQueueCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryTagQueueRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryTagQueueRequest(input, context),
     Action: "TagQueue",
     Version: "2012-11-05"
   });
@@ -497,9 +469,8 @@ export const serializeAws_queryUntagQueueCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryUntagQueueRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryUntagQueueRequest(input, context),
     Action: "UntagQueue",
     Version: "2012-11-05"
   });

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -87,9 +87,8 @@ export const serializeAws_queryAssumeRoleCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAssumeRoleRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAssumeRoleRequest(input, context),
     Action: "AssumeRole",
     Version: "2011-06-15"
   });
@@ -104,9 +103,8 @@ export const serializeAws_queryAssumeRoleWithSAMLCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAssumeRoleWithSAMLRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAssumeRoleWithSAMLRequest(input, context),
     Action: "AssumeRoleWithSAML",
     Version: "2011-06-15"
   });
@@ -121,12 +119,8 @@ export const serializeAws_queryAssumeRoleWithWebIdentityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryAssumeRoleWithWebIdentityRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryAssumeRoleWithWebIdentityRequest(input, context),
     Action: "AssumeRoleWithWebIdentity",
     Version: "2011-06-15"
   });
@@ -141,12 +135,8 @@ export const serializeAws_queryDecodeAuthorizationMessageCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryDecodeAuthorizationMessageRequest(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryDecodeAuthorizationMessageRequest(input, context),
     Action: "DecodeAuthorizationMessage",
     Version: "2011-06-15"
   });
@@ -161,9 +151,8 @@ export const serializeAws_queryGetAccessKeyInfoCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetAccessKeyInfoRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetAccessKeyInfoRequest(input, context),
     Action: "GetAccessKeyInfo",
     Version: "2011-06-15"
   });
@@ -178,9 +167,8 @@ export const serializeAws_queryGetCallerIdentityCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetCallerIdentityRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetCallerIdentityRequest(input, context),
     Action: "GetCallerIdentity",
     Version: "2011-06-15"
   });
@@ -195,9 +183,8 @@ export const serializeAws_queryGetFederationTokenCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetFederationTokenRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetFederationTokenRequest(input, context),
     Action: "GetFederationToken",
     Version: "2011-06-15"
   });
@@ -212,9 +199,8 @@ export const serializeAws_queryGetSessionTokenCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryGetSessionTokenRequest(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryGetSessionTokenRequest(input, context),
     Action: "GetSessionToken",
     Version: "2011-06-15"
   });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -121,13 +121,11 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
     ) {
         TypeScriptWriter writer = context.getWriter();
 
-        // Gather all the explicit input entries.
-        writer.write("const entries = $L;",
-                inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
-
         // Set the form encoded string.
         writer.openBlock("body = buildFormUrlencodedString({", "});", () -> {
-            writer.write("...entries,");
+            // Gather all the explicit input entries.
+            writer.write("...$L,",
+                    inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
             // Set the protocol required values.
             writer.write("Action: $S,", operation.getId().getName());
             writer.write("Version: $S,", context.getService().getVersion());

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -121,13 +121,11 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     ) {
         TypeScriptWriter writer = context.getWriter();
 
-        // Gather all the explicit input entries.
-        writer.write("const entries = $L;",
-                inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
-
         // Set the form encoded string.
         writer.openBlock("body = buildFormUrlencodedString({", "});", () -> {
-            writer.write("...entries,");
+            // Gather all the explicit input entries.
+            writer.write("...$L,",
+                    inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
             // Set the protocol required values.
             writer.write("Action: $S,", operation.getId().getName());
             writer.write("Version: $S,", context.getService().getVersion());

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -119,9 +119,8 @@ export const serializeAws_ec2EmptyInputAndEmptyOutputCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2EmptyInputAndEmptyOutputInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2EmptyInputAndEmptyOutputInput(input, context),
     Action: "EmptyInputAndEmptyOutput",
     Version: "2020-01-08"
   });
@@ -164,9 +163,8 @@ export const serializeAws_ec2NestedStructuresCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2NestedStructuresInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2NestedStructuresInput(input, context),
     Action: "NestedStructures",
     Version: "2020-01-08"
   });
@@ -195,12 +193,8 @@ export const serializeAws_ec2QueryIdempotencyTokenAutoFillCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2QueryIdempotencyTokenAutoFillInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2QueryIdempotencyTokenAutoFillInput(input, context),
     Action: "QueryIdempotencyTokenAutoFill",
     Version: "2020-01-08"
   });
@@ -215,9 +209,8 @@ export const serializeAws_ec2QueryListsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2QueryListsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2QueryListsInput(input, context),
     Action: "QueryLists",
     Version: "2020-01-08"
   });
@@ -232,9 +225,8 @@ export const serializeAws_ec2QueryTimestampsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2QueryTimestampsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2QueryTimestampsInput(input, context),
     Action: "QueryTimestamps",
     Version: "2020-01-08"
   });
@@ -263,9 +255,8 @@ export const serializeAws_ec2SimpleInputParamsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_ec2SimpleInputParamsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_ec2SimpleInputParamsInput(input, context),
     Action: "SimpleInputParams",
     Version: "2020-01-08"
   });

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -148,12 +148,8 @@ export const serializeAws_queryEmptyInputAndEmptyOutputCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryEmptyInputAndEmptyOutputInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryEmptyInputAndEmptyOutputInput(input, context),
     Action: "EmptyInputAndEmptyOutput",
     Version: "2020-01-08"
   });
@@ -224,9 +220,8 @@ export const serializeAws_queryNestedStructuresCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryNestedStructuresInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryNestedStructuresInput(input, context),
     Action: "NestedStructures",
     Version: "2020-01-08"
   });
@@ -255,9 +250,8 @@ export const serializeAws_queryNoInputAndOutputCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryNoInputAndOutputOutput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryNoInputAndOutputOutput(input, context),
     Action: "NoInputAndOutput",
     Version: "2020-01-08"
   });
@@ -272,12 +266,8 @@ export const serializeAws_queryQueryIdempotencyTokenAutoFillCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryQueryIdempotencyTokenAutoFillInput(
-    input,
-    context
-  );
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryQueryIdempotencyTokenAutoFillInput(input, context),
     Action: "QueryIdempotencyTokenAutoFill",
     Version: "2020-01-08"
   });
@@ -292,9 +282,8 @@ export const serializeAws_queryQueryListsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryQueryListsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryQueryListsInput(input, context),
     Action: "QueryLists",
     Version: "2020-01-08"
   });
@@ -309,9 +298,8 @@ export const serializeAws_queryQueryMapsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryQueryMapsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryQueryMapsInput(input, context),
     Action: "QueryMaps",
     Version: "2020-01-08"
   });
@@ -326,9 +314,8 @@ export const serializeAws_queryQueryTimestampsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_queryQueryTimestampsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_queryQueryTimestampsInput(input, context),
     Action: "QueryTimestamps",
     Version: "2020-01-08"
   });
@@ -357,9 +344,8 @@ export const serializeAws_querySimpleInputParamsCommand = async (
     "Content-Type": "application/x-www-form-urlencoded"
   };
   let body: any;
-  const entries = serializeAws_querySimpleInputParamsInput(input, context);
   body = buildFormUrlencodedString({
-    ...entries,
+    ...serializeAws_querySimpleInputParamsInput(input, context),
     Action: "SimpleInputParams",
     Version: "2020-01-08"
   });


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
remove entries before buildFormUrlencodedString

Before:
```ts
  const entries = serializeAws_queryAttachInstancesQuery(input, context);
  body = buildFormUrlencodedString({
    ...entries,
    Action: "AttachInstances",
    Version: "2011-01-01"
  });
```

After:
```ts
  body = buildFormUrlencodedString({
    ...serializeAws_queryAttachInstancesQuery(input, context),
    Action: "AttachInstances",
    Version: "2011-01-01"
  });
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
