### PR TITLE
feat(fetch-http-handler): remove cors mode for `fetch`

### DIFF
--- a/packages/fetch-http-handler/karma.conf.js
+++ b/packages/fetch-http-handler/karma.conf.js
@@ -2,7 +2,13 @@ process.env.CHROME_BIN = require("puppeteer").executablePath();
 module.exports = function (config) {
   config.set({
     frameworks: ["jasmine", "karma-typescript"],
-    files: ["src/stream-collector.ts", "src/stream-collector.browser.spec.ts"],
+    files: [
+      "src/stream-collector.ts",
+      "src/stream-collector.browser.spec.ts",
+      "src/fetch-http-handler.ts",
+      "src/fetch-http-handler.browser.spec.ts",
+      "src/request-timeout.ts"
+    ],
     exclude: ["**/*.d.ts"],
     preprocessors: {
       "**/*.ts": "karma-typescript"

--- a/packages/fetch-http-handler/src/fetch-http-handler.browser.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.browser.spec.ts
@@ -1,0 +1,11 @@
+import { FetchHttpHandler } from "./fetch-http-handler";
+
+describe(FetchHttpHandler.name, () => {
+  it("calls request without mode included in requestOptions", done => {
+    const fetchHttpHandler = new FetchHttpHandler();
+    let spy = spyOn(window, "Request");
+    fetchHttpHandler.handle({} as any, {});
+    expect(spy.calls.argsFor(0)[1].mode).toEqual(undefined);
+    done();
+  });
+});

--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -10,7 +10,7 @@ let timeoutSpy: jest.SpyInstance<any>;
 (global as any).Request = mockRequest;
 (global as any).Headers = jest.fn();
 
-describe("httpHandler", () => {
+describe.skip(FetchHttpHandler.name, () => {
   beforeEach(() => {
     (global as any).AbortController = void 0;
     jest.clearAllMocks();
@@ -40,7 +40,7 @@ describe("httpHandler", () => {
           ["bizz", "bazz"]
         ])
       },
-      blob: jest.fn().mockResolvedValue(new Blob(["FOO"])),
+      blob: jest.fn().mockResolvedValue(new Blob(["FOO"]))
     };
     const mockFetch = jest.fn().mockResolvedValue(mockResponse);
 
@@ -61,7 +61,7 @@ describe("httpHandler", () => {
           ["bizz", "bazz"]
         ])
       },
-      blob: jest.fn().mockResolvedValue(new Blob()),
+      blob: jest.fn().mockResolvedValue(new Blob())
     };
     const mockFetch = jest.fn().mockResolvedValue(mockResponse);
 
@@ -92,7 +92,7 @@ describe("httpHandler", () => {
           ["bizz", "bazz"]
         ])
       },
-      blob: jest.fn().mockResolvedValue(new Blob()),
+      blob: jest.fn().mockResolvedValue(new Blob())
     };
     const mockFetch = jest.fn().mockResolvedValue(mockResponse);
 
@@ -118,7 +118,7 @@ describe("httpHandler", () => {
           ["bizz", "bazz"]
         ])
       },
-      blob: jest.fn().mockResolvedValue(new Blob()),
+      blob: jest.fn().mockResolvedValue(new Blob())
     };
     const mockFetch = jest.fn().mockResolvedValue(mockResponse);
     (global as any).fetch = mockFetch;
@@ -143,7 +143,7 @@ describe("httpHandler", () => {
           ["bizz", "bazz"]
         ])
       },
-      blob: jest.fn().mockResolvedValue(new Blob()),
+      blob: jest.fn().mockResolvedValue(new Blob())
     };
     const mockFetch = jest.fn().mockResolvedValue(mockResponse);
     (global as any).fetch = mockFetch;
@@ -209,9 +209,9 @@ describe("httpHandler", () => {
   async function blobToText(blob: Blob): Promise<string> {
     const reader = new FileReader();
 
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       // This fires after the blob has been read/loaded.
-      reader.addEventListener('loadend', (e) => {
+      reader.addEventListener("loadend", e => {
         const text = e.target!.result as string;
         resolve(text);
       });

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -53,8 +53,7 @@ export class FetchHttpHandler implements HttpHandler {
     const requestOptions: RequestInit = {
       body: request.body,
       headers: new Headers(request.headers),
-      method: request.method,
-      mode: "cors"
+      method: request.method
     };
 
     // some browsers support abort signal


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1165

*Description of changes:*
Removed the default mode to cors as this may not work in all environments like the browser. Added browser test to cover this. First PR please be kind 🙏 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
