### PR TITLE
chore: change Object.keys to Object.entries

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
@@ -2865,10 +2865,13 @@ const serializeAws_restJson1_1FilterCriteriaMap = (
   input: { [key: string]: Criterion },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1Criterion(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Criterion }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1Criterion(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1FindingIdList = (
@@ -2915,10 +2918,13 @@ const serializeAws_restJson1_1TagsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1ValueList = (
@@ -3094,10 +3100,13 @@ const deserializeAws_restJson1_1ConditionKeyMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Criterion = (
@@ -3129,10 +3138,13 @@ const deserializeAws_restJson1_1FilterCriteriaMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Criterion } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1Criterion(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Criterion }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1Criterion(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Finding = (
@@ -3256,10 +3268,13 @@ const deserializeAws_restJson1_1PrincipalMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1SharedViaList = (
@@ -3273,10 +3288,13 @@ const deserializeAws_restJson1_1TagsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ValidationExceptionField = (

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -8884,10 +8884,13 @@ const serializeAws_json1_1AuthorizationResult = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1BusinessReportContentRange = (
@@ -12528,10 +12531,13 @@ const deserializeAws_json1_1Reviews = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1RevokeInvitationResponse = (

--- a/clients/client-amplify/protocols/Aws_restJson1_1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1_1.ts
@@ -5848,20 +5848,26 @@ const serializeAws_restJson1_1EnvironmentVariables = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1FileMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1SubDomainSetting = (
@@ -5887,10 +5893,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1App = (
@@ -6379,20 +6388,26 @@ const deserializeAws_restJson1_1EnvironmentVariables = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1FileUploadUrls = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Job = (
@@ -6495,10 +6510,13 @@ const deserializeAws_restJson1_1Screenshots = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Step = (
@@ -6617,10 +6635,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Webhook = (

--- a/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
@@ -21902,40 +21902,55 @@ const serializeAws_restJson1_1MapOfApiStageThrottleSettings = (
   input: { [key: string]: ThrottleSettings },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1ThrottleSettings(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: ThrottleSettings },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1ThrottleSettings(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfStringToBoolean = (
   input: { [key: string]: boolean },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: boolean }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfStringToList = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1ListOfString(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1ListOfString(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfStringToString = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1QuotaSettings = (
@@ -22779,103 +22794,136 @@ const deserializeAws_restJson1_1MapOfApiStageThrottleSettings = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ThrottleSettings } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ThrottleSettings(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: ThrottleSettings },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ThrottleSettings(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfIntegrationResponse = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: IntegrationResponse } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1IntegrationResponse(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: IntegrationResponse },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1IntegrationResponse(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfKeyUsages = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number[][] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ListOfUsage(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number[][] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ListOfUsage(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfMethod = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Method } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1Method(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Method }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1Method(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfMethodResponse = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MethodResponse } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MethodResponse(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: MethodResponse }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MethodResponse(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfMethodSettings = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MethodSetting } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MethodSetting(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: MethodSetting }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MethodSetting(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfMethodSnapshot = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MethodSnapshot } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MethodSnapshot(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: MethodSnapshot }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MethodSnapshot(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfStringToBoolean = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: boolean } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: boolean }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfStringToList = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ListOfString(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ListOfString(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfStringToString = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Method = (
@@ -23082,13 +23130,16 @@ const deserializeAws_restJson1_1PathToMapOfMethodSnapshot = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: { [key: string]: MethodSnapshot } } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MapOfMethodSnapshot(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: { [key: string]: MethodSnapshot } },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MapOfMethodSnapshot(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1QuotaSettings = (

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
@@ -10521,10 +10521,13 @@ const serializeAws_restJson1_1IntegrationParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1JWTConfiguration = (
@@ -10555,23 +10558,29 @@ const serializeAws_restJson1_1RouteModels = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1RouteParameters = (
   input: { [key: string]: ParameterConstraints },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1ParameterConstraints(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: ParameterConstraints },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1ParameterConstraints(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1RouteSettings = (
@@ -10601,40 +10610,52 @@ const serializeAws_restJson1_1RouteSettingsMap = (
   input: { [key: string]: RouteSettings },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1RouteSettings(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: RouteSettings }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1RouteSettings(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1StageVariablesMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1TemplateMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1__listOf__string = (
@@ -11096,10 +11117,13 @@ const deserializeAws_restJson1_1IntegrationParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1IntegrationResponse = (
@@ -11283,23 +11307,29 @@ const deserializeAws_restJson1_1RouteModels = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1RouteParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ParameterConstraints } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ParameterConstraints(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: ParameterConstraints },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ParameterConstraints(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1RouteResponse = (
@@ -11372,10 +11402,13 @@ const deserializeAws_restJson1_1RouteSettingsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: RouteSettings } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1RouteSettings(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: RouteSettings }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1RouteSettings(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Stage = (
@@ -11464,30 +11497,39 @@ const deserializeAws_restJson1_1StageVariablesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1TemplateMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1__listOfApi = (

--- a/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
@@ -5839,8 +5839,7 @@ const deserializeAws_restJson1_1AccessLog = (
       file: deserializeAws_restJson1_1FileAccessLog(output.file, context)
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1AwsCloudMapInstanceAttribute = (
@@ -5903,8 +5902,7 @@ const deserializeAws_restJson1_1Backend = (
       )
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1Backends = (
@@ -6140,8 +6138,7 @@ const deserializeAws_restJson1_1GrpcRouteMetadataMatchMethod = (
       suffix: output.suffix
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1HeaderMatchMethod = (
@@ -6173,8 +6170,7 @@ const deserializeAws_restJson1_1HeaderMatchMethod = (
       suffix: output.suffix
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1HealthCheckPolicy = (
@@ -6645,8 +6641,7 @@ const deserializeAws_restJson1_1ServiceDiscovery = (
       dns: deserializeAws_restJson1_1DnsServiceDiscovery(output.dns, context)
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1TagList = (
@@ -7017,8 +7012,7 @@ const deserializeAws_restJson1_1VirtualServiceProvider = (
       )
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1VirtualServiceRef = (

--- a/clients/client-appconfig/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1_1.ts
@@ -4553,10 +4553,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Validator = (
@@ -4826,10 +4829,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Validator = (

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -4290,10 +4290,13 @@ const deserializeAws_json1_1Configuration = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ConfigurationTag = (
@@ -4550,10 +4553,13 @@ const deserializeAws_json1_1DescribeConfigurationsAttribute = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1DescribeConfigurationsAttributes = (
@@ -5022,10 +5028,13 @@ const deserializeAws_json1_1SchemaStorageConfig = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ServerInternalErrorException = (

--- a/clients/client-application-insights/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/protocols/Aws_json1_1.ts
@@ -139,6 +139,7 @@ import {
   DescribeProblemObservationsResponse,
   DescribeProblemRequest,
   DescribeProblemResponse,
+  FeedbackKey,
   FeedbackValue,
   InternalServerException,
   ListApplicationsRequest,
@@ -3798,10 +3799,16 @@ const deserializeAws_json1_1Feedback = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FeedbackValue | string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: FeedbackValue | string },
+      [key, value]: [FeedbackKey | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1InternalServerException = (

--- a/clients/client-appstream/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/protocols/Aws_json1_1.ts
@@ -5979,10 +5979,13 @@ const serializeAws_json1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UntagResourceRequest = (
@@ -7394,10 +7397,13 @@ const deserializeAws_json1_1Metadata = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1NetworkAccessConfiguration = (
@@ -7844,10 +7850,13 @@ const deserializeAws_json1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1UntagResourceResponse = (

--- a/clients/client-appsync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1_1.ts
@@ -6825,10 +6825,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1UserPoolConfig = (
@@ -7376,10 +7379,13 @@ const deserializeAws_restJson1_1MapOfStringToString = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1OpenIDConnectConfig = (
@@ -7566,10 +7572,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Type = (

--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -5139,9 +5139,9 @@ const serializeAws_queryAttachInstancesQuery = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5160,9 +5160,9 @@ const serializeAws_queryAttachLoadBalancerTargetGroupsType = (
       input.TargetGroupARNs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupARNs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5181,9 +5181,9 @@ const serializeAws_queryAttachLoadBalancersType = (
       input.LoadBalancerNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5212,9 +5212,9 @@ const serializeAws_queryAutoScalingGroupNamesType = (
       input.AutoScalingGroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AutoScalingGroupNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxRecords !== undefined) {
@@ -5265,9 +5265,9 @@ const serializeAws_queryBatchDeleteScheduledActionType = (
       input.ScheduledActionNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledActionNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5286,9 +5286,9 @@ const serializeAws_queryBatchPutScheduledUpdateGroupActionType = (
       input.ScheduledUpdateGroupActions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledUpdateGroupActions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5304,9 +5304,9 @@ const serializeAws_queryBlockDeviceMapping = (
   }
   if (input.Ebs !== undefined) {
     const memberEntries = serializeAws_queryEbs(input.Ebs, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ebs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NoDevice !== undefined) {
@@ -5326,8 +5326,8 @@ const serializeAws_queryBlockDeviceMappings = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryBlockDeviceMapping(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5383,9 +5383,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DefaultCooldown !== undefined) {
@@ -5411,9 +5411,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
       input.LaunchTemplate,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplate.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LifecycleHookSpecificationList !== undefined) {
@@ -5421,9 +5421,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
       input.LifecycleHookSpecificationList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LifecycleHookSpecificationList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerNames !== undefined) {
@@ -5431,9 +5431,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
       input.LoadBalancerNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxInstanceLifetime !== undefined) {
@@ -5450,9 +5450,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
       input.MixedInstancesPolicy,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MixedInstancesPolicy.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NewInstancesProtectedFromScaleIn !== undefined) {
@@ -5467,9 +5467,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetGroupARNs !== undefined) {
@@ -5477,9 +5477,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
       input.TargetGroupARNs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupARNs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TerminationPolicies !== undefined) {
@@ -5487,9 +5487,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
       input.TerminationPolicies,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TerminationPolicies.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VPCZoneIdentifier !== undefined) {
@@ -5511,9 +5511,9 @@ const serializeAws_queryCreateLaunchConfigurationType = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMappings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClassicLinkVPCId !== undefined) {
@@ -5524,9 +5524,9 @@ const serializeAws_queryCreateLaunchConfigurationType = (
       input.ClassicLinkVPCSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClassicLinkVPCSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EbsOptimized !== undefined) {
@@ -5546,9 +5546,9 @@ const serializeAws_queryCreateLaunchConfigurationType = (
       input.InstanceMonitoring,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceMonitoring.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceType !== undefined) {
@@ -5574,9 +5574,9 @@ const serializeAws_queryCreateLaunchConfigurationType = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SpotPrice !== undefined) {
@@ -5595,9 +5595,9 @@ const serializeAws_queryCreateOrUpdateTagsType = (
   const entries: any = {};
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5613,9 +5613,9 @@ const serializeAws_queryCustomizedMetricSpecification = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -5710,9 +5710,9 @@ const serializeAws_queryDeleteTagsType = (
   const entries: any = {};
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5728,9 +5728,9 @@ const serializeAws_queryDescribeAutoScalingInstancesType = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxRecords !== undefined) {
@@ -5755,9 +5755,9 @@ const serializeAws_queryDescribeLifecycleHooksType = (
       input.LifecycleHookNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LifecycleHookNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5807,9 +5807,9 @@ const serializeAws_queryDescribeNotificationConfigurationsType = (
       input.AutoScalingGroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AutoScalingGroupNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxRecords !== undefined) {
@@ -5840,9 +5840,9 @@ const serializeAws_queryDescribePoliciesType = (
       input.PolicyNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PolicyTypes !== undefined) {
@@ -5850,9 +5850,9 @@ const serializeAws_queryDescribePoliciesType = (
       input.PolicyTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5868,9 +5868,9 @@ const serializeAws_queryDescribeScalingActivitiesType = (
       input.ActivityIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActivityIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AutoScalingGroupName !== undefined) {
@@ -5907,9 +5907,9 @@ const serializeAws_queryDescribeScheduledActionsType = (
       input.ScheduledActionNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledActionNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StartTime !== undefined) {
@@ -5925,9 +5925,9 @@ const serializeAws_queryDescribeTagsType = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilters(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxRecords !== undefined) {
@@ -5952,9 +5952,9 @@ const serializeAws_queryDetachInstancesQuery = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ShouldDecrementDesiredCapacity !== undefined) {
@@ -5977,9 +5977,9 @@ const serializeAws_queryDetachLoadBalancerTargetGroupsType = (
       input.TargetGroupARNs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupARNs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5998,9 +5998,9 @@ const serializeAws_queryDetachLoadBalancersType = (
       input.LoadBalancerNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6016,9 +6016,9 @@ const serializeAws_queryDisableMetricsCollectionQuery = (
   }
   if (input.Metrics !== undefined) {
     const memberEntries = serializeAws_queryMetrics(input.Metrics, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6060,9 +6060,9 @@ const serializeAws_queryEnableMetricsCollectionQuery = (
   }
   if (input.Metrics !== undefined) {
     const memberEntries = serializeAws_queryMetrics(input.Metrics, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6081,9 +6081,9 @@ const serializeAws_queryEnterStandbyQuery = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ShouldDecrementDesiredCapacity !== undefined) {
@@ -6129,9 +6129,9 @@ const serializeAws_queryExitStandbyQuery = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6147,9 +6147,9 @@ const serializeAws_queryFilter = (
   }
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryValues(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6163,8 +6163,8 @@ const serializeAws_queryFilters = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryFilter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6256,9 +6256,9 @@ const serializeAws_queryLaunchConfigurationNamesType = (
       input.LaunchConfigurationNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchConfigurationNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxRecords !== undefined) {
@@ -6280,16 +6280,16 @@ const serializeAws_queryLaunchTemplate = (
       input.LaunchTemplateSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Overrides !== undefined) {
     const memberEntries = serializeAws_queryOverrides(input.Overrides, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Overrides.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6379,8 +6379,8 @@ const serializeAws_queryLifecycleHookSpecifications = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6422,8 +6422,8 @@ const serializeAws_queryMetricDimensions = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryMetricDimension(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6453,9 +6453,9 @@ const serializeAws_queryMixedInstancesPolicy = (
       input.InstancesDistribution,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstancesDistribution.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LaunchTemplate !== undefined) {
@@ -6463,9 +6463,9 @@ const serializeAws_queryMixedInstancesPolicy = (
       input.LaunchTemplate,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplate.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6482,8 +6482,8 @@ const serializeAws_queryOverrides = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6588,9 +6588,9 @@ const serializeAws_queryPutNotificationConfigurationType = (
       input.NotificationTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TopicARN !== undefined) {
@@ -6639,9 +6639,9 @@ const serializeAws_queryPutScalingPolicyType = (
       input.StepAdjustments,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StepAdjustments.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetTrackingConfiguration !== undefined) {
@@ -6649,9 +6649,9 @@ const serializeAws_queryPutScalingPolicyType = (
       input.TargetTrackingConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetTrackingConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6725,9 +6725,9 @@ const serializeAws_queryScalingProcessQuery = (
       input.ScalingProcesses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScalingProcesses.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6786,8 +6786,8 @@ const serializeAws_queryScheduledUpdateGroupActionRequests = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6854,9 +6854,9 @@ const serializeAws_querySetInstanceProtectionQuery = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ProtectedFromScaleIn !== undefined) {
@@ -6890,8 +6890,8 @@ const serializeAws_queryStepAdjustments = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryStepAdjustment(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6923,8 +6923,8 @@ const serializeAws_queryTags = (input: Tag[], context: __SerdeContext): any => {
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6954,9 +6954,9 @@ const serializeAws_queryTargetTrackingConfiguration = (
       input.CustomizedMetricSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CustomizedMetricSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DisableScaleIn !== undefined) {
@@ -6967,9 +6967,9 @@ const serializeAws_queryTargetTrackingConfiguration = (
       input.PredefinedMetricSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PredefinedMetricSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetValue !== undefined) {
@@ -7019,9 +7019,9 @@ const serializeAws_queryUpdateAutoScalingGroupType = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DefaultCooldown !== undefined) {
@@ -7044,9 +7044,9 @@ const serializeAws_queryUpdateAutoScalingGroupType = (
       input.LaunchTemplate,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplate.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxInstanceLifetime !== undefined) {
@@ -7063,9 +7063,9 @@ const serializeAws_queryUpdateAutoScalingGroupType = (
       input.MixedInstancesPolicy,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MixedInstancesPolicy.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NewInstancesProtectedFromScaleIn !== undefined) {
@@ -7083,9 +7083,9 @@ const serializeAws_queryUpdateAutoScalingGroupType = (
       input.TerminationPolicies,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TerminationPolicies.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VPCZoneIdentifier !== undefined) {
@@ -9478,13 +9478,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-backup/protocols/Aws_restJson1_1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1_1.ts
@@ -7290,10 +7290,13 @@ const serializeAws_restJson1_1Metadata = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1ResourceArns = (
@@ -7314,10 +7317,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1BackupJob = (
@@ -7871,10 +7877,13 @@ const deserializeAws_restJson1_1Metadata = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ProtectedResource = (
@@ -8148,10 +8157,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-batch/protocols/Aws_restJson1_1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1_1.ts
@@ -2286,10 +2286,13 @@ const serializeAws_restJson1_1ParametersMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1ResourceRequirement = (
@@ -2331,10 +2334,13 @@ const serializeAws_restJson1_1TagsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Ulimit = (
@@ -2378,10 +2384,13 @@ const deserializeAws_restJson1_1ArrayJobStatusSummary = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ArrayPropertiesDetail = (
@@ -3456,10 +3465,13 @@ const deserializeAws_restJson1_1ParametersMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ResourceRequirement = (
@@ -3512,10 +3524,13 @@ const deserializeAws_restJson1_1TagsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Ulimit = (

--- a/clients/client-budgets/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/protocols/Aws_json1_1.ts
@@ -2022,10 +2022,13 @@ const serializeAws_json1_1CostFilters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1DimensionValues(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1DimensionValues(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1CostTypes = (
@@ -2290,10 +2293,13 @@ const serializeAws_json1_1PlannedBudgetLimits = (
   input: { [key: string]: Spend },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1Spend(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Spend }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1Spend(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1Spend = (
@@ -2564,10 +2570,13 @@ const deserializeAws_json1_1CostFilters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1DimensionValues(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1DimensionValues(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1CostTypes = (
@@ -2906,10 +2915,13 @@ const deserializeAws_json1_1PlannedBudgetLimits = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Spend } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1Spend(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Spend }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1Spend(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Spend = (

--- a/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
@@ -14178,20 +14178,26 @@ const serializeAws_restJson1_1RuleMap = (
   input: { [key: string]: Rule },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1Rule(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Rule }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1Rule(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1RuleParameterMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1SchemaFacet = (
@@ -15443,10 +15449,13 @@ const deserializeAws_restJson1_1LinkNameToObjectIdentifierMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ObjectIdentifierAndLinkNameList = (
@@ -15486,10 +15495,13 @@ const deserializeAws_restJson1_1ObjectIdentifierToLinkNameMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ObjectReference = (
@@ -15615,20 +15627,26 @@ const deserializeAws_restJson1_1RuleMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Rule } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1Rule(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Rule }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1Rule(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1RuleParameterMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1SchemaFacet = (

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -5367,9 +5367,9 @@ const serializeAws_queryContinueUpdateRollbackInput = (
       input.ResourcesToSkip,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourcesToSkip.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RoleARN !== undefined) {
@@ -5391,9 +5391,9 @@ const serializeAws_queryCreateChangeSetInput = (
       input.Capabilities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ChangeSetName !== undefined) {
@@ -5413,9 +5413,9 @@ const serializeAws_queryCreateChangeSetInput = (
       input.NotificationARNs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationARNs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Parameters !== undefined) {
@@ -5423,9 +5423,9 @@ const serializeAws_queryCreateChangeSetInput = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceTypes !== undefined) {
@@ -5433,9 +5433,9 @@ const serializeAws_queryCreateChangeSetInput = (
       input.ResourceTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourcesToImport !== undefined) {
@@ -5443,9 +5443,9 @@ const serializeAws_queryCreateChangeSetInput = (
       input.ResourcesToImport,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourcesToImport.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RoleARN !== undefined) {
@@ -5456,9 +5456,9 @@ const serializeAws_queryCreateChangeSetInput = (
       input.RollbackConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RollbackConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackName !== undefined) {
@@ -5466,9 +5466,9 @@ const serializeAws_queryCreateChangeSetInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateBody !== undefined) {
@@ -5493,9 +5493,9 @@ const serializeAws_queryCreateStackInput = (
       input.Capabilities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientRequestToken !== undefined) {
@@ -5512,9 +5512,9 @@ const serializeAws_queryCreateStackInput = (
       input.NotificationARNs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationARNs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OnFailure !== undefined) {
@@ -5525,9 +5525,9 @@ const serializeAws_queryCreateStackInput = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceTypes !== undefined) {
@@ -5535,9 +5535,9 @@ const serializeAws_queryCreateStackInput = (
       input.ResourceTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RoleARN !== undefined) {
@@ -5548,9 +5548,9 @@ const serializeAws_queryCreateStackInput = (
       input.RollbackConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RollbackConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackName !== undefined) {
@@ -5564,9 +5564,9 @@ const serializeAws_queryCreateStackInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateBody !== undefined) {
@@ -5608,9 +5608,9 @@ const serializeAws_queryDeleteStackInput = (
       input.RetainResources,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RetainResources.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RoleARN !== undefined) {
@@ -5714,9 +5714,9 @@ const serializeAws_queryDescribeStackResourceDriftsInput = (
       input.StackResourceDriftStatusFilters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StackResourceDriftStatusFilters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5808,9 +5808,9 @@ const serializeAws_queryDetectStackDriftInput = (
       input.LogicalResourceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogicalResourceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackName !== undefined) {
@@ -5843,9 +5843,9 @@ const serializeAws_queryEstimateTemplateCostInput = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateBody !== undefined) {
@@ -5988,9 +5988,9 @@ const serializeAws_queryListStacksInput = (
       input.StackStatusFilter,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StackStatusFilter.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6139,8 +6139,8 @@ const serializeAws_queryParameters = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryParameter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6192,9 +6192,9 @@ const serializeAws_queryRegisterTypeInput = (
       input.LoggingConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoggingConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SchemaHandlerPackage !== undefined) {
@@ -6236,9 +6236,9 @@ const serializeAws_queryResourceToImport = (
       input.ResourceIdentifier,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceIdentifier.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceType !== undefined) {
@@ -6268,8 +6268,8 @@ const serializeAws_queryResourcesToImport = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryResourceToImport(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6315,9 +6315,9 @@ const serializeAws_queryRollbackConfiguration = (
       input.RollbackTriggers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RollbackTriggers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6345,8 +6345,8 @@ const serializeAws_queryRollbackTriggers = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryRollbackTrigger(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6452,8 +6452,8 @@ const serializeAws_queryTags = (input: Tag[], context: __SerdeContext): any => {
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6470,9 +6470,9 @@ const serializeAws_queryUpdateStackInput = (
       input.Capabilities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientRequestToken !== undefined) {
@@ -6483,9 +6483,9 @@ const serializeAws_queryUpdateStackInput = (
       input.NotificationARNs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationARNs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Parameters !== undefined) {
@@ -6493,9 +6493,9 @@ const serializeAws_queryUpdateStackInput = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceTypes !== undefined) {
@@ -6503,9 +6503,9 @@ const serializeAws_queryUpdateStackInput = (
       input.ResourceTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RoleARN !== undefined) {
@@ -6516,9 +6516,9 @@ const serializeAws_queryUpdateStackInput = (
       input.RollbackConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RollbackConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackName !== undefined) {
@@ -6538,9 +6538,9 @@ const serializeAws_queryUpdateStackInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateBody !== undefined) {
@@ -6606,9 +6606,9 @@ const serializeAws_queryCreateStackInstancesInput = (
       input.Accounts,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OperationId === undefined) {
@@ -6622,9 +6622,9 @@ const serializeAws_queryCreateStackInstancesInput = (
       input.OperationPreferences,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OperationPreferences.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ParameterOverrides !== undefined) {
@@ -6632,16 +6632,16 @@ const serializeAws_queryCreateStackInstancesInput = (
       input.ParameterOverrides,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterOverrides.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Regions !== undefined) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackSetName !== undefined) {
@@ -6663,9 +6663,9 @@ const serializeAws_queryCreateStackSetInput = (
       input.Capabilities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientRequestToken === undefined) {
@@ -6685,9 +6685,9 @@ const serializeAws_queryCreateStackSetInput = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackSetName !== undefined) {
@@ -6695,9 +6695,9 @@ const serializeAws_queryCreateStackSetInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateBody !== undefined) {
@@ -6719,9 +6719,9 @@ const serializeAws_queryDeleteStackInstancesInput = (
       input.Accounts,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OperationId === undefined) {
@@ -6735,16 +6735,16 @@ const serializeAws_queryDeleteStackInstancesInput = (
       input.OperationPreferences,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OperationPreferences.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Regions !== undefined) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RetainStacks !== undefined) {
@@ -6825,9 +6825,9 @@ const serializeAws_queryDetectStackSetDriftInput = (
       input.OperationPreferences,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OperationPreferences.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackSetName !== undefined) {
@@ -6948,9 +6948,9 @@ const serializeAws_queryStackSetOperationPreferences = (
       input.RegionOrder,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RegionOrder.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6980,9 +6980,9 @@ const serializeAws_queryUpdateStackInstancesInput = (
       input.Accounts,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OperationId === undefined) {
@@ -6996,9 +6996,9 @@ const serializeAws_queryUpdateStackInstancesInput = (
       input.OperationPreferences,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OperationPreferences.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ParameterOverrides !== undefined) {
@@ -7006,16 +7006,16 @@ const serializeAws_queryUpdateStackInstancesInput = (
       input.ParameterOverrides,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterOverrides.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Regions !== undefined) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackSetName !== undefined) {
@@ -7034,9 +7034,9 @@ const serializeAws_queryUpdateStackSetInput = (
       input.Accounts,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AdministrationRoleARN !== undefined) {
@@ -7047,9 +7047,9 @@ const serializeAws_queryUpdateStackSetInput = (
       input.Capabilities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -7069,9 +7069,9 @@ const serializeAws_queryUpdateStackSetInput = (
       input.OperationPreferences,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OperationPreferences.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Parameters !== undefined) {
@@ -7079,16 +7079,16 @@ const serializeAws_queryUpdateStackSetInput = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Regions !== undefined) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StackSetName !== undefined) {
@@ -7096,9 +7096,9 @@ const serializeAws_queryUpdateStackSetInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateBody !== undefined) {
@@ -10637,13 +10637,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
@@ -1939,10 +1939,13 @@ const serializeAws_json1_1Filters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1Strings(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1Strings(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1InitializeClusterRequest = (
@@ -2347,10 +2350,13 @@ const deserializeAws_json1_1ExternalSubnetMapping = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Hsm = (

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1_1.ts
@@ -464,20 +464,26 @@ const deserializeAws_restJson1_1Exprs = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Facets = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: BucketInfo } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1BucketInfo(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: BucketInfo }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1BucketInfo(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1FieldStats = (
@@ -526,20 +532,26 @@ const deserializeAws_restJson1_1Fields = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1FieldValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1FieldValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Highlights = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Hit = (
@@ -617,10 +629,13 @@ const deserializeAws_restJson1_1Stats = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FieldStats } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1FieldStats(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: FieldStats }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1FieldStats(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1SuggestModel = (

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -3278,9 +3278,9 @@ const serializeAws_queryAnalysisScheme = (
       input.AnalysisOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AnalysisOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AnalysisSchemeLanguage !== undefined) {
@@ -3373,9 +3373,9 @@ const serializeAws_queryDefineAnalysisSchemeRequest = (
       input.AnalysisScheme,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AnalysisScheme.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DomainName !== undefined) {
@@ -3397,9 +3397,9 @@ const serializeAws_queryDefineExpressionRequest = (
       input.Expression,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Expression.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3418,9 +3418,9 @@ const serializeAws_queryDefineIndexFieldRequest = (
       input.IndexField,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IndexField.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3436,9 +3436,9 @@ const serializeAws_queryDefineSuggesterRequest = (
   }
   if (input.Suggester !== undefined) {
     const memberEntries = serializeAws_querySuggester(input.Suggester, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Suggester.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3521,9 +3521,9 @@ const serializeAws_queryDescribeAnalysisSchemesRequest = (
       input.AnalysisSchemeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AnalysisSchemeNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Deployed !== undefined) {
@@ -3573,9 +3573,9 @@ const serializeAws_queryDescribeDomainsRequest = (
       input.DomainNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DomainNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3597,9 +3597,9 @@ const serializeAws_queryDescribeExpressionsRequest = (
       input.ExpressionNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExpressionNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3621,9 +3621,9 @@ const serializeAws_queryDescribeIndexFieldsRequest = (
       input.FieldNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FieldNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3670,9 +3670,9 @@ const serializeAws_queryDescribeSuggestersRequest = (
       input.SuggesterNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SuggesterNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3819,9 +3819,9 @@ const serializeAws_queryIndexField = (
       input.DateArrayOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DateArrayOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DateOptions !== undefined) {
@@ -3829,9 +3829,9 @@ const serializeAws_queryIndexField = (
       input.DateOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DateOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DoubleArrayOptions !== undefined) {
@@ -3839,9 +3839,9 @@ const serializeAws_queryIndexField = (
       input.DoubleArrayOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DoubleArrayOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DoubleOptions !== undefined) {
@@ -3849,9 +3849,9 @@ const serializeAws_queryIndexField = (
       input.DoubleOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DoubleOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IndexFieldName !== undefined) {
@@ -3865,9 +3865,9 @@ const serializeAws_queryIndexField = (
       input.IntArrayOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IntArrayOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IntOptions !== undefined) {
@@ -3875,9 +3875,9 @@ const serializeAws_queryIndexField = (
       input.IntOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IntOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LatLonOptions !== undefined) {
@@ -3885,9 +3885,9 @@ const serializeAws_queryIndexField = (
       input.LatLonOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LatLonOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LiteralArrayOptions !== undefined) {
@@ -3895,9 +3895,9 @@ const serializeAws_queryIndexField = (
       input.LiteralArrayOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LiteralArrayOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LiteralOptions !== undefined) {
@@ -3905,9 +3905,9 @@ const serializeAws_queryIndexField = (
       input.LiteralOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LiteralOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TextArrayOptions !== undefined) {
@@ -3915,9 +3915,9 @@ const serializeAws_queryIndexField = (
       input.TextArrayOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TextArrayOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TextOptions !== undefined) {
@@ -3925,9 +3925,9 @@ const serializeAws_queryIndexField = (
       input.TextOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TextOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4097,9 +4097,9 @@ const serializeAws_querySuggester = (
       input.DocumentSuggesterOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DocumentSuggesterOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SuggesterName !== undefined) {
@@ -4181,9 +4181,9 @@ const serializeAws_queryUpdateDomainEndpointOptionsRequest = (
       input.DomainEndpointOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DomainEndpointOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DomainName !== undefined) {
@@ -4205,9 +4205,9 @@ const serializeAws_queryUpdateScalingParametersRequest = (
       input.ScalingParameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScalingParameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5912,13 +5912,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -4011,10 +4011,13 @@ const serializeAws_json1_1TransformerPaths = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UntagResourceRequest = (
@@ -5052,10 +5055,13 @@ const deserializeAws_json1_1TransformerPaths = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1UntagResourceResponse = (

--- a/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
@@ -5008,10 +5008,13 @@ const serializeAws_json1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TestEventMessages = (
@@ -5359,10 +5362,13 @@ const deserializeAws_json1_1ExtractedValues = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1FilterLogEventsResponse = (
@@ -5645,10 +5651,13 @@ const deserializeAws_json1_1LogRecord = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1LogStream = (
@@ -6248,10 +6257,13 @@ const deserializeAws_json1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TestMetricFilterResponse = (

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -3096,9 +3096,9 @@ const serializeAws_queryAnomalyDetectorConfiguration = (
       input.ExcludedTimeRanges,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedTimeRanges.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricTimezone !== undefined) {
@@ -3115,8 +3115,8 @@ const serializeAws_queryAnomalyDetectorExcludedTimeRanges = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryRange(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -3159,9 +3159,9 @@ const serializeAws_queryDeleteAlarmsInput = (
       input.AlarmNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3177,9 +3177,9 @@ const serializeAws_queryDeleteAnomalyDetectorInput = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -3204,9 +3204,9 @@ const serializeAws_queryDeleteDashboardsInput = (
       input.DashboardNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DashboardNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3222,9 +3222,9 @@ const serializeAws_queryDeleteInsightRulesInput = (
       input.RuleNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3266,9 +3266,9 @@ const serializeAws_queryDescribeAlarmsForMetricInput = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ExtendedStatistic !== undefined) {
@@ -3308,9 +3308,9 @@ const serializeAws_queryDescribeAlarmsInput = (
       input.AlarmNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxRecords !== undefined) {
@@ -3335,9 +3335,9 @@ const serializeAws_queryDescribeAnomalyDetectorsInput = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -3405,8 +3405,8 @@ const serializeAws_queryDimensionFilters = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryDimensionFilter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -3421,8 +3421,8 @@ const serializeAws_queryDimensions = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryDimension(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -3439,9 +3439,9 @@ const serializeAws_queryDisableAlarmActionsInput = (
       input.AlarmNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3457,9 +3457,9 @@ const serializeAws_queryDisableInsightRulesInput = (
       input.RuleNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3475,9 +3475,9 @@ const serializeAws_queryEnableAlarmActionsInput = (
       input.AlarmNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3493,9 +3493,9 @@ const serializeAws_queryEnableInsightRulesInput = (
       input.RuleNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3541,9 +3541,9 @@ const serializeAws_queryGetInsightRuleReportInput = (
       input.Metrics,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OrderBy !== undefined) {
@@ -3577,9 +3577,9 @@ const serializeAws_queryGetMetricDataInput = (
       input.MetricDataQueries,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricDataQueries.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NextToken !== undefined) {
@@ -3604,9 +3604,9 @@ const serializeAws_queryGetMetricStatisticsInput = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EndTime !== undefined) {
@@ -3617,9 +3617,9 @@ const serializeAws_queryGetMetricStatisticsInput = (
       input.ExtendedStatistics,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExtendedStatistics.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -3639,9 +3639,9 @@ const serializeAws_queryGetMetricStatisticsInput = (
       input.Statistics,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Statistics.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Unit !== undefined) {
@@ -3714,9 +3714,9 @@ const serializeAws_queryListMetricsInput = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -3752,9 +3752,9 @@ const serializeAws_queryMetric = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -3774,8 +3774,8 @@ const serializeAws_queryMetricData = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryMetricDatum(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -3790,8 +3790,8 @@ const serializeAws_queryMetricDataQueries = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryMetricDataQuery(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -3817,9 +3817,9 @@ const serializeAws_queryMetricDataQuery = (
       input.MetricStat,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricStat.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Period !== undefined) {
@@ -3838,9 +3838,9 @@ const serializeAws_queryMetricDatum = (
   const entries: any = {};
   if (input.Counts !== undefined) {
     const memberEntries = serializeAws_queryCounts(input.Counts, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Counts.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Dimensions !== undefined) {
@@ -3848,9 +3848,9 @@ const serializeAws_queryMetricDatum = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -3861,9 +3861,9 @@ const serializeAws_queryMetricDatum = (
       input.StatisticValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StatisticValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StorageResolution !== undefined) {
@@ -3880,9 +3880,9 @@ const serializeAws_queryMetricDatum = (
   }
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryValues(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3895,9 +3895,9 @@ const serializeAws_queryMetricStat = (
   const entries: any = {};
   if (input.Metric !== undefined) {
     const memberEntries = serializeAws_queryMetric(input.Metric, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metric.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Period !== undefined) {
@@ -3922,9 +3922,9 @@ const serializeAws_queryPutAnomalyDetectorInput = (
       input.Configuration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Configuration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Dimensions !== undefined) {
@@ -3932,9 +3932,9 @@ const serializeAws_queryPutAnomalyDetectorInput = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -3993,9 +3993,9 @@ const serializeAws_queryPutMetricAlarmInput = (
       input.AlarmActions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmActions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AlarmDescription !== undefined) {
@@ -4015,9 +4015,9 @@ const serializeAws_queryPutMetricAlarmInput = (
       input.Dimensions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EvaluateLowSampleCountPercentile !== undefined) {
@@ -4035,9 +4035,9 @@ const serializeAws_queryPutMetricAlarmInput = (
       input.InsufficientDataActions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InsufficientDataActions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetricName !== undefined) {
@@ -4048,9 +4048,9 @@ const serializeAws_queryPutMetricAlarmInput = (
       input.Metrics,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Namespace !== undefined) {
@@ -4061,9 +4061,9 @@ const serializeAws_queryPutMetricAlarmInput = (
       input.OKActions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OKActions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Period !== undefined) {
@@ -4074,9 +4074,9 @@ const serializeAws_queryPutMetricAlarmInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Threshold !== undefined) {
@@ -4104,9 +4104,9 @@ const serializeAws_queryPutMetricDataInput = (
       input.MetricData,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricData.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Namespace !== undefined) {
@@ -4227,8 +4227,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -4245,9 +4245,9 @@ const serializeAws_queryTagResourceInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4263,9 +4263,9 @@ const serializeAws_queryUntagResourceInput = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6038,13 +6038,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-codebuild/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/protocols/Aws_json1_1.ts
@@ -5723,10 +5723,13 @@ const deserializeAws_json1_1ReportStatusCounts = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Reports = (

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -21816,10 +21816,13 @@ const serializeAws_json1_1TagsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1Target = (
@@ -27005,10 +27008,13 @@ const deserializeAws_json1_1TagsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TagsMapRequiredException = (

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -411,6 +411,7 @@ import {
   TagResourceInput,
   TagResourceOutput,
   TagSetListLimitExceededException,
+  TargetFilterName,
   TargetGroupInfo,
   TargetGroupPairInfo,
   TargetInstances,
@@ -10152,10 +10153,16 @@ const serializeAws_json1_1TargetFilters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1FilterValueList(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string[] },
+      [key, value]: [TargetFilterName | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1FilterValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TargetGroupInfo = (

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -4965,10 +4965,13 @@ const serializeAws_json1_1ArtifactStoreMap = (
   input: { [key: string]: ArtifactStore },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ArtifactStore(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: ArtifactStore }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ArtifactStore(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1BlockerDeclaration = (
@@ -5673,10 +5676,13 @@ const serializeAws_json1_1ActionConfigurationMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ActionTypeId = (
@@ -5751,20 +5757,26 @@ const serializeAws_json1_1OutputVariablesMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1QueryParamMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AcknowledgeJobOutput = (
@@ -6374,10 +6386,13 @@ const deserializeAws_json1_1ArtifactStoreMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ArtifactStore } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1ArtifactStore(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: ArtifactStore }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1ArtifactStore(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1BlockerDeclaration = (
@@ -7401,10 +7416,13 @@ const deserializeAws_json1_1ResolvedActionConfigurationMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1RetryStageExecutionOutput = (
@@ -7964,10 +7982,13 @@ const deserializeAws_json1_1ActionConfigurationMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ActionContext = (
@@ -8130,10 +8151,13 @@ const deserializeAws_json1_1OutputVariablesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1OutputVariablesSizeExceededException = (

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
@@ -1720,10 +1720,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Target = (
@@ -1804,10 +1807,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1TargetSummary = (

--- a/clients/client-codestar/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/protocols/Aws_json1_1.ts
@@ -2508,20 +2508,26 @@ const serializeAws_json1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TemplateParameterMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1Toolchain = (
@@ -3059,10 +3065,13 @@ const deserializeAws_json1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TeamMember = (

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -17022,10 +17022,13 @@ const serializeAws_json1_1AttributeMappingType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1AttributeNameListType = (
@@ -17049,10 +17052,13 @@ const serializeAws_json1_1AuthParametersType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1BlockedIPRangeListType = (
@@ -17073,10 +17079,13 @@ const serializeAws_json1_1ChallengeResponsesType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ChangePasswordRequest = (
@@ -17098,10 +17107,13 @@ const serializeAws_json1_1ClientMetadataType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ClientPermissionListType = (
@@ -18243,10 +18255,13 @@ const serializeAws_json1_1ProviderDetailsType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ProviderUserIdentifierType = (
@@ -19054,10 +19069,13 @@ const serializeAws_json1_1UserPoolTagsType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UsernameAttributesListType = (
@@ -19647,10 +19665,13 @@ const deserializeAws_json1_1AttributeMappingType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AttributeType = (
@@ -19782,10 +19803,13 @@ const deserializeAws_json1_1ChallengeParametersType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ChallengeResponseListType = (
@@ -21440,10 +21464,13 @@ const deserializeAws_json1_1ProviderDetailsType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ProvidersListType = (
@@ -22593,10 +22620,13 @@ const deserializeAws_json1_1UserPoolTagsType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1UserPoolType = (

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -3353,20 +3353,26 @@ const serializeAws_json1_1IdentityPoolTagsType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1IdentityProviders = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ListIdentitiesInput = (
@@ -3415,10 +3421,13 @@ const serializeAws_json1_1LoginsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1LookupDeveloperIdentityInput = (
@@ -3506,20 +3515,26 @@ const serializeAws_json1_1RoleMappingMap = (
   input: { [key: string]: RoleMapping },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1RoleMapping(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: RoleMapping }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1RoleMapping(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1RolesMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1RulesConfigurationType = (
@@ -3951,10 +3966,13 @@ const deserializeAws_json1_1IdentityPoolTagsType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1IdentityPoolsList = (
@@ -3970,10 +3988,13 @@ const deserializeAws_json1_1IdentityProviders = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1InternalErrorException = (
@@ -4234,20 +4255,26 @@ const deserializeAws_json1_1RoleMappingMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: RoleMapping } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1RoleMapping(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: RoleMapping }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1RoleMapping(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1RolesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1RulesConfigurationType = (

--- a/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
@@ -3222,10 +3222,13 @@ const serializeAws_restJson1_1Events = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1PushSync = (
@@ -3351,10 +3354,13 @@ const deserializeAws_restJson1_1Events = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1IdentityPoolUsage = (

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -11123,13 +11123,16 @@ const serializeAws_json1_1RemediationParameters = (
   input: { [key: string]: RemediationParameterValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1RemediationParameterValue(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: RemediationParameterValue },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1RemediationParameterValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ResourceCountFilters = (
@@ -11433,10 +11436,13 @@ const serializeAws_json1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TagsList = (
@@ -15456,13 +15462,16 @@ const deserializeAws_json1_1RemediationParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: RemediationParameterValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1RemediationParameterValue(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: RemediationParameterValue },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1RemediationParameterValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ResourceCount = (
@@ -15823,10 +15832,13 @@ const deserializeAws_json1_1SupplementaryConfiguration = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Tag = (
@@ -15857,10 +15869,13 @@ const deserializeAws_json1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TooManyTagsException = (

--- a/clients/client-connect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1_1.ts
@@ -4776,10 +4776,13 @@ const serializeAws_restJson1_1Attributes = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1ChatMessage = (
@@ -4901,10 +4904,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1UserIdentityInfo = (
@@ -4938,10 +4944,13 @@ const deserializeAws_restJson1_1Attributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1CurrentMetric = (
@@ -5485,10 +5494,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1User = (

--- a/clients/client-cost-explorer/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/protocols/Aws_json1_1.ts
@@ -2779,10 +2779,13 @@ const deserializeAws_json1_1Attributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1BillExpirationException = (
@@ -4006,10 +4009,13 @@ const deserializeAws_json1_1Metrics = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MetricValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1MetricValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: MetricValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1MetricValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ModifyRecommendationDetail = (

--- a/clients/client-data-pipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/protocols/Aws_json1_1.ts
@@ -3062,10 +3062,13 @@ const deserializeAws_json1_1PipelineObjectMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: PipelineObject } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1PipelineObject(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: PipelineObject }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1PipelineObject(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1PollForTaskOutput = (

--- a/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
@@ -3707,10 +3707,13 @@ const serializeAws_restJson1_1MapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1RequestDetails = (
@@ -4174,10 +4177,13 @@ const deserializeAws_restJson1_1MapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1OriginDetails = (

--- a/clients/client-device-farm/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/protocols/Aws_json1_1.ts
@@ -355,11 +355,13 @@ import {
   DeviceFilter,
   DeviceInstance,
   DeviceMinutes,
+  DevicePlatform,
   DevicePool,
   DevicePoolCompatibilityResult,
   DeviceSelectionConfiguration,
   DeviceSelectionResult,
   ExecutionConfiguration,
+  ExecutionResult,
   GetAccountSettingsRequest,
   GetAccountSettingsResult,
   GetDeviceInstanceRequest,
@@ -10134,10 +10136,13 @@ const serializeAws_json1_1TestParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UntagResourceRequest = (
@@ -11946,10 +11951,13 @@ const deserializeAws_json1_1MaxSlotMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MonetaryAmount = (
@@ -12144,10 +12152,13 @@ const deserializeAws_json1_1OfferingStatusMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: OfferingStatus } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1OfferingStatus(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: OfferingStatus }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1OfferingStatus(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1OfferingTransaction = (
@@ -12320,10 +12331,16 @@ const deserializeAws_json1_1PurchasedDevicesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: number },
+      [key, value]: [DevicePlatform | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Radios = (
@@ -13174,10 +13191,16 @@ const deserializeAws_json1_1UniqueProblemsByExecutionResultMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: UniqueProblem[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1UniqueProblems(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: UniqueProblem[] },
+      [key, value]: [ExecutionResult | string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1UniqueProblems(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1UntagResourceResponse = (

--- a/clients/client-dlm/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1_1.ts
@@ -1360,10 +1360,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1TagsToAddList = (
@@ -1759,10 +1762,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1TagsToAddList = (

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -5832,9 +5832,9 @@ const serializeAws_queryAddTagsToResourceMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5893,9 +5893,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
       input.DisableLogTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisableLogTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableLogTypes !== undefined) {
@@ -5903,9 +5903,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
       input.EnableLogTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableLogTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5922,9 +5922,9 @@ const serializeAws_queryCopyDBClusterParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBClusterParameterGroupDescription !== undefined) {
@@ -5958,9 +5958,9 @@ const serializeAws_queryCopyDBClusterSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBClusterSnapshotIdentifier !== undefined) {
@@ -5980,9 +5980,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BackupRetentionPeriod !== undefined) {
@@ -6005,9 +6005,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Engine !== undefined) {
@@ -6039,9 +6039,9 @@ const serializeAws_queryCreateDBClusterMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -6049,9 +6049,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6073,9 +6073,9 @@ const serializeAws_queryCreateDBClusterParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6094,9 +6094,9 @@ const serializeAws_queryCreateDBClusterSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6133,9 +6133,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6157,16 +6157,16 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6243,9 +6243,9 @@ const serializeAws_queryDescribeCertificatesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6267,9 +6267,9 @@ const serializeAws_queryDescribeDBClusterParameterGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6291,9 +6291,9 @@ const serializeAws_queryDescribeDBClusterParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6332,9 +6332,9 @@ const serializeAws_queryDescribeDBClusterSnapshotsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludePublic !== undefined) {
@@ -6365,9 +6365,9 @@ const serializeAws_queryDescribeDBClustersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6398,9 +6398,9 @@ const serializeAws_queryDescribeDBEngineVersionsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListSupportedCharacterSets !== undefined) {
@@ -6428,9 +6428,9 @@ const serializeAws_queryDescribeDBInstancesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6452,9 +6452,9 @@ const serializeAws_queryDescribeDBSubnetGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6476,9 +6476,9 @@ const serializeAws_queryDescribeEngineDefaultClusterParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6497,9 +6497,9 @@ const serializeAws_queryDescribeEventCategoriesMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceType !== undefined) {
@@ -6524,16 +6524,16 @@ const serializeAws_queryDescribeEventsMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6570,9 +6570,9 @@ const serializeAws_queryDescribeOrderableDBInstanceOptionsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LicenseModel !== undefined) {
@@ -6597,9 +6597,9 @@ const serializeAws_queryDescribePendingMaintenanceActionsMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -6654,9 +6654,9 @@ const serializeAws_queryFilter = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6670,8 +6670,8 @@ const serializeAws_queryFilterList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryFilter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Filter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Filter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6711,9 +6711,9 @@ const serializeAws_queryListTagsForResourceMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceName !== undefined) {
@@ -6751,9 +6751,9 @@ const serializeAws_queryModifyDBClusterMessage = (
       input.CloudwatchLogsExportConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CloudwatchLogsExportConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBClusterIdentifier !== undefined) {
@@ -6788,9 +6788,9 @@ const serializeAws_queryModifyDBClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6809,9 +6809,9 @@ const serializeAws_queryModifyDBClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6833,9 +6833,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
       input.ValuesToAdd,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ValuesToRemove !== undefined) {
@@ -6843,9 +6843,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
       input.ValuesToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6899,9 +6899,9 @@ const serializeAws_queryModifyDBSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6953,8 +6953,8 @@ const serializeAws_queryParametersList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryParameter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Parameter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Parameter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6985,9 +6985,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7006,9 +7006,9 @@ const serializeAws_queryResetDBClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetAllParameters !== undefined) {
@@ -7027,9 +7027,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBClusterIdentifier !== undefined) {
@@ -7046,9 +7046,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Engine !== undefined) {
@@ -7068,9 +7068,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -7078,9 +7078,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7105,9 +7105,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.KmsKeyId !== undefined) {
@@ -7125,9 +7125,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UseLatestRestorableTime !== undefined) {
@@ -7138,9 +7138,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7200,8 +7200,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Tag.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Tag.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -10099,13 +10099,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
@@ -906,10 +906,13 @@ const deserializeAws_json1_0AttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0AttributeValue = (
@@ -1027,10 +1030,13 @@ const deserializeAws_json1_0MapAttributeValue = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0NumberSetAttributeValue = (

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -5541,10 +5541,16 @@ const serializeAws_json1_0AttributeUpdates = (
   input: { [key: string]: AttributeValueUpdate },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0AttributeValueUpdate(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: AttributeValueUpdate },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_0AttributeValueUpdate(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0AttributeValue = (
@@ -5674,10 +5680,16 @@ const serializeAws_json1_0BatchGetRequestMap = (
   input: { [key: string]: KeysAndAttributes },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0KeysAndAttributes(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: KeysAndAttributes },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_0KeysAndAttributes(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0BatchWriteItemInput = (
@@ -5704,10 +5716,13 @@ const serializeAws_json1_0BatchWriteItemRequestMap = (
   input: { [key: string]: WriteRequest[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0WriteRequests(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: WriteRequest[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_0WriteRequests(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0BinarySetAttributeValue = (
@@ -6118,10 +6133,16 @@ const serializeAws_json1_0ExpectedAttributeMap = (
   input: { [key: string]: ExpectedAttributeValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0ExpectedAttributeValue(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: ExpectedAttributeValue },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_0ExpectedAttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0ExpectedAttributeValue = (
@@ -6149,30 +6170,39 @@ const serializeAws_json1_0ExpressionAttributeNameMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0ExpressionAttributeValueMap = (
   input: { [key: string]: AttributeValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0AttributeValue(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0FilterConditionMap = (
   input: { [key: string]: Condition },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0Condition(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Condition }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_0Condition(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0Get = (input: Get, context: __SerdeContext): any => {
@@ -6350,20 +6380,26 @@ const serializeAws_json1_0Key = (
   input: { [key: string]: AttributeValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0AttributeValue(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0KeyConditions = (
   input: { [key: string]: Condition },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0Condition(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Condition }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_0Condition(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0KeyList = (
@@ -6528,10 +6564,13 @@ const serializeAws_json1_0MapAttributeValue = (
   input: { [key: string]: AttributeValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0AttributeValue(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0NonKeyAttributeNameList = (
@@ -6678,10 +6717,13 @@ const serializeAws_json1_0PutItemInputAttributeMap = (
   input: { [key: string]: AttributeValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_0AttributeValue(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_0PutRequest = (
@@ -7725,10 +7767,13 @@ const deserializeAws_json1_0AttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0AttributeNameList = (
@@ -8055,20 +8100,32 @@ const deserializeAws_json1_0BatchGetRequestMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: KeysAndAttributes } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0KeysAndAttributes(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: KeysAndAttributes },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0KeysAndAttributes(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0BatchGetResponseMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: { [key: string]: AttributeValue }[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0ItemList(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: { [key: string]: AttributeValue }[] },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0ItemList(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0BatchWriteItemOutput = (
@@ -8106,10 +8163,13 @@ const deserializeAws_json1_0BatchWriteItemRequestMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: WriteRequest[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0WriteRequests(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: WriteRequest[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0WriteRequests(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0BillingModeSummary = (
@@ -8645,10 +8705,13 @@ const deserializeAws_json1_0ExpressionAttributeNameMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0FailureException = (
@@ -8926,10 +8989,13 @@ const deserializeAws_json1_0ItemCollectionKeyAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0ItemCollectionMetrics = (
@@ -8970,13 +9036,16 @@ const deserializeAws_json1_0ItemCollectionMetricsPerTable = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ItemCollectionMetrics[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0ItemCollectionMetricsMultiple(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: ItemCollectionMetrics[] },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0ItemCollectionMetricsMultiple(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0ItemCollectionSizeEstimateRange = (
@@ -9034,10 +9103,13 @@ const deserializeAws_json1_0Key = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0KeyList = (
@@ -9302,10 +9374,13 @@ const deserializeAws_json1_0MapAttributeValue = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0NonKeyAttributeNameList = (
@@ -9463,10 +9538,13 @@ const deserializeAws_json1_0PutItemInputAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0PutItemOutput = (
@@ -10053,10 +10131,13 @@ const deserializeAws_json1_0SecondaryIndexesCapacityMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Capacity } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_0Capacity(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Capacity }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_0Capacity(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_0SourceTableDetails = (

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -31394,9 +31394,9 @@ const serializeAws_ec2AcceptReservedInstancesExchangeQuoteRequest = (
       input.ReservedInstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetConfigurations !== undefined) {
@@ -31404,9 +31404,9 @@ const serializeAws_ec2AcceptReservedInstancesExchangeQuoteRequest = (
       input.TargetConfigurations,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetConfiguration.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -31456,9 +31456,9 @@ const serializeAws_ec2AcceptVpcEndpointConnectionsRequest = (
       input.VpcEndpointIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -31562,9 +31562,9 @@ const serializeAws_ec2AllocateHostsRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -31599,9 +31599,9 @@ const serializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkRequest = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcId !== undefined) {
@@ -31623,9 +31623,9 @@ const serializeAws_ec2AssignIpv6AddressesRequest = (
       input.Ipv6Addresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaceId !== undefined) {
@@ -31650,9 +31650,9 @@ const serializeAws_ec2AssignPrivateIpAddressesRequest = (
       input.PrivateIpAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddress.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecondaryPrivateIpAddressCount !== undefined) {
@@ -31741,9 +31741,9 @@ const serializeAws_ec2AssociateIamInstanceProfileRequest = (
       input.IamInstanceProfile,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamInstanceProfile.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceId !== undefined) {
@@ -31799,9 +31799,9 @@ const serializeAws_ec2AssociateTransitGatewayMulticastDomainRequest = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayAttachmentId !== undefined) {
@@ -31884,9 +31884,9 @@ const serializeAws_ec2AttachClassicLinkVpcRequest = (
       input.Groups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceId !== undefined) {
@@ -32048,9 +32048,9 @@ const serializeAws_ec2AuthorizeSecurityGroupEgressRequest = (
       input.IpPermissions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IpProtocol !== undefined) {
@@ -32093,9 +32093,9 @@ const serializeAws_ec2AuthorizeSecurityGroupIngressRequest = (
       input.IpPermissions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IpProtocol !== undefined) {
@@ -32160,9 +32160,9 @@ const serializeAws_ec2BlockDeviceMapping = (
   }
   if (input.Ebs !== undefined) {
     const memberEntries = serializeAws_ec2EbsBlockDevice(input.Ebs, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ebs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NoDevice !== undefined) {
@@ -32182,8 +32182,8 @@ const serializeAws_ec2BlockDeviceMappingList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2BlockDeviceMapping(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -32198,8 +32198,8 @@ const serializeAws_ec2BlockDeviceMappingRequestList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2BlockDeviceMapping(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`BlockDeviceMapping.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`BlockDeviceMapping.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -32232,9 +32232,9 @@ const serializeAws_ec2BundleInstanceRequest = (
   }
   if (input.Storage !== undefined) {
     const memberEntries = serializeAws_ec2Storage(input.Storage, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Storage.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -32337,9 +32337,9 @@ const serializeAws_ec2CancelSpotFleetRequestsRequest = (
       input.SpotFleetRequestIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotFleetRequestId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TerminateInstances !== undefined) {
@@ -32361,11 +32361,11 @@ const serializeAws_ec2CancelSpotInstanceRequestsRequest = (
       input.SpotInstanceRequestIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotInstanceRequestId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -32409,9 +32409,9 @@ const serializeAws_ec2CapacityReservationSpecification = (
       input.CapacityReservationTarget,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationTarget.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -32473,8 +32473,8 @@ const serializeAws_ec2ClassicLoadBalancers = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2ClassicLoadBalancer(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -32491,9 +32491,9 @@ const serializeAws_ec2ClassicLoadBalancersConfig = (
       input.ClassicLoadBalancers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClassicLoadBalancers.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -32530,9 +32530,9 @@ const serializeAws_ec2ClientVpnAuthenticationRequest = (
       input.ActiveDirectory,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActiveDirectory.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MutualAuthentication !== undefined) {
@@ -32540,9 +32540,9 @@ const serializeAws_ec2ClientVpnAuthenticationRequest = (
       input.MutualAuthentication,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MutualAuthentication.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Type !== undefined) {
@@ -32562,8 +32562,8 @@ const serializeAws_ec2ClientVpnAuthenticationRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -32735,9 +32735,9 @@ const serializeAws_ec2CopySnapshotRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -32803,9 +32803,9 @@ const serializeAws_ec2CreateCapacityReservationRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecifications.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tenancy !== undefined) {
@@ -32824,9 +32824,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
       input.AuthenticationOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Authentication.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientCidrBlock !== undefined) {
@@ -32843,9 +32843,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
       input.ConnectionLogOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionLogOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -32856,9 +32856,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
       input.DnsServers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DnsServers.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -32875,9 +32875,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransportProtocol !== undefined) {
@@ -32979,9 +32979,9 @@ const serializeAws_ec2CreateDhcpOptionsRequest = (
       input.DhcpConfigurations,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DhcpConfiguration.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -33027,11 +33027,11 @@ const serializeAws_ec2CreateFleetRequest = (
       input.LaunchTemplateConfigs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateConfigs.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OnDemandOptions !== undefined) {
@@ -33039,9 +33039,9 @@ const serializeAws_ec2CreateFleetRequest = (
       input.OnDemandOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OnDemandOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplaceUnhealthyInstances !== undefined) {
@@ -33052,9 +33052,9 @@ const serializeAws_ec2CreateFleetRequest = (
       input.SpotOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagSpecifications !== undefined) {
@@ -33062,9 +33062,9 @@ const serializeAws_ec2CreateFleetRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetCapacitySpecification !== undefined) {
@@ -33072,9 +33072,9 @@ const serializeAws_ec2CreateFleetRequest = (
       input.TargetCapacitySpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetCapacitySpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TerminateInstancesWithExpiration !== undefined) {
@@ -33124,9 +33124,9 @@ const serializeAws_ec2CreateFlowLogsRequest = (
       input.ResourceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceType !== undefined) {
@@ -33157,9 +33157,9 @@ const serializeAws_ec2CreateFpgaImageRequest = (
       input.InputStorageLocation,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InputStorageLocation.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LogsStorageLocation !== undefined) {
@@ -33167,9 +33167,9 @@ const serializeAws_ec2CreateFpgaImageRequest = (
       input.LogsStorageLocation,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogsStorageLocation.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Name !== undefined) {
@@ -33180,9 +33180,9 @@ const serializeAws_ec2CreateFpgaImageRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -33198,9 +33198,9 @@ const serializeAws_ec2CreateImageRequest = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -33234,9 +33234,9 @@ const serializeAws_ec2CreateInstanceExportTaskRequest = (
       input.ExportToS3Task,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExportToS3.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceId !== undefined) {
@@ -33289,9 +33289,9 @@ const serializeAws_ec2CreateLaunchTemplateRequest = (
       input.LaunchTemplateData,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateData.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LaunchTemplateName !== undefined) {
@@ -33302,9 +33302,9 @@ const serializeAws_ec2CreateLaunchTemplateRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VersionDescription !== undefined) {
@@ -33329,9 +33329,9 @@ const serializeAws_ec2CreateLaunchTemplateVersionRequest = (
       input.LaunchTemplateData,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateData.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LaunchTemplateId !== undefined) {
@@ -33423,9 +33423,9 @@ const serializeAws_ec2CreateNetworkAclEntryRequest = (
       input.IcmpTypeCode,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Icmp.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Ipv6CidrBlock !== undefined) {
@@ -33436,9 +33436,9 @@ const serializeAws_ec2CreateNetworkAclEntryRequest = (
   }
   if (input.PortRange !== undefined) {
     const memberEntries = serializeAws_ec2PortRange(input.PortRange, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PortRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Protocol !== undefined) {
@@ -33506,9 +33506,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
       input.Groups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InterfaceType !== undefined) {
@@ -33522,9 +33522,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
       input.Ipv6Addresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PrivateIpAddress !== undefined) {
@@ -33535,9 +33535,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
       input.PrivateIpAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecondaryPrivateIpAddressCount !== undefined) {
@@ -33586,9 +33586,9 @@ const serializeAws_ec2CreateReservedInstancesListingRequest = (
       input.PriceSchedules,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PriceSchedules.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReservedInstancesId !== undefined) {
@@ -33691,9 +33691,9 @@ const serializeAws_ec2CreateSnapshotRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VolumeId !== undefined) {
@@ -33721,9 +33721,9 @@ const serializeAws_ec2CreateSnapshotsRequest = (
       input.InstanceSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagSpecifications !== undefined) {
@@ -33731,9 +33731,9 @@ const serializeAws_ec2CreateSnapshotsRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -33798,16 +33798,16 @@ const serializeAws_ec2CreateTagsRequest = (
       input.Resources,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -33835,9 +33835,9 @@ const serializeAws_ec2CreateTrafficMirrorFilterRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -33865,9 +33865,9 @@ const serializeAws_ec2CreateTrafficMirrorFilterRuleRequest = (
       input.DestinationPortRange,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DestinationPortRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -33890,9 +33890,9 @@ const serializeAws_ec2CreateTrafficMirrorFilterRuleRequest = (
       input.SourcePortRange,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourcePortRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TrafficDirection !== undefined) {
@@ -33935,9 +33935,9 @@ const serializeAws_ec2CreateTrafficMirrorSessionRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TrafficMirrorFilterId !== undefined) {
@@ -33980,9 +33980,9 @@ const serializeAws_ec2CreateTrafficMirrorTargetRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -34001,9 +34001,9 @@ const serializeAws_ec2CreateTransitGatewayMulticastDomainRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayId !== undefined) {
@@ -34034,9 +34034,9 @@ const serializeAws_ec2CreateTransitGatewayPeeringAttachmentRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayId !== undefined) {
@@ -34061,9 +34061,9 @@ const serializeAws_ec2CreateTransitGatewayRequest = (
       input.Options,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Options.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagSpecifications !== undefined) {
@@ -34071,9 +34071,9 @@ const serializeAws_ec2CreateTransitGatewayRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -34115,9 +34115,9 @@ const serializeAws_ec2CreateTransitGatewayRouteTableRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecifications.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayId !== undefined) {
@@ -34139,9 +34139,9 @@ const serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest = (
       input.Options,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Options.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SubnetIds !== undefined) {
@@ -34149,9 +34149,9 @@ const serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagSpecifications !== undefined) {
@@ -34159,9 +34159,9 @@ const serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecifications.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayId !== undefined) {
@@ -34212,8 +34212,8 @@ const serializeAws_ec2CreateVolumePermissionList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -34230,9 +34230,9 @@ const serializeAws_ec2CreateVolumePermissionModifications = (
       input.Add,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Add.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Remove !== undefined) {
@@ -34240,9 +34240,9 @@ const serializeAws_ec2CreateVolumePermissionModifications = (
       input.Remove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Remove.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -34282,9 +34282,9 @@ const serializeAws_ec2CreateVolumeRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VolumeType !== undefined) {
@@ -34306,9 +34306,9 @@ const serializeAws_ec2CreateVpcEndpointConnectionNotificationRequest = (
       input.ConnectionEvents,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionEvents.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ConnectionNotificationArn !== undefined) {
@@ -34348,9 +34348,9 @@ const serializeAws_ec2CreateVpcEndpointRequest = (
       input.RouteTableIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RouteTableId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecurityGroupIds !== undefined) {
@@ -34358,9 +34358,9 @@ const serializeAws_ec2CreateVpcEndpointRequest = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ServiceName !== undefined) {
@@ -34371,9 +34371,9 @@ const serializeAws_ec2CreateVpcEndpointRequest = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcEndpointType !== undefined) {
@@ -34404,11 +34404,11 @@ const serializeAws_ec2CreateVpcEndpointServiceConfigurationRequest = (
       input.NetworkLoadBalancerArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkLoadBalancerArn.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PrivateDnsName !== undefined) {
@@ -34486,9 +34486,9 @@ const serializeAws_ec2CreateVpnConnectionRequest = (
       input.Options,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Options.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayId !== undefined) {
@@ -34647,9 +34647,9 @@ const serializeAws_ec2DeleteFleetsRequest = (
   }
   if (input.FleetIds !== undefined) {
     const memberEntries = serializeAws_ec2FleetIdSet(input.FleetIds, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FleetId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TerminateInstances !== undefined) {
@@ -34671,9 +34671,9 @@ const serializeAws_ec2DeleteFlowLogsRequest = (
       input.FlowLogIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FlowLogId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -34757,11 +34757,11 @@ const serializeAws_ec2DeleteLaunchTemplateVersionsRequest = (
       input.Versions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateVersion.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -34916,9 +34916,9 @@ const serializeAws_ec2DeleteQueuedReservedInstancesRequest = (
       input.ReservedInstancesIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35027,16 +35027,16 @@ const serializeAws_ec2DeleteTagsRequest = (
       input.Resources,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35210,11 +35210,11 @@ const serializeAws_ec2DeleteVpcEndpointConnectionNotificationsRequest = (
       input.ConnectionNotificationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionNotificationId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35236,9 +35236,9 @@ const serializeAws_ec2DeleteVpcEndpointServiceConfigurationsRequest = (
       input.ServiceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35257,9 +35257,9 @@ const serializeAws_ec2DeleteVpcEndpointsRequest = (
       input.VpcEndpointIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35379,9 +35379,9 @@ const serializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersRequest = (
       input.NetworkInterfaceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayMulticastDomainId !== undefined) {
@@ -35407,9 +35407,9 @@ const serializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesRequest = (
       input.NetworkInterfaceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayMulticastDomainId !== undefined) {
@@ -35429,9 +35429,9 @@ const serializeAws_ec2DescribeAccountAttributesRequest = (
       input.AttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35450,9 +35450,9 @@ const serializeAws_ec2DescribeAddressesRequest = (
       input.AllocationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AllocationId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35460,9 +35460,9 @@ const serializeAws_ec2DescribeAddressesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PublicIps !== undefined) {
@@ -35470,9 +35470,9 @@ const serializeAws_ec2DescribeAddressesRequest = (
       input.PublicIps,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PublicIp.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35502,9 +35502,9 @@ const serializeAws_ec2DescribeAvailabilityZonesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ZoneIds !== undefined) {
@@ -35512,9 +35512,9 @@ const serializeAws_ec2DescribeAvailabilityZonesRequest = (
       input.ZoneIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ZoneId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ZoneNames !== undefined) {
@@ -35522,9 +35522,9 @@ const serializeAws_ec2DescribeAvailabilityZonesRequest = (
       input.ZoneNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ZoneName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35540,9 +35540,9 @@ const serializeAws_ec2DescribeBundleTasksRequest = (
       input.BundleIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BundleId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35550,9 +35550,9 @@ const serializeAws_ec2DescribeBundleTasksRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35585,11 +35585,11 @@ const serializeAws_ec2DescribeCapacityReservationsRequest = (
       input.CapacityReservationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35597,9 +35597,9 @@ const serializeAws_ec2DescribeCapacityReservationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35621,9 +35621,9 @@ const serializeAws_ec2DescribeClassicLinkInstancesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceIds !== undefined) {
@@ -35631,9 +35631,9 @@ const serializeAws_ec2DescribeClassicLinkInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35658,9 +35658,9 @@ const serializeAws_ec2DescribeClientVpnAuthorizationRulesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35685,9 +35685,9 @@ const serializeAws_ec2DescribeClientVpnConnectionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35709,9 +35709,9 @@ const serializeAws_ec2DescribeClientVpnEndpointsRequest = (
       input.ClientVpnEndpointIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClientVpnEndpointId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35719,9 +35719,9 @@ const serializeAws_ec2DescribeClientVpnEndpointsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35746,9 +35746,9 @@ const serializeAws_ec2DescribeClientVpnRoutesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35770,9 +35770,9 @@ const serializeAws_ec2DescribeClientVpnTargetNetworksRequest = (
       input.AssociationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AssociationIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientVpnEndpointId !== undefined) {
@@ -35783,9 +35783,9 @@ const serializeAws_ec2DescribeClientVpnTargetNetworksRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35807,9 +35807,9 @@ const serializeAws_ec2DescribeCoipPoolsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35820,9 +35820,9 @@ const serializeAws_ec2DescribeCoipPoolsRequest = (
   }
   if (input.PoolIds !== undefined) {
     const memberEntries = serializeAws_ec2CoipPoolIdSet(input.PoolIds, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PoolId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35838,9 +35838,9 @@ const serializeAws_ec2DescribeConversionTasksRequest = (
       input.ConversionTaskIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConversionTaskId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35859,9 +35859,9 @@ const serializeAws_ec2DescribeCustomerGatewaysRequest = (
       input.CustomerGatewayIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CustomerGatewayId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35869,9 +35869,9 @@ const serializeAws_ec2DescribeCustomerGatewaysRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -35887,9 +35887,9 @@ const serializeAws_ec2DescribeDhcpOptionsRequest = (
       input.DhcpOptionsIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DhcpOptionsId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -35897,9 +35897,9 @@ const serializeAws_ec2DescribeDhcpOptionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35924,18 +35924,18 @@ const serializeAws_ec2DescribeEgressOnlyInternetGatewaysRequest = (
       input.EgressOnlyInternetGatewayIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EgressOnlyInternetGatewayId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35960,16 +35960,16 @@ const serializeAws_ec2DescribeElasticGpusRequest = (
       input.ElasticGpuIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticGpuId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -35994,16 +35994,16 @@ const serializeAws_ec2DescribeExportImageTasksRequest = (
       input.ExportImageTaskIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExportImageTaskId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36025,16 +36025,16 @@ const serializeAws_ec2DescribeExportTasksRequest = (
       input.ExportTaskIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExportTaskId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -36050,9 +36050,9 @@ const serializeAws_ec2DescribeFastSnapshotRestoresRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36100,9 +36100,9 @@ const serializeAws_ec2DescribeFleetInstancesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FleetId !== undefined) {
@@ -36127,16 +36127,16 @@ const serializeAws_ec2DescribeFleetsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FleetIds !== undefined) {
     const memberEntries = serializeAws_ec2FleetIdSet(input.FleetIds, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FleetId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36158,9 +36158,9 @@ const serializeAws_ec2DescribeFlowLogsRequest = (
   }
   if (input.Filter !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FlowLogIds !== undefined) {
@@ -36168,9 +36168,9 @@ const serializeAws_ec2DescribeFlowLogsRequest = (
       input.FlowLogIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FlowLogId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36209,9 +36209,9 @@ const serializeAws_ec2DescribeFpgaImagesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FpgaImageIds !== undefined) {
@@ -36219,9 +36219,9 @@ const serializeAws_ec2DescribeFpgaImagesRequest = (
       input.FpgaImageIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FpgaImageId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36235,9 +36235,9 @@ const serializeAws_ec2DescribeFpgaImagesRequest = (
       input.Owners,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Owner.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -36250,9 +36250,9 @@ const serializeAws_ec2DescribeHostReservationOfferingsRequest = (
   const entries: any = {};
   if (input.Filter !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxDuration !== undefined) {
@@ -36280,9 +36280,9 @@ const serializeAws_ec2DescribeHostReservationsRequest = (
   const entries: any = {};
   if (input.Filter !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.HostReservationIdSet !== undefined) {
@@ -36290,9 +36290,9 @@ const serializeAws_ec2DescribeHostReservationsRequest = (
       input.HostReservationIdSet,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostReservationIdSet.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36311,9 +36311,9 @@ const serializeAws_ec2DescribeHostsRequest = (
   const entries: any = {};
   if (input.Filter !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.HostIds !== undefined) {
@@ -36321,9 +36321,9 @@ const serializeAws_ec2DescribeHostsRequest = (
       input.HostIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36345,16 +36345,16 @@ const serializeAws_ec2DescribeIamInstanceProfileAssociationsRequest = (
       input.AssociationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AssociationId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36421,16 +36421,16 @@ const serializeAws_ec2DescribeImagesRequest = (
       input.ExecutableUsers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExecutableBy.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImageIds !== undefined) {
@@ -36438,9 +36438,9 @@ const serializeAws_ec2DescribeImagesRequest = (
       input.ImageIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImageId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Owners !== undefined) {
@@ -36448,9 +36448,9 @@ const serializeAws_ec2DescribeImagesRequest = (
       input.Owners,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Owner.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -36466,9 +36466,9 @@ const serializeAws_ec2DescribeImportImageTasksRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImportTaskIds !== undefined) {
@@ -36476,9 +36476,9 @@ const serializeAws_ec2DescribeImportImageTasksRequest = (
       input.ImportTaskIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImportTaskId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36500,9 +36500,9 @@ const serializeAws_ec2DescribeImportSnapshotTasksRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImportTaskIds !== undefined) {
@@ -36510,9 +36510,9 @@ const serializeAws_ec2DescribeImportSnapshotTasksRequest = (
       input.ImportTaskIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImportTaskId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36551,9 +36551,9 @@ const serializeAws_ec2DescribeInstanceCreditSpecificationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceIds !== undefined) {
@@ -36561,9 +36561,9 @@ const serializeAws_ec2DescribeInstanceCreditSpecificationsRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36585,9 +36585,9 @@ const serializeAws_ec2DescribeInstanceStatusRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludeAllInstances !== undefined) {
@@ -36598,9 +36598,9 @@ const serializeAws_ec2DescribeInstanceStatusRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36622,9 +36622,9 @@ const serializeAws_ec2DescribeInstanceTypeOfferingsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LocationType !== undefined) {
@@ -36649,9 +36649,9 @@ const serializeAws_ec2DescribeInstanceTypesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceTypes !== undefined) {
@@ -36659,9 +36659,9 @@ const serializeAws_ec2DescribeInstanceTypesRequest = (
       input.InstanceTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceType.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36683,9 +36683,9 @@ const serializeAws_ec2DescribeInstancesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceIds !== undefined) {
@@ -36693,9 +36693,9 @@ const serializeAws_ec2DescribeInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36717,9 +36717,9 @@ const serializeAws_ec2DescribeInternetGatewaysRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InternetGatewayIds !== undefined) {
@@ -36727,9 +36727,9 @@ const serializeAws_ec2DescribeInternetGatewaysRequest = (
       input.InternetGatewayIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InternetGatewayId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36751,9 +36751,9 @@ const serializeAws_ec2DescribeIpv6PoolsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36767,9 +36767,9 @@ const serializeAws_ec2DescribeIpv6PoolsRequest = (
       input.PoolIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PoolId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -36785,9 +36785,9 @@ const serializeAws_ec2DescribeKeyPairsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.KeyNames !== undefined) {
@@ -36795,9 +36795,9 @@ const serializeAws_ec2DescribeKeyPairsRequest = (
       input.KeyNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `KeyName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.KeyPairIds !== undefined) {
@@ -36805,9 +36805,9 @@ const serializeAws_ec2DescribeKeyPairsRequest = (
       input.KeyPairIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `KeyPairId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -36823,9 +36823,9 @@ const serializeAws_ec2DescribeLaunchTemplateVersionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LaunchTemplateId !== undefined) {
@@ -36851,11 +36851,11 @@ const serializeAws_ec2DescribeLaunchTemplateVersionsRequest = (
       input.Versions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateVersion.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -36871,9 +36871,9 @@ const serializeAws_ec2DescribeLaunchTemplatesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LaunchTemplateIds !== undefined) {
@@ -36881,9 +36881,9 @@ const serializeAws_ec2DescribeLaunchTemplatesRequest = (
       input.LaunchTemplateIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LaunchTemplateNames !== undefined) {
@@ -36891,9 +36891,9 @@ const serializeAws_ec2DescribeLaunchTemplatesRequest = (
       input.LaunchTemplateNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36915,9 +36915,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssocia
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (
@@ -36928,11 +36928,11 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssocia
       input.LocalGatewayRouteTableVirtualInterfaceGroupAssociationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayRouteTableVirtualInterfaceGroupAssociationId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36954,9 +36954,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LocalGatewayRouteTableVpcAssociationIds !== undefined) {
@@ -36964,11 +36964,11 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsRequest = (
       input.LocalGatewayRouteTableVpcAssociationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayRouteTableVpcAssociationId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -36990,9 +36990,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTablesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LocalGatewayRouteTableIds !== undefined) {
@@ -37000,11 +37000,11 @@ const serializeAws_ec2DescribeLocalGatewayRouteTablesRequest = (
       input.LocalGatewayRouteTableIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayRouteTableId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37026,9 +37026,9 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LocalGatewayVirtualInterfaceGroupIds !== undefined) {
@@ -37036,11 +37036,11 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsRequest = (
       input.LocalGatewayVirtualInterfaceGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayVirtualInterfaceGroupId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37062,9 +37062,9 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfacesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LocalGatewayVirtualInterfaceIds !== undefined) {
@@ -37072,11 +37072,11 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfacesRequest = (
       input.LocalGatewayVirtualInterfaceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayVirtualInterfaceId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37098,9 +37098,9 @@ const serializeAws_ec2DescribeLocalGatewaysRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LocalGatewayIds !== undefined) {
@@ -37108,9 +37108,9 @@ const serializeAws_ec2DescribeLocalGatewaysRequest = (
       input.LocalGatewayIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37132,9 +37132,9 @@ const serializeAws_ec2DescribeMovingAddressesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37148,9 +37148,9 @@ const serializeAws_ec2DescribeMovingAddressesRequest = (
       input.PublicIps,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PublicIp.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37163,9 +37163,9 @@ const serializeAws_ec2DescribeNatGatewaysRequest = (
   const entries: any = {};
   if (input.Filter !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37176,9 +37176,9 @@ const serializeAws_ec2DescribeNatGatewaysRequest = (
       input.NatGatewayIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NatGatewayId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NextToken !== undefined) {
@@ -37197,9 +37197,9 @@ const serializeAws_ec2DescribeNetworkAclsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37210,9 +37210,9 @@ const serializeAws_ec2DescribeNetworkAclsRequest = (
       input.NetworkAclIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkAclId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NextToken !== undefined) {
@@ -37245,9 +37245,9 @@ const serializeAws_ec2DescribeNetworkInterfacePermissionsRequest = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37258,11 +37258,11 @@ const serializeAws_ec2DescribeNetworkInterfacePermissionsRequest = (
       input.NetworkInterfacePermissionIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfacePermissionId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NextToken !== undefined) {
@@ -37281,9 +37281,9 @@ const serializeAws_ec2DescribeNetworkInterfacesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37294,9 +37294,9 @@ const serializeAws_ec2DescribeNetworkInterfacesRequest = (
       input.NetworkInterfaceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NextToken !== undefined) {
@@ -37315,9 +37315,9 @@ const serializeAws_ec2DescribePlacementGroupsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.GroupIds !== undefined) {
@@ -37325,9 +37325,9 @@ const serializeAws_ec2DescribePlacementGroupsRequest = (
       input.GroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.GroupNames !== undefined) {
@@ -37335,9 +37335,9 @@ const serializeAws_ec2DescribePlacementGroupsRequest = (
       input.GroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37353,9 +37353,9 @@ const serializeAws_ec2DescribePrefixListsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37369,9 +37369,9 @@ const serializeAws_ec2DescribePrefixListsRequest = (
       input.PrefixListIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrefixListId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37396,9 +37396,9 @@ const serializeAws_ec2DescribePrincipalIdFormatRequest = (
       input.Resources,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Resource.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37420,9 +37420,9 @@ const serializeAws_ec2DescribePublicIpv4PoolsRequest = (
       input.PoolIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PoolId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37441,9 +37441,9 @@ const serializeAws_ec2DescribeRegionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RegionNames !== undefined) {
@@ -37451,9 +37451,9 @@ const serializeAws_ec2DescribeRegionsRequest = (
       input.RegionNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RegionName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37466,9 +37466,9 @@ const serializeAws_ec2DescribeReservedInstancesListingsRequest = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReservedInstancesId !== undefined) {
@@ -37487,9 +37487,9 @@ const serializeAws_ec2DescribeReservedInstancesModificationsRequest = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NextToken !== undefined) {
@@ -37500,11 +37500,11 @@ const serializeAws_ec2DescribeReservedInstancesModificationsRequest = (
       input.ReservedInstancesModificationIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesModificationId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37523,9 +37523,9 @@ const serializeAws_ec2DescribeReservedInstancesOfferingsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludeMarketplace !== undefined) {
@@ -37566,11 +37566,11 @@ const serializeAws_ec2DescribeReservedInstancesOfferingsRequest = (
       input.ReservedInstancesOfferingIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesOfferingId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37586,9 +37586,9 @@ const serializeAws_ec2DescribeReservedInstancesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OfferingClass !== undefined) {
@@ -37602,9 +37602,9 @@ const serializeAws_ec2DescribeReservedInstancesRequest = (
       input.ReservedInstancesIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37620,9 +37620,9 @@ const serializeAws_ec2DescribeRouteTablesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37636,9 +37636,9 @@ const serializeAws_ec2DescribeRouteTablesRequest = (
       input.RouteTableIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RouteTableId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37654,9 +37654,9 @@ const serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FirstSlotStartTimeRange !== undefined) {
@@ -37664,9 +37664,9 @@ const serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest = (
       input.FirstSlotStartTimeRange,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FirstSlotStartTimeRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37686,9 +37686,9 @@ const serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest = (
       input.Recurrence,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Recurrence.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37704,9 +37704,9 @@ const serializeAws_ec2DescribeScheduledInstancesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37720,9 +37720,9 @@ const serializeAws_ec2DescribeScheduledInstancesRequest = (
       input.ScheduledInstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledInstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SlotStartTimeRange !== undefined) {
@@ -37730,9 +37730,9 @@ const serializeAws_ec2DescribeScheduledInstancesRequest = (
       input.SlotStartTimeRange,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SlotStartTimeRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37748,9 +37748,9 @@ const serializeAws_ec2DescribeSecurityGroupReferencesRequest = (
   }
   if (input.GroupId !== undefined) {
     const memberEntries = serializeAws_ec2GroupIds(input.GroupId, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37766,9 +37766,9 @@ const serializeAws_ec2DescribeSecurityGroupsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.GroupIds !== undefined) {
@@ -37776,9 +37776,9 @@ const serializeAws_ec2DescribeSecurityGroupsRequest = (
       input.GroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.GroupNames !== undefined) {
@@ -37786,9 +37786,9 @@ const serializeAws_ec2DescribeSecurityGroupsRequest = (
       input.GroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37827,9 +37827,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37843,9 +37843,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (
       input.OwnerIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Owner.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RestorableByUserIds !== undefined) {
@@ -37853,9 +37853,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (
       input.RestorableByUserIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RestorableBy.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotIds !== undefined) {
@@ -37863,9 +37863,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (
       input.SnapshotIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37947,9 +37947,9 @@ const serializeAws_ec2DescribeSpotFleetRequestsRequest = (
       input.SpotFleetRequestIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotFleetRequestId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -37965,9 +37965,9 @@ const serializeAws_ec2DescribeSpotInstanceRequestsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -37981,11 +37981,11 @@ const serializeAws_ec2DescribeSpotInstanceRequestsRequest = (
       input.SpotInstanceRequestIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotInstanceRequestId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38007,9 +38007,9 @@ const serializeAws_ec2DescribeSpotPriceHistoryRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceTypes !== undefined) {
@@ -38017,9 +38017,9 @@ const serializeAws_ec2DescribeSpotPriceHistoryRequest = (
       input.InstanceTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceType.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38033,9 +38033,9 @@ const serializeAws_ec2DescribeSpotPriceHistoryRequest = (
       input.ProductDescriptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProductDescription.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StartTime !== undefined) {
@@ -38074,9 +38074,9 @@ const serializeAws_ec2DescribeSubnetsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38090,9 +38090,9 @@ const serializeAws_ec2DescribeSubnetsRequest = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38108,9 +38108,9 @@ const serializeAws_ec2DescribeTagsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38132,9 +38132,9 @@ const serializeAws_ec2DescribeTrafficMirrorFiltersRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38148,11 +38148,11 @@ const serializeAws_ec2DescribeTrafficMirrorFiltersRequest = (
       input.TrafficMirrorFilterIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrafficMirrorFilterId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38168,9 +38168,9 @@ const serializeAws_ec2DescribeTrafficMirrorSessionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38184,11 +38184,11 @@ const serializeAws_ec2DescribeTrafficMirrorSessionsRequest = (
       input.TrafficMirrorSessionIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrafficMirrorSessionId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38204,9 +38204,9 @@ const serializeAws_ec2DescribeTrafficMirrorTargetsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38220,11 +38220,11 @@ const serializeAws_ec2DescribeTrafficMirrorTargetsRequest = (
       input.TrafficMirrorTargetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrafficMirrorTargetId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38240,9 +38240,9 @@ const serializeAws_ec2DescribeTransitGatewayAttachmentsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38256,11 +38256,11 @@ const serializeAws_ec2DescribeTransitGatewayAttachmentsRequest = (
       input.TransitGatewayAttachmentIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayAttachmentIds.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38276,9 +38276,9 @@ const serializeAws_ec2DescribeTransitGatewayMulticastDomainsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38292,11 +38292,11 @@ const serializeAws_ec2DescribeTransitGatewayMulticastDomainsRequest = (
       input.TransitGatewayMulticastDomainIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayMulticastDomainIds.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38312,9 +38312,9 @@ const serializeAws_ec2DescribeTransitGatewayPeeringAttachmentsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38328,11 +38328,11 @@ const serializeAws_ec2DescribeTransitGatewayPeeringAttachmentsRequest = (
       input.TransitGatewayAttachmentIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayAttachmentIds.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38348,9 +38348,9 @@ const serializeAws_ec2DescribeTransitGatewayRouteTablesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38364,11 +38364,11 @@ const serializeAws_ec2DescribeTransitGatewayRouteTablesRequest = (
       input.TransitGatewayRouteTableIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayRouteTableIds.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38384,9 +38384,9 @@ const serializeAws_ec2DescribeTransitGatewayVpcAttachmentsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38400,11 +38400,11 @@ const serializeAws_ec2DescribeTransitGatewayVpcAttachmentsRequest = (
       input.TransitGatewayAttachmentIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayAttachmentIds.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38420,9 +38420,9 @@ const serializeAws_ec2DescribeTransitGatewaysRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38436,9 +38436,9 @@ const serializeAws_ec2DescribeTransitGatewaysRequest = (
       input.TransitGatewayIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38471,9 +38471,9 @@ const serializeAws_ec2DescribeVolumeStatusRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38487,9 +38487,9 @@ const serializeAws_ec2DescribeVolumeStatusRequest = (
       input.VolumeIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VolumeId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38505,9 +38505,9 @@ const serializeAws_ec2DescribeVolumesModificationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38521,9 +38521,9 @@ const serializeAws_ec2DescribeVolumesModificationsRequest = (
       input.VolumeIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VolumeId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38539,9 +38539,9 @@ const serializeAws_ec2DescribeVolumesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38555,9 +38555,9 @@ const serializeAws_ec2DescribeVolumesRequest = (
       input.VolumeIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VolumeId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38596,9 +38596,9 @@ const serializeAws_ec2DescribeVpcClassicLinkDnsSupportRequest = (
       input.VpcIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38614,9 +38614,9 @@ const serializeAws_ec2DescribeVpcClassicLinkRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcIds !== undefined) {
@@ -38624,9 +38624,9 @@ const serializeAws_ec2DescribeVpcClassicLinkRequest = (
       input.VpcIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38645,9 +38645,9 @@ const serializeAws_ec2DescribeVpcEndpointConnectionNotificationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38669,9 +38669,9 @@ const serializeAws_ec2DescribeVpcEndpointConnectionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38693,9 +38693,9 @@ const serializeAws_ec2DescribeVpcEndpointServiceConfigurationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38709,9 +38709,9 @@ const serializeAws_ec2DescribeVpcEndpointServiceConfigurationsRequest = (
       input.ServiceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38727,9 +38727,9 @@ const serializeAws_ec2DescribeVpcEndpointServicePermissionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38754,9 +38754,9 @@ const serializeAws_ec2DescribeVpcEndpointServicesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38770,9 +38770,9 @@ const serializeAws_ec2DescribeVpcEndpointServicesRequest = (
       input.ServiceNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38788,9 +38788,9 @@ const serializeAws_ec2DescribeVpcEndpointsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38804,9 +38804,9 @@ const serializeAws_ec2DescribeVpcEndpointsRequest = (
       input.VpcEndpointIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38822,9 +38822,9 @@ const serializeAws_ec2DescribeVpcPeeringConnectionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38838,11 +38838,11 @@ const serializeAws_ec2DescribeVpcPeeringConnectionsRequest = (
       input.VpcPeeringConnectionIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcPeeringConnectionId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38858,9 +38858,9 @@ const serializeAws_ec2DescribeVpcsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -38874,9 +38874,9 @@ const serializeAws_ec2DescribeVpcsRequest = (
       input.VpcIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38892,9 +38892,9 @@ const serializeAws_ec2DescribeVpnConnectionsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpnConnectionIds !== undefined) {
@@ -38902,9 +38902,9 @@ const serializeAws_ec2DescribeVpnConnectionsRequest = (
       input.VpnConnectionIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpnConnectionId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -38920,9 +38920,9 @@ const serializeAws_ec2DescribeVpnGatewaysRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpnGatewayIds !== undefined) {
@@ -38930,9 +38930,9 @@ const serializeAws_ec2DescribeVpnGatewaysRequest = (
       input.VpnGatewayIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpnGatewayId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -39074,9 +39074,9 @@ const serializeAws_ec2DisableFastSnapshotRestoresRequest = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZone.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -39087,9 +39087,9 @@ const serializeAws_ec2DisableFastSnapshotRestoresRequest = (
       input.SourceSnapshotIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceSnapshotId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -39234,9 +39234,9 @@ const serializeAws_ec2DisassociateTransitGatewayMulticastDomainRequest = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayAttachmentId !== undefined) {
@@ -39287,16 +39287,16 @@ const serializeAws_ec2DiskImage = (
   }
   if (input.Image !== undefined) {
     const memberEntries = serializeAws_ec2DiskImageDetail(input.Image, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Image.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Volume !== undefined) {
     const memberEntries = serializeAws_ec2VolumeDetail(input.Volume, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Volume.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -39327,8 +39327,8 @@ const serializeAws_ec2DiskImageList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2DiskImage(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -39345,9 +39345,9 @@ const serializeAws_ec2DnsServersOptionsModifyStructure = (
       input.CustomDnsServers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CustomDnsServers.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Enabled !== undefined) {
@@ -39447,8 +39447,8 @@ const serializeAws_ec2ElasticGpuSpecificationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`ElasticGpuSpecification.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`ElasticGpuSpecification.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -39466,8 +39466,8 @@ const serializeAws_ec2ElasticGpuSpecifications = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -39499,8 +39499,8 @@ const serializeAws_ec2ElasticInferenceAccelerators = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -39528,9 +39528,9 @@ const serializeAws_ec2EnableFastSnapshotRestoresRequest = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZone.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -39541,9 +39541,9 @@ const serializeAws_ec2EnableFastSnapshotRestoresRequest = (
       input.SourceSnapshotIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceSnapshotId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -39691,9 +39691,9 @@ const serializeAws_ec2ExportImageRequest = (
       input.S3ExportLocation,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `S3ExportLocation.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -39769,9 +39769,9 @@ const serializeAws_ec2ExportTransitGatewayRoutesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.S3Bucket !== undefined) {
@@ -39796,9 +39796,9 @@ const serializeAws_ec2Filter = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Value.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -39812,8 +39812,8 @@ const serializeAws_ec2FilterList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2Filter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Filter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Filter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -39844,8 +39844,8 @@ const serializeAws_ec2FleetLaunchTemplateConfigListRequest = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -39862,9 +39862,9 @@ const serializeAws_ec2FleetLaunchTemplateConfigRequest = (
       input.LaunchTemplateSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Overrides !== undefined) {
@@ -39872,9 +39872,9 @@ const serializeAws_ec2FleetLaunchTemplateConfigRequest = (
       input.Overrides,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Overrides.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -39891,8 +39891,8 @@ const serializeAws_ec2FleetLaunchTemplateOverridesListRequest = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -39915,9 +39915,9 @@ const serializeAws_ec2FleetLaunchTemplateOverridesRequest = (
   }
   if (input.Placement !== undefined) {
     const memberEntries = serializeAws_ec2Placement(input.Placement, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Placement.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Priority !== undefined) {
@@ -40029,9 +40029,9 @@ const serializeAws_ec2GetCoipPoolUsageRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -40126,9 +40126,9 @@ const serializeAws_ec2GetHostReservationPurchasePreviewRequest = (
       input.HostIdSet,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostIdSet.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OfferingId !== undefined) {
@@ -40178,9 +40178,9 @@ const serializeAws_ec2GetReservedInstancesExchangeQuoteRequest = (
       input.ReservedInstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetConfigurations !== undefined) {
@@ -40188,9 +40188,9 @@ const serializeAws_ec2GetReservedInstancesExchangeQuoteRequest = (
       input.TargetConfigurations,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetConfiguration.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -40206,9 +40206,9 @@ const serializeAws_ec2GetTransitGatewayAttachmentPropagationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -40233,9 +40233,9 @@ const serializeAws_ec2GetTransitGatewayMulticastDomainAssociationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -40261,9 +40261,9 @@ const serializeAws_ec2GetTransitGatewayRouteTableAssociationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -40288,9 +40288,9 @@ const serializeAws_ec2GetTransitGatewayRouteTablePropagationsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -40340,8 +40340,8 @@ const serializeAws_ec2GroupIdentifierList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2GroupIdentifier(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40409,8 +40409,8 @@ const serializeAws_ec2IKEVersionsRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40478,9 +40478,9 @@ const serializeAws_ec2ImageDiskContainer = (
   }
   if (input.UserBucket !== undefined) {
     const memberEntries = serializeAws_ec2UserBucket(input.UserBucket, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserBucket.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -40494,8 +40494,8 @@ const serializeAws_ec2ImageDiskContainerList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2ImageDiskContainer(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40554,8 +40554,8 @@ const serializeAws_ec2ImportImageLicenseSpecificationListRequest = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40572,9 +40572,9 @@ const serializeAws_ec2ImportImageRequest = (
   }
   if (input.ClientData !== undefined) {
     const memberEntries = serializeAws_ec2ClientData(input.ClientData, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClientData.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientToken !== undefined) {
@@ -40588,9 +40588,9 @@ const serializeAws_ec2ImportImageRequest = (
       input.DiskContainers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DiskContainer.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -40610,11 +40610,11 @@ const serializeAws_ec2ImportImageRequest = (
       input.LicenseSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LicenseSpecifications.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LicenseType !== undefined) {
@@ -40645,9 +40645,9 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
       input.GroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.GroupNames !== undefined) {
@@ -40655,9 +40655,9 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
       input.GroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceInitiatedShutdownBehavior !== undefined) {
@@ -40672,9 +40672,9 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
   }
   if (input.Placement !== undefined) {
     const memberEntries = serializeAws_ec2Placement(input.Placement, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Placement.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PrivateIpAddress !== undefined) {
@@ -40685,9 +40685,9 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
   }
   if (input.UserData !== undefined) {
     const memberEntries = serializeAws_ec2UserData(input.UserData, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserData.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -40706,9 +40706,9 @@ const serializeAws_ec2ImportInstanceRequest = (
       input.DiskImages,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DiskImage.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -40719,9 +40719,9 @@ const serializeAws_ec2ImportInstanceRequest = (
       input.LaunchSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Platform !== undefined) {
@@ -40756,9 +40756,9 @@ const serializeAws_ec2ImportSnapshotRequest = (
   const entries: any = {};
   if (input.ClientData !== undefined) {
     const memberEntries = serializeAws_ec2ClientData(input.ClientData, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClientData.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientToken !== undefined) {
@@ -40772,9 +40772,9 @@ const serializeAws_ec2ImportSnapshotRequest = (
       input.DiskContainer,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DiskContainer.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -40821,16 +40821,16 @@ const serializeAws_ec2ImportVolumeRequest = (
   }
   if (input.Image !== undefined) {
     const memberEntries = serializeAws_ec2DiskImageDetail(input.Image, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Image.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Volume !== undefined) {
     const memberEntries = serializeAws_ec2VolumeDetail(input.Volume, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Volume.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -40849,9 +40849,9 @@ const serializeAws_ec2InstanceBlockDeviceMappingSpecification = (
       input.Ebs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ebs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NoDevice !== undefined) {
@@ -40874,8 +40874,8 @@ const serializeAws_ec2InstanceBlockDeviceMappingSpecificationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40893,8 +40893,8 @@ const serializeAws_ec2InstanceCreditSpecificationListRequest = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40947,8 +40947,8 @@ const serializeAws_ec2InstanceIpv6AddressList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2InstanceIpv6Address(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40966,8 +40966,8 @@ const serializeAws_ec2InstanceIpv6AddressListRequest = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`InstanceIpv6Address.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`InstanceIpv6Address.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -40998,9 +40998,9 @@ const serializeAws_ec2InstanceMarketOptionsRequest = (
       input.SpotOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -41045,9 +41045,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
       input.Groups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InterfaceType !== undefined) {
@@ -41061,9 +41061,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
       input.Ipv6Addresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaceId !== undefined) {
@@ -41077,9 +41077,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
       input.PrivateIpAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecondaryPrivateIpAddressCount !== undefined) {
@@ -41103,8 +41103,8 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecificationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41151,9 +41151,9 @@ const serializeAws_ec2IpPermission = (
   }
   if (input.IpRanges !== undefined) {
     const memberEntries = serializeAws_ec2IpRangeList(input.IpRanges, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpRanges.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Ipv6Ranges !== undefined) {
@@ -41161,9 +41161,9 @@ const serializeAws_ec2IpPermission = (
       input.Ipv6Ranges,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Ranges.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PrefixListIds !== undefined) {
@@ -41171,9 +41171,9 @@ const serializeAws_ec2IpPermission = (
       input.PrefixListIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrefixListIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ToPort !== undefined) {
@@ -41184,9 +41184,9 @@ const serializeAws_ec2IpPermission = (
       input.UserIdGroupPairs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Groups.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -41200,8 +41200,8 @@ const serializeAws_ec2IpPermissionList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2IpPermission(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41230,8 +41230,8 @@ const serializeAws_ec2IpRangeList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2IpRange(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41273,8 +41273,8 @@ const serializeAws_ec2Ipv6RangeList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2Ipv6Range(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41329,8 +41329,8 @@ const serializeAws_ec2LaunchPermissionList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2LaunchPermission(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41347,9 +41347,9 @@ const serializeAws_ec2LaunchPermissionModifications = (
       input.Add,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Add.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Remove !== undefined) {
@@ -41357,9 +41357,9 @@ const serializeAws_ec2LaunchPermissionModifications = (
       input.Remove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Remove.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -41376,8 +41376,8 @@ const serializeAws_ec2LaunchSpecsList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41397,9 +41397,9 @@ const serializeAws_ec2LaunchTemplateBlockDeviceMappingRequest = (
       input.Ebs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ebs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NoDevice !== undefined) {
@@ -41422,8 +41422,8 @@ const serializeAws_ec2LaunchTemplateBlockDeviceMappingRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`BlockDeviceMapping.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`BlockDeviceMapping.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41444,9 +41444,9 @@ const serializeAws_ec2LaunchTemplateCapacityReservationSpecificationRequest = (
       input.CapacityReservationTarget,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationTarget.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -41462,9 +41462,9 @@ const serializeAws_ec2LaunchTemplateConfig = (
       input.LaunchTemplateSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Overrides !== undefined) {
@@ -41472,9 +41472,9 @@ const serializeAws_ec2LaunchTemplateConfig = (
       input.Overrides,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Overrides.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -41488,8 +41488,8 @@ const serializeAws_ec2LaunchTemplateConfigList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2LaunchTemplateConfig(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41564,8 +41564,8 @@ const serializeAws_ec2LaunchTemplateElasticInferenceAcceleratorList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41610,9 +41610,9 @@ const serializeAws_ec2LaunchTemplateInstanceMarketOptionsRequest = (
       input.SpotOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -41657,9 +41657,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
       input.Groups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InterfaceType !== undefined) {
@@ -41673,9 +41673,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
       input.Ipv6Addresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaceId !== undefined) {
@@ -41689,9 +41689,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
       input.PrivateIpAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecondaryPrivateIpAddressCount !== undefined) {
@@ -41715,9 +41715,10 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`InstanceNetworkInterfaceSpecification.${counter}.${key}`] =
-        memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[
+        `InstanceNetworkInterfaceSpecification.${counter}.${key}`
+      ] = value;
     });
     counter++;
   }
@@ -41746,8 +41747,8 @@ const serializeAws_ec2LaunchTemplateLicenseSpecificationListRequest = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41804,8 +41805,8 @@ const serializeAws_ec2LaunchTemplateOverridesList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41895,9 +41896,9 @@ const serializeAws_ec2LaunchTemplateTagSpecificationRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -41914,9 +41915,10 @@ const serializeAws_ec2LaunchTemplateTagSpecificationRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`LaunchTemplateTagSpecificationRequest.${counter}.${key}`] =
-        memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[
+        `LaunchTemplateTagSpecificationRequest.${counter}.${key}`
+      ] = value;
     });
     counter++;
   }
@@ -41956,8 +41958,8 @@ const serializeAws_ec2LicenseSpecificationListRequest = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -41974,9 +41976,9 @@ const serializeAws_ec2LoadBalancersConfig = (
       input.ClassicLoadBalancersConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClassicLoadBalancersConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetGroupsConfig !== undefined) {
@@ -41984,9 +41986,9 @@ const serializeAws_ec2LoadBalancersConfig = (
       input.TargetGroupsConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupsConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42000,8 +42002,8 @@ const serializeAws_ec2LoadPermissionListRequest = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2LoadPermissionRequest(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -42018,9 +42020,9 @@ const serializeAws_ec2LoadPermissionModifications = (
       input.Add,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Add.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Remove !== undefined) {
@@ -42028,9 +42030,9 @@ const serializeAws_ec2LoadPermissionModifications = (
       input.Remove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Remove.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42164,9 +42166,9 @@ const serializeAws_ec2ModifyClientVpnEndpointRequest = (
       input.ConnectionLogOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionLogOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -42177,9 +42179,9 @@ const serializeAws_ec2ModifyClientVpnEndpointRequest = (
       input.DnsServers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DnsServers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42248,9 +42250,9 @@ const serializeAws_ec2ModifyFleetRequest = (
       input.TargetCapacitySpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetCapacitySpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42278,9 +42280,9 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
       input.LoadPermission,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadPermission.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Name !== undefined) {
@@ -42294,9 +42296,9 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
       input.ProductCodes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProductCode.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserGroups !== undefined) {
@@ -42304,9 +42306,9 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
       input.UserGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroup.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserIds !== undefined) {
@@ -42314,9 +42316,9 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
       input.UserIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42335,9 +42337,9 @@ const serializeAws_ec2ModifyHostsRequest = (
       input.HostIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.HostRecovery !== undefined) {
@@ -42396,9 +42398,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
       input.Description,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Description.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42412,9 +42414,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
       input.LaunchPermission,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchPermission.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OperationType !== undefined) {
@@ -42425,9 +42427,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
       input.ProductCodes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProductCode.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserGroups !== undefined) {
@@ -42435,9 +42437,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
       input.UserGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroup.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserIds !== undefined) {
@@ -42445,9 +42447,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
       input.UserIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Value !== undefined) {
@@ -42469,9 +42471,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DisableApiTermination !== undefined) {
@@ -42479,9 +42481,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.DisableApiTermination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisableApiTermination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42492,9 +42494,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.EbsOptimized,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EbsOptimized.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnaSupport !== undefined) {
@@ -42502,9 +42504,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.EnaSupport,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnaSupport.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Groups !== undefined) {
@@ -42512,9 +42514,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.Groups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceId !== undefined) {
@@ -42525,9 +42527,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.InstanceInitiatedShutdownBehavior,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceInitiatedShutdownBehavior.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceType !== undefined) {
@@ -42535,16 +42537,16 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.InstanceType,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceType.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Kernel !== undefined) {
     const memberEntries = serializeAws_ec2AttributeValue(input.Kernel, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Kernel.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Ramdisk !== undefined) {
@@ -42552,9 +42554,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.Ramdisk,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ramdisk.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceDestCheck !== undefined) {
@@ -42562,9 +42564,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.SourceDestCheck,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceDestCheck.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SriovNetSupport !== undefined) {
@@ -42572,9 +42574,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.SriovNetSupport,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SriovNetSupport.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserData !== undefined) {
@@ -42582,9 +42584,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.UserData,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserData.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Value !== undefined) {
@@ -42603,9 +42605,9 @@ const serializeAws_ec2ModifyInstanceCapacityReservationAttributesRequest = (
       input.CapacityReservationSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42633,11 +42635,11 @@ const serializeAws_ec2ModifyInstanceCreditSpecificationRequest = (
       input.InstanceCreditSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceCreditSpecification.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42748,9 +42750,9 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
       input.Attachment,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attachment.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -42758,9 +42760,9 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
       input.Description,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Description.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42771,9 +42773,9 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
       input.Groups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaceId !== undefined) {
@@ -42784,9 +42786,9 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
       input.SourceDestCheck,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceDestCheck.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42805,9 +42807,9 @@ const serializeAws_ec2ModifyReservedInstancesRequest = (
       input.ReservedInstancesIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetConfigurations !== undefined) {
@@ -42815,11 +42817,11 @@ const serializeAws_ec2ModifyReservedInstancesRequest = (
       input.TargetConfigurations,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesConfigurationSetItemType.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42838,9 +42840,9 @@ const serializeAws_ec2ModifySnapshotAttributeRequest = (
       input.CreateVolumePermission,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CreateVolumePermission.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42851,9 +42853,9 @@ const serializeAws_ec2ModifySnapshotAttributeRequest = (
       input.GroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroup.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OperationType !== undefined) {
@@ -42867,9 +42869,9 @@ const serializeAws_ec2ModifySnapshotAttributeRequest = (
       input.UserIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -42906,9 +42908,9 @@ const serializeAws_ec2ModifySubnetAttributeRequest = (
       input.AssignIpv6AddressOnCreation,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AssignIpv6AddressOnCreation.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MapPublicIpOnLaunch !== undefined) {
@@ -42916,9 +42918,9 @@ const serializeAws_ec2ModifySubnetAttributeRequest = (
       input.MapPublicIpOnLaunch,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MapPublicIpOnLaunch.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SubnetId !== undefined) {
@@ -42937,9 +42939,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesRequest = (
       input.AddNetworkServices,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddNetworkService.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42950,9 +42952,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesRequest = (
       input.RemoveNetworkServices,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveNetworkService.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TrafficMirrorFilterId !== undefined) {
@@ -42977,9 +42979,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest = (
       input.DestinationPortRange,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DestinationPortRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -42993,9 +42995,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest = (
       input.RemoveFields,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveField.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RuleAction !== undefined) {
@@ -43012,9 +43014,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest = (
       input.SourcePortRange,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourcePortRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TrafficDirection !== undefined) {
@@ -43045,9 +43047,9 @@ const serializeAws_ec2ModifyTrafficMirrorSessionRequest = (
       input.RemoveFields,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveField.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SessionNumber !== undefined) {
@@ -43078,9 +43080,9 @@ const serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest = (
       input.AddSubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddSubnetIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -43091,9 +43093,9 @@ const serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest = (
       input.Options,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Options.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RemoveSubnetIds !== undefined) {
@@ -43101,9 +43103,9 @@ const serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest = (
       input.RemoveSubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveSubnetIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayAttachmentId !== undefined) {
@@ -43136,9 +43138,9 @@ const serializeAws_ec2ModifyVolumeAttributeRequest = (
       input.AutoEnableIO,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AutoEnableIO.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -43183,9 +43185,9 @@ const serializeAws_ec2ModifyVpcAttributeRequest = (
       input.EnableDnsHostnames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableDnsHostnames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableDnsSupport !== undefined) {
@@ -43193,9 +43195,9 @@ const serializeAws_ec2ModifyVpcAttributeRequest = (
       input.EnableDnsSupport,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableDnsSupport.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcId !== undefined) {
@@ -43214,9 +43216,9 @@ const serializeAws_ec2ModifyVpcEndpointConnectionNotificationRequest = (
       input.ConnectionEvents,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionEvents.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ConnectionNotificationArn !== undefined) {
@@ -43241,9 +43243,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (
       input.AddRouteTableIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddRouteTableId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AddSecurityGroupIds !== undefined) {
@@ -43251,9 +43253,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (
       input.AddSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddSecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AddSubnetIds !== undefined) {
@@ -43261,9 +43263,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (
       input.AddSubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddSubnetId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -43280,9 +43282,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (
       input.RemoveRouteTableIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveRouteTableId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RemoveSecurityGroupIds !== undefined) {
@@ -43290,11 +43292,11 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (
       input.RemoveSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveSecurityGroupId.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RemoveSubnetIds !== undefined) {
@@ -43302,9 +43304,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (
       input.RemoveSubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveSubnetId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetPolicy !== undefined) {
@@ -43329,11 +43331,11 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
       input.AddNetworkLoadBalancerArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddNetworkLoadBalancerArn.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -43347,11 +43349,11 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
       input.RemoveNetworkLoadBalancerArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveNetworkLoadBalancerArn.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RemovePrivateDnsName !== undefined) {
@@ -43373,9 +43375,9 @@ const serializeAws_ec2ModifyVpcEndpointServicePermissionsRequest = (
       input.AddAllowedPrincipals,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddAllowedPrincipals.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -43386,11 +43388,11 @@ const serializeAws_ec2ModifyVpcEndpointServicePermissionsRequest = (
       input.RemoveAllowedPrincipals,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveAllowedPrincipals.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ServiceId !== undefined) {
@@ -43409,9 +43411,9 @@ const serializeAws_ec2ModifyVpcPeeringConnectionOptionsRequest = (
       input.AccepterPeeringConnectionOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AccepterPeeringConnectionOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DryRun !== undefined) {
@@ -43422,9 +43424,9 @@ const serializeAws_ec2ModifyVpcPeeringConnectionOptionsRequest = (
       input.RequesterPeeringConnectionOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RequesterPeeringConnectionOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcPeeringConnectionId !== undefined) {
@@ -43503,9 +43505,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsRequest = (
       input.TunnelOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TunnelOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpnConnectionId !== undefined) {
@@ -43530,9 +43532,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.IKEVersions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IKEVersion.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1DHGroupNumbers !== undefined) {
@@ -43540,9 +43542,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase1DHGroupNumbers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1EncryptionAlgorithms !== undefined) {
@@ -43550,11 +43552,11 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase1EncryptionAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1EncryptionAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1IntegrityAlgorithms !== undefined) {
@@ -43562,11 +43564,11 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase1IntegrityAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1IntegrityAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1LifetimeSeconds !== undefined) {
@@ -43577,9 +43579,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase2DHGroupNumbers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase2EncryptionAlgorithms !== undefined) {
@@ -43587,11 +43589,11 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase2EncryptionAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2EncryptionAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase2IntegrityAlgorithms !== undefined) {
@@ -43599,11 +43601,11 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase2IntegrityAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2IntegrityAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase2LifetimeSeconds !== undefined) {
@@ -43640,9 +43642,9 @@ const serializeAws_ec2MonitorInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -43715,9 +43717,9 @@ const serializeAws_ec2NewDhcpConfiguration = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Value.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -43731,8 +43733,8 @@ const serializeAws_ec2NewDhcpConfigurationList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2NewDhcpConfiguration(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -43765,9 +43767,9 @@ const serializeAws_ec2OnDemandOptionsRequest = (
       input.CapacityReservationOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxTotalPrice !== undefined) {
@@ -43829,8 +43831,8 @@ const serializeAws_ec2Phase1DHGroupNumbersRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -43859,8 +43861,8 @@ const serializeAws_ec2Phase1EncryptionAlgorithmsRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -43889,8 +43891,8 @@ const serializeAws_ec2Phase1IntegrityAlgorithmsRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -43919,8 +43921,8 @@ const serializeAws_ec2Phase2DHGroupNumbersRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -43949,8 +43951,8 @@ const serializeAws_ec2Phase2EncryptionAlgorithmsRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -43979,8 +43981,8 @@ const serializeAws_ec2Phase2IntegrityAlgorithmsRequestList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -44092,8 +44094,8 @@ const serializeAws_ec2PrefixListIdList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2PrefixListId(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -44128,8 +44130,8 @@ const serializeAws_ec2PriceScheduleSpecificationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -44147,9 +44149,8 @@ const serializeAws_ec2PrivateIpAddressConfigSet = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`PrivateIpAddressConfigSet.${counter}.${key}`] =
-        memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`PrivateIpAddressConfigSet.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -44181,8 +44182,8 @@ const serializeAws_ec2PrivateIpAddressSpecificationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -44241,9 +44242,9 @@ const serializeAws_ec2ProvisionByoipCidrRequest = (
       input.CidrAuthorizationContext,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CidrAuthorizationContext.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -44287,9 +44288,9 @@ const serializeAws_ec2PurchaseHostReservationRequest = (
       input.HostIdSet,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostIdSet.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LimitPrice !== undefined) {
@@ -44323,8 +44324,8 @@ const serializeAws_ec2PurchaseRequestSet = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2PurchaseRequest(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`PurchaseRequest.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`PurchaseRequest.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -44347,9 +44348,9 @@ const serializeAws_ec2PurchaseReservedInstancesOfferingRequest = (
       input.LimitPrice,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LimitPrice.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PurchaseTime !== undefined) {
@@ -44381,9 +44382,9 @@ const serializeAws_ec2PurchaseScheduledInstancesRequest = (
       input.PurchaseRequests,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PurchaseRequest.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -44415,9 +44416,9 @@ const serializeAws_ec2RebootInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -44449,9 +44450,9 @@ const serializeAws_ec2RegisterImageRequest = (
       input.BillingProducts,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BillingProduct.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BlockDeviceMappings !== undefined) {
@@ -44459,9 +44460,9 @@ const serializeAws_ec2RegisterImageRequest = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -44513,9 +44514,9 @@ const serializeAws_ec2RegisterTransitGatewayMulticastGroupMembersRequest = (
       input.NetworkInterfaceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayMulticastDomainId !== undefined) {
@@ -44541,9 +44542,9 @@ const serializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesRequest = (
       input.NetworkInterfaceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitGatewayMulticastDomainId !== undefined) {
@@ -44597,9 +44598,9 @@ const serializeAws_ec2RejectVpcEndpointConnectionsRequest = (
       input.VpcEndpointIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -44649,9 +44650,9 @@ const serializeAws_ec2ReleaseHostsRequest = (
       input.HostIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -44670,9 +44671,9 @@ const serializeAws_ec2ReplaceIamInstanceProfileAssociationRequest = (
       input.IamInstanceProfile,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamInstanceProfile.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -44714,9 +44715,9 @@ const serializeAws_ec2ReplaceNetworkAclEntryRequest = (
       input.IcmpTypeCode,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Icmp.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Ipv6CidrBlock !== undefined) {
@@ -44727,9 +44728,9 @@ const serializeAws_ec2ReplaceNetworkAclEntryRequest = (
   }
   if (input.PortRange !== undefined) {
     const memberEntries = serializeAws_ec2PortRange(input.PortRange, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PortRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Protocol !== undefined) {
@@ -44850,9 +44851,9 @@ const serializeAws_ec2ReportInstanceStatusRequest = (
       input.Instances,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReasonCodes !== undefined) {
@@ -44860,9 +44861,9 @@ const serializeAws_ec2ReportInstanceStatusRequest = (
       input.ReasonCodes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReasonCode.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StartTime !== undefined) {
@@ -44923,9 +44924,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CapacityReservationSpecification !== undefined) {
@@ -44933,9 +44934,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.CapacityReservationSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CpuOptions !== undefined) {
@@ -44943,9 +44944,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.CpuOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CpuOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CreditSpecification !== undefined) {
@@ -44953,9 +44954,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.CreditSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CreditSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DisableApiTermination !== undefined) {
@@ -44969,11 +44970,11 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.ElasticGpuSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticGpuSpecification.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ElasticInferenceAccelerators !== undefined) {
@@ -44981,11 +44982,11 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.ElasticInferenceAccelerators,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticInferenceAccelerator.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.HibernationOptions !== undefined) {
@@ -44993,9 +44994,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.HibernationOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HibernationOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IamInstanceProfile !== undefined) {
@@ -45003,9 +45004,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.IamInstanceProfile,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamInstanceProfile.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImageId !== undefined) {
@@ -45020,9 +45021,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.InstanceMarketOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceMarketOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceType !== undefined) {
@@ -45039,9 +45040,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.LicenseSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LicenseSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MetadataOptions !== undefined) {
@@ -45049,9 +45050,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.MetadataOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetadataOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Monitoring !== undefined) {
@@ -45059,9 +45060,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.Monitoring,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Monitoring.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaces !== undefined) {
@@ -45069,9 +45070,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.NetworkInterfaces,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Placement !== undefined) {
@@ -45079,9 +45080,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.Placement,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Placement.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RamDiskId !== undefined) {
@@ -45092,9 +45093,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecurityGroups !== undefined) {
@@ -45102,9 +45103,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroup.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagSpecifications !== undefined) {
@@ -45112,9 +45113,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserData !== undefined) {
@@ -45136,9 +45137,9 @@ const serializeAws_ec2RequestSpotFleetRequest = (
       input.SpotFleetRequestConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotFleetRequestConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -45176,9 +45177,9 @@ const serializeAws_ec2RequestSpotInstancesRequest = (
       input.LaunchSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SpotPrice !== undefined) {
@@ -45209,9 +45210,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EbsOptimized !== undefined) {
@@ -45222,9 +45223,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.IamInstanceProfile,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamInstanceProfile.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImageId !== undefined) {
@@ -45244,9 +45245,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.Monitoring,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Monitoring.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaces !== undefined) {
@@ -45254,9 +45255,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.NetworkInterfaces,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Placement !== undefined) {
@@ -45264,9 +45265,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.Placement,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Placement.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RamdiskId !== undefined) {
@@ -45277,9 +45278,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecurityGroups !== undefined) {
@@ -45287,9 +45288,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroup.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SubnetId !== undefined) {
@@ -45362,8 +45363,8 @@ const serializeAws_ec2ReservedInstancesConfigurationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -45603,9 +45604,9 @@ const serializeAws_ec2RevokeSecurityGroupEgressRequest = (
       input.IpPermissions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IpProtocol !== undefined) {
@@ -45648,9 +45649,9 @@ const serializeAws_ec2RevokeSecurityGroupIngressRequest = (
       input.IpPermissions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IpProtocol !== undefined) {
@@ -45692,9 +45693,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CapacityReservationSpecification !== undefined) {
@@ -45702,9 +45703,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.CapacityReservationSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClientToken !== undefined) {
@@ -45715,9 +45716,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.CpuOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CpuOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CreditSpecification !== undefined) {
@@ -45725,9 +45726,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.CreditSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CreditSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DisableApiTermination !== undefined) {
@@ -45744,11 +45745,11 @@ const serializeAws_ec2RunInstancesRequest = (
       input.ElasticGpuSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticGpuSpecification.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ElasticInferenceAccelerators !== undefined) {
@@ -45756,11 +45757,11 @@ const serializeAws_ec2RunInstancesRequest = (
       input.ElasticInferenceAccelerators,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticInferenceAccelerator.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.HibernationOptions !== undefined) {
@@ -45768,9 +45769,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.HibernationOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HibernationOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IamInstanceProfile !== undefined) {
@@ -45778,9 +45779,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.IamInstanceProfile,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamInstanceProfile.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImageId !== undefined) {
@@ -45795,9 +45796,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.InstanceMarketOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceMarketOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstanceType !== undefined) {
@@ -45811,9 +45812,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.Ipv6Addresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Address.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.KernelId !== undefined) {
@@ -45827,9 +45828,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.LaunchTemplate,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplate.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LicenseSpecifications !== undefined) {
@@ -45837,9 +45838,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.LicenseSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LicenseSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxCount !== undefined) {
@@ -45850,9 +45851,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.MetadataOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetadataOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MinCount !== undefined) {
@@ -45863,9 +45864,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.Monitoring,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Monitoring.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaces !== undefined) {
@@ -45873,16 +45874,16 @@ const serializeAws_ec2RunInstancesRequest = (
       input.NetworkInterfaces,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Placement !== undefined) {
     const memberEntries = serializeAws_ec2Placement(input.Placement, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Placement.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PrivateIpAddress !== undefined) {
@@ -45896,9 +45897,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecurityGroups !== undefined) {
@@ -45906,9 +45907,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroup.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SubnetId !== undefined) {
@@ -45919,9 +45920,9 @@ const serializeAws_ec2RunInstancesRequest = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserData !== undefined) {
@@ -45952,9 +45953,9 @@ const serializeAws_ec2RunScheduledInstancesRequest = (
       input.LaunchSpecification,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchSpecification.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ScheduledInstanceId !== undefined) {
@@ -46015,9 +46016,9 @@ const serializeAws_ec2ScheduledInstanceRecurrenceRequest = (
       input.OccurrenceDays,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OccurrenceDay.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OccurrenceRelativeToEnd !== undefined) {
@@ -46042,9 +46043,9 @@ const serializeAws_ec2ScheduledInstancesBlockDeviceMapping = (
       input.Ebs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ebs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NoDevice !== undefined) {
@@ -46067,8 +46068,8 @@ const serializeAws_ec2ScheduledInstancesBlockDeviceMappingSet = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`BlockDeviceMapping.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`BlockDeviceMapping.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -46137,8 +46138,8 @@ const serializeAws_ec2ScheduledInstancesIpv6AddressList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Ipv6Address.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Ipv6Address.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -46155,9 +46156,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EbsOptimized !== undefined) {
@@ -46168,9 +46169,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       input.IamInstanceProfile,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamInstanceProfile.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImageId !== undefined) {
@@ -46190,9 +46191,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       input.Monitoring,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Monitoring.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaces !== undefined) {
@@ -46200,9 +46201,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       input.NetworkInterfaces,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Placement !== undefined) {
@@ -46210,9 +46211,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       input.Placement,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Placement.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RamdiskId !== undefined) {
@@ -46223,9 +46224,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SubnetId !== undefined) {
@@ -46270,9 +46271,9 @@ const serializeAws_ec2ScheduledInstancesNetworkInterface = (
       input.Groups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Group.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Ipv6AddressCount !== undefined) {
@@ -46283,9 +46284,9 @@ const serializeAws_ec2ScheduledInstancesNetworkInterface = (
       input.Ipv6Addresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Address.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaceId !== undefined) {
@@ -46299,11 +46300,11 @@ const serializeAws_ec2ScheduledInstancesNetworkInterface = (
       input.PrivateIpAddressConfigs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddressConfig.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SecondaryPrivateIpAddressCount !== undefined) {
@@ -46327,8 +46328,8 @@ const serializeAws_ec2ScheduledInstancesNetworkInterfaceSet = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`NetworkInterface.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`NetworkInterface.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -46386,9 +46387,9 @@ const serializeAws_ec2SearchLocalGatewayRoutesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LocalGatewayRouteTableId !== undefined) {
@@ -46413,9 +46414,9 @@ const serializeAws_ec2SearchTransitGatewayMulticastGroupsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -46441,9 +46442,9 @@ const serializeAws_ec2SearchTransitGatewayRoutesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxResults !== undefined) {
@@ -46541,9 +46542,9 @@ const serializeAws_ec2SnapshotDiskContainer = (
   }
   if (input.UserBucket !== undefined) {
     const memberEntries = serializeAws_ec2UserBucket(input.UserBucket, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserBucket.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -46575,9 +46576,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       input.BlockDeviceMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EbsOptimized !== undefined) {
@@ -46588,9 +46589,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       input.IamInstanceProfile,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamInstanceProfile.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ImageId !== undefined) {
@@ -46610,9 +46611,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       input.Monitoring,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Monitoring.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaces !== undefined) {
@@ -46620,9 +46621,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       input.NetworkInterfaces,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceSet.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Placement !== undefined) {
@@ -46630,9 +46631,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       input.Placement,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Placement.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RamdiskId !== undefined) {
@@ -46643,9 +46644,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupSet.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SpotPrice !== undefined) {
@@ -46659,9 +46660,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
       input.TagSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecificationSet.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserData !== undefined) {
@@ -46717,9 +46718,9 @@ const serializeAws_ec2SpotFleetRequestConfigData = (
       input.LaunchSpecifications,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchSpecifications.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LaunchTemplateConfigs !== undefined) {
@@ -46727,11 +46728,11 @@ const serializeAws_ec2SpotFleetRequestConfigData = (
       input.LaunchTemplateConfigs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateConfigs.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancersConfig !== undefined) {
@@ -46739,9 +46740,9 @@ const serializeAws_ec2SpotFleetRequestConfigData = (
       input.LoadBalancersConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancersConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OnDemandAllocationStrategy !== undefined) {
@@ -46794,9 +46795,9 @@ const serializeAws_ec2SpotFleetTagSpecification = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -46813,8 +46814,8 @@ const serializeAws_ec2SpotFleetTagSpecificationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -46921,9 +46922,9 @@ const serializeAws_ec2StartInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -46962,9 +46963,9 @@ const serializeAws_ec2StopInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -46977,9 +46978,9 @@ const serializeAws_ec2Storage = (
   const entries: any = {};
   if (input.S3 !== undefined) {
     const memberEntries = serializeAws_ec2S3Storage(input.S3, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `S3.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47031,8 +47032,8 @@ const serializeAws_ec2TagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2Tag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -47049,9 +47050,9 @@ const serializeAws_ec2TagSpecification = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47065,8 +47066,8 @@ const serializeAws_ec2TagSpecificationList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2TagSpecification(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -47118,9 +47119,8 @@ const serializeAws_ec2TargetConfigurationRequestSet = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`TargetConfigurationRequest.${counter}.${key}`] =
-        memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`TargetConfigurationRequest.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -47146,8 +47146,8 @@ const serializeAws_ec2TargetGroups = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2TargetGroup(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -47164,9 +47164,9 @@ const serializeAws_ec2TargetGroupsConfig = (
       input.TargetGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroups.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47205,9 +47205,9 @@ const serializeAws_ec2TerminateInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47359,9 +47359,9 @@ const serializeAws_ec2UnassignIpv6AddressesRequest = (
       input.Ipv6Addresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NetworkInterfaceId !== undefined) {
@@ -47383,9 +47383,9 @@ const serializeAws_ec2UnassignPrivateIpAddressesRequest = (
       input.PrivateIpAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddress.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47404,9 +47404,9 @@ const serializeAws_ec2UnmonitorInstancesRequest = (
       input.InstanceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47431,9 +47431,9 @@ const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressRequest = (
       input.IpPermissions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47458,9 +47458,9 @@ const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressRequest = (
       input.IpPermissions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47541,8 +47541,8 @@ const serializeAws_ec2UserIdGroupPairList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2UserIdGroupPair(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Item.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Item.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -47667,9 +47667,9 @@ const serializeAws_ec2VpnConnectionOptionsSpecification = (
       input.TunnelOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TunnelOptions.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -47701,9 +47701,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.IKEVersions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IKEVersion.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1DHGroupNumbers !== undefined) {
@@ -47711,9 +47711,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase1DHGroupNumbers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1EncryptionAlgorithms !== undefined) {
@@ -47721,11 +47721,11 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase1EncryptionAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1EncryptionAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1IntegrityAlgorithms !== undefined) {
@@ -47733,11 +47733,11 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase1IntegrityAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1IntegrityAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase1LifetimeSeconds !== undefined) {
@@ -47748,9 +47748,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase2DHGroupNumbers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase2EncryptionAlgorithms !== undefined) {
@@ -47758,11 +47758,11 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase2EncryptionAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2EncryptionAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase2IntegrityAlgorithms !== undefined) {
@@ -47770,11 +47770,11 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase2IntegrityAlgorithms,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2IntegrityAlgorithm.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Phase2LifetimeSeconds !== undefined) {
@@ -47809,8 +47809,8 @@ const serializeAws_ec2VpnTunnelOptionsSpecificationsList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -71407,13 +71407,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-ecr/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/protocols/Aws_json1_1.ts
@@ -141,6 +141,7 @@ import {
   DescribeRepositoriesRequest,
   DescribeRepositoriesResponse,
   EmptyUploadException,
+  FindingSeverity,
   GetAuthorizationTokenRequest,
   GetAuthorizationTokenResponse,
   GetDownloadUrlForLayerRequest,
@@ -4761,10 +4762,16 @@ const deserializeAws_json1_1FindingSeverityCounts = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: number },
+      [key, value]: [FindingSeverity | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1GetAuthorizationTokenResponse = (

--- a/clients/client-ecs/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/protocols/Aws_json1_1.ts
@@ -7302,10 +7302,13 @@ const serializeAws_json1_1DockerLabelsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1DockerVolumeConfiguration = (
@@ -7367,10 +7370,13 @@ const serializeAws_json1_1FirelensConfigurationOptionsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1HealthCheck = (
@@ -7689,10 +7695,13 @@ const serializeAws_json1_1LogConfigurationOptionsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ManagedScaling = (
@@ -8253,10 +8262,13 @@ const serializeAws_json1_1StringMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1SubmitAttachmentStateChangesRequest = (
@@ -9972,10 +9984,13 @@ const deserializeAws_json1_1DockerLabelsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1DockerVolumeConfiguration = (
@@ -10085,10 +10100,13 @@ const deserializeAws_json1_1FirelensConfigurationOptionsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1GpuIds = (
@@ -10532,10 +10550,13 @@ const deserializeAws_json1_1LogConfigurationOptionsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ManagedScaling = (
@@ -11452,10 +11473,13 @@ const deserializeAws_json1_1StringMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1SubmitAttachmentStateChangesResponse = (

--- a/clients/client-eks/protocols/Aws_restJson1_1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1_1.ts
@@ -3554,10 +3554,13 @@ const serializeAws_restJson1_1FargateProfileLabel = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1FargateProfileSelector = (
@@ -3658,10 +3661,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1UpdateLabelsPayload = (
@@ -3724,10 +3730,13 @@ const serializeAws_restJson1_1labelsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AutoScalingGroup = (
@@ -3922,10 +3931,13 @@ const deserializeAws_restJson1_1FargateProfileLabel = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1FargateProfileSelector = (
@@ -4238,10 +4250,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Update = (
@@ -4348,10 +4363,13 @@ const deserializeAws_restJson1_1labelsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -4394,9 +4394,9 @@ const serializeAws_queryApplicationResourceLifecycleConfig = (
       input.VersionLifecycleConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VersionLifecycleConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4412,9 +4412,9 @@ const serializeAws_queryApplicationVersionLifecycleConfig = (
       input.MaxAgeRule,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MaxAgeRule.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxCountRule !== undefined) {
@@ -4422,9 +4422,9 @@ const serializeAws_queryApplicationVersionLifecycleConfig = (
       input.MaxCountRule,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MaxCountRule.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4497,9 +4497,9 @@ const serializeAws_queryComposeEnvironmentsMessage = (
       input.VersionLabels,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VersionLabels.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4536,8 +4536,8 @@ const serializeAws_queryConfigurationOptionSettingsList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -4560,16 +4560,16 @@ const serializeAws_queryCreateApplicationMessage = (
       input.ResourceLifecycleConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceLifecycleConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4591,9 +4591,9 @@ const serializeAws_queryCreateApplicationVersionMessage = (
       input.BuildConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BuildConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Description !== undefined) {
@@ -4607,9 +4607,9 @@ const serializeAws_queryCreateApplicationVersionMessage = (
       input.SourceBuildInformation,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceBuildInformation.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceBundle !== undefined) {
@@ -4617,16 +4617,16 @@ const serializeAws_queryCreateApplicationVersionMessage = (
       input.SourceBundle,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceBundle.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VersionLabel !== undefined) {
@@ -4654,9 +4654,9 @@ const serializeAws_queryCreateConfigurationTemplateMessage = (
       input.OptionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PlatformArn !== undefined) {
@@ -4670,16 +4670,16 @@ const serializeAws_queryCreateConfigurationTemplateMessage = (
       input.SourceConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateName !== undefined) {
@@ -4713,9 +4713,9 @@ const serializeAws_queryCreateEnvironmentMessage = (
       input.OptionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OptionsToRemove !== undefined) {
@@ -4723,9 +4723,9 @@ const serializeAws_queryCreateEnvironmentMessage = (
       input.OptionsToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PlatformArn !== undefined) {
@@ -4736,9 +4736,9 @@ const serializeAws_queryCreateEnvironmentMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateName !== undefined) {
@@ -4749,9 +4749,9 @@ const serializeAws_queryCreateEnvironmentMessage = (
       input.Tier,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tier.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VersionLabel !== undefined) {
@@ -4773,9 +4773,9 @@ const serializeAws_queryCreatePlatformVersionRequest = (
       input.OptionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PlatformDefinitionBundle !== undefined) {
@@ -4783,9 +4783,9 @@ const serializeAws_queryCreatePlatformVersionRequest = (
       input.PlatformDefinitionBundle,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PlatformDefinitionBundle.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PlatformName !== undefined) {
@@ -4796,9 +4796,9 @@ const serializeAws_queryCreatePlatformVersionRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4893,9 +4893,9 @@ const serializeAws_queryDescribeApplicationVersionsMessage = (
       input.VersionLabels,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VersionLabels.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4911,9 +4911,9 @@ const serializeAws_queryDescribeApplicationsMessage = (
       input.ApplicationNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ApplicationNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4935,9 +4935,9 @@ const serializeAws_queryDescribeConfigurationOptionsMessage = (
       input.Options,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Options.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PlatformArn !== undefined) {
@@ -4979,9 +4979,9 @@ const serializeAws_queryDescribeEnvironmentHealthRequest = (
       input.AttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnvironmentId !== undefined) {
@@ -5057,9 +5057,9 @@ const serializeAws_queryDescribeEnvironmentsMessage = (
       input.EnvironmentIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnvironmentIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnvironmentNames !== undefined) {
@@ -5067,9 +5067,9 @@ const serializeAws_queryDescribeEnvironmentsMessage = (
       input.EnvironmentNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnvironmentNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludeDeleted !== undefined) {
@@ -5145,9 +5145,9 @@ const serializeAws_queryDescribeInstancesHealthRequest = (
       input.AttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnvironmentId !== undefined) {
@@ -5252,9 +5252,9 @@ const serializeAws_queryListPlatformVersionsRequest = (
       input.Filters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxRecords !== undefined) {
@@ -5336,8 +5336,8 @@ const serializeAws_queryOptionsSpecifierList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryOptionSpecification(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5360,9 +5360,9 @@ const serializeAws_queryPlatformFilter = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5389,8 +5389,8 @@ const serializeAws_queryPlatformFilters = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryPlatformFilter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5556,8 +5556,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5569,8 +5569,8 @@ const serializeAws_queryTags = (input: Tag[], context: __SerdeContext): any => {
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5624,9 +5624,9 @@ const serializeAws_queryUpdateApplicationResourceLifecycleMessage = (
       input.ResourceLifecycleConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceLifecycleConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5665,9 +5665,9 @@ const serializeAws_queryUpdateConfigurationTemplateMessage = (
       input.OptionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OptionsToRemove !== undefined) {
@@ -5675,9 +5675,9 @@ const serializeAws_queryUpdateConfigurationTemplateMessage = (
       input.OptionsToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateName !== undefined) {
@@ -5711,9 +5711,9 @@ const serializeAws_queryUpdateEnvironmentMessage = (
       input.OptionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OptionsToRemove !== undefined) {
@@ -5721,9 +5721,9 @@ const serializeAws_queryUpdateEnvironmentMessage = (
       input.OptionsToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PlatformArn !== undefined) {
@@ -5740,9 +5740,9 @@ const serializeAws_queryUpdateEnvironmentMessage = (
       input.Tier,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tier.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VersionLabel !== undefined) {
@@ -5761,9 +5761,9 @@ const serializeAws_queryUpdateTagsForResourceMessage = (
   }
   if (input.TagsToAdd !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.TagsToAdd, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagsToAdd.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagsToRemove !== undefined) {
@@ -5771,9 +5771,9 @@ const serializeAws_queryUpdateTagsForResourceMessage = (
       input.TagsToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagsToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5795,9 +5795,9 @@ const serializeAws_queryValidateConfigurationSettingsMessage = (
       input.OptionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TemplateName !== undefined) {
@@ -8785,13 +8785,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
@@ -439,20 +439,26 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -4813,9 +4813,9 @@ const serializeAws_queryAction = (
       input.AuthenticateCognitoConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AuthenticateCognitoConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AuthenticateOidcConfig !== undefined) {
@@ -4823,9 +4823,9 @@ const serializeAws_queryAction = (
       input.AuthenticateOidcConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AuthenticateOidcConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FixedResponseConfig !== undefined) {
@@ -4833,9 +4833,9 @@ const serializeAws_queryAction = (
       input.FixedResponseConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FixedResponseConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ForwardConfig !== undefined) {
@@ -4843,9 +4843,9 @@ const serializeAws_queryAction = (
       input.ForwardConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ForwardConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Order !== undefined) {
@@ -4856,9 +4856,9 @@ const serializeAws_queryAction = (
       input.RedirectConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RedirectConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetGroupArn !== undefined) {
@@ -4878,8 +4878,8 @@ const serializeAws_queryActions = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryAction(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -4896,9 +4896,9 @@ const serializeAws_queryAddListenerCertificatesInput = (
       input.Certificates,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListenerArn !== undefined) {
@@ -4917,16 +4917,16 @@ const serializeAws_queryAddTagsInput = (
       input.ResourceArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4956,9 +4956,9 @@ const serializeAws_queryAuthenticateCognitoActionConfig = (
       input.AuthenticationRequestExtraParams,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AuthenticationRequestExtraParams.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OnUnauthenticatedRequest !== undefined) {
@@ -5009,9 +5009,9 @@ const serializeAws_queryAuthenticateOidcActionConfig = (
       input.AuthenticationRequestExtraParams,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AuthenticationRequestExtraParams.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AuthorizationEndpoint !== undefined) {
@@ -5072,8 +5072,8 @@ const serializeAws_queryCertificateList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryCertificate(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5090,9 +5090,9 @@ const serializeAws_queryCreateListenerInput = (
       input.Certificates,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DefaultActions !== undefined) {
@@ -5100,9 +5100,9 @@ const serializeAws_queryCreateListenerInput = (
       input.DefaultActions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DefaultActions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerArn !== undefined) {
@@ -5139,9 +5139,9 @@ const serializeAws_queryCreateLoadBalancerInput = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SubnetMappings !== undefined) {
@@ -5149,23 +5149,23 @@ const serializeAws_queryCreateLoadBalancerInput = (
       input.SubnetMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetMappings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Subnets !== undefined) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Type !== undefined) {
@@ -5181,9 +5181,9 @@ const serializeAws_queryCreateRuleInput = (
   const entries: any = {};
   if (input.Actions !== undefined) {
     const memberEntries = serializeAws_queryActions(input.Actions, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Actions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Conditions !== undefined) {
@@ -5191,9 +5191,9 @@ const serializeAws_queryCreateRuleInput = (
       input.Conditions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Conditions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListenerArn !== undefined) {
@@ -5233,9 +5233,9 @@ const serializeAws_queryCreateTargetGroupInput = (
   }
   if (input.Matcher !== undefined) {
     const memberEntries = serializeAws_queryMatcher(input.Matcher, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Matcher.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Name !== undefined) {
@@ -5316,9 +5316,9 @@ const serializeAws_queryDeregisterTargetsInput = (
       input.Targets,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Targets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5365,9 +5365,9 @@ const serializeAws_queryDescribeListenersInput = (
       input.ListenerArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListenerArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerArn !== undefined) {
@@ -5403,9 +5403,9 @@ const serializeAws_queryDescribeLoadBalancersInput = (
       input.LoadBalancerArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -5416,9 +5416,9 @@ const serializeAws_queryDescribeLoadBalancersInput = (
       input.Names,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PageSize !== undefined) {
@@ -5443,9 +5443,9 @@ const serializeAws_queryDescribeRulesInput = (
   }
   if (input.RuleArns !== undefined) {
     const memberEntries = serializeAws_queryRuleArns(input.RuleArns, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5464,9 +5464,9 @@ const serializeAws_queryDescribeSSLPoliciesInput = (
       input.Names,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PageSize !== undefined) {
@@ -5485,9 +5485,9 @@ const serializeAws_queryDescribeTagsInput = (
       input.ResourceArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5520,9 +5520,9 @@ const serializeAws_queryDescribeTargetGroupsInput = (
       input.Names,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PageSize !== undefined) {
@@ -5533,9 +5533,9 @@ const serializeAws_queryDescribeTargetGroupsInput = (
       input.TargetGroupArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5554,9 +5554,9 @@ const serializeAws_queryDescribeTargetHealthInput = (
       input.Targets,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Targets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5589,9 +5589,9 @@ const serializeAws_queryForwardActionConfig = (
       input.TargetGroupStickinessConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupStickinessConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetGroups !== undefined) {
@@ -5599,9 +5599,9 @@ const serializeAws_queryForwardActionConfig = (
       input.TargetGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5614,9 +5614,9 @@ const serializeAws_queryHostHeaderConditionConfig = (
   const entries: any = {};
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5632,9 +5632,9 @@ const serializeAws_queryHttpHeaderConditionConfig = (
   }
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5647,9 +5647,9 @@ const serializeAws_queryHttpRequestMethodConditionConfig = (
   const entries: any = {};
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5719,8 +5719,8 @@ const serializeAws_queryLoadBalancerAttributes = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5761,9 +5761,9 @@ const serializeAws_queryModifyListenerInput = (
       input.Certificates,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DefaultActions !== undefined) {
@@ -5771,9 +5771,9 @@ const serializeAws_queryModifyListenerInput = (
       input.DefaultActions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DefaultActions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListenerArn !== undefined) {
@@ -5801,9 +5801,9 @@ const serializeAws_queryModifyLoadBalancerAttributesInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerArn !== undefined) {
@@ -5819,9 +5819,9 @@ const serializeAws_queryModifyRuleInput = (
   const entries: any = {};
   if (input.Actions !== undefined) {
     const memberEntries = serializeAws_queryActions(input.Actions, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Actions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Conditions !== undefined) {
@@ -5829,9 +5829,9 @@ const serializeAws_queryModifyRuleInput = (
       input.Conditions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Conditions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RuleArn !== undefined) {
@@ -5850,9 +5850,9 @@ const serializeAws_queryModifyTargetGroupAttributesInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetGroupArn !== undefined) {
@@ -5889,9 +5889,9 @@ const serializeAws_queryModifyTargetGroupInput = (
   }
   if (input.Matcher !== undefined) {
     const memberEntries = serializeAws_queryMatcher(input.Matcher, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Matcher.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetGroupArn !== undefined) {
@@ -5910,9 +5910,9 @@ const serializeAws_queryPathPatternConditionConfig = (
   const entries: any = {};
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5928,9 +5928,9 @@ const serializeAws_queryQueryStringConditionConfig = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5961,8 +5961,8 @@ const serializeAws_queryQueryStringKeyValuePairList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6008,9 +6008,9 @@ const serializeAws_queryRegisterTargetsInput = (
       input.Targets,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Targets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6026,9 +6026,9 @@ const serializeAws_queryRemoveListenerCertificatesInput = (
       input.Certificates,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListenerArn !== undefined) {
@@ -6047,16 +6047,16 @@ const serializeAws_queryRemoveTagsInput = (
       input.ResourceArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeys(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6101,9 +6101,9 @@ const serializeAws_queryRuleCondition = (
       input.HostHeaderConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostHeaderConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.HttpHeaderConfig !== undefined) {
@@ -6111,9 +6111,9 @@ const serializeAws_queryRuleCondition = (
       input.HttpHeaderConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HttpHeaderConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.HttpRequestMethodConfig !== undefined) {
@@ -6121,9 +6121,9 @@ const serializeAws_queryRuleCondition = (
       input.HttpRequestMethodConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HttpRequestMethodConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PathPatternConfig !== undefined) {
@@ -6131,9 +6131,9 @@ const serializeAws_queryRuleCondition = (
       input.PathPatternConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PathPatternConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueryStringConfig !== undefined) {
@@ -6141,9 +6141,9 @@ const serializeAws_queryRuleCondition = (
       input.QueryStringConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `QueryStringConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceIpConfig !== undefined) {
@@ -6151,16 +6151,16 @@ const serializeAws_queryRuleCondition = (
       input.SourceIpConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIpConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6174,8 +6174,8 @@ const serializeAws_queryRuleConditionList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryRuleCondition(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6190,8 +6190,8 @@ const serializeAws_queryRulePriorityList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryRulePriorityPair(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6249,9 +6249,9 @@ const serializeAws_querySetRulePrioritiesInput = (
       input.RulePriorities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RulePriorities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6270,9 +6270,9 @@ const serializeAws_querySetSecurityGroupsInput = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6291,16 +6291,16 @@ const serializeAws_querySetSubnetsInput = (
       input.SubnetMappings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetMappings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Subnets !== undefined) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6313,9 +6313,9 @@ const serializeAws_querySourceIpConditionConfig = (
   const entries: any = {};
   if (input.Values !== undefined) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6359,8 +6359,8 @@ const serializeAws_querySubnetMappings = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_querySubnetMapping(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6412,8 +6412,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6445,8 +6445,8 @@ const serializeAws_queryTargetDescriptions = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTargetDescription(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6491,8 +6491,8 @@ const serializeAws_queryTargetGroupAttributes = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6507,8 +6507,8 @@ const serializeAws_queryTargetGroupList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTargetGroupTuple(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -9172,13 +9172,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -3554,9 +3554,9 @@ const serializeAws_queryAddAvailabilityZonesInput = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -3575,16 +3575,16 @@ const serializeAws_queryAddTagsInput = (
       input.LoadBalancerNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3612,8 +3612,8 @@ const serializeAws_queryAdditionalAttributes = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryAdditionalAttribute(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -3633,9 +3633,9 @@ const serializeAws_queryApplySecurityGroupsToLoadBalancerInput = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3651,9 +3651,9 @@ const serializeAws_queryAttachLoadBalancerToSubnetsInput = (
   }
   if (input.Subnets !== undefined) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3682,9 +3682,9 @@ const serializeAws_queryConfigureHealthCheckInput = (
       input.HealthCheck,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HealthCheck.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -3728,16 +3728,16 @@ const serializeAws_queryCreateAccessPointInput = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Listeners !== undefined) {
     const memberEntries = serializeAws_queryListeners(input.Listeners, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Listeners.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -3751,23 +3751,23 @@ const serializeAws_queryCreateAccessPointInput = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Subnets !== undefined) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3814,9 +3814,9 @@ const serializeAws_queryCreateLoadBalancerListenerInput = (
   const entries: any = {};
   if (input.Listeners !== undefined) {
     const memberEntries = serializeAws_queryListeners(input.Listeners, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Listeners.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -3838,9 +3838,9 @@ const serializeAws_queryCreateLoadBalancerPolicyInput = (
       input.PolicyAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyAttributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PolicyName !== undefined) {
@@ -3887,9 +3887,9 @@ const serializeAws_queryDeleteLoadBalancerListenerInput = (
       input.LoadBalancerPorts,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerPorts.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3916,9 +3916,9 @@ const serializeAws_queryDeregisterEndPointsInput = (
   const entries: any = {};
   if (input.Instances !== undefined) {
     const memberEntries = serializeAws_queryInstances(input.Instances, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Instances.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -3937,9 +3937,9 @@ const serializeAws_queryDescribeAccessPointsInput = (
       input.LoadBalancerNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -3972,9 +3972,9 @@ const serializeAws_queryDescribeEndPointStateInput = (
   const entries: any = {};
   if (input.Instances !== undefined) {
     const memberEntries = serializeAws_queryInstances(input.Instances, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Instances.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -4007,9 +4007,9 @@ const serializeAws_queryDescribeLoadBalancerPoliciesInput = (
       input.PolicyNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4025,9 +4025,9 @@ const serializeAws_queryDescribeLoadBalancerPolicyTypesInput = (
       input.PolicyTypeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyTypeNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4043,9 +4043,9 @@ const serializeAws_queryDescribeTagsInput = (
       input.LoadBalancerNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4061,9 +4061,9 @@ const serializeAws_queryDetachLoadBalancerFromSubnetsInput = (
   }
   if (input.Subnets !== undefined) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4111,8 +4111,8 @@ const serializeAws_queryInstances = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryInstance(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -4150,8 +4150,8 @@ const serializeAws_queryListeners = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryListener(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -4165,9 +4165,9 @@ const serializeAws_queryLoadBalancerAttributes = (
   const entries: any = {};
   if (input.AccessLog !== undefined) {
     const memberEntries = serializeAws_queryAccessLog(input.AccessLog, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AccessLog.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.AdditionalAttributes !== undefined) {
@@ -4175,9 +4175,9 @@ const serializeAws_queryLoadBalancerAttributes = (
       input.AdditionalAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AdditionalAttributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ConnectionDraining !== undefined) {
@@ -4185,9 +4185,9 @@ const serializeAws_queryLoadBalancerAttributes = (
       input.ConnectionDraining,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionDraining.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ConnectionSettings !== undefined) {
@@ -4195,9 +4195,9 @@ const serializeAws_queryLoadBalancerAttributes = (
       input.ConnectionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CrossZoneLoadBalancing !== undefined) {
@@ -4205,9 +4205,9 @@ const serializeAws_queryLoadBalancerAttributes = (
       input.CrossZoneLoadBalancing,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CrossZoneLoadBalancing.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4249,9 +4249,9 @@ const serializeAws_queryModifyLoadBalancerAttributesInput = (
       input.LoadBalancerAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerAttributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -4282,8 +4282,8 @@ const serializeAws_queryPolicyAttributes = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryPolicyAttribute(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -4336,9 +4336,9 @@ const serializeAws_queryRegisterEndPointsInput = (
   const entries: any = {};
   if (input.Instances !== undefined) {
     const memberEntries = serializeAws_queryInstances(input.Instances, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Instances.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -4357,9 +4357,9 @@ const serializeAws_queryRemoveAvailabilityZonesInput = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LoadBalancerName !== undefined) {
@@ -4378,16 +4378,16 @@ const serializeAws_queryRemoveTagsInput = (
       input.LoadBalancerNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4439,9 +4439,9 @@ const serializeAws_querySetLoadBalancerPoliciesForBackendServerInput = (
       input.PolicyNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4463,9 +4463,9 @@ const serializeAws_querySetLoadBalancerPoliciesOfListenerInput = (
       input.PolicyNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4503,8 +4503,8 @@ const serializeAws_queryTagKeyList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTagKeyOnly(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -4530,8 +4530,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -6294,13 +6294,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
@@ -2902,10 +2902,13 @@ const serializeAws_restJson1_1CodecOptions = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Composition = (
@@ -3294,10 +3297,13 @@ const serializeAws_restJson1_1UserMetadata = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1VideoParameters = (
@@ -3567,10 +3573,13 @@ const deserializeAws_restJson1_1CodecOptions = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Composition = (
@@ -4382,10 +4391,13 @@ const deserializeAws_restJson1_1UserMetadata = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1VideoParameters = (

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -7330,9 +7330,9 @@ const serializeAws_queryAddTagsToResourceMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7378,9 +7378,9 @@ const serializeAws_queryBatchApplyUpdateActionMessage = (
       input.CacheClusterIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheClusterIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicationGroupIds !== undefined) {
@@ -7388,9 +7388,9 @@ const serializeAws_queryBatchApplyUpdateActionMessage = (
       input.ReplicationGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicationGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ServiceUpdateName !== undefined) {
@@ -7409,9 +7409,9 @@ const serializeAws_queryBatchStopUpdateActionMessage = (
       input.CacheClusterIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheClusterIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicationGroupIds !== undefined) {
@@ -7419,9 +7419,9 @@ const serializeAws_queryBatchStopUpdateActionMessage = (
       input.ReplicationGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicationGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ServiceUpdateName !== undefined) {
@@ -7499,9 +7499,9 @@ const serializeAws_queryConfigureShard = (
       input.PreferredAvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredAvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7555,9 +7555,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
       input.CacheSecurityGroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CacheSubnetGroupName !== undefined) {
@@ -7586,9 +7586,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
       input.PreferredAvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredAvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PreferredMaintenanceWindow !== undefined) {
@@ -7602,9 +7602,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotArns !== undefined) {
@@ -7612,9 +7612,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
       input.SnapshotArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotName !== undefined) {
@@ -7628,9 +7628,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7683,9 +7683,9 @@ const serializeAws_queryCreateCacheSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7719,9 +7719,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
       input.CacheSecurityGroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CacheSubnetGroupName !== undefined) {
@@ -7741,9 +7741,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
       input.NodeGroupConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NodeGroupConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NotificationTopicArn !== undefined) {
@@ -7763,9 +7763,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
       input.PreferredCacheClusterAZs,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredCacheClusterAZs.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PreferredMaintenanceWindow !== undefined) {
@@ -7788,9 +7788,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotArns !== undefined) {
@@ -7798,9 +7798,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
       input.SnapshotArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotName !== undefined) {
@@ -7814,9 +7814,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TransitEncryptionEnabled !== undefined) {
@@ -7870,8 +7870,8 @@ const serializeAws_queryCustomerNodeEndpointList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -7894,9 +7894,9 @@ const serializeAws_queryDecreaseReplicaCountMessage = (
       input.ReplicaConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicaConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicasToRemove !== undefined) {
@@ -7904,9 +7904,9 @@ const serializeAws_queryDecreaseReplicaCountMessage = (
       input.ReplicasToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicasToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicationGroupId !== undefined) {
@@ -8256,9 +8256,9 @@ const serializeAws_queryDescribeServiceUpdatesMessage = (
       input.ServiceUpdateStatus,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceUpdateStatus.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8303,9 +8303,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
       input.CacheClusterIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheClusterIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Engine !== undefined) {
@@ -8322,9 +8322,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
       input.ReplicationGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicationGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ServiceUpdateName !== undefined) {
@@ -8335,9 +8335,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
       input.ServiceUpdateStatus,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceUpdateStatus.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ServiceUpdateTimeRange !== undefined) {
@@ -8345,9 +8345,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
       input.ServiceUpdateTimeRange,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceUpdateTimeRange.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ShowNodeLevelUpdateStatus !== undefined) {
@@ -8358,9 +8358,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
       input.UpdateActionStatus,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UpdateActionStatus.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8382,9 +8382,9 @@ const serializeAws_queryIncreaseReplicaCountMessage = (
       input.ReplicaConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicaConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicationGroupId !== undefined) {
@@ -8459,9 +8459,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
       input.CacheNodeIdsToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheNodeIdsToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CacheNodeType !== undefined) {
@@ -8475,9 +8475,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
       input.CacheSecurityGroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EngineVersion !== undefined) {
@@ -8488,9 +8488,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
       input.NewAvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NewAvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NotificationTopicArn !== undefined) {
@@ -8510,9 +8510,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotRetentionLimit !== undefined) {
@@ -8537,9 +8537,9 @@ const serializeAws_queryModifyCacheParameterGroupMessage = (
       input.ParameterNameValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterNameValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8561,9 +8561,9 @@ const serializeAws_queryModifyCacheSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8600,9 +8600,9 @@ const serializeAws_queryModifyReplicationGroupMessage = (
       input.CacheSecurityGroupNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EngineVersion !== undefined) {
@@ -8634,9 +8634,9 @@ const serializeAws_queryModifyReplicationGroupMessage = (
       input.SecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotRetentionLimit !== undefined) {
@@ -8667,9 +8667,9 @@ const serializeAws_queryModifyReplicationGroupShardConfigurationMessage = (
       input.NodeGroupsToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NodeGroupsToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.NodeGroupsToRetain !== undefined) {
@@ -8677,9 +8677,9 @@ const serializeAws_queryModifyReplicationGroupShardConfigurationMessage = (
       input.NodeGroupsToRetain,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NodeGroupsToRetain.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicationGroupId !== undefined) {
@@ -8690,9 +8690,9 @@ const serializeAws_queryModifyReplicationGroupShardConfigurationMessage = (
       input.ReshardingConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReshardingConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8714,9 +8714,9 @@ const serializeAws_queryNodeGroupConfiguration = (
       input.ReplicaAvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicaAvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicaCount !== undefined) {
@@ -8739,8 +8739,8 @@ const serializeAws_queryNodeGroupConfigurationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`NodeGroupConfiguration.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`NodeGroupConfiguration.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -8795,8 +8795,8 @@ const serializeAws_queryParameterNameValueList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryParameterNameValue(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`ParameterNameValue.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`ParameterNameValue.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -8847,9 +8847,9 @@ const serializeAws_queryRebootCacheClusterMessage = (
       input.CacheNodeIdsToReboot,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheNodeIdsToReboot.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8878,9 +8878,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8894,8 +8894,8 @@ const serializeAws_queryReplicaConfigurationList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryConfigureShard(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`ConfigureShard.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`ConfigureShard.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -8928,9 +8928,9 @@ const serializeAws_queryResetCacheParameterGroupMessage = (
       input.ParameterNameValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterNameValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetAllParameters !== undefined) {
@@ -8952,9 +8952,9 @@ const serializeAws_queryReshardingConfiguration = (
       input.PreferredAvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredAvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8971,8 +8971,8 @@ const serializeAws_queryReshardingConfigurationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`ReshardingConfiguration.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`ReshardingConfiguration.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -9045,9 +9045,9 @@ const serializeAws_queryStartMigrationMessage = (
       input.CustomerNodeEndpointList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CustomerNodeEndpointList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplicationGroupId !== undefined) {
@@ -9088,8 +9088,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Tag.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Tag.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -12842,13 +12842,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
@@ -120,6 +120,7 @@ import {
   Limits,
   LogPublishingOption,
   LogPublishingOptionsStatus,
+  LogType,
   NodeToNodeEncryptionOptions,
   NodeToNodeEncryptionOptionsStatus,
   OptionStatus,
@@ -3485,10 +3486,13 @@ const serializeAws_restJson1_1AdvancedOptions = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1CognitoOptions = (
@@ -3599,10 +3603,16 @@ const serializeAws_restJson1_1LogPublishingOptions = (
   input: { [key: string]: LogPublishingOption },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1LogPublishingOption(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: LogPublishingOption },
+      [key, value]: [LogType | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1LogPublishingOption(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1NodeToNodeEncryptionOptions = (
@@ -3724,10 +3734,13 @@ const deserializeAws_restJson1_1AdvancedOptions = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AdvancedOptionsStatus = (
@@ -4304,10 +4317,13 @@ const deserializeAws_restJson1_1EndpointsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1InstanceCountLimits = (
@@ -4394,10 +4410,13 @@ const deserializeAws_restJson1_1LimitsByRole = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Limits } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1Limits(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Limits }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1Limits(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1LogPublishingOption = (
@@ -4422,13 +4441,16 @@ const deserializeAws_restJson1_1LogPublishingOptions = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: LogPublishingOption } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1LogPublishingOption(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: LogPublishingOption },
+      [key, value]: [LogType | string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1LogPublishingOption(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1LogPublishingOptionsStatus = (

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -4090,10 +4090,13 @@ const serializeAws_json1_1StringMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1SupportedProductConfig = (
@@ -6753,10 +6756,13 @@ const deserializeAws_json1_1StringMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1SupportedProductsList = (

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -4011,10 +4011,13 @@ const serializeAws_json1_1TransformerPaths = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UntagResourceRequest = (
@@ -5052,10 +5055,13 @@ const deserializeAws_json1_1TransformerPaths = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1UntagResourceResponse = (

--- a/clients/client-firehose/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/protocols/Aws_json1_1.ts
@@ -1525,10 +1525,13 @@ const serializeAws_json1_1ColumnToJsonKeyMappings = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1CopyCommand = (
@@ -2712,10 +2715,13 @@ const deserializeAws_json1_1ColumnToJsonKeyMappings = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ConcurrentModificationException = (

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -69,8 +69,10 @@ import {
 import {
   AssociateAdminAccountRequest,
   ComplianceViolator,
+  CustomerPolicyScopeIdType,
   DeleteNotificationChannelRequest,
   DeletePolicyRequest,
+  DependentServiceName,
   DisassociateAdminAccountRequest,
   EvaluationResult,
   GetAdminAccountRequest,
@@ -1988,13 +1990,16 @@ const serializeAws_json1_1CustomerPolicyScopeMap = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1CustomerPolicyScopeIdList(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string[] },
+      [key, value]: [CustomerPolicyScopeIdType | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1CustomerPolicyScopeIdList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1DeleteNotificationChannelRequest = (
@@ -2316,13 +2321,16 @@ const deserializeAws_json1_1CustomerPolicyScopeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1CustomerPolicyScopeIdList(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string[] },
+      [key, value]: [CustomerPolicyScopeIdType | string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1CustomerPolicyScopeIdList(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1EvaluationResult = (
@@ -2505,10 +2513,16 @@ const deserializeAws_json1_1IssueInfoMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [DependentServiceName | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1LimitExceededException = (

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -3248,10 +3248,13 @@ const serializeAws_json1_1FeaturizationMethodParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1FeaturizationPipeline = (
@@ -3534,10 +3537,13 @@ const serializeAws_json1_1TrainingParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UpdateDatasetGroupRequest = (
@@ -4334,10 +4340,13 @@ const deserializeAws_json1_1FeaturizationMethodParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1FeaturizationPipeline = (
@@ -4362,10 +4371,13 @@ const deserializeAws_json1_1FieldStatistics = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Statistics } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1Statistics(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Statistics }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1Statistics(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ForecastDimensions = (
@@ -5076,10 +5088,13 @@ const deserializeAws_json1_1TrainingParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1UpdateDatasetGroupResponse = (

--- a/clients/client-forecastquery/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/protocols/Aws_json1_1.ts
@@ -239,10 +239,13 @@ const serializeAws_json1_1Filters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1QueryForecastRequest = (
@@ -333,10 +336,13 @@ const deserializeAws_json1_1Predictions = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: DataPoint[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1TimeSeries(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: DataPoint[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1TimeSeries(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1QueryForecastResponse = (

--- a/clients/client-frauddetector/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/protocols/Aws_json1_1.ts
@@ -3523,10 +3523,13 @@ const serializeAws_json1_1CsvIndexToVariableMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1DeleteDetectorVersionRequest = (
@@ -3580,20 +3583,29 @@ const serializeAws_json1_1EventAttributeMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ExternalModelEndpointDataBlobMap = (
   input: { [key: string]: ModelEndpointDataBlob },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ModelEndpointDataBlob(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: ModelEndpointDataBlob },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ModelEndpointDataBlob(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1GetDetectorVersionRequest = (
@@ -3721,20 +3733,26 @@ const serializeAws_json1_1JsonKeyToVariableMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1LabelMapper = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ListOfStrings(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ListOfStrings(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1LabelSchema = (
@@ -4286,10 +4304,13 @@ const deserializeAws_json1_1CsvIndexToVariableMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1DeleteDetectorVersionResult = (
@@ -4693,20 +4714,26 @@ const deserializeAws_json1_1JsonKeyToVariableMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1LabelMapper = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1ListOfStrings(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1ListOfStrings(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1LabelSchema = (
@@ -4755,10 +4782,13 @@ const deserializeAws_json1_1MetricsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Model = (
@@ -4877,10 +4907,13 @@ const deserializeAws_json1_1ModelPredictionMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ModelScores = (

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -10396,10 +10396,13 @@ const serializeAws_json1_1LatencyMap = (
   input: { [key: string]: number },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ListAliasesInput = (
@@ -10509,20 +10512,26 @@ const serializeAws_json1_1PlayerAttributeMap = (
   input: { [key: string]: AttributeValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1AttributeValue(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1PlayerDataMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1PlayerIdList = (
@@ -10858,10 +10867,13 @@ const serializeAws_json1_1StringDoubleMap = (
   input: { [key: string]: number },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1StringList = (
@@ -12831,10 +12843,13 @@ const deserializeAws_json1_1LatencyMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1LimitExceededException = (
@@ -13228,10 +13243,13 @@ const deserializeAws_json1_1PlayerAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1AttributeValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1AttributeValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1PlayerLatency = (
@@ -13778,10 +13796,13 @@ const deserializeAws_json1_1StringDoubleMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1StringList = (

--- a/clients/client-glacier/protocols/Aws_restJson1_1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1_1.ts
@@ -5491,10 +5491,13 @@ const serializeAws_restJson1_1hashmap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1DataRetrievalPolicy = (
@@ -5597,10 +5600,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1VaultAccessPolicy = (
@@ -6028,10 +6034,13 @@ const deserializeAws_restJson1_1hashmap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DataRetrievalPolicy = (
@@ -6186,10 +6195,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1UploadListElement = (

--- a/clients/client-glue/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/protocols/Aws_json1_1.ts
@@ -539,6 +539,7 @@ import {
   Connection,
   ConnectionInput,
   ConnectionPasswordEncryption,
+  ConnectionPropertyKey,
   ConnectionsList,
   Crawl,
   Crawler,
@@ -15054,10 +15055,13 @@ const serializeAws_json1_1TagsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1BatchCreatePartitionRequest = (
@@ -15283,10 +15287,16 @@ const serializeAws_json1_1ConnectionProperties = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [ConnectionPropertyKey | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1CreateConnectionRequest = (
@@ -15768,10 +15778,13 @@ const serializeAws_json1_1LocationMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1MatchCriteria = (
@@ -15802,10 +15815,13 @@ const serializeAws_json1_1ParametersMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1PartitionInput = (
@@ -16512,10 +16528,13 @@ const serializeAws_json1_1MapValue = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1PublicKeysList = (
@@ -17194,10 +17213,13 @@ const serializeAws_json1_1GenericMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1GetJobRequest = (
@@ -17609,10 +17631,13 @@ const serializeAws_json1_1WorkflowRunProperties = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1BatchGetCrawlersRequest = (
@@ -18403,10 +18428,13 @@ const deserializeAws_json1_1TagsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AccessDeniedException = (
@@ -18852,10 +18880,16 @@ const deserializeAws_json1_1ConnectionProperties = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [ConnectionPropertyKey | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1CreateConnectionResponse = (
@@ -19072,10 +19106,13 @@ const deserializeAws_json1_1ErrorByName = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ErrorDetail } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1ErrorDetail(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: ErrorDetail }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1ErrorDetail(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1GetCatalogImportStatusResponse = (
@@ -19349,10 +19386,13 @@ const deserializeAws_json1_1LocationMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MatchCriteria = (
@@ -19392,10 +19432,13 @@ const deserializeAws_json1_1ParametersMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Partition = (
@@ -20480,10 +20523,13 @@ const deserializeAws_json1_1MapValue = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1PublicKeysList = (
@@ -21734,10 +21780,13 @@ const deserializeAws_json1_1GenericMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1GetJobResponse = (
@@ -22593,10 +22642,13 @@ const deserializeAws_json1_1WorkflowRunProperties = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1WorkflowRunStatistics = (

--- a/clients/client-greengrass/protocols/Aws_restJson1_1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1_1.ts
@@ -11040,10 +11040,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1UpdateTargets = (
@@ -11133,10 +11136,13 @@ const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1BulkDeployment = (
@@ -12076,10 +12082,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1VersionInformation = (
@@ -12234,10 +12243,13 @@ const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-groundstation/protocols/Aws_restJson1_1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1_1.ts
@@ -3763,10 +3763,13 @@ const serializeAws_restJson1_1TagsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1UplinkSpectrumConfig = (
@@ -3951,8 +3954,7 @@ const deserializeAws_restJson1_1ConfigTypeData = (
       )
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1ContactData = (
@@ -4434,10 +4436,13 @@ const deserializeAws_restJson1_1TagsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1UplinkSpectrumConfig = (

--- a/clients/client-guardduty/protocols/Aws_restJson1_1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1_1.ts
@@ -6131,10 +6131,13 @@ const serializeAws_restJson1_1Criterion = (
   input: { [key: string]: Condition },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1Condition(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Condition }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1Condition(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1DestinationProperties = (
@@ -6225,10 +6228,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AccessKeyDetails = (
@@ -6393,10 +6399,13 @@ const deserializeAws_restJson1_1CountBySeverity = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Country = (
@@ -6420,10 +6429,13 @@ const deserializeAws_restJson1_1Criterion = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Condition } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1Condition(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Condition }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1Condition(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Destination = (
@@ -7296,10 +7308,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Tags = (

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -1312,10 +1312,13 @@ const serializeAws_json1_1tagSet = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1DescribeAffectedAccountsForOrganizationRequest = (
@@ -1715,20 +1718,26 @@ const deserializeAws_json1_1eventMetadata = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1tagSet = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ConcurrentModificationException = (

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -15348,9 +15348,9 @@ const serializeAws_queryContextEntry = (
       input.ContextKeyValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ContextKeyValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -15364,8 +15364,8 @@ const serializeAws_queryContextEntryListType = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryContextEntry(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -15462,9 +15462,9 @@ const serializeAws_queryCreateOpenIDConnectProviderRequest = (
       input.ClientIDList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClientIDList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ThumbprintList !== undefined) {
@@ -15472,9 +15472,9 @@ const serializeAws_queryCreateOpenIDConnectProviderRequest = (
       input.ThumbprintList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ThumbprintList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Url !== undefined) {
@@ -15545,9 +15545,9 @@ const serializeAws_queryCreateRoleRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -15611,9 +15611,9 @@ const serializeAws_queryCreateUserRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserName !== undefined) {
@@ -16024,9 +16024,9 @@ const serializeAws_queryGetAccountAuthorizationDetailsRequest = (
       input.Filter,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -16048,9 +16048,9 @@ const serializeAws_queryGetContextKeysForCustomPolicyRequest = (
       input.PolicyInputList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -16066,9 +16066,9 @@ const serializeAws_queryGetContextKeysForPrincipalPolicyRequest = (
       input.PolicyInputList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PolicySourceArn !== undefined) {
@@ -16566,9 +16566,9 @@ const serializeAws_queryListPoliciesGrantingServiceAccessRequest = (
       input.ServiceNamespaces,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceNamespaces.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17012,9 +17012,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
       input.ActionNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CallerArn !== undefined) {
@@ -17025,9 +17025,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
       input.ContextEntries,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ContextEntries.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -17041,9 +17041,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
       input.PolicyInputList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceArns !== undefined) {
@@ -17051,9 +17051,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
       input.ResourceArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceHandlingOption !== undefined) {
@@ -17078,9 +17078,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
       input.ActionNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CallerArn !== undefined) {
@@ -17091,9 +17091,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
       input.ContextEntries,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ContextEntries.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -17107,9 +17107,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
       input.PolicyInputList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PolicySourceArn !== undefined) {
@@ -17120,9 +17120,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
       input.ResourceArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceHandlingOption !== undefined) {
@@ -17171,9 +17171,9 @@ const serializeAws_queryTagRoleRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17186,9 +17186,9 @@ const serializeAws_queryTagUserRequest = (
   const entries: any = {};
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserName !== undefined) {
@@ -17210,9 +17210,9 @@ const serializeAws_queryUntagRoleRequest = (
       input.TagKeys,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17228,9 +17228,9 @@ const serializeAws_queryUntagUserRequest = (
       input.TagKeys,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UserName !== undefined) {
@@ -17352,9 +17352,9 @@ const serializeAws_queryUpdateOpenIDConnectProviderThumbprintRequest = (
       input.ThumbprintList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ThumbprintList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17601,8 +17601,8 @@ const serializeAws_querytagListType = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -22003,13 +22003,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
@@ -7859,10 +7859,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AccountList = (
@@ -8936,10 +8939,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -5806,10 +5806,16 @@ const deserializeAws_json1_1AssessmentRunFindingCounts = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: number },
+      [key, value]: [Severity | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AssessmentRunInProgressArnList = (
@@ -6371,10 +6377,13 @@ const deserializeAws_json1_1ExclusionMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Exclusion } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1Exclusion(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Exclusion }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1Exclusion(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ExclusionPreview = (
@@ -6436,10 +6445,16 @@ const deserializeAws_json1_1FailedItems = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FailedItemDetails } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1FailedItemDetails(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: FailedItemDetails },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1FailedItemDetails(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Finding = (

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
@@ -1880,10 +1880,13 @@ const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Attributes = (
@@ -1920,10 +1923,13 @@ const deserializeAws_restJson1_1DeviceAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DeviceDescription = (
@@ -2026,10 +2032,13 @@ const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
@@ -2294,20 +2294,26 @@ const serializeAws_restJson1_1DefaultPlacementAttributeMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1DeviceCallbackOverrideMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1DeviceTemplate = (
@@ -2329,20 +2335,26 @@ const serializeAws_restJson1_1DeviceTemplateMap = (
   input: { [key: string]: DeviceTemplate },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1DeviceTemplate(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: DeviceTemplate }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1DeviceTemplate(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1PlacementAttributeMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1PlacementTemplate = (
@@ -2369,40 +2381,52 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DefaultPlacementAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DeviceCallbackOverrideMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DeviceMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DeviceTemplate = (
@@ -2430,20 +2454,26 @@ const deserializeAws_restJson1_1DeviceTemplateMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: DeviceTemplate } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1DeviceTemplate(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: DeviceTemplate }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1DeviceTemplate(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1PlacementAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1PlacementDescription = (
@@ -2615,10 +2645,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
@@ -837,20 +837,26 @@ const serializeAws_restJson1_1DetailsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DetailsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1JobExecution = (

--- a/clients/client-iot/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1_1.ts
@@ -809,6 +809,7 @@ import {
   ActiveViolation,
   AddThingsToThingGroupParams,
   AlertTarget,
+  AlertTargetType,
   Allowed,
   AssetPropertyTimestamp,
   AssetPropertyValue,
@@ -821,6 +822,7 @@ import {
   AuditMitigationActionsTaskMetadata,
   AuditMitigationActionsTaskTarget,
   AuditNotificationTarget,
+  AuditNotificationType,
   AuditTaskMetadata,
   AuthInfo,
   AuthResult,
@@ -859,6 +861,7 @@ import {
   ElasticsearchAction,
   EnableIoTLoggingParams,
   ErrorInfo,
+  EventType,
   ExplicitDeny,
   ExponentialRolloutRate,
   Field,
@@ -31769,10 +31772,16 @@ const serializeAws_restJson1_1EventConfigurations = (
   input: { [key: string]: Configuration },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1Configuration(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: Configuration },
+      [key, value]: [EventType | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1Configuration(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1PolicyNames = (
@@ -32406,10 +32415,13 @@ const serializeAws_restJson1_1HttpHeaders = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MqttContext = (
@@ -32429,20 +32441,26 @@ const serializeAws_restJson1_1Parameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1PublicKeyMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1RegistrationConfig = (
@@ -32671,30 +32689,39 @@ const serializeAws_restJson1_1DetailsMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AdditionalParameterMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AttributesMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AwsJobExecutionsRolloutConfig = (
@@ -32946,10 +32973,13 @@ const serializeAws_restJson1_1Attributes = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1BillingGroupProperties = (
@@ -33142,39 +33172,42 @@ const serializeAws_restJson1_1AuditCheckConfigurations = (
   input: { [key: string]: AuditCheckConfiguration },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1AuditCheckConfiguration(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: AuditCheckConfiguration },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1AuditCheckConfiguration(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AuditCheckToActionsMapping = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1MitigationActionNameList(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1MitigationActionNameList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AuditCheckToReasonCodeFilter = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1ReasonForNonComplianceCodes(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1ReasonForNonComplianceCodes(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AuditMitigationActionsTaskTarget = (
@@ -33210,13 +33243,16 @@ const serializeAws_restJson1_1AuditNotificationTargetConfigurations = (
   input: { [key: string]: AuditNotificationTarget },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1AuditNotificationTarget(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: AuditNotificationTarget },
+      [key, value]: [AuditNotificationType | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1AuditNotificationTarget(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1FindingIds = (
@@ -33311,10 +33347,16 @@ const serializeAws_restJson1_1AlertTargets = (
   input: { [key: string]: AlertTarget },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1AlertTarget(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: AlertTarget },
+      [key, value]: [AlertTargetType | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1AlertTarget(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Behavior = (
@@ -33454,10 +33496,16 @@ const deserializeAws_restJson1_1EventConfigurations = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Configuration } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1Configuration(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: Configuration },
+      [key, value]: [EventType | string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1Configuration(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1PolicyTargets = (
@@ -35097,10 +35145,13 @@ const deserializeAws_restJson1_1PublicKeyMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1RegistrationConfig = (
@@ -35124,10 +35175,13 @@ const deserializeAws_restJson1_1ResourceArns = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Resources = (
@@ -36030,30 +36084,39 @@ const deserializeAws_restJson1_1DetailsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AdditionalParameterMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AttributesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AwsJobExecutionsRolloutConfig = (
@@ -36493,10 +36556,13 @@ const deserializeAws_restJson1_1Attributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1BillingGroupMetadata = (
@@ -36994,13 +37060,16 @@ const deserializeAws_restJson1_1AuditCheckConfigurations = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AuditCheckConfiguration } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1AuditCheckConfiguration(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: AuditCheckConfiguration },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1AuditCheckConfiguration(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AuditCheckDetails = (
@@ -37042,39 +37111,45 @@ const deserializeAws_restJson1_1AuditCheckToActionsMapping = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MitigationActionNameList(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MitigationActionNameList(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AuditCheckToReasonCodeFilter = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ReasonForNonComplianceCodes(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ReasonForNonComplianceCodes(
+        value,
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AuditDetails = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AuditCheckDetails } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1AuditCheckDetails(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: AuditCheckDetails },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1AuditCheckDetails(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AuditFinding = (
@@ -37235,13 +37310,19 @@ const deserializeAws_restJson1_1AuditMitigationActionsTaskStatistics = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: TaskStatisticsForAuditCheck } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1TaskStatisticsForAuditCheck(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: TaskStatisticsForAuditCheck },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1TaskStatisticsForAuditCheck(
+        value,
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AuditMitigationActionsTaskTarget = (
@@ -37294,13 +37375,16 @@ const deserializeAws_restJson1_1AuditNotificationTargetConfigurations = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AuditNotificationTarget } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1AuditNotificationTarget(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: AuditNotificationTarget },
+      [key, value]: [AuditNotificationType | string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1AuditNotificationTarget(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AuditTaskMetadata = (
@@ -37521,10 +37605,13 @@ const deserializeAws_restJson1_1StringMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1TargetAuditCheckNames = (
@@ -37688,10 +37775,16 @@ const deserializeAws_restJson1_1AlertTargets = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AlertTarget } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1AlertTarget(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: AlertTarget },
+      [key, value]: [AlertTargetType | string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1AlertTarget(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Behavior = (

--- a/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
@@ -5309,10 +5309,13 @@ const serializeAws_restJson1_1AttributeNameMapping = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AttributeNames = (
@@ -5964,10 +5967,13 @@ const deserializeAws_restJson1_1AttributeNameMapping = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AttributeNames = (

--- a/clients/client-kafka/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1_1.ts
@@ -3540,10 +3540,13 @@ const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1BrokerEBSVolumeInfo = (
@@ -4246,10 +4249,13 @@ const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -3809,10 +3809,13 @@ const serializeAws_json1_1ValueImportanceMap = (
   input: { [key: string]: number },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AccessControlListConfiguration = (
@@ -5303,10 +5306,13 @@ const deserializeAws_json1_1ValueImportanceMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
@@ -4909,10 +4909,13 @@ const serializeAws_json1_1PropertyMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1RecordColumn = (
@@ -6728,10 +6731,13 @@ const deserializeAws_json1_1PropertyMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1RawInputRecords = (

--- a/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
@@ -2856,10 +2856,13 @@ const serializeAws_restJson1_1ResourceTags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1SingleMasterChannelEndpointConfiguration = (
@@ -3013,10 +3016,13 @@ const deserializeAws_restJson1_1ResourceTags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1SingleMasterConfiguration = (

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -3944,10 +3944,13 @@ const serializeAws_json1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UpdateShardCountInput = (
@@ -4909,8 +4912,7 @@ const deserializeAws_json1_1SubscribeToShardEventStream = (
       )
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_json1_1SubscribeToShardOutput = (

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -7284,10 +7284,13 @@ const serializeAws_json1_1EncryptionContextType = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1GenerateDataKeyPairRequest = (
@@ -8198,10 +8201,13 @@ const deserializeAws_json1_1EncryptionContextType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ExpiredImportTokenException = (

--- a/clients/client-lambda/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1_1.ts
@@ -9434,10 +9434,13 @@ const serializeAws_restJson1_1AdditionalVersionWeights = (
   input: { [key: string]: number },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1AliasRoutingConfiguration = (
@@ -9502,10 +9505,13 @@ const serializeAws_restJson1_1EnvironmentVariables = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1FunctionCode = (
@@ -9583,10 +9589,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1TracingConfig = (
@@ -9667,10 +9676,13 @@ const deserializeAws_restJson1_1AdditionalVersionWeights = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AliasConfiguration = (
@@ -9827,10 +9839,13 @@ const deserializeAws_restJson1_1EnvironmentVariables = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1EventSourceMappingConfiguration = (
@@ -10333,10 +10348,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1TracingConfigResponse = (

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
@@ -6745,10 +6745,13 @@ const deserializeAws_restJson1_1ChannelConfigurationMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1CodeHook = (

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
@@ -1449,10 +1449,13 @@ const serializeAws_restJson1_1StringMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DialogAction = (
@@ -1560,10 +1563,13 @@ const deserializeAws_restJson1_1StringMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Button = (

--- a/clients/client-lightsail/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/protocols/Aws_json1_1.ts
@@ -633,6 +633,7 @@ import {
   IsVpcPeeredResult,
   KeyPair,
   LoadBalancer,
+  LoadBalancerAttributeName,
   LoadBalancerTlsCertificate,
   LoadBalancerTlsCertificateDomainValidationOption,
   LoadBalancerTlsCertificateDomainValidationRecord,
@@ -15922,10 +15923,13 @@ const serializeAws_json1_1AttachedDiskMap = (
   input: { [key: string]: DiskMap[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1DiskMapList(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: DiskMap[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1DiskMapList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1AutoSnapshotAddOnRequest = (
@@ -16574,10 +16578,13 @@ const serializeAws_json1_1DomainEntryOptions = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1DomainNameList = (
@@ -18722,10 +18729,13 @@ const deserializeAws_json1_1DomainEntryOptions = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1DomainList = (
@@ -20280,10 +20290,16 @@ const deserializeAws_json1_1LoadBalancerConfigurationOptions = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [LoadBalancerAttributeName | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1LoadBalancerList = (

--- a/clients/client-machine-learning/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/protocols/Aws_json1_1.ts
@@ -151,6 +151,7 @@ import {
   DescribeMLModelsOutput,
   DescribeTagsInput,
   DescribeTagsOutput,
+  DetailsAttributes,
   Evaluation,
   GetBatchPredictionInput,
   GetBatchPredictionOutput,
@@ -3544,10 +3545,13 @@ const serializeAws_json1_1Record = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1RedshiftDataSpec = (
@@ -3650,10 +3654,13 @@ const serializeAws_json1_1TrainingParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UpdateBatchPredictionInput = (
@@ -4193,10 +4200,16 @@ const deserializeAws_json1_1DetailsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [DetailsAttributes | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Evaluation = (
@@ -4837,10 +4850,13 @@ const deserializeAws_json1_1PerformanceMetricsProperties = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1PredictOutput = (
@@ -5037,10 +5053,13 @@ const deserializeAws_json1_1ScoreValuePerLabelMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Tag = (
@@ -5084,10 +5103,13 @@ const deserializeAws_json1_1TrainingParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1UpdateBatchPredictionOutput = (

--- a/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
@@ -202,10 +202,13 @@ const serializeAws_json1_1CustomerDefinedValues = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1GenerateDataSetRequest = (

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -5,6 +5,7 @@ import {
 import {
   Entitlement,
   EntitlementValue,
+  GetEntitlementFilterName,
   GetEntitlementsRequest,
   GetEntitlementsResult,
   InternalServiceErrorException,
@@ -186,10 +187,16 @@ const serializeAws_json1_1GetEntitlementFilters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1FilterValueList(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string[] },
+      [key, value]: [GetEntitlementFilterName | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1FilterValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1GetEntitlementsRequest = (

--- a/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
@@ -3022,10 +3022,13 @@ const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Encryption = (
@@ -3413,10 +3416,13 @@ const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
@@ -7421,40 +7421,55 @@ const serializeAws_restJson1_1__mapOfAudioSelector = (
   input: { [key: string]: AudioSelector },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1AudioSelector(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: AudioSelector }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1AudioSelector(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1__mapOfAudioSelectorGroup = (
   input: { [key: string]: AudioSelectorGroup },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1AudioSelectorGroup(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: AudioSelectorGroup },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1AudioSelectorGroup(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1__mapOfCaptionSelector = (
   input: { [key: string]: CaptionSelector },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1CaptionSelector(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: CaptionSelector }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1CaptionSelector(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AacSettings = (
@@ -12604,43 +12619,55 @@ const deserializeAws_restJson1_1__mapOfAudioSelector = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AudioSelector } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1AudioSelector(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: AudioSelector }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1AudioSelector(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1__mapOfAudioSelectorGroup = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AudioSelectorGroup } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1AudioSelectorGroup(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: AudioSelectorGroup },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1AudioSelectorGroup(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1__mapOfCaptionSelector = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: CaptionSelector } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1CaptionSelector(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: CaptionSelector }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1CaptionSelector(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-medialive/protocols/Aws_restJson1_1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1_1.ts
@@ -11602,10 +11602,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1TeletextDestinationSettings = (
@@ -16976,10 +16979,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1TeletextDestinationSettings = (

--- a/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
@@ -3553,10 +3553,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1__listOfHlsManifestCreateOrUpdateParameters = (
@@ -3586,10 +3589,13 @@ const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AdTriggers = (
@@ -4192,10 +4198,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1__listOfChannel = (
@@ -4261,10 +4270,13 @@ const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
@@ -926,10 +926,13 @@ const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1CdnConfiguration = (
@@ -1093,10 +1096,13 @@ const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-mobile/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1_1.ts
@@ -1571,10 +1571,13 @@ const deserializeAws_restJson1_1Attributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1BundleDetails = (

--- a/clients/client-mq/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1_1.ts
@@ -3646,10 +3646,13 @@ const serializeAws_restJson1_1__mapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AvailabilityZone = (
@@ -4180,10 +4183,13 @@ const deserializeAws_restJson1_1__mapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -7779,9 +7779,9 @@ const serializeAws_queryAddTagsToResourceMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7840,9 +7840,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
       input.DisableLogTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisableLogTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableLogTypes !== undefined) {
@@ -7850,9 +7850,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
       input.EnableLogTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableLogTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7869,9 +7869,9 @@ const serializeAws_queryCopyDBClusterParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBClusterParameterGroupDescription !== undefined) {
@@ -7905,9 +7905,9 @@ const serializeAws_queryCopyDBClusterSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBClusterSnapshotIdentifier !== undefined) {
@@ -7928,9 +7928,9 @@ const serializeAws_queryCopyDBParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBParameterGroupDescription !== undefined) {
@@ -7954,9 +7954,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BackupRetentionPeriod !== undefined) {
@@ -7985,9 +7985,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -8032,9 +8032,9 @@ const serializeAws_queryCreateDBClusterMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -8042,9 +8042,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8066,9 +8066,9 @@ const serializeAws_queryCreateDBClusterParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8087,9 +8087,9 @@ const serializeAws_queryCreateDBClusterSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8138,9 +8138,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
       input.DBSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBSubnetGroupName !== undefined) {
@@ -8160,9 +8160,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -8231,9 +8231,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TdeCredentialArn !== undefined) {
@@ -8250,9 +8250,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8274,9 +8274,9 @@ const serializeAws_queryCreateDBParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8298,16 +8298,16 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8326,9 +8326,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnsTopicArn !== undefined) {
@@ -8339,9 +8339,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
       input.SourceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceType !== undefined) {
@@ -8352,9 +8352,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8472,9 +8472,9 @@ const serializeAws_queryDescribeDBClusterParameterGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8496,9 +8496,9 @@ const serializeAws_queryDescribeDBClusterParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8537,9 +8537,9 @@ const serializeAws_queryDescribeDBClusterSnapshotsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludePublic !== undefined) {
@@ -8570,9 +8570,9 @@ const serializeAws_queryDescribeDBClustersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8603,9 +8603,9 @@ const serializeAws_queryDescribeDBEngineVersionsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListSupportedCharacterSets !== undefined) {
@@ -8633,9 +8633,9 @@ const serializeAws_queryDescribeDBInstancesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8657,9 +8657,9 @@ const serializeAws_queryDescribeDBParameterGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8681,9 +8681,9 @@ const serializeAws_queryDescribeDBParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8708,9 +8708,9 @@ const serializeAws_queryDescribeDBSubnetGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8732,9 +8732,9 @@ const serializeAws_queryDescribeEngineDefaultClusterParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8756,9 +8756,9 @@ const serializeAws_queryDescribeEngineDefaultParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8777,9 +8777,9 @@ const serializeAws_queryDescribeEventCategoriesMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceType !== undefined) {
@@ -8795,9 +8795,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8828,16 +8828,16 @@ const serializeAws_queryDescribeEventsMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8874,9 +8874,9 @@ const serializeAws_queryDescribeOrderableDBInstanceOptionsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LicenseModel !== undefined) {
@@ -8901,9 +8901,9 @@ const serializeAws_queryDescribePendingMaintenanceActionsMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -8969,9 +8969,9 @@ const serializeAws_queryFilter = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8985,8 +8985,8 @@ const serializeAws_queryFilterList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryFilter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Filter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Filter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -9026,9 +9026,9 @@ const serializeAws_queryListTagsForResourceMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceName !== undefined) {
@@ -9066,9 +9066,9 @@ const serializeAws_queryModifyDBClusterMessage = (
       input.CloudwatchLogsExportConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CloudwatchLogsExportConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBClusterIdentifier !== undefined) {
@@ -9110,9 +9110,9 @@ const serializeAws_queryModifyDBClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9131,9 +9131,9 @@ const serializeAws_queryModifyDBClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9155,9 +9155,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
       input.ValuesToAdd,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ValuesToRemove !== undefined) {
@@ -9165,9 +9165,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
       input.ValuesToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9201,9 +9201,9 @@ const serializeAws_queryModifyDBInstanceMessage = (
       input.CloudwatchLogsExportConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CloudwatchLogsExportConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CopyTagsToSnapshot !== undefined) {
@@ -9226,9 +9226,9 @@ const serializeAws_queryModifyDBInstanceMessage = (
       input.DBSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBSubnetGroupName !== undefined) {
@@ -9306,9 +9306,9 @@ const serializeAws_queryModifyDBInstanceMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9327,9 +9327,9 @@ const serializeAws_queryModifyDBParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9351,9 +9351,9 @@ const serializeAws_queryModifyDBSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9372,9 +9372,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnsTopicArn !== undefined) {
@@ -9435,8 +9435,8 @@ const serializeAws_queryParametersList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryParameter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Parameter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Parameter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -9506,9 +9506,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9527,9 +9527,9 @@ const serializeAws_queryResetDBClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetAllParameters !== undefined) {
@@ -9551,9 +9551,9 @@ const serializeAws_queryResetDBParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetAllParameters !== undefined) {
@@ -9572,9 +9572,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBClusterIdentifier !== undefined) {
@@ -9597,9 +9597,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -9626,9 +9626,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -9636,9 +9636,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9666,9 +9666,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -9696,9 +9696,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UseLatestRestorableTime !== undefined) {
@@ -9709,9 +9709,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9762,8 +9762,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Tag.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Tag.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -13858,13 +13858,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-opsworks/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/protocols/Aws_json1_1.ts
@@ -297,6 +297,7 @@ import {
 import {
   AgentVersion,
   App,
+  AppAttributesKeys,
   AssignInstanceRequest,
   AssignVolumeRequest,
   AssociateElasticIpRequest,
@@ -391,6 +392,7 @@ import {
   InstanceIdentity,
   InstancesCount,
   Layer,
+  LayerAttributesKeys,
   LifecycleEventConfiguration,
   ListTagsRequest,
   ListTagsResult,
@@ -422,6 +424,7 @@ import {
   Source,
   SslConfiguration,
   Stack,
+  StackAttributesKeys,
   StackConfigurationManager,
   StackSummary,
   StartInstanceRequest,
@@ -6699,10 +6702,16 @@ const serializeAws_json1_1AppAttributes = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [AppAttributesKeys | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1AssignInstanceRequest = (
@@ -7201,10 +7210,13 @@ const serializeAws_json1_1DailyAutoScalingSchedule = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1DataSource = (
@@ -7294,10 +7306,13 @@ const serializeAws_json1_1DeploymentCommandArgs = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1Strings(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1Strings(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1DeregisterEcsClusterRequest = (
@@ -7689,10 +7704,16 @@ const serializeAws_json1_1LayerAttributes = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [LayerAttributesKeys | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1LifecycleEventConfiguration = (
@@ -7915,10 +7936,16 @@ const serializeAws_json1_1StackAttributes = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [StackAttributesKeys | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1StackConfigurationManager = (
@@ -7998,10 +8025,13 @@ const serializeAws_json1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1UnassignInstanceRequest = (
@@ -8473,10 +8503,16 @@ const deserializeAws_json1_1AppAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [AppAttributesKeys | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Apps = (
@@ -8815,10 +8851,13 @@ const deserializeAws_json1_1DailyAutoScalingSchedule = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1DataSource = (
@@ -8927,10 +8966,13 @@ const deserializeAws_json1_1DeploymentCommandArgs = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1Strings(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1Strings(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Deployments = (
@@ -9875,10 +9917,16 @@ const deserializeAws_json1_1LayerAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [LayerAttributesKeys | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Layers = (
@@ -10037,10 +10085,13 @@ const deserializeAws_json1_1Parameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Permission = (
@@ -10572,10 +10623,16 @@ const deserializeAws_json1_1StackAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [StackAttributesKeys | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1StackConfigurationManager = (
@@ -10646,10 +10703,13 @@ const deserializeAws_json1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TemporaryCredential = (

--- a/clients/client-personalize-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-personalize-runtime/protocols/Aws_restJson1_1.ts
@@ -277,10 +277,13 @@ const serializeAws_restJson1_1Context = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1InputList = (

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -4520,10 +4520,13 @@ const serializeAws_json1_1FeatureTransformationParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1GetSolutionMetricsRequest = (
@@ -4618,10 +4621,13 @@ const serializeAws_json1_1HyperParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1IntegerHyperParameterRange = (
@@ -6136,20 +6142,26 @@ const deserializeAws_json1_1FeatureTransformationParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1FeaturizationParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1GetSolutionMetricsResponse = (
@@ -6276,10 +6288,13 @@ const deserializeAws_json1_1HyperParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1IntegerHyperParameterRange = (
@@ -6497,10 +6512,13 @@ const deserializeAws_json1_1Metrics = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Recipe = (
@@ -6593,10 +6611,13 @@ const deserializeAws_json1_1ResourceConfig = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1S3DataConfig = (

--- a/clients/client-pi/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/protocols/Aws_json1_1.ts
@@ -382,10 +382,13 @@ const serializeAws_json1_1MetricQueryFilterMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1MetricQueryList = (
@@ -536,10 +539,13 @@ const deserializeAws_json1_1DimensionMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1GetResourceMetricsResponse = (

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
@@ -6226,10 +6226,16 @@ const deserializeAws_restJson1_1BlacklistReport = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: BlacklistEntry[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1BlacklistEntries(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: BlacklistEntry[] },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1BlacklistEntries(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1CloudWatchDestination = (

--- a/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
@@ -18843,106 +18843,139 @@ const serializeAws_restJson1_1MapOfActivity = (
   input: { [key: string]: Activity },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1Activity(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Activity }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1Activity(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfAddressConfiguration = (
   input: { [key: string]: AddressConfiguration },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1AddressConfiguration(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: AddressConfiguration },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1AddressConfiguration(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfAttributeDimension = (
   input: { [key: string]: AttributeDimension },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1AttributeDimension(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: AttributeDimension },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1AttributeDimension(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfEndpointSendConfiguration = (
   input: { [key: string]: EndpointSendConfiguration },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1EndpointSendConfiguration(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: EndpointSendConfiguration },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1EndpointSendConfiguration(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfEvent = (
   input: { [key: string]: Event },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1Event(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: Event }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1Event(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfEventsBatch = (
   input: { [key: string]: EventsBatch },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1EventsBatch(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: EventsBatch }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1EventsBatch(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfListOf__string = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1ListOf__string(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1ListOf__string(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOfMetricDimension = (
   input: { [key: string]: MetricDimension },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1MetricDimension(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: MetricDimension }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1MetricDimension(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOf__double = (
   input: { [key: string]: number },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1MapOf__string = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Message = (
@@ -22318,142 +22351,184 @@ const deserializeAws_restJson1_1MapOfActivity = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: Activity } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1Activity(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: Activity }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1Activity(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfAttributeDimension = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: AttributeDimension } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1AttributeDimension(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: AttributeDimension },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1AttributeDimension(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfChannelResponse = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ChannelResponse } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ChannelResponse(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: ChannelResponse }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ChannelResponse(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfEndpointMessageResult = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: EndpointMessageResult } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1EndpointMessageResult(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: EndpointMessageResult },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1EndpointMessageResult(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfEventItemResponse = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: EventItemResponse } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1EventItemResponse(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: EventItemResponse },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1EventItemResponse(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfItemResponse = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ItemResponse } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ItemResponse(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: ItemResponse }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ItemResponse(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfListOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ListOf__string(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ListOf__string(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfMapOfEndpointMessageResult = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: { [key: string]: EndpointMessageResult } } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MapOfEndpointMessageResult(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: { [key: string]: EndpointMessageResult } },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MapOfEndpointMessageResult(
+        value,
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfMessageResult = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MessageResult } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MessageResult(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: MessageResult }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MessageResult(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOfMetricDimension = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MetricDimension } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1MetricDimension(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: MetricDimension }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1MetricDimension(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOf__double = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOf__integer = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1MapOf__string = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Message = (

--- a/clients/client-qldb/protocols/Aws_restJson1_1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1_1.ts
@@ -1990,10 +1990,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1ValueHolder = (
@@ -2138,10 +2141,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ValueHolder = (

--- a/clients/client-quicksight/protocols/Aws_restJson1_1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1_1.ts
@@ -13482,10 +13482,13 @@ const serializeAws_restJson1_1IdentityMap = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1IdentityNameList(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1IdentityNameList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1IdentityNameList = (
@@ -13580,10 +13583,13 @@ const serializeAws_restJson1_1LogicalTableMap = (
   input: { [key: string]: LogicalTable },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1LogicalTable(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: LogicalTable }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1LogicalTable(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1LogicalTableSource = (
@@ -13691,10 +13697,13 @@ const serializeAws_restJson1_1PhysicalTableMap = (
   input: { [key: string]: PhysicalTable },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1PhysicalTable(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: PhysicalTable }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1PhysicalTable(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1PostgreSqlParameters = (
@@ -15262,10 +15271,13 @@ const deserializeAws_restJson1_1IdentityMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1IdentityNameList(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1IdentityNameList(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1IdentityNameList = (
@@ -15429,10 +15441,13 @@ const deserializeAws_restJson1_1LogicalTableMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: LogicalTable } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1LogicalTable(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: LogicalTable }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1LogicalTable(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1LogicalTableSource = (
@@ -15566,10 +15581,13 @@ const deserializeAws_restJson1_1PhysicalTableMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: PhysicalTable } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1PhysicalTable(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: PhysicalTable }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1PhysicalTable(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1PostgreSqlParameters = (

--- a/clients/client-rds-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1_1.ts
@@ -1152,8 +1152,7 @@ const deserializeAws_restJson1_1ArrayValue = (
       )
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1ArrayValueList = (
@@ -1287,8 +1286,7 @@ const deserializeAws_restJson1_1Field = (
       stringValue: output.stringValue
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1_1FieldList = (
@@ -1523,8 +1521,7 @@ const deserializeAws_restJson1_1Value = (
       )
     };
   }
-  const key = Object.keys(output)[0];
-  return { $unknown: [key, output[key]] };
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -16863,9 +16863,9 @@ const serializeAws_queryAddTagsToResourceMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -16969,9 +16969,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
       input.DisableLogTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisableLogTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableLogTypes !== undefined) {
@@ -16979,9 +16979,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
       input.EnableLogTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableLogTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17009,9 +17009,9 @@ const serializeAws_queryConnectionPoolConfiguration = (
       input.SessionPinningFilters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SessionPinningFilters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17028,9 +17028,9 @@ const serializeAws_queryCopyDBClusterParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBClusterParameterGroupDescription !== undefined) {
@@ -17064,9 +17064,9 @@ const serializeAws_queryCopyDBClusterSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBClusterSnapshotIdentifier !== undefined) {
@@ -17087,9 +17087,9 @@ const serializeAws_queryCopyDBParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBParameterGroupDescription !== undefined) {
@@ -17125,9 +17125,9 @@ const serializeAws_queryCopyDBSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBSnapshotIdentifier !== undefined) {
@@ -17146,9 +17146,9 @@ const serializeAws_queryCopyOptionGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetOptionGroupDescription !== undefined) {
@@ -17200,9 +17200,9 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
       input.ExcludedMembers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedMembers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StaticMembers !== undefined) {
@@ -17210,16 +17210,16 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
       input.StaticMembers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StaticMembers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17235,9 +17235,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BacktrackWindow !== undefined) {
@@ -17272,9 +17272,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableHttpEndpoint !== undefined) {
@@ -17328,9 +17328,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.ScalingConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScalingConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StorageEncrypted !== undefined) {
@@ -17338,9 +17338,9 @@ const serializeAws_queryCreateDBClusterMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -17348,9 +17348,9 @@ const serializeAws_queryCreateDBClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17372,9 +17372,9 @@ const serializeAws_queryCreateDBClusterParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17393,9 +17393,9 @@ const serializeAws_queryCreateDBClusterSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17444,9 +17444,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
       input.DBSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBSubnetGroupName !== undefined) {
@@ -17466,9 +17466,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -17535,9 +17535,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
       input.ProcessorFeatures,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PromotionTier !== undefined) {
@@ -17554,9 +17554,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TdeCredentialArn !== undefined) {
@@ -17573,9 +17573,9 @@ const serializeAws_queryCreateDBInstanceMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17621,9 +17621,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -17669,9 +17669,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
       input.ProcessorFeatures,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PubliclyAccessible !== undefined) {
@@ -17685,9 +17685,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UseDefaultProcessorFeatures !== undefined) {
@@ -17698,9 +17698,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17722,9 +17722,9 @@ const serializeAws_queryCreateDBParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17740,9 +17740,9 @@ const serializeAws_queryCreateDBProxyRequest = (
       input.Auth,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Auth.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBProxyName !== undefined) {
@@ -17765,9 +17765,9 @@ const serializeAws_queryCreateDBProxyRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -17775,9 +17775,9 @@ const serializeAws_queryCreateDBProxyRequest = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSubnetIds !== undefined) {
@@ -17785,9 +17785,9 @@ const serializeAws_queryCreateDBProxyRequest = (
       input.VpcSubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17806,9 +17806,9 @@ const serializeAws_queryCreateDBSecurityGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17827,9 +17827,9 @@ const serializeAws_queryCreateDBSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17851,16 +17851,16 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17879,9 +17879,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnsTopicArn !== undefined) {
@@ -17892,9 +17892,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
       input.SourceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceType !== undefined) {
@@ -17905,9 +17905,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -17961,9 +17961,9 @@ const serializeAws_queryCreateOptionGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -18183,9 +18183,9 @@ const serializeAws_queryDeregisterDBProxyTargetsRequest = (
       input.DBClusterIdentifiers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBClusterIdentifiers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBInstanceIdentifiers !== undefined) {
@@ -18193,9 +18193,9 @@ const serializeAws_queryDeregisterDBProxyTargetsRequest = (
       input.DBInstanceIdentifiers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBInstanceIdentifiers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBProxyName !== undefined) {
@@ -18225,9 +18225,9 @@ const serializeAws_queryDescribeCertificatesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18249,9 +18249,9 @@ const serializeAws_queryDescribeCustomAvailabilityZonesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18276,9 +18276,9 @@ const serializeAws_queryDescribeDBClusterBacktracksMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18303,9 +18303,9 @@ const serializeAws_queryDescribeDBClusterEndpointsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18327,9 +18327,9 @@ const serializeAws_queryDescribeDBClusterParameterGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18351,9 +18351,9 @@ const serializeAws_queryDescribeDBClusterParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18392,9 +18392,9 @@ const serializeAws_queryDescribeDBClusterSnapshotsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludePublic !== undefined) {
@@ -18425,9 +18425,9 @@ const serializeAws_queryDescribeDBClustersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludeShared !== undefined) {
@@ -18461,9 +18461,9 @@ const serializeAws_queryDescribeDBEngineVersionsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludeAll !== undefined) {
@@ -18497,9 +18497,9 @@ const serializeAws_queryDescribeDBInstanceAutomatedBackupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18521,9 +18521,9 @@ const serializeAws_queryDescribeDBInstancesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18554,9 +18554,9 @@ const serializeAws_queryDescribeDBLogFilesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18578,9 +18578,9 @@ const serializeAws_queryDescribeDBParameterGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18602,9 +18602,9 @@ const serializeAws_queryDescribeDBParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18629,9 +18629,9 @@ const serializeAws_queryDescribeDBProxiesRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18653,9 +18653,9 @@ const serializeAws_queryDescribeDBProxyTargetGroupsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18680,9 +18680,9 @@ const serializeAws_queryDescribeDBProxyTargetsRequest = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18707,9 +18707,9 @@ const serializeAws_queryDescribeDBSecurityGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18748,9 +18748,9 @@ const serializeAws_queryDescribeDBSnapshotsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.IncludePublic !== undefined) {
@@ -18781,9 +18781,9 @@ const serializeAws_queryDescribeDBSubnetGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18805,9 +18805,9 @@ const serializeAws_queryDescribeEngineDefaultClusterParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18829,9 +18829,9 @@ const serializeAws_queryDescribeEngineDefaultParametersMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18850,9 +18850,9 @@ const serializeAws_queryDescribeEventCategoriesMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceType !== undefined) {
@@ -18868,9 +18868,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18901,16 +18901,16 @@ const serializeAws_queryDescribeEventsMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -18938,9 +18938,9 @@ const serializeAws_queryDescribeGlobalClustersMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.GlobalClusterIdentifier !== undefined) {
@@ -18962,9 +18962,9 @@ const serializeAws_queryDescribeInstallationMediaMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.InstallationMediaId !== undefined) {
@@ -18989,9 +18989,9 @@ const serializeAws_queryDescribeOptionGroupOptionsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MajorEngineVersion !== undefined) {
@@ -19016,9 +19016,9 @@ const serializeAws_queryDescribeOptionGroupsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MajorEngineVersion !== undefined) {
@@ -19052,9 +19052,9 @@ const serializeAws_queryDescribeOrderableDBInstanceOptionsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LicenseModel !== undefined) {
@@ -19079,9 +19079,9 @@ const serializeAws_queryDescribePendingMaintenanceActionsMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -19109,9 +19109,9 @@ const serializeAws_queryDescribeReservedDBInstancesMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LeaseId !== undefined) {
@@ -19155,9 +19155,9 @@ const serializeAws_queryDescribeReservedDBInstancesOfferingsMessage = (
   }
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -19189,9 +19189,9 @@ const serializeAws_queryDescribeSourceRegionsMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -19290,9 +19290,9 @@ const serializeAws_queryFilter = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19306,8 +19306,8 @@ const serializeAws_queryFilterList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryFilter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Filter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Filter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -19370,9 +19370,9 @@ const serializeAws_queryListTagsForResourceMessage = (
   const entries: any = {};
   if (input.Filters !== undefined) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResourceName !== undefined) {
@@ -19444,9 +19444,9 @@ const serializeAws_queryModifyDBClusterEndpointMessage = (
       input.ExcludedMembers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedMembers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StaticMembers !== undefined) {
@@ -19454,9 +19454,9 @@ const serializeAws_queryModifyDBClusterEndpointMessage = (
       input.StaticMembers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StaticMembers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19484,9 +19484,9 @@ const serializeAws_queryModifyDBClusterMessage = (
       input.CloudwatchLogsExportConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CloudwatchLogsExportConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CopyTagsToSnapshot !== undefined) {
@@ -19538,9 +19538,9 @@ const serializeAws_queryModifyDBClusterMessage = (
       input.ScalingConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScalingConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -19548,9 +19548,9 @@ const serializeAws_queryModifyDBClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19569,9 +19569,9 @@ const serializeAws_queryModifyDBClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19593,9 +19593,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
       input.ValuesToAdd,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ValuesToRemove !== undefined) {
@@ -19603,9 +19603,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
       input.ValuesToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19642,9 +19642,9 @@ const serializeAws_queryModifyDBInstanceMessage = (
       input.CloudwatchLogsExportConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CloudwatchLogsExportConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CopyTagsToSnapshot !== undefined) {
@@ -19667,9 +19667,9 @@ const serializeAws_queryModifyDBInstanceMessage = (
       input.DBSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBSubnetGroupName !== undefined) {
@@ -19739,9 +19739,9 @@ const serializeAws_queryModifyDBInstanceMessage = (
       input.ProcessorFeatures,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PromotionTier !== undefined) {
@@ -19767,9 +19767,9 @@ const serializeAws_queryModifyDBInstanceMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19788,9 +19788,9 @@ const serializeAws_queryModifyDBParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19806,9 +19806,9 @@ const serializeAws_queryModifyDBProxyRequest = (
       input.Auth,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Auth.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBProxyName !== undefined) {
@@ -19834,9 +19834,9 @@ const serializeAws_queryModifyDBProxyRequest = (
       input.SecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19852,9 +19852,9 @@ const serializeAws_queryModifyDBProxyTargetGroupRequest = (
       input.ConnectionPoolConfig,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionPoolConfig.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBProxyName !== undefined) {
@@ -19885,9 +19885,9 @@ const serializeAws_queryModifyDBSnapshotAttributeMessage = (
       input.ValuesToAdd,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ValuesToRemove !== undefined) {
@@ -19895,9 +19895,9 @@ const serializeAws_queryModifyDBSnapshotAttributeMessage = (
       input.ValuesToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19936,9 +19936,9 @@ const serializeAws_queryModifyDBSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -19957,9 +19957,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnsTopicArn !== undefined) {
@@ -20007,9 +20007,9 @@ const serializeAws_queryModifyOptionGroupMessage = (
       input.OptionsToInclude,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToInclude.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OptionsToRemove !== undefined) {
@@ -20017,9 +20017,9 @@ const serializeAws_queryModifyOptionGroupMessage = (
       input.OptionsToRemove,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20035,9 +20035,9 @@ const serializeAws_queryOptionConfiguration = (
       input.DBSecurityGroupMemberships,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroupMemberships.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OptionName !== undefined) {
@@ -20048,9 +20048,9 @@ const serializeAws_queryOptionConfiguration = (
       input.OptionSettings,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OptionVersion !== undefined) {
@@ -20064,9 +20064,9 @@ const serializeAws_queryOptionConfiguration = (
       input.VpcSecurityGroupMemberships,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupMemberships.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20080,8 +20080,8 @@ const serializeAws_queryOptionConfigurationList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryOptionConfiguration(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`OptionConfiguration.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`OptionConfiguration.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -20144,8 +20144,8 @@ const serializeAws_queryOptionSettingsList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryOptionSetting(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`OptionSetting.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`OptionSetting.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -20192,9 +20192,9 @@ const serializeAws_queryParameter = (
       input.SupportedEngineModes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SupportedEngineModes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20208,8 +20208,8 @@ const serializeAws_queryParametersList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryParameter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Parameter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Parameter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -20238,8 +20238,8 @@ const serializeAws_queryProcessorFeatureList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryProcessorFeature(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`ProcessorFeature.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`ProcessorFeature.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -20291,9 +20291,9 @@ const serializeAws_queryPurchaseReservedDBInstancesOfferingMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20323,9 +20323,9 @@ const serializeAws_queryRegisterDBProxyTargetsRequest = (
       input.DBClusterIdentifiers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBClusterIdentifiers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBInstanceIdentifiers !== undefined) {
@@ -20333,9 +20333,9 @@ const serializeAws_queryRegisterDBProxyTargetsRequest = (
       input.DBInstanceIdentifiers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBInstanceIdentifiers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBProxyName !== undefined) {
@@ -20419,9 +20419,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20440,9 +20440,9 @@ const serializeAws_queryResetDBClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetAllParameters !== undefined) {
@@ -20464,9 +20464,9 @@ const serializeAws_queryResetDBParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetAllParameters !== undefined) {
@@ -20485,9 +20485,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BacktrackWindow !== undefined) {
@@ -20522,9 +20522,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -20578,9 +20578,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -20588,9 +20588,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20606,9 +20606,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.AvailabilityZones,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BacktrackWindow !== undefined) {
@@ -20637,9 +20637,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -20669,9 +20669,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.ScalingConfiguration,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScalingConfiguration.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SnapshotIdentifier !== undefined) {
@@ -20679,9 +20679,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -20689,9 +20689,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20725,9 +20725,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -20755,9 +20755,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UseLatestRestorableTime !== undefined) {
@@ -20768,9 +20768,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20822,9 +20822,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -20854,9 +20854,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
       input.ProcessorFeatures,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PubliclyAccessible !== undefined) {
@@ -20867,9 +20867,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TdeCredentialArn !== undefined) {
@@ -20886,9 +20886,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -20931,9 +20931,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
       input.DBSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DBSubnetGroupName !== undefined) {
@@ -20947,9 +20947,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -21013,9 +21013,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
       input.ProcessorFeatures,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PubliclyAccessible !== undefined) {
@@ -21044,9 +21044,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.UseDefaultProcessorFeatures !== undefined) {
@@ -21057,9 +21057,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -21105,9 +21105,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
       input.EnableCloudwatchLogsExports,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EnableIAMDatabaseAuthentication !== undefined) {
@@ -21137,9 +21137,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
       input.ProcessorFeatures,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PubliclyAccessible !== undefined) {
@@ -21160,9 +21160,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TargetDBInstanceIdentifier !== undefined) {
@@ -21185,9 +21185,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -21378,8 +21378,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Tag.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Tag.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -21417,8 +21417,8 @@ const serializeAws_queryUserAuthConfigList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryUserAuthConfig(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -29708,13 +29708,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -12160,9 +12160,9 @@ const serializeAws_queryBatchDeleteClusterSnapshotsRequest = (
       input.Identifiers,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identifiers.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12185,9 +12185,9 @@ const serializeAws_queryBatchModifyClusterSnapshotsMessage = (
       input.SnapshotIdentifierList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotIdentifierList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12268,9 +12268,9 @@ const serializeAws_queryCreateClusterMessage = (
       input.ClusterSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClusterSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClusterSubnetGroupName !== undefined) {
@@ -12306,9 +12306,9 @@ const serializeAws_queryCreateClusterMessage = (
       input.IamRoles,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamRoles.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.KmsKeyId !== undefined) {
@@ -12347,9 +12347,9 @@ const serializeAws_queryCreateClusterMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.VpcSecurityGroupIds !== undefined) {
@@ -12357,9 +12357,9 @@ const serializeAws_queryCreateClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12381,9 +12381,9 @@ const serializeAws_queryCreateClusterParameterGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12402,9 +12402,9 @@ const serializeAws_queryCreateClusterSecurityGroupMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12427,9 +12427,9 @@ const serializeAws_queryCreateClusterSnapshotMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12451,16 +12451,16 @@ const serializeAws_queryCreateClusterSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12479,9 +12479,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Severity !== undefined) {
@@ -12495,9 +12495,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
       input.SourceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceType !== undefined) {
@@ -12508,9 +12508,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12527,9 +12527,9 @@ const serializeAws_queryCreateHsmClientCertificateMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12560,9 +12560,9 @@ const serializeAws_queryCreateHsmConfigurationMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12599,9 +12599,9 @@ const serializeAws_queryCreateScheduledActionMessage = (
       input.TargetAction,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12620,9 +12620,9 @@ const serializeAws_queryCreateSnapshotCopyGrantMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12644,9 +12644,9 @@ const serializeAws_queryCreateSnapshotScheduleMessage = (
       input.ScheduleDefinitions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduleDefinitions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ScheduleDescription !== undefined) {
@@ -12657,9 +12657,9 @@ const serializeAws_queryCreateSnapshotScheduleMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12675,9 +12675,9 @@ const serializeAws_queryCreateTagsMessage = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12765,9 +12765,8 @@ const serializeAws_queryDeleteClusterSnapshotMessageList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`DeleteClusterSnapshotMessage.${counter}.${key}`] =
-        memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`DeleteClusterSnapshotMessage.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -12862,9 +12861,9 @@ const serializeAws_queryDeleteTagsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12880,9 +12879,9 @@ const serializeAws_queryDescribeAccountAttributesMessage = (
       input.AttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12921,9 +12920,9 @@ const serializeAws_queryDescribeClusterParameterGroupsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -12931,9 +12930,9 @@ const serializeAws_queryDescribeClusterParameterGroupsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -12975,9 +12974,9 @@ const serializeAws_queryDescribeClusterSecurityGroupsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -12985,9 +12984,9 @@ const serializeAws_queryDescribeClusterSecurityGroupsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13027,9 +13026,9 @@ const serializeAws_queryDescribeClusterSnapshotsMessage = (
       input.SortingEntities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SortingEntities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StartTime !== undefined) {
@@ -13037,9 +13036,9 @@ const serializeAws_queryDescribeClusterSnapshotsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13047,9 +13046,9 @@ const serializeAws_queryDescribeClusterSnapshotsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13071,9 +13070,9 @@ const serializeAws_queryDescribeClusterSubnetGroupsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13081,9 +13080,9 @@ const serializeAws_queryDescribeClusterSubnetGroupsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13142,9 +13141,9 @@ const serializeAws_queryDescribeClustersMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13152,9 +13151,9 @@ const serializeAws_queryDescribeClustersMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13204,9 +13203,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13214,9 +13213,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13268,9 +13267,9 @@ const serializeAws_queryDescribeHsmClientCertificatesMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13278,9 +13277,9 @@ const serializeAws_queryDescribeHsmClientCertificatesMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13302,9 +13301,9 @@ const serializeAws_queryDescribeHsmConfigurationsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13312,9 +13311,9 @@ const serializeAws_queryDescribeHsmConfigurationsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13347,9 +13346,9 @@ const serializeAws_queryDescribeNodeConfigurationOptionsMessage = (
       input.Filters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -13448,9 +13447,9 @@ const serializeAws_queryDescribeScheduledActionsMessage = (
       input.Filters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Marker !== undefined) {
@@ -13487,9 +13486,9 @@ const serializeAws_queryDescribeSnapshotCopyGrantsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13497,9 +13496,9 @@ const serializeAws_queryDescribeSnapshotCopyGrantsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13524,9 +13523,9 @@ const serializeAws_queryDescribeSnapshotSchedulesMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13534,9 +13533,9 @@ const serializeAws_queryDescribeSnapshotSchedulesMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13581,9 +13580,9 @@ const serializeAws_queryDescribeTagsMessage = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TagValues !== undefined) {
@@ -13591,9 +13590,9 @@ const serializeAws_queryDescribeTagsMessage = (
       input.TagValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13691,9 +13690,9 @@ const serializeAws_queryGetClusterCredentialsMessage = (
       input.DbGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DbGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DbName !== undefined) {
@@ -13762,9 +13761,9 @@ const serializeAws_queryModifyClusterIamRolesMessage = (
       input.AddIamRoles,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddIamRoles.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClusterIdentifier !== undefined) {
@@ -13775,9 +13774,9 @@ const serializeAws_queryModifyClusterIamRolesMessage = (
       input.RemoveIamRoles,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveIamRoles.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13834,9 +13833,9 @@ const serializeAws_queryModifyClusterMessage = (
       input.ClusterSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClusterSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClusterType !== undefined) {
@@ -13894,9 +13893,9 @@ const serializeAws_queryModifyClusterMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13915,9 +13914,9 @@ const serializeAws_queryModifyClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13974,9 +13973,9 @@ const serializeAws_queryModifyClusterSubnetGroupMessage = (
       input.SubnetIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -13995,9 +13994,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
       input.EventCategories,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Severity !== undefined) {
@@ -14011,9 +14010,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
       input.SourceIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SourceType !== undefined) {
@@ -14056,9 +14055,9 @@ const serializeAws_queryModifyScheduledActionMessage = (
       input.TargetAction,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -14091,9 +14090,9 @@ const serializeAws_queryModifySnapshotScheduleMessage = (
       input.ScheduleDefinitions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduleDefinitions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ScheduleIdentifier !== undefined) {
@@ -14118,9 +14117,9 @@ const serializeAws_queryNodeConfigurationOptionsFilter = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Value.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -14137,9 +14136,8 @@ const serializeAws_queryNodeConfigurationOptionsFilterList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`NodeConfigurationOptionsFilter.${counter}.${key}`] =
-        memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`NodeConfigurationOptionsFilter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -14189,8 +14187,8 @@ const serializeAws_queryParametersList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryParameter(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Parameter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Parameter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -14235,9 +14233,9 @@ const serializeAws_queryResetClusterParameterGroupMessage = (
       input.Parameters,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ResetAllParameters !== undefined) {
@@ -14298,9 +14296,9 @@ const serializeAws_queryRestoreFromClusterSnapshotMessage = (
       input.ClusterSecurityGroups,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClusterSecurityGroups.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ClusterSubnetGroupName !== undefined) {
@@ -14324,9 +14322,9 @@ const serializeAws_queryRestoreFromClusterSnapshotMessage = (
       input.IamRoles,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamRoles.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.KmsKeyId !== undefined) {
@@ -14371,9 +14369,9 @@ const serializeAws_queryRestoreFromClusterSnapshotMessage = (
       input.VpcSecurityGroupIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -14485,9 +14483,9 @@ const serializeAws_queryScheduledActionFilter = (
       input.Values,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -14504,8 +14502,8 @@ const serializeAws_queryScheduledActionFilterList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`ScheduledActionFilter.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`ScheduledActionFilter.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -14522,9 +14520,9 @@ const serializeAws_queryScheduledActionType = (
       input.ResizeCluster,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResizeCluster.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -14568,8 +14566,8 @@ const serializeAws_querySnapshotSortingEntityList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`SnapshotSortingEntity.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`SnapshotSortingEntity.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -14634,8 +14632,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Tag.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Tag.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -20491,13 +20489,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
@@ -1211,10 +1211,13 @@ const serializeAws_json1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TagResourcesInput = (
@@ -1345,10 +1348,13 @@ const deserializeAws_json1_1FailedResourcesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FailureInfo } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1FailureInfo(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: FailureInfo }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1FailureInfo(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1FailureInfo = (

--- a/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
@@ -2145,10 +2145,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Group = (
@@ -2304,10 +2307,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-robomaker/protocols/Aws_restJson1_1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1_1.ts
@@ -5888,10 +5888,13 @@ const serializeAws_restJson1_1EnvironmentVariableMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1Filter = (
@@ -6143,10 +6146,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1VPCConfig = (
@@ -6371,10 +6377,13 @@ const deserializeAws_restJson1_1EnvironmentVariableMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1Fleet = (
@@ -7162,10 +7171,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1VPCConfigResponse = (

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -11392,10 +11392,13 @@ const serializeAws_json1_1CollectionParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1CompressionTypes = (
@@ -13075,10 +13078,13 @@ const serializeAws_json1_1EnvironmentMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ExperimentConfig = (
@@ -13194,10 +13200,13 @@ const serializeAws_json1_1HookParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1HumanLoopActivationConditionsConfig = (
@@ -13543,10 +13552,13 @@ const serializeAws_json1_1HyperParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1InferenceSpecification = (
@@ -14787,10 +14799,13 @@ const serializeAws_json1_1MonitoringEnvironmentMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1MonitoringInput = (
@@ -15175,10 +15190,13 @@ const serializeAws_json1_1ProcessingEnvironmentMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ProcessingInput = (
@@ -15445,10 +15463,13 @@ const serializeAws_json1_1RuleParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1S3DataSource = (
@@ -15935,10 +15956,13 @@ const serializeAws_json1_1TransformEnvironmentMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TransformInput = (
@@ -16065,10 +16089,16 @@ const serializeAws_json1_1TrialComponentArtifacts = (
   input: { [key: string]: TrialComponentArtifact },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1TrialComponentArtifact(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: TrialComponentArtifact },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1TrialComponentArtifact(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TrialComponentParameterValue = (
@@ -16085,13 +16115,16 @@ const serializeAws_json1_1TrialComponentParameters = (
   input: { [key: string]: TrialComponentParameterValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1TrialComponentParameterValue(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: TrialComponentParameterValue },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1TrialComponentParameterValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TrialComponentStatus = (
@@ -17470,10 +17503,13 @@ const deserializeAws_json1_1CollectionParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1CompilationJobSummaries = (
@@ -20316,10 +20352,13 @@ const deserializeAws_json1_1EnvironmentMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Experiment = (
@@ -20639,10 +20678,13 @@ const deserializeAws_json1_1HookParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1HumanLoopActivationConditionsConfig = (
@@ -21274,10 +21316,13 @@ const deserializeAws_json1_1HyperParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1InferenceSpecification = (
@@ -22823,10 +22868,13 @@ const deserializeAws_json1_1MonitoringEnvironmentMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MonitoringExecutionSummary = (
@@ -23514,10 +23562,13 @@ const deserializeAws_json1_1ProcessingEnvironmentMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ProcessingInput = (
@@ -24048,10 +24099,13 @@ const deserializeAws_json1_1RuleParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1S3DataSource = (
@@ -24802,10 +24856,13 @@ const deserializeAws_json1_1TransformEnvironmentMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TransformInput = (
@@ -25171,13 +25228,16 @@ const deserializeAws_json1_1TrialComponentArtifacts = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: TrialComponentArtifact } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1TrialComponentArtifact(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: TrialComponentArtifact },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1TrialComponentArtifact(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TrialComponentMetricSummaries = (
@@ -25249,13 +25309,16 @@ const deserializeAws_json1_1TrialComponentParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: TrialComponentParameterValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1TrialComponentParameterValue(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: TrialComponentParameterValue },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1TrialComponentParameterValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TrialComponentSimpleSummaries = (

--- a/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
@@ -1372,10 +1372,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ParentSavingsPlanOffering = (
@@ -1773,10 +1776,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-schemas/protocols/Aws_restJson1_1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1_1.ts
@@ -5003,10 +5003,13 @@ const serializeAws_restJson1_1Tags = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1__listOfGetDiscoveredSchemaVersionItemInput = (
@@ -5165,10 +5168,13 @@ const deserializeAws_restJson1_1Tags = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1__listOfDiscovererSummary = (

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -3288,13 +3288,13 @@ const deserializeAws_json1_1SecretVersionsToStagesMapType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1SecretVersionStagesType(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1SecretVersionStagesType(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Tag = (

--- a/clients/client-securityhub/protocols/Aws_restJson1_1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1_1.ts
@@ -6806,10 +6806,13 @@ const serializeAws_restJson1_1FieldMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1IpFilter = (
@@ -7171,10 +7174,13 @@ const serializeAws_restJson1_1StandardsInputParameterMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1StandardsSubscriptionArns = (
@@ -7240,10 +7246,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1ThreatIntelIndicator = (
@@ -8813,10 +8822,13 @@ const deserializeAws_restJson1_1FieldMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ImportFindingsError = (
@@ -9617,10 +9629,13 @@ const deserializeAws_restJson1_1StandardsInputParameterMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1StandardsSubscription = (
@@ -9698,10 +9713,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1ThreatIntelIndicator = (

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -489,18 +489,22 @@ import {
   Principal,
   ProductViewAggregationValue,
   ProductViewDetail,
+  ProductViewFilterBy,
   ProductViewSummary,
+  PropertyKey,
   ProvisionProductInput,
   ProvisionProductOutput,
   ProvisionedProductAttribute,
   ProvisionedProductDetail,
   ProvisionedProductPlanDetails,
   ProvisionedProductPlanSummary,
+  ProvisionedProductViewFilterBy,
   ProvisioningArtifact,
   ProvisioningArtifactDetail,
   ProvisioningArtifactParameter,
   ProvisioningArtifactPreferences,
   ProvisioningArtifactProperties,
+  ProvisioningArtifactPropertyName,
   ProvisioningArtifactSummary,
   ProvisioningArtifactView,
   ProvisioningParameter,
@@ -527,6 +531,7 @@ import {
   SearchProvisionedProductsInput,
   SearchProvisionedProductsOutput,
   ServiceActionAssociation,
+  ServiceActionDefinitionKey,
   ServiceActionDetail,
   ServiceActionSummary,
   ShareDetails,
@@ -9275,13 +9280,13 @@ const serializeAws_json1_1ExecutionParameterMap = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ExecutionParameterValueList(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ExecutionParameterValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ExecutionParameterValueList = (
@@ -9586,10 +9591,16 @@ const serializeAws_json1_1ProductViewFilters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ProductViewFilterValues(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string[] },
+      [key, value]: [ProductViewFilterBy | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ProductViewFilterValues(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ProvisionProductInput = (
@@ -9637,23 +9648,35 @@ const serializeAws_json1_1ProvisionedProductFilters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ProvisionedProductViewFilterValues(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string[] },
+      [key, value]: [ProvisionedProductViewFilterBy | string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ProvisionedProductViewFilterValues(
+        value,
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ProvisionedProductProperties = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [PropertyKey | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ProvisionedProductViewFilterValues = (
@@ -9667,10 +9690,13 @@ const serializeAws_json1_1ProvisioningArtifactInfo = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ProvisioningArtifactProperties = (
@@ -9871,10 +9897,16 @@ const serializeAws_json1_1ServiceActionDefinitionMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [ServiceActionDefinitionKey | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1SourceProvisioningArtifactProperties = (
@@ -9890,10 +9922,16 @@ const serializeAws_json1_1SourceProvisioningArtifactPropertiesMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [ProvisioningArtifactPropertyName | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1StackSetAccounts = (
@@ -11883,13 +11921,16 @@ const deserializeAws_json1_1ProductViewAggregations = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ProductViewAggregationValue[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1ProductViewAggregationValues(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: ProductViewAggregationValue[] },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1ProductViewAggregationValues(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ProductViewDetail = (
@@ -12263,10 +12304,16 @@ const deserializeAws_json1_1ProvisionedProductProperties = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [PropertyKey | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ProvisioningArtifact = (
@@ -12342,10 +12389,13 @@ const deserializeAws_json1_1ProvisioningArtifactInfo = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ProvisioningArtifactParameter = (
@@ -12893,10 +12943,16 @@ const deserializeAws_json1_1ServiceActionDefinitionMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [ServiceActionDefinitionKey | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ServiceActionDetail = (

--- a/clients/client-service-quotas/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/protocols/Aws_json1_1.ts
@@ -3262,10 +3262,13 @@ const deserializeAws_json1_1MetricDimensionsMapDefinition = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MetricInfo = (

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -138,6 +138,7 @@ import {
   OperationFilter,
   OperationNotFound,
   OperationSummary,
+  OperationTargetType,
   RegisterInstanceRequest,
   RegisterInstanceResponse,
   ResourceInUse,
@@ -2332,10 +2333,13 @@ const serializeAws_json1_1Attributes = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1CreateHttpNamespaceRequest = (
@@ -2756,10 +2760,13 @@ const deserializeAws_json1_1Attributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1CreateHttpNamespaceResponse = (
@@ -3130,10 +3137,16 @@ const deserializeAws_json1_1InstanceHealthStatusMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: HealthStatus | string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: HealthStatus | string },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1InstanceNotFound = (
@@ -3470,10 +3483,16 @@ const deserializeAws_json1_1OperationTargetsMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [OperationTargetType | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1RegisterInstanceResponse = (

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -7212,16 +7212,16 @@ const serializeAws_queryBody = (input: Body, context: __SerdeContext): any => {
   const entries: any = {};
   if (input.Html !== undefined) {
     const memberEntries = serializeAws_queryContent(input.Html, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Html.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Text !== undefined) {
     const memberEntries = serializeAws_queryContent(input.Text, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Text.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7269,9 +7269,9 @@ const serializeAws_queryBouncedRecipientInfo = (
       input.RecipientDsnFields,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RecipientDsnFields.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7288,8 +7288,8 @@ const serializeAws_queryBouncedRecipientInfoList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -7306,9 +7306,9 @@ const serializeAws_queryBulkEmailDestination = (
       input.Destination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Destination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplacementTags !== undefined) {
@@ -7316,9 +7316,9 @@ const serializeAws_queryBulkEmailDestination = (
       input.ReplacementTags,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplacementTags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplacementTemplateData !== undefined) {
@@ -7338,8 +7338,8 @@ const serializeAws_queryBulkEmailDestinationList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -7370,9 +7370,9 @@ const serializeAws_queryCloudWatchDestination = (
       input.DimensionConfigurations,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DimensionConfigurations.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7406,8 +7406,8 @@ const serializeAws_queryCloudWatchDimensionConfigurations = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -7465,9 +7465,9 @@ const serializeAws_queryCreateConfigurationSetEventDestinationRequest = (
       input.EventDestination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventDestination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7483,9 +7483,9 @@ const serializeAws_queryCreateConfigurationSetRequest = (
       input.ConfigurationSet,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConfigurationSet.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7504,9 +7504,9 @@ const serializeAws_queryCreateConfigurationSetTrackingOptionsRequest = (
       input.TrackingOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrackingOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7548,9 +7548,9 @@ const serializeAws_queryCreateReceiptFilterRequest = (
       input.Filter,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7566,9 +7566,9 @@ const serializeAws_queryCreateReceiptRuleRequest = (
   }
   if (input.Rule !== undefined) {
     const memberEntries = serializeAws_queryReceiptRule(input.Rule, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Rule.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RuleSetName !== undefined) {
@@ -7595,9 +7595,9 @@ const serializeAws_queryCreateTemplateRequest = (
   const entries: any = {};
   if (input.Template !== undefined) {
     const memberEntries = serializeAws_queryTemplate(input.Template, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Template.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7762,9 +7762,9 @@ const serializeAws_queryDescribeConfigurationSetRequest = (
       input.ConfigurationSetAttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConfigurationSetAttributeNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ConfigurationSetName !== undefined) {
@@ -7808,9 +7808,9 @@ const serializeAws_queryDestination = (
       input.BccAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BccAddresses.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CcAddresses !== undefined) {
@@ -7818,9 +7818,9 @@ const serializeAws_queryDestination = (
       input.CcAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CcAddresses.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ToAddresses !== undefined) {
@@ -7828,9 +7828,9 @@ const serializeAws_queryDestination = (
       input.ToAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ToAddresses.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7846,9 +7846,9 @@ const serializeAws_queryEventDestination = (
       input.CloudWatchDestination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CloudWatchDestination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Enabled !== undefined) {
@@ -7859,9 +7859,9 @@ const serializeAws_queryEventDestination = (
       input.KinesisFirehoseDestination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `KinesisFirehoseDestination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MatchingEventTypes !== undefined) {
@@ -7869,9 +7869,9 @@ const serializeAws_queryEventDestination = (
       input.MatchingEventTypes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MatchingEventTypes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Name !== undefined) {
@@ -7882,9 +7882,9 @@ const serializeAws_queryEventDestination = (
       input.SNSDestination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SNSDestination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7925,8 +7925,8 @@ const serializeAws_queryExtensionFieldList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryExtensionField(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -7954,9 +7954,9 @@ const serializeAws_queryGetIdentityDkimAttributesRequest = (
       input.Identities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7972,9 +7972,9 @@ const serializeAws_queryGetIdentityMailFromDomainAttributesRequest = (
       input.Identities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -7990,9 +7990,9 @@ const serializeAws_queryGetIdentityNotificationAttributesRequest = (
       input.Identities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8011,9 +8011,9 @@ const serializeAws_queryGetIdentityPoliciesRequest = (
       input.PolicyNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8029,9 +8029,9 @@ const serializeAws_queryGetIdentityVerificationAttributesRequest = (
       input.Identities,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8188,16 +8188,16 @@ const serializeAws_queryMessage = (
   const entries: any = {};
   if (input.Body !== undefined) {
     const memberEntries = serializeAws_queryBody(input.Body, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Body.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Subject !== undefined) {
     const memberEntries = serializeAws_queryContent(input.Subject, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subject.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8217,9 +8217,9 @@ const serializeAws_queryMessageDsn = (
       input.ExtensionFields,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExtensionFields.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReportingMta !== undefined) {
@@ -8236,8 +8236,8 @@ const serializeAws_queryMessageTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryMessageTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -8270,9 +8270,9 @@ const serializeAws_queryPutConfigurationSetDeliveryOptionsRequest = (
       input.DeliveryOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DeliveryOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8316,9 +8316,9 @@ const serializeAws_queryReceiptAction = (
       input.AddHeaderAction,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddHeaderAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BounceAction !== undefined) {
@@ -8326,9 +8326,9 @@ const serializeAws_queryReceiptAction = (
       input.BounceAction,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BounceAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.LambdaAction !== undefined) {
@@ -8336,23 +8336,23 @@ const serializeAws_queryReceiptAction = (
       input.LambdaAction,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LambdaAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.S3Action !== undefined) {
     const memberEntries = serializeAws_queryS3Action(input.S3Action, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `S3Action.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.SNSAction !== undefined) {
     const memberEntries = serializeAws_querySNSAction(input.SNSAction, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SNSAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StopAction !== undefined) {
@@ -8360,9 +8360,9 @@ const serializeAws_queryReceiptAction = (
       input.StopAction,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StopAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.WorkmailAction !== undefined) {
@@ -8370,9 +8370,9 @@ const serializeAws_queryReceiptAction = (
       input.WorkmailAction,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `WorkmailAction.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8386,8 +8386,8 @@ const serializeAws_queryReceiptActionsList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryReceiptAction(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -8404,9 +8404,9 @@ const serializeAws_queryReceiptFilter = (
       input.IpFilter,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpFilter.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Name !== undefined) {
@@ -8439,9 +8439,9 @@ const serializeAws_queryReceiptRule = (
       input.Actions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Actions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Enabled !== undefined) {
@@ -8455,9 +8455,9 @@ const serializeAws_queryReceiptRule = (
       input.Recipients,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Recipients.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ScanEnabled !== undefined) {
@@ -8498,9 +8498,9 @@ const serializeAws_queryRecipientDsnFields = (
       input.ExtensionFields,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExtensionFields.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FinalRecipient !== undefined) {
@@ -8542,9 +8542,9 @@ const serializeAws_queryReorderReceiptRuleSetRequest = (
       input.RuleNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RuleSetName !== undefined) {
@@ -8614,9 +8614,9 @@ const serializeAws_querySendBounceRequest = (
       input.BouncedRecipientInfoList,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BouncedRecipientInfoList.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Explanation !== undefined) {
@@ -8627,9 +8627,9 @@ const serializeAws_querySendBounceRequest = (
       input.MessageDsn,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageDsn.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.OriginalMessageId !== undefined) {
@@ -8651,9 +8651,9 @@ const serializeAws_querySendBulkTemplatedEmailRequest = (
       input.DefaultTags,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DefaultTags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.DefaultTemplateData !== undefined) {
@@ -8664,9 +8664,9 @@ const serializeAws_querySendBulkTemplatedEmailRequest = (
       input.Destinations,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Destinations.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplyToAddresses !== undefined) {
@@ -8674,9 +8674,9 @@ const serializeAws_querySendBulkTemplatedEmailRequest = (
       input.ReplyToAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplyToAddresses.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReturnPath !== undefined) {
@@ -8730,16 +8730,16 @@ const serializeAws_querySendEmailRequest = (
       input.Destination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Destination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Message !== undefined) {
     const memberEntries = serializeAws_queryMessage(input.Message, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Message.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplyToAddresses !== undefined) {
@@ -8747,9 +8747,9 @@ const serializeAws_querySendEmailRequest = (
       input.ReplyToAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplyToAddresses.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReturnPath !== undefined) {
@@ -8766,9 +8766,9 @@ const serializeAws_querySendEmailRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryMessageTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8787,9 +8787,9 @@ const serializeAws_querySendRawEmailRequest = (
       input.Destinations,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Destinations.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FromArn !== undefined) {
@@ -8800,9 +8800,9 @@ const serializeAws_querySendRawEmailRequest = (
       input.RawMessage,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RawMessage.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReturnPathArn !== undefined) {
@@ -8816,9 +8816,9 @@ const serializeAws_querySendRawEmailRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryMessageTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -8837,9 +8837,9 @@ const serializeAws_querySendTemplatedEmailRequest = (
       input.Destination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Destination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReplyToAddresses !== undefined) {
@@ -8847,9 +8847,9 @@ const serializeAws_querySendTemplatedEmailRequest = (
       input.ReplyToAddresses,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplyToAddresses.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ReturnPath !== undefined) {
@@ -8866,9 +8866,9 @@ const serializeAws_querySendTemplatedEmailRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryMessageTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Template !== undefined) {
@@ -9073,9 +9073,9 @@ const serializeAws_queryUpdateConfigurationSetEventDestinationRequest = (
       input.EventDestination,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventDestination.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9122,9 +9122,9 @@ const serializeAws_queryUpdateConfigurationSetTrackingOptionsRequest = (
       input.TrackingOptions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrackingOptions.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -9163,9 +9163,9 @@ const serializeAws_queryUpdateReceiptRuleRequest = (
   const entries: any = {};
   if (input.Rule !== undefined) {
     const memberEntries = serializeAws_queryReceiptRule(input.Rule, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Rule.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RuleSetName !== undefined) {
@@ -9181,9 +9181,9 @@ const serializeAws_queryUpdateTemplateRequest = (
   const entries: any = {};
   if (input.Template !== undefined) {
     const memberEntries = serializeAws_queryTemplate(input.Template, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Template.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -11894,13 +11894,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-sesv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1_1.ts
@@ -7226,10 +7226,16 @@ const deserializeAws_restJson1_1BlacklistReport = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: BlacklistEntry[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1BlacklistEntries(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: BlacklistEntry[] },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1BlacklistEntries(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1CloudWatchDestination = (

--- a/clients/client-signer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1_1.ts
@@ -1940,10 +1940,13 @@ const serializeAws_restJson1_1SigningParameters = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1SigningPlatformOverrides = (
@@ -1975,10 +1978,13 @@ const serializeAws_restJson1_1TagMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1EncryptionAlgorithmOptions = (
@@ -2214,10 +2220,13 @@ const deserializeAws_restJson1_1SigningParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1SigningPlatform = (
@@ -2363,10 +2372,13 @@ const deserializeAws_restJson1_1TagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -4616,9 +4616,9 @@ const serializeAws_queryAddPermissionInput = (
       input.AWSAccountId,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AWSAccountId.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ActionName !== undefined) {
@@ -4626,9 +4626,9 @@ const serializeAws_queryAddPermissionInput = (
       input.ActionName,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionName.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Label !== undefined) {
@@ -4678,9 +4678,9 @@ const serializeAws_queryCreatePlatformApplicationInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Name !== undefined) {
@@ -4702,9 +4702,9 @@ const serializeAws_queryCreatePlatformEndpointInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.CustomUserData !== undefined) {
@@ -4729,9 +4729,9 @@ const serializeAws_queryCreateTopicInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Name !== undefined) {
@@ -4739,9 +4739,9 @@ const serializeAws_queryCreateTopicInput = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4825,9 +4825,9 @@ const serializeAws_queryGetSMSAttributesInput = (
       input.attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -4977,8 +4977,8 @@ const serializeAws_queryMessageAttributeMap = (
       input[key],
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`entry.${counter}.Value.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`entry.${counter}.Value.${key}`] = value;
     });
     counter++;
   });
@@ -5026,9 +5026,9 @@ const serializeAws_queryPublishInput = (
       input.MessageAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageAttributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MessageStructure !== undefined) {
@@ -5073,9 +5073,9 @@ const serializeAws_querySetEndpointAttributesInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.EndpointArn !== undefined) {
@@ -5094,9 +5094,9 @@ const serializeAws_querySetPlatformApplicationAttributesInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PlatformApplicationArn !== undefined) {
@@ -5115,9 +5115,9 @@ const serializeAws_querySetSMSAttributesInput = (
       input.attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5167,9 +5167,9 @@ const serializeAws_querySubscribeInput = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Endpoint !== undefined) {
@@ -5233,8 +5233,8 @@ const serializeAws_queryTagList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -5251,9 +5251,9 @@ const serializeAws_queryTagResourceRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -5294,9 +5294,9 @@ const serializeAws_queryUntagResourceRequest = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -6334,13 +6334,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -2088,9 +2088,9 @@ const serializeAws_queryAddPermissionRequest = (
       input.AWSAccountIds,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AWSAccountId.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Actions !== undefined) {
@@ -2098,9 +2098,9 @@ const serializeAws_queryAddPermissionRequest = (
       input.Actions,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Label !== undefined) {
@@ -2148,11 +2148,11 @@ const serializeAws_queryChangeMessageVisibilityBatchRequest = (
       input.Entries,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ChangeMessageVisibilityBatchRequestEntry.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueUrl !== undefined) {
@@ -2189,8 +2189,8 @@ const serializeAws_queryChangeMessageVisibilityBatchRequestEntryList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -2224,9 +2224,9 @@ const serializeAws_queryCreateQueueRequest = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attribute.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueName !== undefined) {
@@ -2234,9 +2234,9 @@ const serializeAws_queryCreateQueueRequest = (
   }
   if (input.tags !== undefined) {
     const memberEntries = serializeAws_queryTagMap(input.tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -2252,11 +2252,11 @@ const serializeAws_queryDeleteMessageBatchRequest = (
       input.Entries,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DeleteMessageBatchRequestEntry.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueUrl !== undefined) {
@@ -2290,8 +2290,8 @@ const serializeAws_queryDeleteMessageBatchRequestEntryList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -2333,9 +2333,9 @@ const serializeAws_queryGetQueueAttributesRequest = (
       input.AttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueUrl !== undefined) {
@@ -2414,9 +2414,9 @@ const serializeAws_queryMessageAttributeValue = (
       input.BinaryListValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BinaryListValue.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BinaryValue !== undefined) {
@@ -2430,9 +2430,9 @@ const serializeAws_queryMessageAttributeValue = (
       input.StringListValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StringListValue.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StringValue !== undefined) {
@@ -2453,8 +2453,8 @@ const serializeAws_queryMessageBodyAttributeMap = (
       input[key],
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`entry.${counter}.Value.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`entry.${counter}.Value.${key}`] = value;
     });
     counter++;
   });
@@ -2473,8 +2473,8 @@ const serializeAws_queryMessageBodySystemAttributeMap = (
       input[key],
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`entry.${counter}.Value.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`entry.${counter}.Value.${key}`] = value;
     });
     counter++;
   });
@@ -2491,9 +2491,9 @@ const serializeAws_queryMessageSystemAttributeValue = (
       input.BinaryListValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BinaryListValue.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.BinaryValue !== undefined) {
@@ -2507,9 +2507,9 @@ const serializeAws_queryMessageSystemAttributeValue = (
       input.StringListValues,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StringListValue.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StringValue !== undefined) {
@@ -2553,9 +2553,9 @@ const serializeAws_queryReceiveMessageRequest = (
       input.AttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MaxNumberOfMessages !== undefined) {
@@ -2566,9 +2566,9 @@ const serializeAws_queryReceiveMessageRequest = (
       input.MessageAttributeNames,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageAttributeName.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueUrl !== undefined) {
@@ -2610,11 +2610,11 @@ const serializeAws_querySendMessageBatchRequest = (
       input.Entries,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SendMessageBatchRequestEntry.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueUrl !== undefined) {
@@ -2639,9 +2639,9 @@ const serializeAws_querySendMessageBatchRequestEntry = (
       input.MessageAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageAttribute.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MessageBody !== undefined) {
@@ -2658,11 +2658,11 @@ const serializeAws_querySendMessageBatchRequestEntry = (
       input.MessageSystemAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageSystemAttribute.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -2679,8 +2679,8 @@ const serializeAws_querySendMessageBatchRequestEntryList = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -2700,9 +2700,9 @@ const serializeAws_querySendMessageRequest = (
       input.MessageAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageAttribute.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MessageBody !== undefined) {
@@ -2719,11 +2719,11 @@ const serializeAws_querySendMessageRequest = (
       input.MessageSystemAttributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageSystemAttribute.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueUrl !== undefined) {
@@ -2742,9 +2742,9 @@ const serializeAws_querySetQueueAttributesRequest = (
       input.Attributes,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attribute.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.QueueUrl !== undefined) {
@@ -2803,9 +2803,9 @@ const serializeAws_queryTagQueueRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_queryTagMap(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -2821,9 +2821,9 @@ const serializeAws_queryUntagQueueRequest = (
   }
   if (input.TagKeys !== undefined) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKey.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -3608,13 +3608,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -16294,13 +16294,13 @@ const serializeAws_json1_1AutomationParameterMap = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1AutomationParameterValueList(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1AutomationParameterValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1AutomationParameterValueList = (
@@ -16393,10 +16393,13 @@ const serializeAws_json1_1ComplianceItemDetails = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ComplianceItemEntry = (
@@ -18034,20 +18037,26 @@ const serializeAws_json1_1InventoryItemContentContext = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1InventoryItemEntry = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1InventoryItemEntryList = (
@@ -18467,15 +18476,19 @@ const serializeAws_json1_1MaintenanceWindowTaskParameters = (
   input: { [key: string]: MaintenanceWindowTaskParameterValueExpression },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[
-      key
-    ] = serializeAws_json1_1MaintenanceWindowTaskParameterValueExpression(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: MaintenanceWindowTaskParameterValueExpression },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1MaintenanceWindowTaskParameterValueExpression(
+        value,
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ModifyDocumentPermissionRequest = (
@@ -18570,10 +18583,13 @@ const serializeAws_json1_1OpsAggregatorValueMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1OpsFilter = (
@@ -18662,10 +18678,16 @@ const serializeAws_json1_1OpsItemOperationalData = (
   input: { [key: string]: OpsItemDataValue },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1OpsItemDataValue(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: OpsItemDataValue },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1OpsItemDataValue(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1OpsItemOpsDataKeysList = (
@@ -18750,10 +18772,13 @@ const serializeAws_json1_1Parameters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ParameterValueList(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ParameterValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1ParametersFilter = (
@@ -19363,13 +19388,16 @@ const serializeAws_json1_1SessionManagerParameters = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1SessionManagerParameterValueList(
-      input[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1SessionManagerParameterValueList(
+        value,
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1StartAssociationsOnceRequest = (
@@ -19558,10 +19586,13 @@ const serializeAws_json1_1TargetMap = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1TargetMapValueList(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1TargetMapValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1TargetMapValueList = (
@@ -20420,10 +20451,13 @@ const deserializeAws_json1_1AssociationStatusAggregatedCount = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AssociationVersionInfo = (
@@ -20864,13 +20898,13 @@ const deserializeAws_json1_1AutomationParameterMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1AutomationParameterValueList(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1AutomationParameterValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AutomationParameterValueList = (
@@ -21293,10 +21327,13 @@ const deserializeAws_json1_1ComplianceItemDetails = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1ComplianceItemList = (
@@ -23825,10 +23862,13 @@ const deserializeAws_json1_1InstanceAssociationStatusAggregatedCount = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: number }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1InstanceAssociationStatusInfo = (
@@ -24858,10 +24898,13 @@ const deserializeAws_json1_1InventoryItemEntry = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1InventoryItemEntryList = (
@@ -24966,10 +25009,16 @@ const deserializeAws_json1_1InventoryResultItemMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: InventoryResultItem } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1InventoryResultItem(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: InventoryResultItem },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1InventoryResultItem(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1InvocationDoesNotExist = (
@@ -25857,15 +25906,19 @@ const deserializeAws_json1_1MaintenanceWindowTaskParameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MaintenanceWindowTaskParameterValueExpression } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[
-      key
-    ] = deserializeAws_json1_1MaintenanceWindowTaskParameterValueExpression(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: MaintenanceWindowTaskParameterValueExpression },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1MaintenanceWindowTaskParameterValueExpression(
+        value,
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MaintenanceWindowTaskParametersList = (
@@ -25930,10 +25983,13 @@ const deserializeAws_json1_1NormalStringMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1NotificationConfig = (
@@ -26003,10 +26059,13 @@ const deserializeAws_json1_1OpsEntityItemEntry = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1OpsEntityItemEntryList = (
@@ -26022,10 +26081,13 @@ const deserializeAws_json1_1OpsEntityItemMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: OpsEntityItem } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1OpsEntityItem(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: OpsEntityItem }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1OpsEntityItem(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1OpsEntityList = (
@@ -26235,10 +26297,16 @@ const deserializeAws_json1_1OpsItemOperationalData = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: OpsItemDataValue } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1OpsItemDataValue(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: OpsItemDataValue },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1OpsItemDataValue(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1OpsItemParameterNamesList = (
@@ -26652,10 +26720,13 @@ const deserializeAws_json1_1Parameters = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1ParameterValueList(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1ParameterValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1Patch = (
@@ -26906,10 +26977,13 @@ const deserializeAws_json1_1PatchPropertyEntry = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1PatchRule = (
@@ -28128,10 +28202,13 @@ const deserializeAws_json1_1TargetMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1TargetMapValueList(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1TargetMapValueList(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1TargetMapValueList = (

--- a/clients/client-storage-gateway/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/protocols/Aws_json1_1.ts
@@ -8814,10 +8814,13 @@ const deserializeAws_json1_1errorDetails = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1AddCacheOutput = (

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -1015,9 +1015,9 @@ const serializeAws_queryAssumeRoleRequest = (
       input.PolicyArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RoleArn !== undefined) {
@@ -1031,9 +1031,9 @@ const serializeAws_queryAssumeRoleRequest = (
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.TokenCode !== undefined) {
@@ -1044,9 +1044,9 @@ const serializeAws_queryAssumeRoleRequest = (
       input.TransitiveTagKeys,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitiveTagKeys.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -1068,9 +1068,9 @@ const serializeAws_queryAssumeRoleWithSAMLRequest = (
       input.PolicyArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.PrincipalArn !== undefined) {
@@ -1101,9 +1101,9 @@ const serializeAws_queryAssumeRoleWithWebIdentityRequest = (
       input.PolicyArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ProviderId !== undefined) {
@@ -1170,16 +1170,16 @@ const serializeAws_queryGetFederationTokenRequest = (
       input.PolicyArns,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.Tags !== undefined) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -1235,8 +1235,8 @@ const serializeAws_querypolicyDescriptorListType = (
       entry,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -1264,8 +1264,8 @@ const serializeAws_querytagListType = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryTag(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -1738,13 +1738,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/clients/client-workdocs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1_1.ts
@@ -172,6 +172,8 @@ import {
   DeactivatingLastSystemUserException,
   DocumentLockedForCommentsException,
   DocumentMetadata,
+  DocumentSourceType,
+  DocumentThumbnailType,
   DocumentVersionMetadata,
   DraftUploadOutOfSyncException,
   EntityAlreadyExistsException,
@@ -7291,10 +7293,13 @@ const serializeAws_restJson1_1CustomMetadataMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1NotificationOptions = (
@@ -7490,10 +7495,13 @@ const deserializeAws_restJson1_1CustomMetadataMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DocumentMetadata = (
@@ -7552,20 +7560,32 @@ const deserializeAws_restJson1_1DocumentSourceUrlMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [DocumentSourceType | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DocumentThumbnailUrlMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: string },
+      [key, value]: [DocumentThumbnailType | string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1DocumentVersionMetadata = (
@@ -7938,10 +7958,13 @@ const deserializeAws_restJson1_1SignedHeaderMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1StorageRuleType = (

--- a/clients/client-xray/protocols/Aws_restJson1_1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1_1.ts
@@ -2365,10 +2365,13 @@ const serializeAws_restJson1_1AttributeMap = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1BackendConnectionErrors = (
@@ -2603,23 +2606,29 @@ const deserializeAws_restJson1_1Annotations = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: ValueWithServiceIds[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1ValuesWithServiceIds(
-      output[key],
-      context
-    );
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: ValueWithServiceIds[] },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1ValuesWithServiceIds(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1AvailabilityZoneDetail = (

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -162,11 +162,11 @@ final class AwsProtocolUtils {
 
         // Write a single function to handle combining a map in to a valid query string.
         writer.addImport("extendedEncodeURIComponent", "__extendedEncodeURIComponent", "@aws-sdk/smithy-client");
-        writer.openBlock("const buildFormUrlencodedString = (entries: any): string => Object.keys(entries).map(",
+        writer.openBlock("const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string => Object.entries(formEntries).map(",
             ").join(\"&\");",
             () -> 
-                writer.write("key => __extendedEncodeURIComponent(key) + '=' + "
-                    + "__extendedEncodeURIComponent(entries[key])")
+                writer.write("([key, value]) => __extendedEncodeURIComponent(key) + '=' + "
+                    + "__extendedEncodeURIComponent(value)")
         );
         writer.write("");
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Map;
 import java.util.TreeMap;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.DocumentShape;
@@ -73,14 +74,20 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
     protected void deserializeMap(GenerationContext context, MapShape shape) {
         TypeScriptWriter writer = context.getWriter();
         Shape target = context.getModel().expectShape(shape.getValue().getTarget());
+        SymbolProvider symbolProvider = context.getSymbolProvider();
 
         // Get the right serialization for each entry in the map. Undefined
         // outputs won't have this deserializer invoked.
-        writer.openBlock("return Object.keys(output).reduce((acc: any, key: string) => {", "}, {});", () -> {
-            // Dispatch to the output value provider for any additional handling.
-            writer.write("acc[key] = $L;", target.accept(getMemberVisitor("output[key]")));
-            writer.write("return acc;");
-        });
+        writer.openBlock("return Object.entries(output).reduce((acc: $T, [key, value]: [$T, any]) => ({",
+            "}), {});",
+            symbolProvider.toSymbol(shape),
+            symbolProvider.toSymbol(shape.getKey()),
+            () -> {
+                writer.write("...acc,");
+                // Dispatch to the output value provider for any additional handling.
+                writer.write("[key]: $L", target.accept(getMemberVisitor("value")));
+            }
+        );
     }
 
     @Override
@@ -130,7 +137,6 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
             });
         });
         // Or write to the unknown member the element in the output.
-        writer.write("const key = Object.keys(output)[0];");
-        writer.write("return { $$unknown: [key, output[key]] };");
+        writer.write("return { $$unknown: Object.entries(output)[0] };");
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -135,8 +135,8 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
         QueryMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation);
         // Map entries that supply entry lists need to have them joined properly.
         writer.write("const memberEntries = $L;", target.accept(inputVisitor));
-        writer.openBlock("Object.keys(memberEntries).forEach(key => {", "});",
-                () -> writer.write("entries[`$L.$${key}`] = memberEntries[key];", entryWrapper));
+        writer.openBlock("Object.entries(memberEntries).forEach(([key, value]) => {", "});",
+                () -> writer.write("entries[`$L.$${key}`] = value;", entryWrapper));
     }
 
     @Override
@@ -228,7 +228,7 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
         writer.write("const memberEntries = $L;", target.accept(inputVisitor));
 
         // Consolidate every entry in the list.
-        writer.openBlock("Object.keys(memberEntries).forEach(key => {", "});", () -> {
+        writer.openBlock("Object.entries(memberEntries).forEach(([key, value]) => {", "});", () -> {
             // Remove the last segment for any flattened entities.
             if (isFlattened) {
                 writer.write("const loc = `$L.$${key.substring(key.indexOf('.') + 1)}`;", locationName);
@@ -236,7 +236,7 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
                 writer.write("const loc = `$L.$${key}`;", locationName);
             }
 
-            writer.write("entries[loc] = memberEntries[key];");
+            writer.write("entries[loc] = value;");
         });
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -250,7 +250,6 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
         });
 
         // Or write output element to the unknown member.
-        writer.write("const key = Object.keys(output)[0];");
-        writer.write("return { $$unknown: [key, output[key]] };");
+        writer.write("return { $$unknown: Object.entries(output)[0] };");
     }
 }

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -1273,9 +1273,9 @@ const serializeAws_ec2NestedStructuresInput = (
   const entries: any = {};
   if (input.Nested !== undefined) {
     const memberEntries = serializeAws_ec2StructArg(input.Nested, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Nested.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -1305,16 +1305,16 @@ const serializeAws_ec2QueryListsInput = (
       input.ComplexListArg,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ComplexListArg.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListArg !== undefined) {
     const memberEntries = serializeAws_ec2StringList(input.ListArg, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArg.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListArgWithXmlName !== undefined) {
@@ -1322,9 +1322,9 @@ const serializeAws_ec2QueryListsInput = (
       input.ListArgWithXmlName,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Hi.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListArgWithXmlNameMember !== undefined) {
@@ -1332,11 +1332,11 @@ const serializeAws_ec2QueryListsInput = (
       input.ListArgWithXmlNameMember,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArgWithXmlNameMember.${key.substring(
         key.indexOf(".") + 1
       )}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -1411,9 +1411,9 @@ const serializeAws_ec2StructArg = (
       input.RecursiveArg,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RecursiveArg.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StringArg !== undefined) {
@@ -1430,8 +1430,8 @@ const serializeAws_ec2GreetingList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_ec2GreetingStruct(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`Member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`Member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -2152,13 +2152,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -436,50 +436,68 @@ const serializeAws_json1_1MapOfKitchenSinks = (
   input: { [key: string]: KitchenSink },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1KitchenSink(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: KitchenSink }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1KitchenSink(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1MapOfListsOfStrings = (
   input: { [key: string]: string[] },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1ListOfStrings(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1ListOfStrings(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1MapOfMapOfStrings = (
   input: { [key: string]: { [key: string]: string } },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1MapOfStrings(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: { [key: string]: string } },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: serializeAws_json1_1MapOfStrings(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1MapOfStrings = (
   input: { [key: string]: string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1MapOfStructs = (
   input: { [key: string]: SimpleStruct },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_json1_1SimpleStruct(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: SimpleStruct }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_json1_1SimpleStruct(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_json1_1SimpleStruct = (
@@ -731,50 +749,68 @@ const deserializeAws_json1_1MapOfKitchenSinks = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: KitchenSink } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1KitchenSink(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: KitchenSink }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1KitchenSink(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MapOfListsOfStrings = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string[] } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1ListOfStrings(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string[] }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1ListOfStrings(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MapOfMapOfStrings = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: { [key: string]: string } } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1MapOfStrings(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: { [key: string]: string } },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1MapOfStrings(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MapOfStrings = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1MapOfStructs = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: SimpleStruct } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_json1_1SimpleStruct(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: SimpleStruct }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_json1_1SimpleStruct(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1SimpleStruct = (

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -1600,8 +1600,8 @@ const serializeAws_queryComplexMap = (
   Object.keys(input).forEach(key => {
     entries[`entry.${counter}.key`] = key;
     const memberEntries = serializeAws_queryGreetingStruct(input[key], context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`entry.${counter}.value.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`entry.${counter}.value.${key}`] = value;
     });
     counter++;
   });
@@ -1638,8 +1638,8 @@ const serializeAws_queryMapOfLists = (
   Object.keys(input).forEach(key => {
     entries[`entry.${counter}.key`] = key;
     const memberEntries = serializeAws_queryStringList(input[key], context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`entry.${counter}.value.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`entry.${counter}.value.${key}`] = value;
     });
     counter++;
   });
@@ -1667,9 +1667,9 @@ const serializeAws_queryNestedStructuresInput = (
   const entries: any = {};
   if (input.Nested !== undefined) {
     const memberEntries = serializeAws_queryStructArg(input.Nested, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Nested.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -1707,9 +1707,9 @@ const serializeAws_queryQueryListsInput = (
       input.ComplexListArg,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ComplexListArg.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FlattenedListArg !== undefined) {
@@ -1717,9 +1717,9 @@ const serializeAws_queryQueryListsInput = (
       input.FlattenedListArg,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FlattenedListArg.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FlattenedListArgWithXmlName !== undefined) {
@@ -1727,16 +1727,16 @@ const serializeAws_queryQueryListsInput = (
       input.FlattenedListArgWithXmlName,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Hi.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListArg !== undefined) {
     const memberEntries = serializeAws_queryStringList(input.ListArg, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArg.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.ListArgWithXmlNameMember !== undefined) {
@@ -1744,9 +1744,9 @@ const serializeAws_queryQueryListsInput = (
       input.ListArgWithXmlNameMember,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArgWithXmlNameMember.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -1762,9 +1762,9 @@ const serializeAws_queryQueryMapsInput = (
       input.ComplexMapArg,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ComplexMapArg.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FlattenedMap !== undefined) {
@@ -1772,9 +1772,9 @@ const serializeAws_queryQueryMapsInput = (
       input.FlattenedMap,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FlattenedMap.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.FlattenedMapWithXmlName !== undefined) {
@@ -1782,16 +1782,16 @@ const serializeAws_queryQueryMapsInput = (
       input.FlattenedMapWithXmlName,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Hi.${key.substring(key.indexOf(".") + 1)}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MapArg !== undefined) {
     const memberEntries = serializeAws_queryStringMap(input.MapArg, context);
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MapArg.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MapOfLists !== undefined) {
@@ -1799,9 +1799,9 @@ const serializeAws_queryQueryMapsInput = (
       input.MapOfLists,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MapOfLists.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.MapWithXmlMemberName !== undefined) {
@@ -1809,9 +1809,9 @@ const serializeAws_queryQueryMapsInput = (
       input.MapWithXmlMemberName,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MapWithXmlMemberName.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.RenamedMapArg !== undefined) {
@@ -1819,9 +1819,9 @@ const serializeAws_queryQueryMapsInput = (
       input.RenamedMapArg,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Foo.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   return entries;
@@ -1887,9 +1887,9 @@ const serializeAws_queryStructArg = (
       input.RecursiveArg,
       context
     );
-    Object.keys(memberEntries).forEach(key => {
+    Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RecursiveArg.${key}`;
-      entries[loc] = memberEntries[key];
+      entries[loc] = value;
     });
   }
   if (input.StringArg !== undefined) {
@@ -1906,8 +1906,8 @@ const serializeAws_queryGreetingList = (
   let counter = 1;
   for (let entry of input) {
     const memberEntries = serializeAws_queryGreetingStruct(entry, context);
-    Object.keys(memberEntries).forEach(key => {
-      entries[`member.${counter}.${key}`] = memberEntries[key];
+    Object.entries(memberEntries).forEach(([key, value]) => {
+      entries[`member.${counter}.${key}`] = value;
     });
     counter++;
   }
@@ -2762,13 +2762,15 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (entries: any): string =>
-  Object.keys(entries)
+const buildFormUrlencodedString = (formEntries: {
+  [key: string]: string;
+}): string =>
+  Object.entries(formEntries)
     .map(
-      key =>
+      ([key, value]) =>
         __extendedEncodeURIComponent(key) +
         "=" +
-        __extendedEncodeURIComponent(entries[key])
+        __extendedEncodeURIComponent(value)
     )
     .join("&");
 

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1_1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1_1.ts
@@ -3042,10 +3042,13 @@ const serializeAws_restJson1_1JsonMapsInputOutputMap = (
   input: { [key: string]: GreetingStruct },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = serializeAws_restJson1_1GreetingStruct(input[key], context);
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: GreetingStruct }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: serializeAws_restJson1_1GreetingStruct(value, context)
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1NestedPayload = (
@@ -3125,10 +3128,16 @@ const serializeAws_restJson1_1FooEnumMap = (
   input: { [key: string]: FooEnum | string },
   context: __SerdeContext
 ): any => {
-  return Object.keys(input).reduce((acc: any, key: string) => {
-    acc[key] = input[key];
-    return acc;
-  }, {});
+  return Object.entries(input).reduce(
+    (
+      acc: { [key: string]: FooEnum | string },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const serializeAws_restJson1_1FooEnumSet = (
@@ -3199,10 +3208,13 @@ const deserializeAws_restJson1_1JsonMapsInputOutputMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: GreetingStruct } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = deserializeAws_restJson1_1GreetingStruct(output[key], context);
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: GreetingStruct }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: deserializeAws_restJson1_1GreetingStruct(value, context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1NestedPayload = (
@@ -3302,10 +3314,16 @@ const deserializeAws_restJson1_1FooEnumMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FooEnum | string } => {
-  return Object.keys(output).reduce((acc: any, key: string) => {
-    acc[key] = output[key];
-    return acc;
-  }, {});
+  return Object.entries(output).reduce(
+    (
+      acc: { [key: string]: FooEnum | string },
+      [key, value]: [string, any]
+    ) => ({
+      ...acc,
+      [key]: value
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restJson1_1FooEnumSet = (


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* change Object.keys to Object.entries so that object doesn't have to be called in arrow function
* also added type-checks for accumulators
* also used destructuring assignment inside reduce 

**serializer**
* Before
```ts
const serializeAws_restJson1_1FilterCriteriaMap = (
  input: { [key: string]: Criterion },
  context: __SerdeContext
): any => {
  return Object.keys(input).reduce((acc: any, key: string) => {
    acc[key] = serializeAws_restJson1_1Criterion(input[key], context);
    return acc;
  }, {});
};
```
* After
```ts
const serializeAws_restJson1_1FilterCriteriaMap = (
  input: { [key: string]: Criterion },
  context: __SerdeContext
): any => {
  return Object.entries(input).reduce(
    (acc: { [key: string]: Criterion }, [key, value]: [string, any]) => ({
      ...acc,
      [key]: serializeAws_restJson1_1Criterion(value, context)
    }),
    {}
  );
};
```

**deserializer**
* Before
```ts
const deserializeAws_restJson1_1ConditionKeyMap = (
  output: any,
  context: __SerdeContext
): { [key: string]: string } => {
  return Object.keys(output).reduce((acc: any, key: string) => {
    acc[key] = output[key];
    return acc;
  }, {});
};
```
* After
```ts
const deserializeAws_restJson1_1ConditionKeyMap = (
  output: any,
  context: __SerdeContext
): { [key: string]: string } => {
  return Object.entries(output).reduce(
    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
      ...acc,
      [key]: value
    }),
    {}
  );
};
```

**buildFormUrlencodedString**
* Before
```ts
const buildFormUrlencodedString = (entries: any): string =>
  Object.keys(entries)
    .map(
      key =>
      ([key, value]) =>
        __extendedEncodeURIComponent(key) +
        "=" +
        __extendedEncodeURIComponent(entries[key])
    )
    .join("&");
```
* After
```ts
const buildFormUrlencodedString = (formEntries: {
  [key: string]: string;
}): string =>
  Object.entries(formEntries)
    .map(
      ([key, value]) =>
        __extendedEncodeURIComponent(key) +
        "=" +
        __extendedEncodeURIComponent(value)
    )
    .join("&");
```

**memberEntries**
* Before
```ts
    Object.keys(memberEntries).forEach(key => {
      const loc = `ScalingParameters.${key}`;
      entries[loc] = memberEntries[key];
    });
```
```ts
    Object.keys(memberEntries).forEach(key => {
      entries[`member.${counter}.${key}`] = memberEntries[key];
```
* After
```ts
    Object.entries(memberEntries).forEach(([key, value]) => {
      const loc = `ScalingParameters.${key}`;
      entries[loc] = value;
    });
```
```ts
    Object.entries(memberEntries).forEach(([key, value]) => {
      entries[`member.${counter}.${key}`] = value;
    });
```

**return statements in some deserialize functions**
* Before
```ts
  const key = Object.keys(output)[0];
  return { $unknown: [key, output[key]] };
```
* After
```ts
  return { $unknown: Object.entries(output)[0] };
```

---
Verified that integration tests are successful:
```console
$ AWS_PROFILE=<profile> yarn test:integration                                                                                         
yarn run v1.22.4
$ cucumber-js --fail-fast
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

153 scenarios (153 passed)
534 steps (534 passed)
0m56.560s
Done in 59.43s.
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
