### PR TITLE
chore: use destructuring in xml deserializeMap

### DIFF
--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -4902,10 +4902,13 @@ const deserializeAws_queryDomainNameMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryDomainStatus = (

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -4637,10 +4637,13 @@ const deserializeAws_queryDatapointValueMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = parseFloat(pair["value"]);
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: parseFloat(pair["value"])
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryDatapointValues = (

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -6673,10 +6673,13 @@ const deserializeAws_queryAuthenticateCognitoActionAuthenticationRequestExtraPar
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryAuthenticateCognitoActionConfig = (
@@ -6736,10 +6739,13 @@ const deserializeAws_queryAuthenticateOidcActionAuthenticationRequestExtraParams
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryAuthenticateOidcActionConfig = (

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -18235,10 +18235,13 @@ const deserializeAws_queryEvalDecisionDetailsType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: PolicyEvaluationDecisionType | string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryEvaluationResult = (
@@ -21874,10 +21877,13 @@ const deserializeAws_querysummaryMapType = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: number } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = parseInt(pair["value"]);
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: parseInt(pair["value"])
+    }),
+    {}
+  );
 };
 
 const deserializeAws_querytagListType = (

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -3469,10 +3469,13 @@ const deserializeAws_restXmlS3UserMetadata = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restXmlVpcConfiguration = (

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -9918,13 +9918,16 @@ const deserializeAws_queryDkimAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: IdentityDkimAttributes } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = deserializeAws_queryIdentityDkimAttributes(
-      pair["value"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: deserializeAws_queryIdentityDkimAttributes(
+        pair["value"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryEventDestination = (
@@ -10877,13 +10880,16 @@ const deserializeAws_queryMailFromDomainAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: IdentityMailFromDomainAttributes } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = deserializeAws_queryIdentityMailFromDomainAttributes(
-      pair["value"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: deserializeAws_queryIdentityMailFromDomainAttributes(
+        pair["value"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryMailFromDomainNotVerifiedException = (
@@ -10936,23 +10942,29 @@ const deserializeAws_queryNotificationAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: IdentityNotificationAttributes } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = deserializeAws_queryIdentityNotificationAttributes(
-      pair["value"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: deserializeAws_queryIdentityNotificationAttributes(
+        pair["value"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryPolicyMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryPolicyNameList = (
@@ -11733,13 +11745,16 @@ const deserializeAws_queryVerificationAttributes = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: IdentityVerificationAttributes } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = deserializeAws_queryIdentityVerificationAttributes(
-      pair["value"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: deserializeAws_queryIdentityVerificationAttributes(
+        pair["value"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryVerificationTokenList = (

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -5914,10 +5914,13 @@ const deserializeAws_queryMapStringToString = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryNotFoundException = (
@@ -6092,10 +6095,13 @@ const deserializeAws_querySubscriptionAttributesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_querySubscriptionLimitExceededException = (
@@ -6215,10 +6221,13 @@ const deserializeAws_queryTopicAttributesMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryTopicLimitExceededException = (

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -3251,13 +3251,16 @@ const deserializeAws_queryMessageBodyAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: MessageAttributeValue } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["Name"]] = deserializeAws_queryMessageAttributeValue(
-      pair["Value"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["Name"]]: deserializeAws_queryMessageAttributeValue(
+        pair["Value"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryMessageList = (
@@ -3283,10 +3286,13 @@ const deserializeAws_queryMessageSystemAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["Name"]] = pair["Value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["Name"]]: pair["Value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryOverLimit = (
@@ -3313,10 +3319,13 @@ const deserializeAws_queryQueueAttributeMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["Name"]] = pair["Value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["Name"]]: pair["Value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryQueueDeletedRecently = (
@@ -3502,10 +3511,13 @@ const deserializeAws_queryTagMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["Key"]] = pair["Value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["Key"]]: pair["Value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryTooManyEntriesInBatchRequest = (

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -104,11 +104,11 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
 
         // Get the right serialization for each entry in the map. Undefined
         // outputs won't have this deserializer invoked.
-        writer.openBlock("return output.reduce((acc: any, pair: any) => {", "}, {});", () -> {
+        writer.openBlock("return output.reduce((acc: any, pair: any) => ({", "}), {});", () -> {
+            writer.write("...acc,");
             // Dispatch to the output value provider for any additional handling.
             String dataSource = getUnnamedTargetWrapper(context, target, "pair[\"" + valueLocation + "\"]");
-            writer.write("acc[pair[$S]] = $L;", keyLocation, target.accept(getMemberVisitor(dataSource)));
-            writer.write("return acc;");
+            writer.write("[pair[$S]]: $L", keyLocation, target.accept(getMemberVisitor(dataSource)));
         });
     }
 

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -2019,10 +2019,13 @@ const deserializeAws_ec2FooEnumMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FooEnum | string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_ec2FooEnumSet = (

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -2041,10 +2041,13 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNameOutputMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["K"]] = pair["V"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["K"]]: pair["V"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryGreetingWithErrorsOutput = (
@@ -2478,13 +2481,13 @@ const deserializeAws_queryXmlMapsOutputMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: GreetingStruct } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = deserializeAws_queryGreetingStruct(
-      pair["value"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: deserializeAws_queryGreetingStruct(pair["value"], context)
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryXmlMapsXmlNameOutput = (
@@ -2511,13 +2514,16 @@ const deserializeAws_queryXmlMapsXmlNameOutputMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: GreetingStruct } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["Attribute"]] = deserializeAws_queryGreetingStruct(
-      pair["Setting"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["Attribute"]]: deserializeAws_queryGreetingStruct(
+        pair["Setting"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryXmlNamespaceNested = (
@@ -2615,10 +2621,13 @@ const deserializeAws_queryFooEnumMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FooEnum | string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_queryFooEnumSet = (

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -4496,10 +4496,13 @@ const deserializeAws_restXmlFlattenedXmlMapWithXmlNameInputOutputMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["K"]] = pair["V"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["K"]]: pair["V"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restXmlNestedPayload = (
@@ -4660,26 +4663,32 @@ const deserializeAws_restXmlXmlMapsInputOutputMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: GreetingStruct } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = deserializeAws_restXmlGreetingStruct(
-      pair["value"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: deserializeAws_restXmlGreetingStruct(
+        pair["value"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restXmlXmlMapsXmlNameInputOutputMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: GreetingStruct } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["Attribute"]] = deserializeAws_restXmlGreetingStruct(
-      pair["Setting"],
-      context
-    );
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["Attribute"]]: deserializeAws_restXmlGreetingStruct(
+        pair["Setting"],
+        context
+      )
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restXmlXmlNamespaceNested = (
@@ -4734,10 +4743,13 @@ const deserializeAws_restXmlFooEnumMap = (
   output: any,
   context: __SerdeContext
 ): { [key: string]: FooEnum | string } => {
-  return output.reduce((acc: any, pair: any) => {
-    acc[pair["key"]] = pair["value"];
-    return acc;
-  }, {});
+  return output.reduce(
+    (acc: any, pair: any) => ({
+      ...acc,
+      [pair["key"]]: pair["value"]
+    }),
+    {}
+  );
 };
 
 const deserializeAws_restXmlFooEnumSet = (


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
use destructuring in xml deserializeMap
* Before
```ts
const deserializeAws_queryDomainNameMap = (
  output: any,
  context: __SerdeContext
): { [key: string]: string } => {
  return output.reduce((acc: any, pair: any) => {
    acc[pair["key"]] = pair["value"];
    return acc;
  }, {});
};
```
* After
```ts
const deserializeAws_queryDomainNameMap = (
  output: any,
  context: __SerdeContext
): { [key: string]: string } => {
  return output.reduce(
    (acc: any, pair: any) => ({
      ...acc,
      [pair["key"]]: pair["value"]
    }),
    {}
  );
};
```

Verified by running the following in browser JavaScript console:
```js
const obj = [{ key: "one", value: "1" }];

obj.reduce((acc, pair) => {
  acc[pair["key"]] = pair["value"];
  return acc;
}, {});

obj.reduce((acc, pair) => ({ ...acc, [pair["key"]]: pair["value"] }), {});
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
