### PR TITLE
feat: add retry quotas to StandardRetryStrategy

### DIFF
--- a/packages/middleware-retry/src/constants.ts
+++ b/packages/middleware-retry/src/constants.ts
@@ -15,3 +15,25 @@ export const MAXIMUM_RETRY_DELAY = 20 * 1000;
  * encountered.
  */
 export const THROTTLING_RETRY_DELAY_BASE = 500;
+
+/**
+ * Initial number of retry tokens in Retry Quota
+ */
+export const INITIAL_RETRY_TOKENS = 500;
+
+/**
+ * The total amount of retry tokens to be decremented from retry token balance.
+ */
+export const RETRY_COST = 5;
+
+/**
+ * The total amount of retry tokens to be decremented from retry token balance
+ * when a throttling error is encountered.
+ */
+export const TIMEOUT_RETRY_COST = 10;
+
+/**
+ * The total amount of retry token to be incremented from retry token balance
+ * if an SDK operation invocation succeeds without requiring a retry request.
+ */
+export const NO_RETRY_INCREMENT = 1;

--- a/packages/middleware-retry/src/defaultRetryQuota.spec.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.spec.ts
@@ -1,0 +1,147 @@
+import { defaultRetryQuota } from "./defaultRetryQuota";
+import { SdkError } from "@aws-sdk/smithy-client";
+import {
+  INITIAL_RETRY_TOKENS,
+  TIMEOUT_RETRY_COST,
+  RETRY_COST,
+  NO_RETRY_INCREMENT
+} from "./constants";
+
+describe("defaultRetryQuota", () => {
+  const getMockError = () => new Error() as SdkError;
+  const getMockTimeoutError = () =>
+    Object.assign(new Error(), {
+      name: "TimeoutError"
+    }) as SdkError;
+
+  const getDrainedRetryQuota = (targetCapacity: number, error: SdkError) => {
+    const retryQuota = defaultRetryQuota();
+    let availableCapacity = INITIAL_RETRY_TOKENS;
+    while (availableCapacity >= targetCapacity) {
+      retryQuota.retrieveRetryToken(error);
+      availableCapacity -= targetCapacity;
+    }
+    return retryQuota;
+  };
+
+  describe("hasRetryTokens", () => {
+    describe("returns true if capacity is available", () => {
+      it("when it's TimeoutError", () => {
+        const timeoutError = getMockTimeoutError();
+        expect(defaultRetryQuota().hasRetryTokens(timeoutError)).toBe(true);
+      });
+
+      it("when it's not TimeoutError", () => {
+        expect(defaultRetryQuota().hasRetryTokens(getMockError())).toBe(true);
+      });
+    });
+
+    describe("returns false if capacity is not available", () => {
+      it("when it's TimeoutError", () => {
+        const timeoutError = getMockTimeoutError();
+        const retryQuota = getDrainedRetryQuota(
+          TIMEOUT_RETRY_COST,
+          timeoutError
+        );
+        expect(retryQuota.hasRetryTokens(timeoutError)).toBe(false);
+      });
+
+      it("when it's not TimeoutError", () => {
+        const error = getMockError();
+        const retryQuota = getDrainedRetryQuota(RETRY_COST, error);
+        expect(retryQuota.hasRetryTokens(error)).toBe(false);
+      });
+    });
+  });
+
+  describe("retrieveRetryToken", () => {
+    describe("returns retry tokens amount if available", () => {
+      it("when it's TimeoutError", () => {
+        const timeoutError = getMockTimeoutError();
+        expect(defaultRetryQuota().retrieveRetryToken(timeoutError)).toBe(
+          TIMEOUT_RETRY_COST
+        );
+      });
+
+      it("when it's not TimeoutError", () => {
+        expect(defaultRetryQuota().retrieveRetryToken(getMockError())).toBe(
+          RETRY_COST
+        );
+      });
+    });
+
+    describe("throws error if retry tokens not available", () => {
+      it("when it's TimeoutError", () => {
+        const timeoutError = getMockTimeoutError();
+        const retryQuota = getDrainedRetryQuota(
+          TIMEOUT_RETRY_COST,
+          timeoutError
+        );
+        expect(() => {
+          retryQuota.retrieveRetryToken(timeoutError);
+        }).toThrowError(new Error("No retry token available"));
+      });
+
+      it("when it's not TimeoutError", () => {
+        const error = getMockError();
+        const retryQuota = getDrainedRetryQuota(RETRY_COST, error);
+        expect(() => {
+          retryQuota.retrieveRetryToken(error);
+        }).toThrowError(new Error("No retry token available"));
+      });
+    });
+  });
+
+  describe("releaseRetryToken", () => {
+    it("adds capacityReleaseAmount if passed", () => {
+      const error = getMockError();
+      const retryQuota = getDrainedRetryQuota(RETRY_COST, error);
+
+      // Ensure that retry tokens are not available.
+      expect(retryQuota.hasRetryTokens(error)).toBe(false);
+
+      // Release RETRY_COST tokens.
+      retryQuota.releaseRetryToken(RETRY_COST);
+      expect(retryQuota.hasRetryTokens(error)).toBe(true);
+      expect(retryQuota.retrieveRetryToken(error)).toBe(RETRY_COST);
+      expect(retryQuota.hasRetryTokens(error)).toBe(false);
+    });
+
+    it("adds NO_RETRY_INCREMENT if capacityReleaseAmount not passed", () => {
+      const error = getMockError();
+      const retryQuota = getDrainedRetryQuota(RETRY_COST, error);
+
+      // retry tokens will not be available till NO_RETRY_INCREMENT is added
+      // till it's equal to RETRY_COST - (INITIAL_RETRY_TOKENS % RETRY_COST)
+      let tokensReleased = 0;
+      const tokensToBeReleased =
+        RETRY_COST - (INITIAL_RETRY_TOKENS % RETRY_COST);
+      while (tokensReleased < tokensToBeReleased) {
+        expect(retryQuota.hasRetryTokens(error)).toBe(false);
+        retryQuota.releaseRetryToken();
+        tokensReleased += NO_RETRY_INCREMENT;
+      }
+      expect(retryQuota.hasRetryTokens(error)).toBe(true);
+    });
+
+    it("ensures availableCapacity is maxed at INITIAL_RETRY_TOKENS", () => {
+      const error = getMockError();
+      const retryQuota = defaultRetryQuota();
+
+      // release 100 tokens.
+      [...Array(100).keys()].forEach(key => {
+        retryQuota.releaseRetryToken();
+      });
+
+      // availableCapacity is still maxed at INITIAL_RETRY_TOKENS
+      // hasRetryTokens would be true only till INITIAL_RETRY_TOKENS/RETRY_COST times
+      [...Array(Math.floor(INITIAL_RETRY_TOKENS / RETRY_COST)).keys()].forEach(
+        key => {
+          expect(retryQuota.hasRetryTokens(error)).toBe(true);
+          retryQuota.retrieveRetryToken(error);
+        }
+      );
+      expect(retryQuota.hasRetryTokens(error)).toBe(false);
+    });
+  });
+});

