### PR TITLE
feat: read maxAttempts value from retry-config

### DIFF
--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -55,7 +55,9 @@ describe("defaultStrategy", () => {
       output: { $metadata: {} }
     });
 
-    const retryStrategy = new StandardRetryStrategy(maxAttempts);
+    const retryStrategy = new StandardRetryStrategy(() =>
+      Promise.resolve(maxAttempts.toString())
+    );
     return retryStrategy.retry(next, { request: { headers: {} } } as any);
   };
 
@@ -66,7 +68,9 @@ describe("defaultStrategy", () => {
     const mockError = options?.mockError ?? new Error("mockError");
     next = jest.fn().mockRejectedValue(mockError);
 
-    const retryStrategy = new StandardRetryStrategy(maxAttempts);
+    const retryStrategy = new StandardRetryStrategy(() =>
+      Promise.resolve(maxAttempts.toString())
+    );
     try {
       await retryStrategy.retry(next, { request: { headers: {} } } as any);
     } catch (error) {
@@ -90,7 +94,9 @@ describe("defaultStrategy", () => {
       .mockRejectedValueOnce(mockError)
       .mockResolvedValueOnce(mockResponse);
 
-    const retryStrategy = new StandardRetryStrategy(maxAttempts);
+    const retryStrategy = new StandardRetryStrategy(() =>
+      Promise.resolve(maxAttempts.toString())
+    );
     return retryStrategy.retry(next, { request: { headers: {} } } as any);
   };
 
@@ -110,7 +116,9 @@ describe("defaultStrategy", () => {
       .mockRejectedValueOnce(mockError)
       .mockResolvedValueOnce(mockResponse);
 
-    const retryStrategy = new StandardRetryStrategy(maxAttempts);
+    const retryStrategy = new StandardRetryStrategy(() =>
+      Promise.resolve(maxAttempts.toString())
+    );
     return retryStrategy.retry(next, { request: { headers: {} } } as any);
   };
 
@@ -118,63 +126,86 @@ describe("defaultStrategy", () => {
     jest.clearAllMocks();
   });
 
-  it("sets maxAttempts as class member variable", () => {
-    [1, 2, 3].forEach(maxAttempts => {
-      const retryStrategy = new StandardRetryStrategy(maxAttempts);
-      expect(retryStrategy.maxAttempts).toBe(maxAttempts);
+  it("sets maxAttemptsProvider as class member variable", () => {
+    ["1", "2", "3"].forEach(maxAttempts => {
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.resolve(maxAttempts)
+      );
+      expect(retryStrategy["maxAttemptsProvider"]()).resolves.toBe(maxAttempts);
     });
   });
 
   describe("retryDecider init", () => {
     it("sets defaultRetryDecider if options is undefined", () => {
-      const retryStrategy = new StandardRetryStrategy(maxAttempts);
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.resolve(maxAttempts.toString())
+      );
       expect(retryStrategy["retryDecider"]).toBe(defaultRetryDecider);
     });
 
     it("sets defaultRetryDecider if options.retryDecider is undefined", () => {
-      const retryStrategy = new StandardRetryStrategy(maxAttempts, {});
+      const retryStrategy = new StandardRetryStrategy(
+        () => Promise.resolve(maxAttempts.toString()),
+        {}
+      );
       expect(retryStrategy["retryDecider"]).toBe(defaultRetryDecider);
     });
 
     it("sets options.retryDecider if defined", () => {
       const retryDecider = jest.fn();
-      const retryStrategy = new StandardRetryStrategy(maxAttempts, {
-        retryDecider
-      });
+      const retryStrategy = new StandardRetryStrategy(
+        () => Promise.resolve(maxAttempts.toString()),
+        {
+          retryDecider
+        }
+      );
       expect(retryStrategy["retryDecider"]).toBe(retryDecider);
     });
   });
 
   describe("delayDecider init", () => {
     it("sets defaultDelayDecider if options is undefined", () => {
-      const retryStrategy = new StandardRetryStrategy(maxAttempts);
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.resolve(maxAttempts.toString())
+      );
       expect(retryStrategy["delayDecider"]).toBe(defaultDelayDecider);
     });
 
     it("sets defaultDelayDecider if options.delayDecider undefined", () => {
-      const retryStrategy = new StandardRetryStrategy(maxAttempts, {});
+      const retryStrategy = new StandardRetryStrategy(
+        () => Promise.resolve(maxAttempts.toString()),
+        {}
+      );
       expect(retryStrategy["delayDecider"]).toBe(defaultDelayDecider);
     });
 
     it("sets options.delayDecider if defined", () => {
       const delayDecider = jest.fn();
-      const retryStrategy = new StandardRetryStrategy(maxAttempts, {
-        delayDecider
-      });
+      const retryStrategy = new StandardRetryStrategy(
+        () => Promise.resolve(maxAttempts.toString()),
+        {
+          delayDecider
+        }
+      );
       expect(retryStrategy["delayDecider"]).toBe(delayDecider);
     });
   });
 
   describe("retryQuota init", () => {
     it("sets getDefaultRetryQuota if options is undefined", () => {
-      const retryStrategy = new StandardRetryStrategy(maxAttempts);
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.resolve(maxAttempts.toString())
+      );
       expect(retryStrategy["retryQuota"]).toBe(
         getDefaultRetryQuota(INITIAL_RETRY_TOKENS)
       );
     });
 
     it("sets getDefaultRetryQuota if options.delayDecider undefined", () => {
-      const retryStrategy = new StandardRetryStrategy(maxAttempts, {});
+      const retryStrategy = new StandardRetryStrategy(
+        () => Promise.resolve(maxAttempts.toString()),
+        {}
+      );
       expect(retryStrategy["retryQuota"]).toBe(
         getDefaultRetryQuota(INITIAL_RETRY_TOKENS)
       );
@@ -182,9 +213,12 @@ describe("defaultStrategy", () => {
 
     it("sets options.retryQuota if defined", () => {
       const retryQuota = {} as RetryQuota;
-      const retryStrategy = new StandardRetryStrategy(maxAttempts, {
-        retryQuota
-      });
+      const retryStrategy = new StandardRetryStrategy(
+        () => Promise.resolve(maxAttempts.toString()),
+        {
+          retryQuota
+        }
+      );
       expect(retryStrategy["retryQuota"]).toBe(retryQuota);
     });
   });
@@ -483,7 +517,9 @@ describe("defaultStrategy", () => {
         output: { $metadata: {} }
       });
 
-      const retryStrategy = new StandardRetryStrategy(maxAttempts);
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.resolve(maxAttempts.toString())
+      );
       await retryStrategy.retry(next, { request: { headers: {} } } as any);
       await retryStrategy.retry(next, { request: { headers: {} } } as any);
 
@@ -565,7 +601,9 @@ describe("defaultStrategy", () => {
         throw mockError;
       });
 
-      const retryStrategy = new StandardRetryStrategy(maxAttempts);
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.resolve(maxAttempts.toString())
+      );
       try {
         await retryStrategy.retry(next, { request: { headers: {} } } as any);
       } catch (error) {
@@ -574,6 +612,56 @@ describe("defaultStrategy", () => {
       }
 
       expect(next).toHaveBeenCalledTimes(maxAttempts);
+      ((isInstance as unknown) as jest.Mock).mockReturnValue(false);
+    });
+  });
+
+  describe("defaults maxAttempts to 3", () => {
+    it("when maxAttemptsProvider throws error", async () => {
+      const maxAttempts = 3;
+      const { isInstance } = HttpRequest;
+      ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
+
+      next = jest.fn(args => {
+        expect(args.request.headers["amz-sdk-request"]).toBe(
+          `attempt=1; max=${maxAttempts}`
+        );
+        return Promise.resolve({
+          response: "mockResponse",
+          output: { $metadata: {} }
+        });
+      });
+
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.reject("ERROR")
+      );
+      await retryStrategy.retry(next, { request: { headers: {} } } as any);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      ((isInstance as unknown) as jest.Mock).mockReturnValue(false);
+    });
+
+    it("when parseInt fails on maxAttemptsProvider", async () => {
+      const maxAttempts = 3;
+      const { isInstance } = HttpRequest;
+      ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
+
+      next = jest.fn(args => {
+        expect(args.request.headers["amz-sdk-request"]).toBe(
+          `attempt=1; max=${maxAttempts}`
+        );
+        return Promise.resolve({
+          response: "mockResponse",
+          output: { $metadata: {} }
+        });
+      });
+
+      const retryStrategy = new StandardRetryStrategy(() =>
+        Promise.resolve("not-a-number")
+      );
+      await retryStrategy.retry(next, { request: { headers: {} } } as any);
+
+      expect(next).toHaveBeenCalledTimes(1);
       ((isInstance as unknown) as jest.Mock).mockReturnValue(false);
     });
   });

--- a/packages/middleware-retry/src/retryMiddleware.spec.ts
+++ b/packages/middleware-retry/src/retryMiddleware.spec.ts
@@ -18,11 +18,11 @@ describe("getRetryPlugin", () => {
     jest.clearAllMocks();
   });
 
-  describe("adds retryMiddleware if maxAttempts > 1", () => {
-    [2, 3, 4].forEach(maxAttempts => {
+  describe("adds retryMiddleware", () => {
+    [1, 2, 3].forEach(maxAttempts => {
       it(`when maxAttempts=${maxAttempts}`, () => {
         getRetryPlugin({
-          maxAttempts,
+          maxAttempts: () => Promise.resolve(maxAttempts.toString()),
           retryStrategy: {} as RetryStrategy
         }).applyToStack(
           (mockClientStack as unknown) as MiddlewareStack<any, any>
@@ -31,20 +31,6 @@ describe("getRetryPlugin", () => {
         expect(mockClientStack.add.mock.calls[0][1]).toEqual(
           retryMiddlewareOptions
         );
-      });
-    });
-  });
-
-  describe("skips adding retryMiddleware if maxAttempts <= 1", () => {
-    [0, 1].forEach(maxAttempts => {
-      it(`when maxAttempts=${maxAttempts}`, () => {
-        getRetryPlugin({
-          maxAttempts,
-          retryStrategy: {} as RetryStrategy
-        }).applyToStack(
-          (mockClientStack as unknown) as MiddlewareStack<any, any>
-        );
-        expect(mockClientStack.add).toHaveBeenCalledTimes(0);
       });
     });
   });
@@ -67,7 +53,7 @@ describe("retryMiddleware", () => {
     };
 
     await retryMiddleware({
-      maxAttempts,
+      maxAttempts: () => Promise.resolve(maxAttempts.toString()),
       retryStrategy: mockRetryStrategy
     })(next)(args as FinalizeHandlerArguments<any>);
     expect(mockRetryStrategy.retry).toHaveBeenCalledTimes(1);

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -30,8 +30,6 @@ export const getRetryPlugin = (
   options: RetryResolvedConfig
 ): Pluggable<any, any> => ({
   applyToStack: clientStack => {
-    if (options.maxAttempts > 1) {
-      clientStack.add(retryMiddleware(options), retryMiddlewareOptions);
-    }
+    clientStack.add(retryMiddleware(options), retryMiddlewareOptions);
   }
 });

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -58,11 +58,6 @@ export interface BodyLengthCalculator {
  */
 export interface RetryStrategy {
   /**
-   * the maximum number of times requests that encounter potentially
-   * transient failures should be retried
-   */
-  maxAttempts: number;
-  /**
    * the retry behavior the will invoke the next handler and handle the retry accordingly.
    * This function should also update the $metadata from the response accordingly.
    * @see {@link ResponseMetadata}


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/1284

*Description of changes:*

read maxAttempts value from retry-config
* `maxAttempts` is now updated from `number` to `Provider<string>`
  * Reason: The values in environment variables and config are stored as strings, and retry-config-provider utility functions are shared between maxAttempts (string) and retryMode (string)
* `maxAttempts` is removed from `RetryStrategy` interface
* retryMiddleware is always added in getRetryPlugin, as maxAttempts value is not available.
  * retryMiddleware decides to not retry in case maxAttempts is less than or equal to 1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
