### PR TITLE
chore: allow un-overwritable scripts and devDependencies in package.json

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -49,7 +49,7 @@ const mergeManifest = (fromContent = {}, toContent) => {
   for (const name of fromNames) {
     if (typeof toContent[name] === "object") {
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
-      if (name === "scripts" || "devDependencies") {
+      if (name === "scripts" || name === "devDependencies") {
         // Allow target package.json(toContent) has its own special script or
         // dev dependencies that won't be overwritten in codegen
         merged[name] = { ...toContent[name], ...merged[name] };


### PR DESCRIPTION
There are 2 changes with this PR:
1. If a client's package.json contains a local NPM `scripts` or `devDependencies`, they would be removed by codegen because these new entries don't exist package.json's template. This change avoids removing these entries. 
What is not changed: for the entries in `scripts` or `devDependencies` and exist in both newly generated client and existing client, the script prefers the ones in existing client.

2. Temporarily pin the newly added internal dependencies version. We will review this before GA.(maybe re-introduce the range dependencies)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
