### PR TITLE
chore: prettify load-rest-json-error-code-stub.ts

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/load-rest-json-error-code-stub.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/load-rest-json-error-code-stub.ts
@@ -1,20 +1,17 @@
 /**
  * Load an error code for the aws.rest-json-1.1 protocol.
  */
-const loadRestJsonErrorCode = (
-  output: __HttpResponse,
-  data: any
-): string => {
+const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string => {
   const findKey = (object: any, key: string) =>
     Object.keys(object).find(k => k.toLowerCase() === key.toLowerCase());
 
   const sanitizeErrorCode = (rawValue: string): string => {
     let cleanValue = rawValue;
-    if (cleanValue.indexOf(':') >= 0) {
-      cleanValue = cleanValue.split(':')[0];
+    if (cleanValue.indexOf(":") >= 0) {
+      cleanValue = cleanValue.split(":")[0];
     }
-    if (cleanValue.indexOf('#') >= 0) {
-      cleanValue = cleanValue.split('#')[1];
+    if (cleanValue.indexOf("#") >= 0) {
+      cleanValue = cleanValue.split("#")[1];
     }
     return cleanValue;
   };
@@ -28,9 +25,9 @@ const loadRestJsonErrorCode = (
     return sanitizeErrorCode(data.code);
   }
 
-  if (data['__type'] !== undefined) {
-    return sanitizeErrorCode(data['__type']);
+  if (data["__type"] !== undefined) {
+    return sanitizeErrorCode(data["__type"]);
   }
 
-  return '';
-}
+  return "";
+};


### PR DESCRIPTION
*Issue #, if available:*
This was noticed when dependabot updated prettier https://github.com/aws/aws-sdk-js-v3/pull/1200#pullrequestreview-428305930

*Description of changes:*
* prettify load-rest-json-error-code-stub.ts
* it's currently prettified when merging into protocols file. For example: https://github.com/aws/aws-sdk-js-v3/blob/cd4813013063fc015678bfb1e71d7c1bbc26e2ab/clients/client-accessanalyzer/protocols/Aws_restJson1.ts#L3458-L3487

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
