### PR TITLE
chore: rename ExponentialBackOff to Standard for RetryStrategy

### DIFF
--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -1,5 +1,5 @@
 import { RetryStrategy } from "@aws-sdk/types";
-import { ExponentialBackOffStrategy } from "./defaultStrategy";
+import { StandardRetryStrategy } from "./defaultStrategy";
 
 export interface RetryInputConfig {
   /**
@@ -11,10 +11,12 @@ export interface RetryInputConfig {
    */
   retryStrategy?: RetryStrategy;
 }
+
 export interface RetryResolvedConfig {
   maxAttempts: number;
   retryStrategy: RetryStrategy;
 }
+
 export function resolveRetryConfig<T>(
   input: T & RetryInputConfig
 ): T & RetryResolvedConfig {
@@ -22,7 +24,6 @@ export function resolveRetryConfig<T>(
   return {
     ...input,
     maxAttempts,
-    retryStrategy:
-      input.retryStrategy || new ExponentialBackOffStrategy(maxAttempts)
+    retryStrategy: input.retryStrategy || new StandardRetryStrategy(maxAttempts)
   };
 }

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -33,7 +33,7 @@ export interface DelayDecider {
   (delayBase: number, attempts: number): number;
 }
 
-export class ExponentialBackOffStrategy implements RetryStrategy {
+export class StandardRetryStrategy implements RetryStrategy {
   constructor(
     public readonly maxAttempts: number,
     private retryDecider: RetryDecider = defaultRetryDecider,

--- a/packages/middleware-retry/src/index.spec.ts
+++ b/packages/middleware-retry/src/index.spec.ts
@@ -5,7 +5,7 @@ import {
 import { retryMiddleware } from "./retryMiddleware";
 import { resolveRetryConfig } from "./configurations";
 import * as delayDeciderModule from "./delayDecider";
-import { ExponentialBackOffStrategy, RetryDecider } from "./defaultStrategy";
+import { StandardRetryStrategy, RetryDecider } from "./defaultStrategy";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { SdkError } from "@aws-sdk/smithy-client";
 
@@ -75,7 +75,7 @@ describe("retryMiddleware", () => {
       "defaultDelayDecider"
     );
     const retryDecider: RetryDecider = (error: SdkError) => true;
-    const strategy = new ExponentialBackOffStrategy(maxAttempts, retryDecider);
+    const strategy = new StandardRetryStrategy(maxAttempts, retryDecider);
     const retryHandler = retryMiddleware({
       maxAttempts,
       retryStrategy: strategy


### PR DESCRIPTION
*Issue #, if available:*
* To align with naming schema to be used in standard retry strategy (internal JS-1537)
* Similar to https://github.com/aws/aws-sdk-js-v3/pull/1244

*Description of changes:*
* BREAKING: rename ExponentialBackOffStrategy to StandardRetryStrategy
* verified that amplify team doesn't pass maxRetries while consuming gamma versions of SDK https://github.com/aws-amplify/amplify-js/search?q=maxRetries&unscoped_q=maxRetries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
