### PR TITLE
test: enable termination protection in CloudFormation integ test

### DIFF
--- a/features/cloudformation/step_definitions/cloudformation.js
+++ b/features/cloudformation/step_definitions/cloudformation.js
@@ -14,7 +14,8 @@ Given("I create a CloudFormation stack with name prefix {string}", function (
   this.templateBody = '{"Resources":{"member":{"Type":"AWS::SQS::Queue"}}}';
   const params = {
     TemplateBody: this.templateBody,
-    StackName: this.stackName
+    StackName: this.stackName,
+    EnableTerminationProtection: true
   };
   this.request(null, "createStack", params, callback, false);
 });


### PR DESCRIPTION
*Issue #, if available:*
Similar to https://github.com/aws/aws-sdk-js/pull/3252

*Description of changes:*
enable termination protection in CloudFormation integ test

Verified that integration tests are successful:
```console
$ AWS_PROFILE=<profile> yarn test:integration --tags @cloudformation
yarn run v1.22.4
$ cucumber-js --fail-fast --tags @cloudformation
.........

2 scenarios (2 passed)
5 steps (5 passed)
0m00.149s
Done in 2.13s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