--- a/packages/middleware-retry/src/defaultRetryQuota.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.ts
@@ -1,0 +1,40 @@
+import { RetryQuota } from "./defaultStrategy";
+import { SdkError } from "@aws-sdk/smithy-client";
+import {
+  INITIAL_RETRY_TOKENS,
+  RETRY_COST,
+  TIMEOUT_RETRY_COST,
+  NO_RETRY_INCREMENT
+} from "./constants";
+
+export const defaultRetryQuota = (): RetryQuota => {
+  const MAX_CAPACITY = INITIAL_RETRY_TOKENS;
+  let availableCapacity = INITIAL_RETRY_TOKENS;
+
+  const getCapacityAmount = (error: SdkError) =>
+    error.name === "TimeoutError" ? TIMEOUT_RETRY_COST : RETRY_COST;
+
+  const hasRetryTokens = (error: SdkError) =>
+    getCapacityAmount(error) <= availableCapacity;
+
+  const retrieveRetryToken = (error: SdkError) => {
+    if (!hasRetryTokens(error)) {
+      // retryStrategy should stop retrying, and return last error
+      throw new Error("No retry token available");
+    }
+    const capacityAmount = getCapacityAmount(error);
+    availableCapacity -= capacityAmount;
+    return capacityAmount;
+  };
+
+  const releaseRetryToken = (capacityReleaseAmount?: number) => {
+    availableCapacity += capacityReleaseAmount ?? NO_RETRY_INCREMENT;
+    availableCapacity = Math.min(availableCapacity, MAX_CAPACITY);
+  };
+
+  return Object.freeze({
+    hasRetryTokens,
+    retrieveRetryToken,
+    releaseRetryToken
+  });
+};

