### PR TITLE
docs: add notes to discourage external usage of dependencies

### DIFF
--- a/packages/body-checksum-browser/README.md
+++ b/packages/body-checksum-browser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/body-checksum-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/body-checksum-browser.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-browser)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/body-checksum-browser/README.md
+++ b/packages/body-checksum-browser/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/body-checksum-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/body-checksum-browser.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-browser)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/body-checksum-browser/README.md
+++ b/packages/body-checksum-browser/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/body-checksum-node/README.md
+++ b/packages/body-checksum-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/body-checksum-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/body-checksum-node.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-node)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/body-checksum-node/README.md
+++ b/packages/body-checksum-node/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/body-checksum-node/README.md
+++ b/packages/body-checksum-node/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/body-checksum-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/body-checksum-node.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-node)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/chunked-blob-reader-native/README.md
+++ b/packages/chunked-blob-reader-native/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/chunked-blob-reader-native/beta.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader-native)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/chunked-blob-reader-native.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader-native)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/chunked-blob-reader-native/README.md
+++ b/packages/chunked-blob-reader-native/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/chunked-blob-reader-native/beta.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader-native)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/chunked-blob-reader-native.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader-native)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/chunked-blob-reader-native/README.md
+++ b/packages/chunked-blob-reader-native/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/chunked-blob-reader/README.md
+++ b/packages/chunked-blob-reader/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/chunked-blob-reader/beta.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/chunked-blob-reader.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/chunked-blob-reader/README.md
+++ b/packages/chunked-blob-reader/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/chunked-blob-reader/beta.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/chunked-blob-reader.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-blob-reader)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/chunked-blob-reader/README.md
+++ b/packages/chunked-blob-reader/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/chunked-stream-reader-node/README.md
+++ b/packages/chunked-stream-reader-node/README.md
@@ -11,4 +11,4 @@ This package is meant for the AWS SDK for JavaScript to enable reading a stream 
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/chunked-stream-reader-node/README.md
+++ b/packages/chunked-stream-reader-node/README.md
@@ -7,6 +7,8 @@ Exports a streamReader function that accepts a readable stream, a function to ca
 
 This package is meant for the AWS SDK for JavaScript to enable reading a stream with consistent chunk sizes.
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/chunked-stream-reader-node/README.md
+++ b/packages/chunked-stream-reader-node/README.md
@@ -6,3 +6,7 @@
 Exports a streamReader function that accepts a readable stream, a function to call on each chunk, and a chunk size in bytes to buffer interally before calling the supplied function.
 
 This package is meant for the AWS SDK for JavaScript to enable reading a stream with consistent chunk sizes.
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/client-documentation-generator/README.md
+++ b/packages/client-documentation-generator/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/client-documentation-generator/beta.svg)](https://www.npmjs.com/package/@aws-sdk/client-documentation-generator)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/client-documentation-generator.svg)](https://www.npmjs.com/package/@aws-sdk/client-documentation-generator)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/client-documentation-generator/README.md
+++ b/packages/client-documentation-generator/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/client-documentation-generator/beta.svg)](https://www.npmjs.com/package/@aws-sdk/client-documentation-generator)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/client-documentation-generator.svg)](https://www.npmjs.com/package/@aws-sdk/client-documentation-generator)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/client-documentation-generator/README.md
+++ b/packages/client-documentation-generator/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/config-resolver/README.md
+++ b/packages/config-resolver/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/config-resolver/beta.svg)](https://www.npmjs.com/package/@aws-sdk/config-resolver)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/config-resolver.svg)](https://www.npmjs.com/package/@aws-sdk/config-resolver)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/config-resolver/README.md
+++ b/packages/config-resolver/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/config-resolver/beta.svg)](https://www.npmjs.com/package/@aws-sdk/config-resolver)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/config-resolver.svg)](https://www.npmjs.com/package/@aws-sdk/config-resolver)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/config-resolver/README.md
+++ b/packages/config-resolver/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/eventstream-handler-node/README.md
+++ b/packages/eventstream-handler-node/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-handler-node/alpha.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-handler-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-handler-node.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-handler-node)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/eventstream-handler-node/README.md
+++ b/packages/eventstream-handler-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-handler-node/alpha.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-handler-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-handler-node.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-handler-node)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/eventstream-handler-node/README.md
+++ b/packages/eventstream-handler-node/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/eventstream-serde-browser/README.md
+++ b/packages/eventstream-serde-browser/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-browser/alpha.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-browser.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-browser)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/eventstream-serde-browser/README.md
+++ b/packages/eventstream-serde-browser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-browser/alpha.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-browser.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-browser)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/eventstream-serde-browser/README.md
+++ b/packages/eventstream-serde-browser/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/eventstream-serde-config-resolver/README.md
+++ b/packages/eventstream-serde-config-resolver/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver/alpha.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/eventstream-serde-config-resolver/README.md
+++ b/packages/eventstream-serde-config-resolver/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/eventstream-serde-config-resolver/README.md
+++ b/packages/eventstream-serde-config-resolver/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver/alpha.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-config-resolver)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/eventstream-serde-node/README.md
+++ b/packages/eventstream-serde-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-node.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-node)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/eventstream-serde-node/README.md
+++ b/packages/eventstream-serde-node/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-node.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-node)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/eventstream-serde-node/README.md
+++ b/packages/eventstream-serde-node/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/eventstream-serde-universal/README.md
+++ b/packages/eventstream-serde-universal/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-universal/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-universal)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-universal.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-universal)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/eventstream-serde-universal/README.md
+++ b/packages/eventstream-serde-universal/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-universal/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-universal)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-universal.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-universal)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/eventstream-serde-universal/README.md
+++ b/packages/eventstream-serde-universal/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/hash-blob-browser/README.md
+++ b/packages/hash-blob-browser/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/hash-blob-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/hash-blob-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/hash-blob-browser.svg)](https://www.npmjs.com/package/@aws-sdk/hash-blob-browser)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/hash-blob-browser/README.md
+++ b/packages/hash-blob-browser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/hash-blob-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/hash-blob-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/hash-blob-browser.svg)](https://www.npmjs.com/package/@aws-sdk/hash-blob-browser)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/hash-blob-browser/README.md
+++ b/packages/hash-blob-browser/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/hash-node/README.md
+++ b/packages/hash-node/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/hash-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/hash-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/hash-node.svg)](https://www.npmjs.com/package/@aws-sdk/hash-node)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/hash-node/README.md
+++ b/packages/hash-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/hash-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/hash-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/hash-node.svg)](https://www.npmjs.com/package/@aws-sdk/hash-node)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/hash-node/README.md
+++ b/packages/hash-node/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/hash-stream-node/README.md
+++ b/packages/hash-stream-node/README.md
@@ -7,6 +7,8 @@ A utility for calculating the hash of Node.JS readable streams. This package is
 currently only compatible with file streams, as no other stream type can be
 replayed.
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/hash-stream-node/README.md
+++ b/packages/hash-stream-node/README.md
@@ -11,4 +11,4 @@ replayed.
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/hash-stream-node/README.md
+++ b/packages/hash-stream-node/README.md
@@ -6,3 +6,7 @@
 A utility for calculating the hash of Node.JS readable streams. This package is
 currently only compatible with file streams, as no other stream type can be
 replayed.
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/invalid-dependency/README.md
+++ b/packages/invalid-dependency/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/invalid-dependency/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/invalid-dependency)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/invalid-dependency.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/invalid-dependency)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/invalid-dependency/README.md
+++ b/packages/invalid-dependency/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/invalid-dependency/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/invalid-dependency)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/invalid-dependency.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/invalid-dependency)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/invalid-dependency/README.md
+++ b/packages/invalid-dependency/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/is-array-buffer/README.md
+++ b/packages/is-array-buffer/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/is-array-buffer/beta.svg)](https://www.npmjs.com/package/@aws-sdk/is-array-buffer)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/is-array-buffer.svg)](https://www.npmjs.com/package/@aws-sdk/is-array-buffer)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/is-array-buffer/README.md
+++ b/packages/is-array-buffer/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/is-array-buffer/README.md
+++ b/packages/is-array-buffer/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/is-array-buffer/beta.svg)](https://www.npmjs.com/package/@aws-sdk/is-array-buffer)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/is-array-buffer.svg)](https://www.npmjs.com/package/@aws-sdk/is-array-buffer)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/md5-js/README.md
+++ b/packages/md5-js/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/md5-js/beta.svg)](https://www.npmjs.com/package/@aws-sdk/md5-js)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/md5-js.svg)](https://www.npmjs.com/package/@aws-sdk/md5-js)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/md5-js/README.md
+++ b/packages/md5-js/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/md5-js/README.md
+++ b/packages/md5-js/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/md5-js/beta.svg)](https://www.npmjs.com/package/@aws-sdk/md5-js)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/md5-js.svg)](https://www.npmjs.com/package/@aws-sdk/md5-js)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/property-provider/README.md
+++ b/packages/property-provider/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/property-provider/beta.svg)](https://www.npmjs.com/package/@aws-sdk/property-provider)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/property-provider.svg)](https://www.npmjs.com/package/@aws-sdk/property-provider)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/property-provider/README.md
+++ b/packages/property-provider/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/property-provider/beta.svg)](https://www.npmjs.com/package/@aws-sdk/property-provider)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/property-provider.svg)](https://www.npmjs.com/package/@aws-sdk/property-provider)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/property-provider/README.md
+++ b/packages/property-provider/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/querystring-builder/README.md
+++ b/packages/querystring-builder/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/querystring-builder/beta.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-builder)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/querystring-builder.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-builder)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/querystring-builder/README.md
+++ b/packages/querystring-builder/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/querystring-builder/beta.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-builder)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/querystring-builder.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-builder)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/querystring-builder/README.md
+++ b/packages/querystring-builder/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/querystring-parser/README.md
+++ b/packages/querystring-parser/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/querystring-parser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-parser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/querystring-parser.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-parser)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/querystring-parser/README.md
+++ b/packages/querystring-parser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/querystring-parser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-parser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/querystring-parser.svg)](https://www.npmjs.com/package/@aws-sdk/querystring-parser)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/querystring-parser/README.md
+++ b/packages/querystring-parser/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/region-provider/README.md
+++ b/packages/region-provider/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/region-provider/beta.svg)](https://www.npmjs.com/package/@aws-sdk/region-provider)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/region-provider.svg)](https://www.npmjs.com/package/@aws-sdk/region-provider)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/region-provider/README.md
+++ b/packages/region-provider/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/region-provider/beta.svg)](https://www.npmjs.com/package/@aws-sdk/region-provider)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/region-provider.svg)](https://www.npmjs.com/package/@aws-sdk/region-provider)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/region-provider/README.md
+++ b/packages/region-provider/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/sha256-tree-hash/README.md
+++ b/packages/sha256-tree-hash/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/sha256-tree-hash/beta.svg)](https://www.npmjs.com/package/@aws-sdk/sha256-tree-hash)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/sha256-tree-hash.svg)](https://www.npmjs.com/package/@aws-sdk/sha256-tree-hash)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/sha256-tree-hash/README.md
+++ b/packages/sha256-tree-hash/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/sha256-tree-hash/beta.svg)](https://www.npmjs.com/package/@aws-sdk/sha256-tree-hash)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/sha256-tree-hash.svg)](https://www.npmjs.com/package/@aws-sdk/sha256-tree-hash)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/sha256-tree-hash/README.md
+++ b/packages/sha256-tree-hash/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/smithy-client/README.md
+++ b/packages/smithy-client/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/smithy-client/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/smithy-client)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/smithy-client.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/smithy-client)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/smithy-client/README.md
+++ b/packages/smithy-client/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/smithy-client/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/smithy-client)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/smithy-client.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/smithy-client)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/smithy-client/README.md
+++ b/packages/smithy-client/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/url-parser-browser/README.md
+++ b/packages/url-parser-browser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/url-parser-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/url-parser-browser.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-browser)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/url-parser-browser/README.md
+++ b/packages/url-parser-browser/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/url-parser-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/url-parser-browser.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-browser)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/url-parser-browser/README.md
+++ b/packages/url-parser-browser/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/url-parser-node/README.md
+++ b/packages/url-parser-node/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/url-parser-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/url-parser-node.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-node)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/url-parser-node/README.md
+++ b/packages/url-parser-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/url-parser-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/url-parser-node.svg)](https://www.npmjs.com/package/@aws-sdk/url-parser-node)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/url-parser-node/README.md
+++ b/packages/url-parser-node/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/util-body-length-browser/README.md
+++ b/packages/util-body-length-browser/README.md
@@ -9,4 +9,4 @@ Determines the length of a request body in browsers
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/util-body-length-browser/README.md
+++ b/packages/util-body-length-browser/README.md
@@ -4,3 +4,7 @@
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-body-length-browser.svg)](https://www.npmjs.com/package/@aws-sdk/util-body-length-browser)
 
 Determines the length of a request body in browsers
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/util-body-length-browser/README.md
+++ b/packages/util-body-length-browser/README.md
@@ -5,6 +5,8 @@
 
 Determines the length of a request body in browsers
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/util-body-length-node/README.md
+++ b/packages/util-body-length-node/README.md
@@ -9,4 +9,4 @@ Determines the length of a request body in node.js
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/util-body-length-node/README.md
+++ b/packages/util-body-length-node/README.md
@@ -1,6 +1,10 @@
 # @aws-sdk/util-body-length-node
 
-Determines the length of a request body in node.js
-
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-body-length-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-body-length-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-body-length-node.svg)](https://www.npmjs.com/package/@aws-sdk/util-body-length-node)
+
+Determines the length of a request body in node.js
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/util-body-length-node/README.md
+++ b/packages/util-body-length-node/README.md
@@ -5,6 +5,8 @@
 
 Determines the length of a request body in node.js
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/util-buffer-from/README.md
+++ b/packages/util-buffer-from/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-buffer-from/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-buffer-from)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-buffer-from.svg)](https://www.npmjs.com/package/@aws-sdk/util-buffer-from)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/util-buffer-from/README.md
+++ b/packages/util-buffer-from/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-buffer-from/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-buffer-from)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-buffer-from.svg)](https://www.npmjs.com/package/@aws-sdk/util-buffer-from)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/util-buffer-from/README.md
+++ b/packages/util-buffer-from/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/util-hex-encoding/README.md
+++ b/packages/util-hex-encoding/README.md
@@ -2,9 +2,3 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-hex-encoding/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-hex-encoding)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-hex-encoding.svg)](https://www.npmjs.com/package/@aws-sdk/util-hex-encoding)
-
-> An internal package
-
-## Usage
-
-You probably shouldn't, at least directly.

--- a/packages/util-hex-encoding/README.md
+++ b/packages/util-hex-encoding/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-hex-encoding/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-hex-encoding)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-hex-encoding.svg)](https://www.npmjs.com/package/@aws-sdk/util-hex-encoding)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/util-hex-encoding/README.md
+++ b/packages/util-hex-encoding/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-hex-encoding/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-hex-encoding)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-hex-encoding.svg)](https://www.npmjs.com/package/@aws-sdk/util-hex-encoding)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/util-hex-encoding/README.md
+++ b/packages/util-hex-encoding/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/util-uri-escape/README.md
+++ b/packages/util-uri-escape/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-uri-escape/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-uri-escape)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-uri-escape.svg)](https://www.npmjs.com/package/@aws-sdk/util-uri-escape)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/util-uri-escape/README.md
+++ b/packages/util-uri-escape/README.md
@@ -1,4 +1,8 @@
-# util-uri-encode
+# util-uri-escape
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-uri-escape/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-uri-escape)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-uri-escape.svg)](https://www.npmjs.com/package/@aws-sdk/util-uri-escape)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/util-uri-escape/README.md
+++ b/packages/util-uri-escape/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/util-user-agent-browser/README.md
+++ b/packages/util-user-agent-browser/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-user-agent-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-user-agent-browser.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-browser)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/util-user-agent-browser/README.md
+++ b/packages/util-user-agent-browser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-user-agent-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-user-agent-browser.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-browser)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/util-user-agent-browser/README.md
+++ b/packages/util-user-agent-browser/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/util-user-agent-node/README.md
+++ b/packages/util-user-agent-node/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-user-agent-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-user-agent-node.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-node)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/util-user-agent-node/README.md
+++ b/packages/util-user-agent-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-user-agent-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-user-agent-node.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-node)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/util-user-agent-node/README.md
+++ b/packages/util-user-agent-node/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.

