### PR TITLE
fix: use copyFileSync from node

### DIFF
--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -1,6 +1,6 @@
 const path = require("path");
-const { copyFileSync, emptyDirSync } = require("fs-extra");
-const { readdirSync, lstatSync } = require("fs");
+const { emptyDirSync } = require("fs-extra");
+const { copyFileSync, readdirSync, lstatSync } = require("fs");
 const { spawnProcess } = require("./spawn-process");
 const {
   CODE_GEN_ROOT,
@@ -22,10 +22,7 @@ const generateClients = async models => {
       console.log(`copying model ${modelFileName}...`);
       copyFileSync(
         modelPath,
-        path.join(TEMP_CODE_GEN_INPUT_DIR, modelFileName),
-        {
-          overwrite: true
-        }
+        path.join(TEMP_CODE_GEN_INPUT_DIR, modelFileName)
       );
     }
   } else if (Array.isArray(models)) {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1312

*Description of changes:*
use copyFileSync from node instead of fs-extra
* fs.copyFileSync docs in node: https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_mode
 * the API was added in `v8.5.0`, and we use Node.js 10+ for generating clients
* copyFileSync from fs-extra uses native node implementation https://github.com/jprichardson/node-fs-extra/pull/505

Verified that `yarn generate-clients` succeeds to fix the bug:
```console
$ yarn generate-clients -m ~/Downloads/temp
yarn run v1.22.4
$ node ./scripts/generate-clients -m /home/trivikr/Downloads/temp
preparing models from /home/trivikr/Downloads/temp...
copying model s3.2006-03-01.json...

...

child process exited with code 0
copying @aws-sdk/client-s3 from /local/home/trivikr/workspace/aws-sdk-js-v3/codegen/sdk-codegen/build/smithyprojections/sdk-codegen/s3.2006-03-01/typescript-codegen to /local/home/trivikr/workspace/aws-sdk-js-v3/clients
copying @aws-sdk/aws-ec2 from /local/home/trivikr/workspace/aws-sdk-js-v3/codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-ec2/typescript-codegen to /local/home/trivikr/workspace/aws-sdk-js-v3/protocol_tests
copying @aws-sdk/aws-json from /local/home/trivikr/workspace/aws-sdk-js-v3/codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-json/typescript-codegen to /local/home/trivikr/workspace/aws-sdk-js-v3/protocol_tests
copying @aws-sdk/aws-query from /local/home/trivikr/workspace/aws-sdk-js-v3/codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-query/typescript-codegen to /local/home/trivikr/workspace/aws-sdk-js-v3/protocol_tests
copying @aws-sdk/aws-restjson from /local/home/trivikr/workspace/aws-sdk-js-v3/codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-restjson/typescript-codegen to /local/home/trivikr/workspace/aws-sdk-js-v3/protocol_tests
copying @aws-sdk/aws-restxml from /local/home/trivikr/workspace/aws-sdk-js-v3/codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-restxml/typescript-codegen to /local/home/trivikr/workspace/aws-sdk-js-v3/protocol_tests
Done in 13.43s.
```

generate-clients also succeed in other cases:
* `yarn generate-clients`
* `yarn generate-clients -g codegen/sdk-codegen/aws-models/s3.2006-03-01.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