--- a/packages/middleware-retry/src/defaultRetryQuota.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.ts
@@ -7,7 +7,7 @@ import {
   NO_RETRY_INCREMENT
 } from "./constants";
 
-export const defaultRetryQuota = (): RetryQuota => {
+export const getDefaultRetryQuota = (): RetryQuota => {
   const MAX_CAPACITY = INITIAL_RETRY_TOKENS;
   let availableCapacity = INITIAL_RETRY_TOKENS;
 
@@ -17,7 +17,7 @@ export const defaultRetryQuota = (): RetryQuota => {
   const hasRetryTokens = (error: SdkError) =>
     getCapacityAmount(error) <= availableCapacity;
 
-  const retrieveRetryToken = (error: SdkError) => {
+  const retrieveRetryTokens = (error: SdkError) => {
     if (!hasRetryTokens(error)) {
       // retryStrategy should stop retrying, and return last error
       throw new Error("No retry token available");
@@ -27,14 +27,14 @@ export const defaultRetryQuota = (): RetryQuota => {
     return capacityAmount;
   };
 
-  const releaseRetryToken = (capacityReleaseAmount?: number) => {
+  const releaseRetryTokens = (capacityReleaseAmount?: number) => {
     availableCapacity += capacityReleaseAmount ?? NO_RETRY_INCREMENT;
     availableCapacity = Math.min(availableCapacity, MAX_CAPACITY);
   };
 
   return Object.freeze({
     hasRetryTokens,
-    retrieveRetryToken,
-    releaseRetryToken
+    retrieveRetryTokens,
+    releaseRetryTokens
   });
 };

--- a/packages/middleware-retry/src/defaultRetryQuota.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.ts
@@ -1,15 +1,16 @@
 import { RetryQuota } from "./defaultStrategy";
 import { SdkError } from "@aws-sdk/smithy-client";
 import {
-  INITIAL_RETRY_TOKENS,
   RETRY_COST,
   TIMEOUT_RETRY_COST,
   NO_RETRY_INCREMENT
 } from "./constants";
 
-export const getDefaultRetryQuota = (): RetryQuota => {
-  const MAX_CAPACITY = INITIAL_RETRY_TOKENS;
-  let availableCapacity = INITIAL_RETRY_TOKENS;
+export const getDefaultRetryQuota = (
+  initialRetryTokens: number
+): RetryQuota => {
+  const MAX_CAPACITY = initialRetryTokens;
+  let availableCapacity = initialRetryTokens;
 
   const getCapacityAmount = (error: SdkError) =>
     error.name === "TimeoutError" ? TIMEOUT_RETRY_COST : RETRY_COST;

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_RETRY_DELAY_BASE,
-  THROTTLING_RETRY_DELAY_BASE
+  THROTTLING_RETRY_DELAY_BASE,
+  INITIAL_RETRY_TOKENS
 } from "./constants";
 import { isThrottlingError } from "@aws-sdk/service-error-classification";
 import { defaultDelayDecider } from "./delayDecider";
@@ -154,12 +155,16 @@ describe("defaultStrategy", () => {
   describe("retryQuota init", () => {
     it("sets getDefaultRetryQuota if options is undefined", () => {
       const retryStrategy = new StandardRetryStrategy(maxAttempts);
-      expect(retryStrategy["retryQuota"]).toBe(getDefaultRetryQuota());
+      expect(retryStrategy["retryQuota"]).toBe(
+        getDefaultRetryQuota(INITIAL_RETRY_TOKENS)
+      );
     });
 
     it("sets getDefaultRetryQuota if options.delayDecider undefined", () => {
       const retryStrategy = new StandardRetryStrategy(maxAttempts, {});
-      expect(retryStrategy["retryQuota"]).toBe(getDefaultRetryQuota());
+      expect(retryStrategy["retryQuota"]).toBe(
+        getDefaultRetryQuota(INITIAL_RETRY_TOKENS)
+      );
     });
 
     it("sets options.retryQuota if defined", () => {
@@ -253,19 +258,19 @@ describe("defaultStrategy", () => {
   describe("retryQuota", () => {
     describe("hasRetryTokens", () => {
       it("not called on successful operation", async () => {
-        const { hasRetryTokens } = getDefaultRetryQuota();
+        const { hasRetryTokens } = getDefaultRetryQuota(INITIAL_RETRY_TOKENS);
         await mockSuccessfulOperation(maxAttempts);
         expect(hasRetryTokens).not.toHaveBeenCalled();
       });
 
       it("called once in case of single failure", async () => {
-        const { hasRetryTokens } = getDefaultRetryQuota();
+        const { hasRetryTokens } = getDefaultRetryQuota(INITIAL_RETRY_TOKENS);
         await mockSuccessAfterOneFail(maxAttempts);
         expect(hasRetryTokens).toHaveBeenCalledTimes(1);
       });
 
       it("called once on each retry request", async () => {
-        const { hasRetryTokens } = getDefaultRetryQuota();
+        const { hasRetryTokens } = getDefaultRetryQuota(INITIAL_RETRY_TOKENS);
         await mockFailedOperation(maxAttempts);
         expect(hasRetryTokens).toHaveBeenCalledTimes(maxAttempts - 1);
       });
@@ -273,7 +278,9 @@ describe("defaultStrategy", () => {
 
     describe("releaseRetryTokens", () => {
       it("called once without param on successful operation", async () => {
-        const { releaseRetryTokens } = getDefaultRetryQuota();
+        const { releaseRetryTokens } = getDefaultRetryQuota(
+          INITIAL_RETRY_TOKENS
+        );
         await mockSuccessfulOperation(maxAttempts);
         expect(releaseRetryTokens).toHaveBeenCalledTimes(1);
         expect(releaseRetryTokens).toHaveBeenCalledWith(undefined);
@@ -284,7 +291,7 @@ describe("defaultStrategy", () => {
         const {
           releaseRetryTokens,
           retrieveRetryTokens
-        } = getDefaultRetryQuota();
+        } = getDefaultRetryQuota(INITIAL_RETRY_TOKENS);
         (retrieveRetryTokens as jest.Mock).mockReturnValueOnce(retryTokens);
 
         await mockSuccessAfterOneFail(maxAttempts);
@@ -299,7 +306,7 @@ describe("defaultStrategy", () => {
         const {
           releaseRetryTokens,
           retrieveRetryTokens
-        } = getDefaultRetryQuota();
+        } = getDefaultRetryQuota(INITIAL_RETRY_TOKENS);
 
         (retrieveRetryTokens as jest.Mock)
           .mockReturnValueOnce(retryTokensFirst)
@@ -311,7 +318,9 @@ describe("defaultStrategy", () => {
       });
 
       it("not called on unsuccessful operation", async () => {
-        const { releaseRetryTokens } = getDefaultRetryQuota();
+        const { releaseRetryTokens } = getDefaultRetryQuota(
+          INITIAL_RETRY_TOKENS
+        );
         await mockFailedOperation(maxAttempts);
         expect(releaseRetryTokens).not.toHaveBeenCalled();
       });
@@ -319,19 +328,25 @@ describe("defaultStrategy", () => {
 
     describe("retrieveRetryTokens", () => {
       it("not called on successful operation", async () => {
-        const { retrieveRetryTokens } = getDefaultRetryQuota();
+        const { retrieveRetryTokens } = getDefaultRetryQuota(
+          INITIAL_RETRY_TOKENS
+        );
         await mockSuccessfulOperation(maxAttempts);
         expect(retrieveRetryTokens).not.toHaveBeenCalled();
       });
 
       it("called once in case of single failure", async () => {
-        const { retrieveRetryTokens } = getDefaultRetryQuota();
+        const { retrieveRetryTokens } = getDefaultRetryQuota(
+          INITIAL_RETRY_TOKENS
+        );
         await mockSuccessAfterOneFail(maxAttempts);
         expect(retrieveRetryTokens).toHaveBeenCalledTimes(1);
       });
 
       it("called once on each retry request", async () => {
-        const { retrieveRetryTokens } = getDefaultRetryQuota();
+        const { retrieveRetryTokens } = getDefaultRetryQuota(
+          INITIAL_RETRY_TOKENS
+        );
         await mockFailedOperation(maxAttempts);
         expect(retrieveRetryTokens).toHaveBeenCalledTimes(maxAttempts - 1);
       });
@@ -372,7 +387,7 @@ describe("defaultStrategy", () => {
         hasRetryTokens,
         retrieveRetryTokens,
         releaseRetryTokens
-      } = getDefaultRetryQuota();
+      } = getDefaultRetryQuota(INITIAL_RETRY_TOKENS);
       (hasRetryTokens as jest.Mock).mockReturnValueOnce(false);
 
       const mockError = new Error();

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -5,7 +5,7 @@ import {
 import { isThrottlingError } from "@aws-sdk/service-error-classification";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
-import { StandardRetryStrategy } from "./defaultStrategy";
+import { StandardRetryStrategy, RetryQuota } from "./defaultStrategy";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 
 jest.mock("@aws-sdk/service-error-classification", () => ({
@@ -143,6 +143,26 @@ describe("defaultStrategy", () => {
         delayDecider
       });
       expect(retryStrategy["delayDecider"]).toBe(delayDecider);
+    });
+  });
+
+  describe("retryQuota", () => {
+    it("sets getDefaultRetryQuota if options is undefined", () => {
+      const retryStrategy = new StandardRetryStrategy(maxAttempts);
+      expect(retryStrategy["retryQuota"]).toBe(getDefaultRetryQuota());
+    });
+
+    it("sets getDefaultRetryQuota if options.delayDecider undefined", () => {
+      const retryStrategy = new StandardRetryStrategy(maxAttempts, {});
+      expect(retryStrategy["retryQuota"]).toBe(getDefaultRetryQuota());
+    });
+
+    it("sets options.retryQuota if defined", () => {
+      const retryQuota = {} as RetryQuota;
+      const retryStrategy = new StandardRetryStrategy(maxAttempts, {
+        retryQuota
+      });
+      expect(retryStrategy["retryQuota"]).toBe(retryQuota);
     });
   });
 

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -66,7 +66,7 @@ export interface StandardRetryStrategyOptions {
 export class StandardRetryStrategy implements RetryStrategy {
   private retryDecider: RetryDecider;
   private delayDecider: DelayDecider;
-  private retryQuota?: RetryQuota;
+  // private retryQuota?: RetryQuota;
 
   constructor(
     public readonly maxAttempts: number,
@@ -74,7 +74,7 @@ export class StandardRetryStrategy implements RetryStrategy {
   ) {
     this.retryDecider = options?.retryDecider ?? defaultRetryDecider;
     this.delayDecider = options?.delayDecider ?? defaultDelayDecider;
-    this.retryQuota = options?.retryQuota;
+    // this.retryQuota = options?.retryQuota;
   }
 
   private shouldRetry(error: SdkError, attempts: number) {

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_RETRY_DELAY_BASE,
-  THROTTLING_RETRY_DELAY_BASE
+  THROTTLING_RETRY_DELAY_BASE,
+  INITIAL_RETRY_TOKENS
 } from "./constants";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
@@ -75,7 +76,8 @@ export class StandardRetryStrategy implements RetryStrategy {
   ) {
     this.retryDecider = options?.retryDecider ?? defaultRetryDecider;
     this.delayDecider = options?.delayDecider ?? defaultDelayDecider;
-    this.retryQuota = options?.retryQuota ?? getDefaultRetryQuota();
+    this.retryQuota =
+      options?.retryQuota ?? getDefaultRetryQuota(INITIAL_RETRY_TOKENS);
   }
 
   private shouldRetry(error: SdkError, attempts: number) {


### PR DESCRIPTION
*Issue #, if available:*
Internal tracking issue JS-1812

*Description of changes:*
add retry quotas to StandardRetryStrategy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
