### PR TITLE
chore: rename maxRetries to maxAttempts

### DIFF
--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -5,24 +5,24 @@ export interface RetryInputConfig {
   /**
    * The maximum number of times requests that encounter potentially transient failures should be retried
    */
-  maxRetries?: number;
+  maxAttempts?: number;
   /**
    * The strategy to retry the request. Using built-in exponential backoff strategy by default.
    */
   retryStrategy?: RetryStrategy;
 }
 export interface RetryResolvedConfig {
-  maxRetries: number;
+  maxAttempts: number;
   retryStrategy: RetryStrategy;
 }
 export function resolveRetryConfig<T>(
   input: T & RetryInputConfig
 ): T & RetryResolvedConfig {
-  const maxRetries = input.maxRetries === undefined ? 3 : input.maxRetries;
+  const maxAttempts = input.maxAttempts === undefined ? 3 : input.maxAttempts;
   return {
     ...input,
-    maxRetries,
+    maxAttempts,
     retryStrategy:
-      input.retryStrategy || new ExponentialBackOffStrategy(maxRetries)
+      input.retryStrategy || new ExponentialBackOffStrategy(maxAttempts)
   };
 }

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -3,7 +3,7 @@ import { ExponentialBackOffStrategy } from "./defaultStrategy";
 
 export interface RetryInputConfig {
   /**
-   * The maximum number of times requests that encounter potentially transient failures should be retried
+   * The maximum number of times requests that encounter retryable failures should be attempted.
    */
   maxAttempts?: number;
   /**

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -52,7 +52,7 @@ export class ExponentialBackOffStrategy implements RetryStrategy {
     while (true) {
       try {
         const { response, output } = await next(args);
-        output.$metadata.retries = attempts;
+        output.$metadata.attempts = attempts + 1;
         output.$metadata.totalRetryDelay = totalDelay;
 
         return { response, output };
@@ -75,7 +75,7 @@ export class ExponentialBackOffStrategy implements RetryStrategy {
           err.$metadata = {};
         }
 
-        err.$metadata.retries = attempts;
+        err.$metadata.attempts = attempts;
         err.$metadata.totalRetryDelay = totalDelay;
         throw err;
       }

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -35,12 +35,12 @@ export interface DelayDecider {
 
 export class ExponentialBackOffStrategy implements RetryStrategy {
   constructor(
-    public readonly maxRetries: number,
+    public readonly maxAttempts: number,
     private retryDecider: RetryDecider = defaultRetryDecider,
     private delayDecider: DelayDecider = defaultDelayDecider
   ) {}
   private shouldRetry(error: SdkError, retryAttempted: number) {
-    return retryAttempted < this.maxRetries && this.retryDecider(error);
+    return retryAttempted < this.maxAttempts && this.retryDecider(error);
   }
 
   async retry<Input extends object, Ouput extends MetadataBearer>(

--- a/packages/middleware-retry/src/index.spec.ts
+++ b/packages/middleware-retry/src/index.spec.ts
@@ -19,7 +19,7 @@ describe("retryMiddleware", () => {
     const {
       output: { $metadata }
     } = await retryHandler({ input: {}, request: new HttpRequest({}) });
-    expect($metadata.retries).toBe(0);
+    expect($metadata.attempts).toBe(1);
     expect($metadata.totalRetryDelay).toBe(0);
 
     expect(next.mock.calls.length).toBe(1);

--- a/packages/middleware-retry/src/index.spec.ts
+++ b/packages/middleware-retry/src/index.spec.ts
@@ -38,7 +38,7 @@ describe("retryMiddleware", () => {
       retryHandler({ input: {}, request: new HttpRequest({}) })
     ).rejects.toMatchObject(error);
 
-    expect(next.mock.calls.length).toBe(maxAttempts + 1);
+    expect(next.mock.calls.length).toBe(maxAttempts);
   });
 
   it("should not retry if the error is not transient", async () => {
@@ -85,8 +85,8 @@ describe("retryMiddleware", () => {
 
     expect(next.mock.calls.length).toBe(3);
     expect(delayDeciderMock.mock.calls).toEqual([
-      [DEFAULT_RETRY_DELAY_BASE, 0],
-      [THROTTLING_RETRY_DELAY_BASE, 1]
+      [DEFAULT_RETRY_DELAY_BASE, 1],
+      [THROTTLING_RETRY_DELAY_BASE, 2]
     ]);
   });
 });

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -31,7 +31,7 @@ export const getRetryPlugin = (
   options: RetryResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
-    if (options.maxRetries > 0) {
+    if (options.maxAttempts > 0) {
       clientStack.add(retryMiddleware(options), retryMiddlewareOptions);
     }
   }

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -31,7 +31,7 @@ export const getRetryPlugin = (
   options: RetryResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
-    if (options.maxAttempts > 0) {
+    if (options.maxAttempts > 1) {
       clientStack.add(retryMiddleware(options), retryMiddlewareOptions);
     }
   }

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -28,9 +28,9 @@ export interface ResponseMetadata {
   cfId?: string;
 
   /**
-   * The number of times this operation was retried.
+   * The number of times this operation was attempted.
    */
-  retries?: number;
+  attempts?: number;
 
   /**
    * The total amount of time (in milliseconds) that was spent waiting between

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -61,7 +61,7 @@ export interface RetryStrategy {
    * the maximum number of times requests that encounter potentially
    * transient failures should be retried
    */
-  maxRetries: number;
+  maxAttempts: number;
   /**
    * the retry behavior the will invoke the next handler and handle the retry accordingly.
    * This function should also update the $metadata from the response accordingly.


### PR DESCRIPTION
*Issue #, if available:*
To align with naming schema to be used in standard retry strategy (internal JS-1537) 

*Description of changes:*
* BREAKING: rename maxRetries to maxAttempts
* verified that amplify team doesn't pass maxRetries while consuming gamma versions of SDK https://github.com/aws-amplify/amplify-js/search?q=maxRetries&unscoped_q=maxRetries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
