### PR TITLE
chore: re-add client-transcribe-streaming scripts

### DIFF
--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -13,8 +13,11 @@
     "remove-js": "rimraf *.js && rimraf ./commands/*.js && rimraf ./models/*.js && rimraf ./protocols/*.js",
     "remove-maps": "rimraf *.js.map && rimraf ./commands/*.js.map && rimraf ./models/*.js.map && rimraf ./protocols/*.js.map",
     "test": "jest --coverage --passWithNoTests",
+    "test:integration": "jest --config jest.integ.config.js",
+    "build:cjs": "tsc",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "postbuild": "cp test/speech.wav dist/cjs/test"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1218

*Description of changes:*
* The custom scripts required for client-transcribe-streaming were removed in codegen PR https://github.com/aws/aws-sdk-js-v3/pull/1213. This PR re-introduces them.
* The codegen was updated to not overwrite these scripts in https://github.com/aws/aws-sdk-js-v3/pull/1207

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
