### PR TITLE
chore(property-provider): refactor memoize to use arrow functions

### DIFF
--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -371,7 +371,7 @@ describe("defaultProvider", () => {
 
     expect(await provider()).toEqual(creds);
 
-    expect(provider()).toBe(provider());
+    expect(provider()).toStrictEqual(provider());
 
     expect(await provider()).toEqual(creds);
     expect((fromEnv() as any).mock.calls.length).toBe(1);

--- a/packages/property-provider/src/memoize.spec.ts
+++ b/packages/property-provider/src/memoize.spec.ts
@@ -49,8 +49,6 @@ describe("memoize", () => {
 
     describe("should not reinvoke the underlying provider while isExpired returns `false`", () => {
       const isExpiredFalseTest = async (requiresRefresh?: any) => {
-        expect.assertions(repeatTimes + 2);
-
         isExpired.mockReturnValue(false);
         const memoized = memoize(provider, isExpired, requiresRefresh);
 
@@ -59,10 +57,13 @@ describe("memoize", () => {
         }
 
         expect(isExpired).toHaveBeenCalledTimes(repeatTimes);
+        if (requiresRefresh) {
+          expect(requiresRefresh).toHaveBeenCalledTimes(repeatTimes);
+        }
         expect(provider).toHaveBeenCalledTimes(1);
       };
 
-      it("when requiresRefresh is not passed", () => {
+      it("when requiresRefresh is not passed", async () => {
         return isExpiredFalseTest();
       });
 
@@ -74,8 +75,6 @@ describe("memoize", () => {
 
     describe("should reinvoke the underlying provider when isExpired returns `true`", () => {
       const isExpiredTrueTest = async (requiresRefresh?: any) => {
-        expect.assertions(repeatTimes + 2);
-
         const memoized = memoize(provider, isExpired, requiresRefresh);
 
         for (const index in [...Array(repeatTimes).keys()]) {
@@ -83,6 +82,9 @@ describe("memoize", () => {
         }
 
         expect(isExpired).toHaveBeenCalledTimes(repeatTimes);
+        if (requiresRefresh) {
+          expect(requiresRefresh).toHaveBeenCalledTimes(repeatTimes);
+        }
         expect(provider).toHaveBeenCalledTimes(repeatTimes + 1);
       };
 
@@ -98,8 +100,6 @@ describe("memoize", () => {
 
     describe("should return the same promise for invocations 2-infinity if `requiresRefresh` returns `false`", () => {
       const requiresRefreshFalseTest = async () => {
-        expect.assertions(repeatTimes * 2 + 1);
-
         const memoized = memoize(provider, isExpired, requiresRefresh);
         const result = memoized();
         expect(await result).toBe(mockReturn);
@@ -108,6 +108,9 @@ describe("memoize", () => {
           expect(memoized()).toStrictEqual(result);
           expect(provider).toHaveBeenCalledTimes(1);
         }
+
+        expect(requiresRefresh).toHaveBeenCalledTimes(1);
+        expect(isExpired).not.toHaveBeenCalled();
       };
 
       it("when isExpired returns true", () => {

--- a/packages/property-provider/src/memoize.spec.ts
+++ b/packages/property-provider/src/memoize.spec.ts
@@ -1,79 +1,123 @@
 import { memoize } from "./memoize";
-import { Provider } from "@aws-sdk/types";
 
 describe("memoize", () => {
+  let provider: jest.Mock;
+  const mockReturn = "foo";
+  const repeatTimes = 10;
+
+  beforeEach(() => {
+    provider = jest.fn().mockResolvedValue(mockReturn);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("static memoization", () => {
     it("should cache the resolved provider", async () => {
-      const provider = jest.fn().mockResolvedValue("foo");
+      expect.assertions(repeatTimes * 2);
+
       const memoized = memoize(provider);
 
-      expect(await memoized()).toEqual("foo");
-      expect(provider.mock.calls.length).toBe(1);
-      expect(await memoized()).toEqual("foo");
-      expect(provider.mock.calls.length).toBe(1);
+      for (const index in [...Array(repeatTimes).keys()]) {
+        expect(await memoized()).toStrictEqual(mockReturn);
+        expect(provider).toHaveBeenCalledTimes(1);
+      }
     });
 
     it("should always return the same promise", () => {
-      const provider = jest.fn().mockResolvedValue("foo");
+      expect.assertions(repeatTimes * 2);
+
       const memoized = memoize(provider);
       const result = memoized();
 
-      expect(memoized()).toBe(result);
+      for (const index in [...Array(repeatTimes).keys()]) {
+        expect(memoized()).toStrictEqual(result);
+        expect(provider).toHaveBeenCalledTimes(1);
+      }
     });
   });
 
   describe("refreshing memoization", () => {
-    it("should not reinvoke the underlying provider while isExpired returns `false`", async () => {
-      const provider = jest.fn().mockResolvedValue("foo");
-      const isExpired = jest.fn().mockReturnValue(false);
-      const memoized = memoize(provider, isExpired);
+    let isExpired: jest.Mock;
+    let requiresRefresh: jest.Mock;
 
-      const checkCount = 10;
-      for (let i = 0; i < checkCount; i++) {
-        expect(await memoized()).toBe("foo");
-      }
-
-      expect(isExpired.mock.calls.length).toBe(checkCount);
-      expect(provider.mock.calls.length).toBe(1);
+    beforeEach(() => {
+      isExpired = jest.fn().mockReturnValue(true);
+      requiresRefresh = jest.fn().mockReturnValue(false);
     });
 
-    it("should reinvoke the underlying provider when isExpired returns `true`", async () => {
-      const provider = jest.fn().mockResolvedValue("foo");
-      const isExpired = jest.fn().mockReturnValue(false);
-      const memoized = memoize(provider, isExpired);
+    describe("should not reinvoke the underlying provider while isExpired returns `false`", () => {
+      const isExpiredFalseTest = async (requiresRefresh?: any) => {
+        expect.assertions(repeatTimes + 2);
 
-      const checkCount = 10;
-      for (let i = 0; i < checkCount; i++) {
-        expect(await memoized()).toBe("foo");
-      }
+        isExpired.mockReturnValue(false);
+        const memoized = memoize(provider, isExpired, requiresRefresh);
 
-      expect(isExpired.mock.calls.length).toBe(checkCount);
-      expect(provider.mock.calls.length).toBe(1);
+        for (const index in [...Array(repeatTimes).keys()]) {
+          expect(await memoized()).toEqual(mockReturn);
+        }
 
-      isExpired.mockReturnValueOnce(true);
-      for (let i = 0; i < checkCount; i++) {
-        expect(await memoized()).toBe("foo");
-      }
+        expect(isExpired).toHaveBeenCalledTimes(repeatTimes);
+        expect(provider).toHaveBeenCalledTimes(1);
+      };
 
-      expect(isExpired.mock.calls.length).toBe(checkCount * 2);
-      expect(provider.mock.calls.length).toBe(2);
+      it("when requiresRefresh is not passed", () => {
+        return isExpiredFalseTest();
+      });
+
+      it("when requiresRefresh returns true", () => {
+        requiresRefresh.mockReturnValue(true);
+        return isExpiredFalseTest(requiresRefresh);
+      });
     });
 
-    it("should return the same promise for invocations 2-infinity if `requiresRefresh` returns `false`", async () => {
-      const provider = jest.fn().mockResolvedValue("foo");
-      const isExpired = jest.fn().mockReturnValue(true);
-      const requiresRefresh = jest.fn().mockReturnValue(false);
+    describe("should reinvoke the underlying provider when isExpired returns `true`", () => {
+      const isExpiredTrueTest = async (requiresRefresh?: any) => {
+        expect.assertions(repeatTimes + 2);
 
-      const memoized = memoize(provider, isExpired, requiresRefresh);
-      expect(await memoized()).toBe("foo");
-      const set = new Set<Promise<string>>();
+        const memoized = memoize(provider, isExpired, requiresRefresh);
 
-      const checkCount = 10;
-      for (let i = 0; i < checkCount; i++) {
-        set.add(memoized());
-      }
+        for (const index in [...Array(repeatTimes).keys()]) {
+          expect(await memoized()).toEqual(mockReturn);
+        }
 
-      expect(set.size).toBe(1);
+        expect(isExpired).toHaveBeenCalledTimes(repeatTimes);
+        expect(provider).toHaveBeenCalledTimes(repeatTimes + 1);
+      };
+
+      it("when requiresRefresh is not passed", () => {
+        return isExpiredTrueTest();
+      });
+
+      it("when requiresRefresh returns true", () => {
+        requiresRefresh.mockReturnValue(true);
+        return isExpiredTrueTest(requiresRefresh);
+      });
+    });
+
+    describe("should return the same promise for invocations 2-infinity if `requiresRefresh` returns `false`", () => {
+      const requiresRefreshFalseTest = async () => {
+        expect.assertions(repeatTimes * 2 + 1);
+
+        const memoized = memoize(provider, isExpired, requiresRefresh);
+        const result = memoized();
+        expect(await result).toBe(mockReturn);
+
+        for (const index in [...Array(repeatTimes).keys()]) {
+          expect(memoized()).toStrictEqual(result);
+          expect(provider).toHaveBeenCalledTimes(1);
+        }
+      };
+
+      it("when isExpired returns true", () => {
+        return requiresRefreshFalseTest();
+      });
+
+      it("when isExpired returns false", () => {
+        isExpired.mockReturnValue(false);
+        return requiresRefreshFalseTest();
+      });
     });
   });
 });

--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -1,48 +1,50 @@
 import { Provider } from "@aws-sdk/types";
 
-/**
- *
- * Decorates a provider function with either static memoization.
- *
- * To create a statically memoized provider, supply a provider as the only
- * argument to this function. The provider will be invoked once, and all
- * invocations of the provider returned by `memoize` will return the same
- * promise object.
- *
- * @param provider The provider whose result should be cached indefinitely.
- */
-export function memoize<T>(provider: Provider<T>): Provider<T>;
+interface MemoizeOverload {
+  /**
+   *
+   * Decorates a provider function with either static memoization.
+   *
+   * To create a statically memoized provider, supply a provider as the only
+   * argument to this function. The provider will be invoked once, and all
+   * invocations of the provider returned by `memoize` will return the same
+   * promise object.
+   *
+   * @param provider The provider whose result should be cached indefinitely.
+   */
+  <T>(provider: Provider<T>): Provider<T>;
 
-/**
- * Decorates a provider function with refreshing memoization.
- *
- * @param provider          The provider whose result should be cached.
- * @param isExpired         A function that will evaluate the resolved value and
- *                          determine if it is expired. For example, when
- *                          memoizing AWS credential providers, this function
- *                          should return `true` when the credential's
- *                          expiration is in the past (or very near future) and
- *                          `false` otherwise.
- * @param requiresRefresh   A function that will evaluate the resolved value and
- *                          determine if it represents static value or one that
- *                          will eventually need to be refreshed. For example,
- *                          AWS credentials that have no defined expiration will
- *                          never need to be refreshed, so this function would
- *                          return `true` if the credentials resolved by the
- *                          underlying provider had an expiration and `false`
- *                          otherwise.
- */
-export function memoize<T>(
-  provider: Provider<T>,
-  isExpired: (resolved: T) => boolean,
-  requiresRefresh?: (resolved: T) => boolean
-): Provider<T>;
+  /**
+   * Decorates a provider function with refreshing memoization.
+   *
+   * @param provider          The provider whose result should be cached.
+   * @param isExpired         A function that will evaluate the resolved value and
+   *                          determine if it is expired. For example, when
+   *                          memoizing AWS credential providers, this function
+   *                          should return `true` when the credential's
+   *                          expiration is in the past (or very near future) and
+   *                          `false` otherwise.
+   * @param requiresRefresh   A function that will evaluate the resolved value and
+   *                          determine if it represents static value or one that
+   *                          will eventually need to be refreshed. For example,
+   *                          AWS credentials that have no defined expiration will
+   *                          never need to be refreshed, so this function would
+   *                          return `true` if the credentials resolved by the
+   *                          underlying provider had an expiration and `false`
+   *                          otherwise.
+   */
+  <T>(
+    provider: Provider<T>,
+    isExpired: (resolved: T) => boolean,
+    requiresRefresh?: (resolved: T) => boolean
+  ): Provider<T>;
+}
 
-export function memoize<T>(
+export const memoize: MemoizeOverload = <T>(
   provider: Provider<T>,
   isExpired?: (resolved: T) => boolean,
   requiresRefresh?: (resolved: T) => boolean
-): Provider<T> {
+): Provider<T> => {
   if (isExpired === undefined) {
     // This is a static memoization; no need to incorporate refreshing
     const result = provider();
@@ -52,22 +54,19 @@ export function memoize<T>(
   let result = provider();
   let isConstant: boolean = false;
 
-  return () => {
+  return async () => {
     if (isConstant) {
       return result;
     }
 
-    return result.then(resolved => {
-      if (requiresRefresh && !requiresRefresh(resolved)) {
-        isConstant = true;
-        return resolved;
-      }
-
-      if (isExpired(resolved)) {
-        return (result = provider());
-      }
-
+    const resolved = await result;
+    if (requiresRefresh && !requiresRefresh(resolved)) {
+      isConstant = true;
       return resolved;
-    });
+    }
+    if (isExpired(resolved)) {
+      return (result = provider());
+    }
+    return resolved;
   };
-}
+};


### PR DESCRIPTION
*Issue #, if available:*
Refactored while going through region-provider in https://github.com/aws/aws-sdk-js-v3/pull/1280

*Description of changes:*
refactor memoize to use arrow functions
* [TypeScript function overloads](https://dev.to/krzysztofzuraw/typescript-function-overloads-1iff)
* [expect .toStrictEqual(value) in Jest](https://jestjs.io/docs/en/expect#tostrictequalvalue)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
