### PR TITLE
fix: overwrite clients in protocol clients

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -24,12 +24,13 @@ const getOverwritablePredicate = packageName => pathName => {
   return (
     pathName
       .toLowerCase()
-      .indexOf(
+      .startsWith(
         packageName
           .toLowerCase()
           .replace("@aws-sdk/client-", "")
+          .replace("@aws-sdk/aws-", "")
           .replace(/-/g, "")
-      ) >= 0 || overwritablePathnames.indexOf(pathName) >= 0
+      ) || overwritablePathnames.indexOf(pathName) >= 0
   );
 };
 


### PR DESCRIPTION
*Issue #, if available:*
Came across this bug while working on codegen to introduce retry-config-provider from  https://github.com/aws/aws-sdk-js-v3/pull/1282 in runtimeConfig

*Description of changes:*
overwrite clients in protocol clients

The clients in protocol clients are not overwritten because they are prefixed with `aws-` and not `client-`

<details>
<summary>Code</summary>

```js
const isPathnameClientInPackageName = (pathName, packageName) =>
  pathName
    .toLowerCase()
    .indexOf(
      packageName
        .toLowerCase()
        .replace("@aws-sdk/client-", "")
        .replace(/-/g, "")
    ) >= 0;

// logs true
console.log(isPathnameClientInPackageName("S3.ts", "@aws-sdk/client-s3"));
console.log(isPathnameClientInPackageName("S3Client.ts", "@aws-sdk/client-s3"));

// logs false
console.log(
  isPathnameClientInPackageName("JsonProtocol.ts", "@aws-sdk/aws-json")
);
console.log(
  isPathnameClientInPackageName("JsonProtocolClient.ts", "@aws-sdk/aws-json")
);
```

</details>

It's fixed by checking for `aws-` prefix.

<details>
<summary>Code</summary>

```
const isPathnameClientInPackageName = (pathName, packageName) =>
  pathName
    .toLowerCase()
    .startsWith(
      packageName
        .toLowerCase()
        .replace("@aws-sdk/client-", "")
        .replace("@aws-sdk/aws-", "")
        .replace(/-/g, "")
    );

// logs true
console.log(isPathnameClientInPackageName("S3.ts", "@aws-sdk/client-s3"));
console.log(isPathnameClientInPackageName("S3Client.ts", "@aws-sdk/client-s3"));

// logs true
console.log(
  isPathnameClientInPackageName("JsonProtocol.ts", "@aws-sdk/aws-json")
);
console.log(
  isPathnameClientInPackageName("JsonProtocolClient.ts", "@aws-sdk/aws-json")
);
```

</details>

This PR also tests that pathName starts with the string (so that protocol names like `"json"` doesn't set extensions to true)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
