### PR TITLE
chore: add missing throttling errors 

### DIFF
--- a/packages/middleware-retry/src/retryDecider.ts
+++ b/packages/middleware-retry/src/retryDecider.ts
@@ -1,7 +1,6 @@
 import { RETRYABLE_STATUS_CODES } from "./constants";
 import {
   isClockSkewError,
-  isStillProcessingError,
   isThrottlingError
 } from "@aws-sdk/service-error-classification";
 import { MetadataBearer, SdkError } from "@aws-sdk/types";
@@ -23,11 +22,7 @@ export const defaultRetryDecider = (error: SdkError) => {
     return true;
   }
 
-  return (
-    isStillProcessingError(error) ||
-    isThrottlingError(error) ||
-    isClockSkewError(error)
-  );
+  return isThrottlingError(error) || isClockSkewError(error);
 };
 
 function hasMetadata(error: any): error is MetadataBearer {

--- a/packages/service-error-classification/src/constants.ts
+++ b/packages/service-error-classification/src/constants.ts
@@ -15,11 +15,6 @@ export const CLOCK_SKEW_ERROR_CODES = [
 ];
 
 /**
- * Errors encountered when the state presumed by an operation is not yet ready.
- */
-export const STILL_PROCESSING_ERROR_CODES = ["PriorRequestNotComplete"];
-
-/**
  * Errors that indicate the SDK is being throttled.
  *
  * These errors are always retryable.

--- a/packages/service-error-classification/src/constants.ts
+++ b/packages/service-error-classification/src/constants.ts
@@ -25,14 +25,18 @@ export const STILL_PROCESSING_ERROR_CODES = ["PriorRequestNotComplete"];
  * These errors are always retryable.
  */
 export const THROTTLING_ERROR_CODES = [
-  "BandwidthLimitExceeded",
-  "ProvisionedThroughputExceededException",
-  "RequestLimitExceeded",
-  "RequestThrottled",
-  "RequestThrottledException",
-  "SlowDown",
-  "ThrottledException",
   "Throttling",
   "ThrottlingException",
-  "TooManyRequestsException"
+  "ThrottledException",
+  "RequestThrottledException",
+  "TooManyRequestsException",
+  "ProvisionedThroughputExceededException",
+  "TransactionInProgressException",
+  "RequestLimitExceeded",
+  "BandwidthLimitExceeded",
+  "LimitExceededException",
+  "RequestThrottled",
+  "SlowDown",
+  "PriorRequestNotComplete",
+  "EC2ThrottledException"
 ];

--- a/packages/service-error-classification/src/index.spec.ts
+++ b/packages/service-error-classification/src/index.spec.ts
@@ -1,13 +1,5 @@
-import {
-  CLOCK_SKEW_ERROR_CODES,
-  STILL_PROCESSING_ERROR_CODES,
-  THROTTLING_ERROR_CODES
-} from "./constants";
-import {
-  isClockSkewError,
-  isStillProcessingError,
-  isThrottlingError
-} from "./index";
+import { CLOCK_SKEW_ERROR_CODES, THROTTLING_ERROR_CODES } from "./constants";
+import { isClockSkewError, isThrottlingError } from "./index";
 
 const checkForErrorType = (
   isErrorTypeFunc: (error: Error) => boolean,
@@ -31,24 +23,6 @@ describe("isClockSkewError", () => {
     if (!CLOCK_SKEW_ERROR_CODES.includes(name)) {
       it(`should not declare error with the name "${name}" to be a ClockSkew error`, () => {
         checkForErrorType(isClockSkewError, name, false);
-      });
-      break;
-    }
-  }
-});
-
-describe("isStillProcessingError", () => {
-  STILL_PROCESSING_ERROR_CODES.forEach(name => {
-    it(`should declare error with the name "${name}" to be a StillProcessing error`, () => {
-      checkForErrorType(isStillProcessingError, name, true);
-    });
-  });
-
-  while (true) {
-    const name = Math.random().toString(36).substring(2);
-    if (!STILL_PROCESSING_ERROR_CODES.includes(name)) {
-      it(`should not declare error with the name "${name}" to be a StillProcessing error`, () => {
-        checkForErrorType(isStillProcessingError, name, false);
       });
       break;
     }

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -1,14 +1,7 @@
-import {
-  CLOCK_SKEW_ERROR_CODES,
-  STILL_PROCESSING_ERROR_CODES,
-  THROTTLING_ERROR_CODES
-} from "./constants";
+import { CLOCK_SKEW_ERROR_CODES, THROTTLING_ERROR_CODES } from "./constants";
 
 export const isClockSkewError = (error: Error) =>
   CLOCK_SKEW_ERROR_CODES.includes(error.name);
-
-export const isStillProcessingError = (error: Error) =>
-  STILL_PROCESSING_ERROR_CODES.includes(error.name);
 
 export const isThrottlingError = (error: Error) =>
   THROTTLING_ERROR_CODES.includes(error.name);


### PR DESCRIPTION
*Issue #, if available:*
Internally documented in JS-1810

*Description of changes:*
The existing list of Throttling errors was added in Dec 2017 https://github.com/aws/aws-sdk-js-v3/commit/ae1aa480ca578879703c551e6b09a224e955a906
* Missed throttling errors added in this PR:
  * `TransactionInProgressException`
  * `LimitExceededException`
  * `EC2ThrottledException`
* `PriorRequestNotComplete` is moved from StillProcessingError to `ThrottlingError`
  * The API `isStillProcessingError` is being removed. It's internally only used in retryDecider, and low-level to be not used by pre-release users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
