### PR TITLE
chore: convert second param in StandardRetryStrategy to options

### DIFF
--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -33,12 +33,26 @@ export interface DelayDecider {
   (delayBase: number, attempts: number): number;
 }
 
+/**
+ * Strategy options to be passed to StandardRetryStrategy
+ */
+export interface StandardRetryStrategyOptions {
+  retryDecider?: RetryDecider;
+  delayDecider?: DelayDecider;
+}
+
 export class StandardRetryStrategy implements RetryStrategy {
+  private retryDecider: RetryDecider;
+  private delayDecider: DelayDecider;
+
   constructor(
     public readonly maxAttempts: number,
-    private retryDecider: RetryDecider = defaultRetryDecider,
-    private delayDecider: DelayDecider = defaultDelayDecider
-  ) {}
+    options?: StandardRetryStrategyOptions
+  ) {
+    this.retryDecider = options?.retryDecider ?? defaultRetryDecider;
+    this.delayDecider = options?.delayDecider ?? defaultDelayDecider;
+  }
+
   private shouldRetry(error: SdkError, attempts: number) {
     return attempts < this.maxAttempts && this.retryDecider(error);
   }

--- a/packages/middleware-retry/src/index.spec.ts
+++ b/packages/middleware-retry/src/index.spec.ts
@@ -75,7 +75,7 @@ describe("retryMiddleware", () => {
       "defaultDelayDecider"
     );
     const retryDecider: RetryDecider = (error: SdkError) => true;
-    const strategy = new StandardRetryStrategy(maxAttempts, retryDecider);
+    const strategy = new StandardRetryStrategy(maxAttempts, { retryDecider });
     const retryHandler = retryMiddleware({
       maxAttempts,
       retryStrategy: strategy


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1155

*Description of changes:*
* convert second param in StandardRetryStrategy to options
* verified that amplify team doesn't use custom StandardRetryStrategy while consuming gamma versions of SDK https://github.com/aws-amplify/amplify-js/search?q=maxRetries&unscoped_q=maxRetries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