--- a/packages/xml-builder/README.md
+++ b/packages/xml-builder/README.md
@@ -3,6 +3,8 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/xml-builder/beta.svg)](https://www.npmjs.com/package/@aws-sdk/xml-builder)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/xml-builder.svg)](https://www.npmjs.com/package/@aws-sdk/xml-builder)
 
+> An internal package
+
 ## Usage
 
 This package is not supposed to be used directly.

--- a/packages/xml-builder/README.md
+++ b/packages/xml-builder/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/xml-builder/beta.svg)](https://www.npmjs.com/package/@aws-sdk/xml-builder)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/xml-builder.svg)](https://www.npmjs.com/package/@aws-sdk/xml-builder)
+
+## Usage
+
+This package is not supposed to be used directly.

--- a/packages/xml-builder/README.md
+++ b/packages/xml-builder/README.md
@@ -7,4 +7,4 @@
 
 ## Usage
 
-This package is not supposed to be used directly.
+You probably shouldn't, at least directly.


### PR DESCRIPTION
*Description of changes:*

Some packages are not supposed to be consumed outside the SDK. So add notes to emphasize this. They are default values of client's dependencies. They are published because the modular nature of the service clients, but they are not fully tested/validated for any usecase outside the SDK.

/cc @Amplifiyer @seebees 

Name | external public?
-- | --
abort-controller | YES
body-checksum-browser | NO
body-checksum-node | NO
chunked-blob-reader | NO
chunked-blob-reader-native | NO
chunked-stream-reader-node | NO
client-documentation-generator | NO
config-resolver | NO
credential-provider-cognito-identity | YES
credential-provider-env | YES
credential-provider-imds | YES
credential-provider-ini | YES
credential-provider-node | YES
credential-provider-process | YES
eventstream-handler-node | NO
eventstream-marshaller | YES
eventstream-serde-browser | NO
eventstream-serde-config-resolver | NO
eventstream-serde-node | NO
eventstream-serde-universal | NO
fetch-http-handler | YES
hash-blob-browser | NO
hash-node | NO
hash-stream-node | NO
invalid-dependency | NO
is-array-buffer | NO
is-node | NO(to remove)
md5-js | NO
middleware-apply-body-checksum | YES
middleware-bucket-endpoint | YES
middleware-content-length | YES
middleware-eventstream | YES
middleware-expect-continue | YES
middleware-header-default | YES
middleware-host-header | YES
middleware-location-constraint | YES
middleware-retry | YES
middleware-sdk-api-gateway | YES
middleware-sdk-ec2 | YES
middleware-sdk-glacier | YES
middleware-sdk-machinelearning | YES
middleware-sdk-rds | YES
middleware-sdk-route53 | YES
middleware-sdk-s3 | YES
middleware-sdk-s3-control | YES
middleware-sdk-sqs | YES
middleware-sdk-transcribe-streaming | YES
middleware-serde | YES
middleware-signing | YES
middleware-ssec | YES
middleware-stack | YES
middleware-user-agent | YES
node-http-handler | YES
property-provider | NO
protocol-http | YES
querystring-builder | NO
querystring-parser | NO
region-provider | NO
s3-request-presigner | YES
service-error-classification | YES
sha256-tree-hash | NO
shared-ini-file-loader | YES
signature-v4 | YES
smithy-client | NO
types | YES
url-parser-browser | NO
url-parser-node | NO
util-base64-browser | YES
util-base64-node | YES
util-base64-universal | NO(to remove)
util-body-length-browser | NO
util-body-length-node | NO
util-buffer-from | NO
util-create-request | YES
util-format-url | YES
util-hex-encoding | YES
util-locate-window | YES
util-uri-escape | NO
util-user-agent-browser | NO
util-user-agent-node | NO
util-utf8-browser | YES
util-utf8-node | YES
util-utf8-universal | NO(ro remove)
xml-builder | NO




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
