### PR TITLE
chore: simplify error codes to be an array of strings

### DIFF
--- a/packages/service-error-classification/src/constants.ts
+++ b/packages/service-error-classification/src/constants.ts
@@ -1,5 +1,3 @@
-export type ErrorCodeSet = { [errorCode: string]: true };
-
 /**
  * Errors encountered when the client clock and server clock cannot agree on the
  * current time.
@@ -7,36 +5,34 @@ export type ErrorCodeSet = { [errorCode: string]: true };
  * These errors are retryable, assuming the SDK has enabled clock skew
  * correction.
  */
-export const CLOCK_SKEW_ERROR_CODES: ErrorCodeSet = {
-  AuthFailure: true,
-  InvalidSignatureException: true,
-  RequestExpired: true,
-  RequestInTheFuture: true,
-  RequestTimeTooSkewed: true,
-  SignatureDoesNotMatch: true
-};
+export const CLOCK_SKEW_ERROR_CODES = [
+  "AuthFailure",
+  "InvalidSignatureException",
+  "RequestExpired",
+  "RequestInTheFuture",
+  "RequestTimeTooSkewed",
+  "SignatureDoesNotMatch"
+];
 
 /**
  * Errors encountered when the state presumed by an operation is not yet ready.
  */
-export const STILL_PROCESSING_ERROR_CODES: ErrorCodeSet = {
-  PriorRequestNotComplete: true
-};
+export const STILL_PROCESSING_ERROR_CODES = ["PriorRequestNotComplete"];
 
 /**
  * Errors that indicate the SDK is being throttled.
  *
  * These errors are always retryable.
  */
-export const THROTTLING_ERROR_CODES: ErrorCodeSet = {
-  BandwidthLimitExceeded: true,
-  ProvisionedThroughputExceededException: true,
-  RequestLimitExceeded: true,
-  RequestThrottled: true,
-  RequestThrottledException: true,
-  SlowDown: true,
-  ThrottledException: true,
-  Throttling: true,
-  ThrottlingException: true,
-  TooManyRequestsException: true
-};
+export const THROTTLING_ERROR_CODES = [
+  "BandwidthLimitExceeded",
+  "ProvisionedThroughputExceededException",
+  "RequestLimitExceeded",
+  "RequestThrottled",
+  "RequestThrottledException",
+  "SlowDown",
+  "ThrottledException",
+  "Throttling",
+  "ThrottlingException",
+  "TooManyRequestsException"
+];

--- a/packages/service-error-classification/src/index.spec.ts
+++ b/packages/service-error-classification/src/index.spec.ts
@@ -9,32 +9,66 @@ import {
   isThrottlingError
 } from "./index";
 
+const checkForErrorType = (
+  isErrorTypeFunc: (error: Error) => boolean,
+  errorName: string,
+  errorTypeResult: boolean
+) => {
+  const error = new Error();
+  error.name = errorName;
+  expect(isErrorTypeFunc(error)).toBe(errorTypeResult);
+};
+
 describe("isClockSkewError", () => {
-  for (const name of Object.keys(CLOCK_SKEW_ERROR_CODES)) {
-    it(`should declare errors with the name ${name} to be throttling errors`, () => {
-      const error = new Error();
-      error.name = name;
-      expect(isClockSkewError(error)).toBe(true);
+  CLOCK_SKEW_ERROR_CODES.forEach(name => {
+    it(`should declare error with the name "${name}" to be a ClockSkew error`, () => {
+      checkForErrorType(isClockSkewError, name, true);
     });
+  });
+
+  while (true) {
+    const name = Math.random().toString(36).substring(2);
+    if (!CLOCK_SKEW_ERROR_CODES.includes(name)) {
+      it(`should not declare error with the name "${name}" to be a ClockSkew error`, () => {
+        checkForErrorType(isClockSkewError, name, false);
+      });
+      break;
+    }
   }
 });
 
 describe("isStillProcessingError", () => {
-  for (const name of Object.keys(STILL_PROCESSING_ERROR_CODES)) {
-    it(`should declare errors with the name ${name} to be throttling errors`, () => {
-      const error = new Error();
-      error.name = name;
-      expect(isStillProcessingError(error)).toBe(true);
+  STILL_PROCESSING_ERROR_CODES.forEach(name => {
+    it(`should declare error with the name "${name}" to be a StillProcessing error`, () => {
+      checkForErrorType(isStillProcessingError, name, true);
     });
+  });
+
+  while (true) {
+    const name = Math.random().toString(36).substring(2);
+    if (!STILL_PROCESSING_ERROR_CODES.includes(name)) {
+      it(`should not declare error with the name "${name}" to be a StillProcessing error`, () => {
+        checkForErrorType(isStillProcessingError, name, false);
+      });
+      break;
+    }
   }
 });
 
 describe("isThrottlingError", () => {
-  for (const name of Object.keys(THROTTLING_ERROR_CODES)) {
-    it(`should declare errors with the name ${name} to be throttling errors`, () => {
-      const error = new Error();
-      error.name = name;
-      expect(isThrottlingError(error)).toBe(true);
+  THROTTLING_ERROR_CODES.forEach(name => {
+    it(`should declare error with the name "${name}" to be a Throttling error`, () => {
+      checkForErrorType(isThrottlingError, name, true);
     });
+  });
+
+  while (true) {
+    const name = Math.random().toString(36).substring(2);
+    if (!THROTTLING_ERROR_CODES.includes(name)) {
+      it(`should not declare error with the name "${name}" to be a Throttling error`, () => {
+        checkForErrorType(isThrottlingError, name, false);
+      });
+      break;
+    }
   }
 });

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -4,14 +4,11 @@ import {
   THROTTLING_ERROR_CODES
 } from "./constants";
 
-export function isClockSkewError(error: Error) {
-  return error.name in CLOCK_SKEW_ERROR_CODES;
-}
+export const isClockSkewError = (error: Error) =>
+  CLOCK_SKEW_ERROR_CODES.includes(error.name);
 
-export function isStillProcessingError(error: Error): boolean {
-  return error.name in STILL_PROCESSING_ERROR_CODES;
-}
+export const isStillProcessingError = (error: Error) =>
+  STILL_PROCESSING_ERROR_CODES.includes(error.name);
 
-export function isThrottlingError(error: Error): boolean {
-  return error.name in THROTTLING_ERROR_CODES;
-}
+export const isThrottlingError = (error: Error) =>
+  THROTTLING_ERROR_CODES.includes(error.name);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

The error codes were of type `{ [errorCode: string]: true }` which contains redundant boolean variable true. This code change simplifies error codes to be array of strings. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
