### PR TITLE
test(credential-provider-imds): cases for fromInstanceMetadata

### DIFF
--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -149,4 +149,15 @@ describe("fromInstanceMetadata", () => {
 
     await expect(fromInstanceMetadata()()).rejects.toEqual(mockError);
   });
+
+  it("throws SyntaxError if requestFromEc2Imds returns unparseable creds", async () => {
+    (httpGet as jest.Mock)
+      .mockResolvedValueOnce(mockProfile)
+      .mockResolvedValueOnce(".");
+    (retry as jest.Mock).mockImplementation((fn: any) => fn());
+
+    await expect(fromInstanceMetadata()()).rejects.toEqual(
+      new SyntaxError("Unexpected token . in JSON at position 0")
+    );
+  });
 });

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -73,6 +73,16 @@ describe("fromInstanceMetadata", () => {
     });
   });
 
+  it("passes {} to providerConfigFromInit if init not defined", async () => {
+    (retry as jest.Mock)
+      .mockResolvedValueOnce(mockProfile)
+      .mockResolvedValueOnce(mockCreds);
+
+    await expect(fromInstanceMetadata()()).resolves.toEqual(mockCreds);
+    expect(providerConfigFromInit).toHaveBeenCalledTimes(1);
+    expect(providerConfigFromInit).toHaveBeenCalledWith({});
+  });
+
   it("passes init to providerConfigFromInit", async () => {
     (retry as jest.Mock)
       .mockResolvedValueOnce(mockProfile)
@@ -95,7 +105,7 @@ describe("fromInstanceMetadata", () => {
     expect((retry as jest.Mock).mock.calls[1][1]).toBe(mockMaxRetries);
   });
 
-  it("throws ProviderError is credentials returns are incorrect", () => {});
+  it("throws ProviderError is credentials returned are incorrect", () => {});
 
   it("throws Error if requestFromEc2Imds for profile fails", () => {});
 

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -73,6 +73,17 @@ describe("fromInstanceMetadata", () => {
     });
   });
 
