### PR TITLE
fix(tsconfig): targeting es5 in middleware-serde

### DIFF
--- a/packages/middleware-serde/tsconfig.json
+++ b/packages/middleware-serde/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es5",
     "module": "commonjs",
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
*Issue #, if available:* #1208

*Description of changes:*
Targeting es2016 causes tsc to output arrow functions.  Those arrow functions are not supported in IE11.  Targeting es5 transpiles arrow functions so that IE11 will work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
