### PR TITLE
chore(credential-provider-imds): providerConfigFromInit arrow function

### DIFF
--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -1,5 +1,8 @@
 export const DEFAULT_TIMEOUT = 1000;
-export const DEFAULT_MAX_RETRIES = 3;
+
+// The default in AWS SDK for Python and CLI (botocore) is no retry or one attempt
+// https://github.com/boto/botocore/blob/646c61a7065933e75bab545b785e6098bc94c081/botocore/utils.py#L273
+export const DEFAULT_MAX_RETRIES = 0;
 
 export interface RemoteProviderConfig {
   /**

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_TIMEOUT = 1000;
-export const DEFAULT_MAX_RETRIES = 0;
+export const DEFAULT_MAX_RETRIES = 3;
 
 export interface RemoteProviderConfig {
   /**

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -15,10 +15,7 @@ export interface RemoteProviderConfig {
 
 export type RemoteProviderInit = Partial<RemoteProviderConfig>;
 
-export function providerConfigFromInit(
-  init: RemoteProviderInit
-): RemoteProviderConfig {
-  const { timeout = DEFAULT_TIMEOUT, maxRetries = DEFAULT_MAX_RETRIES } = init;
-
-  return { maxRetries, timeout };
-}
+export const providerConfigFromInit = ({
+  maxRetries = DEFAULT_MAX_RETRIES,
+  timeout = DEFAULT_TIMEOUT
+}: RemoteProviderInit): RemoteProviderConfig => ({ maxRetries, timeout });


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
converts providerConfigFromInit to an arrow function, and add a comment about DEFAULT_MAX_RETRIES
* DEFAULT_MAX_RETRIES is 0, as it's the default in AWS SDK for Python and CLI ([code](https://github.com/boto/botocore/blob/646c61a7065933e75bab545b785e6098bc94c081/botocore/utils.py#L273))
* AWS SDK for JavaScript v2 has two attempts though ([code](https://github.com/aws/aws-sdk-js/blob/adfbce5de94b4f06aea3ee4d3cd4f89ae87f8809/lib/credentials/ec2_metadata_credentials.js#L49-L52))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