+  it("passes init to providerConfigFromInit", async () => {
+    (retry as jest.Mock)
+      .mockResolvedValueOnce(mockProfile)
+      .mockResolvedValueOnce(mockCreds);
+
+    const init = { maxRetries: 5, timeout: 1213 };
+    await expect(fromInstanceMetadata(init)()).resolves.toEqual(mockCreds);
+    expect(providerConfigFromInit).toHaveBeenCalledTimes(1);
+    expect(providerConfigFromInit).toHaveBeenCalledWith(init);
+  });
+
   it("passes maxRetries returned from providerConfigFromInit to retry", async () => {
     (retry as jest.Mock)
       .mockResolvedValueOnce(mockProfile)
@@ -83,8 +94,6 @@ describe("fromInstanceMetadata", () => {
     expect((retry as jest.Mock).mock.calls[0][1]).toBe(mockMaxRetries);
     expect((retry as jest.Mock).mock.calls[1][1]).toBe(mockMaxRetries);
   });
-
-  it("passes timeout returned from providerConfigFromInit to requestFromEc2Imds", () => {});
 
   it("throws ProviderError is credentials returns are incorrect", () => {});
 

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -4,71 +4,89 @@ import {
   fromImdsCredentials,
   ImdsCredentials
 } from "./remoteProvider/ImdsCredentials";
+import { Credentials } from "@aws-sdk/types";
 
-const mockHttpGet = <any>httpGet;
 jest.mock("./remoteProvider/httpGet", () => ({ httpGet: jest.fn() }));
-
-beforeEach(() => {
-  mockHttpGet.mockReset();
-});
+jest.mock("./remoteProvider/ImdsCredentials", () => ({
+  fromImdsCredentials: jest.fn(),
+  isImdsCredentials: jest.fn().mockReturnValue(true)
+}));
 
 describe("fromInstanceMetadata", () => {
-  const creds: ImdsCredentials = Object.freeze({
+  const mockImdsCreds: ImdsCredentials = Object.freeze({
     AccessKeyId: "foo",
     SecretAccessKey: "bar",
     Token: "baz",
     Expiration: new Date().toISOString()
   });
 
-  it("should resolve credentials by fetching them from the container metadata service", async () => {
-    mockHttpGet.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
-    expect(await fromInstanceMetadata()()).toEqual(fromImdsCredentials(creds));
+  const mockCreds: Credentials = Object.freeze({
+    accessKeyId: mockImdsCreds.AccessKeyId,
+    secretAccessKey: mockImdsCreds.SecretAccessKey,
+    sessionToken: mockImdsCreds.Token,
+    expiration: new Date(mockImdsCreds.Expiration)
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it.only("should resolve credentials by fetching them from the container metadata service", async () => {
+    (httpGet as jest.Mock).mockResolvedValue(JSON.stringify(mockImdsCreds));
+    (fromImdsCredentials as jest.Mock).mockReturnValue(mockCreds);
+
+    await expect(fromInstanceMetadata()()).resolves.toEqual(mockCreds);
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect(fromImdsCredentials).toHaveBeenCalledTimes(1);
   });
 
   it("should retry the fetching operation up to maxRetries times", async () => {
     const maxRetries = 5;
-    mockHttpGet.mockReturnValueOnce(Promise.resolve("foo"));
+    (httpGet as jest.Mock).mockResolvedValueOnce("foo");
     for (let i = 0; i < maxRetries - 1; i++) {
-      mockHttpGet.mockReturnValueOnce(Promise.reject("No!"));
+      (httpGet as jest.Mock).mockResolvedValueOnce("No!");
     }
-    mockHttpGet.mockReturnValueOnce(Promise.resolve(JSON.stringify(creds)));
+    (httpGet as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
 
-    expect(await fromInstanceMetadata({ maxRetries })()).toEqual(
-      fromImdsCredentials(creds)
+    await expect(fromInstanceMetadata({ maxRetries })()).resolves.toEqual(
+      fromImdsCredentials(mockImdsCreds)
     );
-    expect(mockHttpGet.mock.calls.length).toEqual(maxRetries + 1);
+    expect(httpGet).toHaveBeenCalledTimes(maxRetries + 1);
   });
 
   it("should retry responses that receive invalid response values", async () => {
-    mockHttpGet.mockReturnValueOnce(Promise.resolve("foo"));
-    for (let key of Object.keys(creds)) {
-      const invalidCreds: any = { ...creds };
+    (httpGet as jest.Mock).mockResolvedValueOnce("foo");
+    for (let key of Object.keys(mockImdsCreds)) {
+      const invalidCreds: any = { ...mockImdsCreds };
       delete invalidCreds[key];
-      mockHttpGet.mockReturnValueOnce(
-        Promise.resolve(JSON.stringify(invalidCreds))
+      (httpGet as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify(invalidCreds)
       );
     }
-    mockHttpGet.mockReturnValueOnce(Promise.resolve(JSON.stringify(creds)));
+    (httpGet as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
 
     await fromInstanceMetadata({ maxRetries: 100 })();
-    expect(mockHttpGet.mock.calls.length).toEqual(
-      Object.keys(creds).length + 2
+    expect(httpGet).toHaveBeenCalledTimes(
+      Object.keys(mockImdsCreds).length + 2
     );
   });
 
   it("should pass relevant configuration to httpGet", async () => {
     const timeout = Math.ceil(Math.random() * 1000);
     const profile = "foo-profile";
-    mockHttpGet.mockReturnValueOnce(Promise.resolve(profile));
-    mockHttpGet.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
+
+    (httpGet as jest.Mock).mockResolvedValueOnce(profile);
+    (httpGet as jest.Mock).mockResolvedValue(JSON.stringify(mockImdsCreds));
+
     await fromInstanceMetadata({ timeout })();
-    expect(mockHttpGet.mock.calls.length).toEqual(2);
-    expect(mockHttpGet.mock.calls[0][0]).toEqual({
+
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect((httpGet as jest.Mock).mock.calls[0][0]).toEqual({
       host: "169.254.169.254",
       path: "/latest/meta-data/iam/security-credentials/",
       timeout
     });
-    expect(mockHttpGet.mock.calls[1][0]).toEqual({
+    expect((httpGet as jest.Mock).mock.calls[1][0]).toEqual({
       host: "169.254.169.254",
       path: `/latest/meta-data/iam/security-credentials/${profile}`,
       timeout
@@ -78,19 +96,20 @@ describe("fromInstanceMetadata", () => {
   it("should retry the profile name fetch as necessary", async () => {
     const defaultTimeout = 1000;
     const profile = "foo-profile";
-    mockHttpGet.mockReturnValueOnce(Promise.reject("Too busy"));
-    mockHttpGet.mockReturnValueOnce(Promise.resolve(profile));
-    mockHttpGet.mockReturnValueOnce(Promise.resolve(JSON.stringify(creds)));
+
+    (httpGet as jest.Mock).mockRejectedValueOnce("Too busy");
+    (httpGet as jest.Mock).mockResolvedValueOnce(profile);
+    (httpGet as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
 
     await fromInstanceMetadata({ maxRetries: 1 })();
-    expect(mockHttpGet.mock.calls.length).toEqual(3);
-    expect(mockHttpGet.mock.calls[2][0]).toEqual({
+    expect(httpGet).toHaveBeenCalledTimes(3);
+    expect((httpGet as jest.Mock).mock.calls[2][0]).toEqual({
       host: "169.254.169.254",
       path: `/latest/meta-data/iam/security-credentials/${profile}`,
       timeout: defaultTimeout
     });
     for (let index of [0, 1]) {
-      expect(mockHttpGet.mock.calls[index][0]).toEqual({
+      expect((httpGet as jest.Mock).mock.calls[index][0]).toEqual({
         host: "169.254.169.254",
         path: "/latest/meta-data/iam/security-credentials/",
         timeout: defaultTimeout

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -117,7 +117,7 @@ describe("fromInstanceMetadata", () => {
     expect((retry as jest.Mock).mock.calls[1][1]).toBe(mockMaxRetries);
   });
 
-  it("throws ProviderError is credentials returned are incorrect", async () => {
+  it("throws ProviderError if credentials returned are incorrect", async () => {
     (httpGet as jest.Mock)
       .mockResolvedValueOnce(mockProfile)
       .mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
@@ -130,6 +130,11 @@ describe("fromInstanceMetadata", () => {
         "Invalid response received from instance metadata service."
       )
     );
+    expect(retry).toHaveBeenCalledTimes(2);
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect(isImdsCredentials).toHaveBeenCalledTimes(1);
+    expect(isImdsCredentials).toHaveBeenCalledWith(mockImdsCreds);
+    expect(fromImdsCredentials).not.toHaveBeenCalled();
   });
 
   it("throws Error if requestFromEc2Imds for profile fails", async () => {
@@ -138,6 +143,8 @@ describe("fromInstanceMetadata", () => {
     (retry as jest.Mock).mockImplementation((fn: any) => fn());
 
     await expect(fromInstanceMetadata()()).rejects.toEqual(mockError);
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(httpGet).toHaveBeenCalledTimes(1);
   });
 
   it("throws Error if requestFromEc2Imds for credentials fails", async () => {
@@ -148,6 +155,9 @@ describe("fromInstanceMetadata", () => {
     (retry as jest.Mock).mockImplementation((fn: any) => fn());
 
     await expect(fromInstanceMetadata()()).rejects.toEqual(mockError);
+    expect(retry).toHaveBeenCalledTimes(2);
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect(fromImdsCredentials).not.toHaveBeenCalled();
   });
 
   it("throws SyntaxError if requestFromEc2Imds returns unparseable creds", async () => {
@@ -159,5 +169,8 @@ describe("fromInstanceMetadata", () => {
     await expect(fromInstanceMetadata()()).rejects.toEqual(
       new SyntaxError("Unexpected token . in JSON at position 0")
     );
+    expect(retry).toHaveBeenCalledTimes(2);
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect(fromImdsCredentials).not.toHaveBeenCalled();
   });
 });

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -121,7 +121,12 @@ describe("fromInstanceMetadata", () => {
     );
   });
 
-  it("throws Error if requestFromEc2Imds for profile fails", () => {});
+  it("throws Error if requestFromEc2Imds for profile fails", async () => {
+    const mockError = new Error("profile not found");
+    (httpGet as jest.Mock).mockRejectedValueOnce(mockError);
+    (retry as jest.Mock).mockImplementation((fn: any) => fn());
+    await expect(fromInstanceMetadata()()).rejects.toEqual(mockError);
+  });
 
   it("throws Error if requestFromEc2Imds for credentials fails", () => {});
 });

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -5,7 +5,6 @@ import {
   isImdsCredentials
 } from "./remoteProvider/ImdsCredentials";
 import { providerConfigFromInit } from "./remoteProvider/RemoteProviderInit";
-import { Credentials } from "@aws-sdk/types";
 import { retry } from "./remoteProvider/retry";
 import { ProviderError } from "@aws-sdk/property-provider";
 
@@ -32,7 +31,7 @@ describe("fromInstanceMetadata", () => {
     Expiration: new Date().toISOString()
   });
 
-  const mockCreds: Credentials = Object.freeze({
+  const mockCreds = Object.freeze({
     accessKeyId: mockImdsCreds.AccessKeyId,
     secretAccessKey: mockImdsCreds.SecretAccessKey,
     sessionToken: mockImdsCreds.Token,

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -73,7 +73,16 @@ describe("fromInstanceMetadata", () => {
     });
   });
 
-  it("passes maxRetries returned from providerConfigFromInit to retry", () => {});
+  it("passes maxRetries returned from providerConfigFromInit to retry", async () => {
+    (retry as jest.Mock)
+      .mockResolvedValueOnce(mockProfile)
+      .mockResolvedValueOnce(mockCreds);
+
+    await expect(fromInstanceMetadata()()).resolves.toEqual(mockCreds);
+    expect(retry).toHaveBeenCalledTimes(2);
+    expect((retry as jest.Mock).mock.calls[0][1]).toBe(mockMaxRetries);
+    expect((retry as jest.Mock).mock.calls[1][1]).toBe(mockMaxRetries);
+  });
 
   it("passes timeout returned from providerConfigFromInit to requestFromEc2Imds", () => {});
 

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -4,15 +4,33 @@ import {
   fromImdsCredentials,
   ImdsCredentials
 } from "./remoteProvider/ImdsCredentials";
+import { providerConfigFromInit } from "./remoteProvider/RemoteProviderInit";
 import { Credentials } from "@aws-sdk/types";
+import { retry } from "./remoteProvider/retry";
 
 jest.mock("./remoteProvider/httpGet", () => ({ httpGet: jest.fn() }));
 jest.mock("./remoteProvider/ImdsCredentials", () => ({
   fromImdsCredentials: jest.fn(),
   isImdsCredentials: jest.fn().mockReturnValue(true)
 }));
+jest.mock("./remoteProvider/retry", () => ({
+  retry: jest.fn()
+}));
+jest.mock("./remoteProvider/RemoteProviderInit", () => ({
+  providerConfigFromInit: jest.fn()
+}));
 
 describe("fromInstanceMetadata", () => {
+  const mockTimeout = 1000;
+  const mockMaxRetries = 3;
+  const mockProfile = "foo";
+
+  const mockHttpGetOptions = {
+    host: "169.254.169.254",
+    path: "/latest/meta-data/iam/security-credentials/",
+    timeout: mockTimeout
+  };
+
   const mockImdsCreds: ImdsCredentials = Object.freeze({
     AccessKeyId: "foo",
     SecretAccessKey: "bar",
@@ -27,93 +45,41 @@ describe("fromInstanceMetadata", () => {
     expiration: new Date(mockImdsCreds.Expiration)
   });
 
+  beforeEach(() => {
+    (providerConfigFromInit as jest.Mock).mockReturnValue({
+      timeout: mockTimeout,
+      maxRetries: mockMaxRetries
+    });
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  it.only("should resolve credentials by fetching them from the container metadata service", async () => {
-    (httpGet as jest.Mock).mockResolvedValue(JSON.stringify(mockImdsCreds));
+  it("gets profile name from IMDS, and passes profile name to fetch credentials", async () => {
+    (httpGet as jest.Mock)
+      .mockResolvedValueOnce(mockProfile)
+      .mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
+
+    (retry as jest.Mock).mockImplementation((fn: any) => fn());
     (fromImdsCredentials as jest.Mock).mockReturnValue(mockCreds);
 
     await expect(fromInstanceMetadata()()).resolves.toEqual(mockCreds);
     expect(httpGet).toHaveBeenCalledTimes(2);
-    expect(fromImdsCredentials).toHaveBeenCalledTimes(1);
-  });
-
-  it("should retry the fetching operation up to maxRetries times", async () => {
-    const maxRetries = 5;
-    (httpGet as jest.Mock).mockResolvedValueOnce("foo");
-    for (let i = 0; i < maxRetries - 1; i++) {
-      (httpGet as jest.Mock).mockResolvedValueOnce("No!");
-    }
-    (httpGet as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
-
-    await expect(fromInstanceMetadata({ maxRetries })()).resolves.toEqual(
-      fromImdsCredentials(mockImdsCreds)
-    );
-    expect(httpGet).toHaveBeenCalledTimes(maxRetries + 1);
-  });
-
-  it("should retry responses that receive invalid response values", async () => {
-    (httpGet as jest.Mock).mockResolvedValueOnce("foo");
-    for (let key of Object.keys(mockImdsCreds)) {
-      const invalidCreds: any = { ...mockImdsCreds };
-      delete invalidCreds[key];
-      (httpGet as jest.Mock).mockResolvedValueOnce(
-        JSON.stringify(invalidCreds)
-      );
-    }
-    (httpGet as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
-
-    await fromInstanceMetadata({ maxRetries: 100 })();
-    expect(httpGet).toHaveBeenCalledTimes(
-      Object.keys(mockImdsCreds).length + 2
-    );
-  });
-
-  it("should pass relevant configuration to httpGet", async () => {
-    const timeout = Math.ceil(Math.random() * 1000);
-    const profile = "foo-profile";
-
-    (httpGet as jest.Mock).mockResolvedValueOnce(profile);
-    (httpGet as jest.Mock).mockResolvedValue(JSON.stringify(mockImdsCreds));
-
-    await fromInstanceMetadata({ timeout })();
-
-    expect(httpGet).toHaveBeenCalledTimes(2);
-    expect((httpGet as jest.Mock).mock.calls[0][0]).toEqual({
-      host: "169.254.169.254",
-      path: "/latest/meta-data/iam/security-credentials/",
-      timeout
-    });
-    expect((httpGet as jest.Mock).mock.calls[1][0]).toEqual({
-      host: "169.254.169.254",
-      path: `/latest/meta-data/iam/security-credentials/${profile}`,
-      timeout
+    expect(httpGet).toHaveBeenNthCalledWith(1, mockHttpGetOptions);
+    expect(httpGet).toHaveBeenNthCalledWith(2, {
+      ...mockHttpGetOptions,
+      path: `${mockHttpGetOptions.path}${mockProfile}`
     });
   });
 
-  it("should retry the profile name fetch as necessary", async () => {
-    const defaultTimeout = 1000;
-    const profile = "foo-profile";
+  it("passes maxRetries returned from providerConfigFromInit to retry", () => {});
 
-    (httpGet as jest.Mock).mockRejectedValueOnce("Too busy");
-    (httpGet as jest.Mock).mockResolvedValueOnce(profile);
-    (httpGet as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockImdsCreds));
+  it("passes timeout returned from providerConfigFromInit to requestFromEc2Imds", () => {});
 
-    await fromInstanceMetadata({ maxRetries: 1 })();
-    expect(httpGet).toHaveBeenCalledTimes(3);
-    expect((httpGet as jest.Mock).mock.calls[2][0]).toEqual({
-      host: "169.254.169.254",
-      path: `/latest/meta-data/iam/security-credentials/${profile}`,
-      timeout: defaultTimeout
-    });
-    for (let index of [0, 1]) {
-      expect((httpGet as jest.Mock).mock.calls[index][0]).toEqual({
-        host: "169.254.169.254",
-        path: "/latest/meta-data/iam/security-credentials/",
-        timeout: defaultTimeout
-      });
-    }
-  });
+  it("throws ProviderError is credentials returns are incorrect", () => {});
+
+  it("throws Error if requestFromEc2Imds for profile fails", () => {});
+
+  it("throws Error if requestFromEc2Imds for credentials fails", () => {});
 });

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -125,8 +125,17 @@ describe("fromInstanceMetadata", () => {
     const mockError = new Error("profile not found");
     (httpGet as jest.Mock).mockRejectedValueOnce(mockError);
     (retry as jest.Mock).mockImplementation((fn: any) => fn());
+
     await expect(fromInstanceMetadata()()).rejects.toEqual(mockError);
   });
 
-  it("throws Error if requestFromEc2Imds for credentials fails", () => {});
+  it("throws Error if requestFromEc2Imds for credentials fails", async () => {
+    const mockError = new Error("creds not found");
+    (httpGet as jest.Mock)
+      .mockResolvedValueOnce(mockProfile)
+      .mockRejectedValueOnce(mockError);
+    (retry as jest.Mock).mockImplementation((fn: any) => fn());
+
+    await expect(fromInstanceMetadata()()).rejects.toEqual(mockError);
+  });
 });

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -15,9 +15,9 @@ import { ProviderError } from "@aws-sdk/property-provider";
  * Creates a credential provider that will source credentials from the EC2
  * Instance Metadata Service
  */
-export function fromInstanceMetadata(
+export const fromInstanceMetadata = (
   init: RemoteProviderInit = {}
-): CredentialProvider {
+): CredentialProvider => {
   const { timeout, maxRetries } = providerConfigFromInit(init);
   return async () => {
     const profile = (
@@ -40,15 +40,19 @@ export function fromInstanceMetadata(
       return fromImdsCredentials(credsResponse);
     }, maxRetries);
   };
-}
+};
 
 const IMDS_IP = "169.254.169.254";
 const IMDS_PATH = "latest/meta-data/iam/security-credentials";
 
-function requestFromEc2Imds(timeout: number, path?: string): Promise<string> {
-  return httpGet({
+const requestFromEc2Imds = async (
+  timeout: number,
+  path?: string
+): Promise<string> => {
+  const buffer = await httpGet({
     host: IMDS_IP,
     path: `/${IMDS_PATH}/${path ? path : ""}`,
     timeout
-  }).then(buffer => buffer.toString());
-}
+  });
+  return buffer.toString();
+};


### PR DESCRIPTION
*Issue #, if available:*
Done in preparation of IMDS v2 in JS-1802

*Description of changes:*
* add extensive testing for fromInstanceMetadata
* also converts functions to arrow functions and uses async-await

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
