### PR TITLE
test: using existing resources in e2e tests

### DIFF
--- a/clients/client-cognito-identity/e2e/CognitoIdentity.ispec.ts
+++ b/clients/client-cognito-identity/e2e/CognitoIdentity.ispec.ts
@@ -5,93 +5,23 @@
  */
 import { expect } from "chai";
 import { CognitoIdentity } from "../index";
-import { Credentials } from "@aws-sdk/types";
-import { IAM } from "@aws-sdk/client-iam";
 // There will be default values of defaultRegion, credentials, and isBrowser variable in browser tests.
 // Define the values for Node.js tests
 const region: string | undefined =
   (globalThis as any).defaultRegion || undefined;
-const credentials: Credentials | undefined =
-  (globalThis as any).credentials || undefined;
+const IdentityPoolId =
+  (globalThis as any)?.window?.__env__?.AWS_SMOKE_TEST_IDENTITY_POOL_ID ||
+  process?.env?.AWS_SMOKE_TEST_IDENTITY_POOL_ID;
 
 describe("@aws-sdk/client-cognito-identity", function () {
-  this.timeout(50000);
-  // Required in run
   const unAuthClient = new CognitoIdentity({
     region
-  });
-  const authClient = new CognitoIdentity({
-    credentials,
-    region
-  });
-  const iam = new IAM({ credentials, region });
-  const identityPoolName = `aws_sdk_unit_test_${Date.now()}`;
-  const identityPoolRoleName = `${identityPoolName}-role`;
-  let identityPoolRole: string;
-  let identityPoolId: string;
-
-  before(async () => {
-    // Create an identity pool
-    const createIdentityPoolResult = await authClient.createIdentityPool({
-      IdentityPoolName: identityPoolName,
-      AllowUnauthenticatedIdentities: true
-    });
-    expect(createIdentityPoolResult.$metadata.httpStatusCode).to.equal(200);
-    expect(typeof createIdentityPoolResult.IdentityPoolId).to.equal("string");
-    identityPoolId = createIdentityPoolResult.IdentityPoolId as string;
-
-    // Create a role to be attached to identity pool
-    const { Role } = await iam.createRole({
-      RoleName: identityPoolRoleName,
-      AssumeRolePolicyDocument: `{
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Principal": {
-          "Federated": "cognito-identity.amazonaws.com"
-        },
-        "Action": "sts:AssumeRoleWithWebIdentity"
-      }
-    ]
-  }`
-    });
-    identityPoolRole = Role?.Arn as string;
-
-    // wait for role creating
-    // TODO: add RoleExists waiter
-    await new Promise(resolve => setTimeout(resolve, 5000));
-
-    // Set role to identity pool
-    await authClient.setIdentityPoolRoles({
-      IdentityPoolId: identityPoolId,
-      Roles: {
-        unauthenticated: identityPoolRole!
-      }
-    });
-
-    // wait for role propagating
-    // TODO: add waiters
-    await new Promise(resolve => setTimeout(resolve, 10000));
-  });
-
-  after(async () => {
-    // Delete the identity pool
-    if (identityPoolId) {
-      await authClient.deleteIdentityPool({
-        IdentityPoolId: identityPoolId
-      });
-    }
-    // Delete identity pool role
-    if (identityPoolRole) {
-      await iam.deleteRole({ RoleName: identityPoolRoleName });
-    }
   });
 
   it("should successfully fetch Id and get credentials", async () => {
     // Test getId()
     const getIdResult = await unAuthClient.getId({
-      IdentityPoolId: identityPoolId
+      IdentityPoolId
     });
     expect(getIdResult.$metadata.httpStatusCode).to.equal(200);
     expect(typeof getIdResult.IdentityId).to.equal("string");

--- a/clients/client-cognito-identity/e2e/README.md
+++ b/clients/client-cognito-identity/e2e/README.md
@@ -1,0 +1,46 @@
+## Integration test resources
+
+Certain resources need to be created to make sure the integration test
+has backend resources to test against. Follow steps bellow to create them:
+
+1. Create a Cognito Identity Pool
+
+   ```console
+   aws cognito-identity create-identity-pool --identity-pool-name [NAME] --allow-unauthenticated-identities --output text --query '[IdentityPoolId]'
+   ```
+
+   It outputs `IdentityPoolId`.
+
+1. Create a IAM Role
+
+   1. If you create the Identity Pool with AWS console and allow creating roles on your behalf, you can skip this step
+
+   1. Command line:
+
+   ```console
+   aws iam create-role --role-name=[ROLE_NAME] --assume-role-policy-document '{
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": {
+           "Federated": "cognito-identity.amazonaws.com"
+         },
+         "Action": "sts:AssumeRoleWithWebIdentity"
+       }
+     ]
+   }' --output text --query 'Role.Arn'
+   ```
+
+   It outputs `RoleArn`
+
+1. Set the unauthenticated role of the Identity Pool created in Step 1 to the role created in Step 2
+
+   ```console
+   aws cognito-identity set-identity-pool-roles --identity-pool-id [IdentityPoolId] --roles unauthenticated=[RoleArn]
+   ```
+
+1. Run the test with ENV. For example:
+
+   ```console
+   AWS_SMOKE_TEST_REGION=[Region] AWS_SMOKE_TEST_IDENTITY_POOL_ID=[IdentityPoolId] yarn test:e2e
+   ```

--- a/clients/client-cognito-identity/karma.conf.js
+++ b/clients/client-cognito-identity/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function (config) {
     frameworks: ["mocha", "chai"],
     files: ["e2e/**/*.ispec.ts"],
     preprocessors: {
-      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials"]
+      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"]
     },
     webpackMiddleware: {
       stats: "minimal"
@@ -35,6 +35,10 @@ module.exports = function (config) {
       },
       devtool: "inline-source-map"
     },
+    envPreprocessor: [
+      "AWS_SMOKE_TEST_REGION",
+      "AWS_SMOKE_TEST_IDENTITY_POOL_ID"
+    ],
     plugins: [
       "@aws-sdk/karma-credential-loader",
       "karma-chrome-launcher",
@@ -43,7 +47,8 @@ module.exports = function (config) {
       "karma-chai",
       "karma-webpack",
       "karma-coverage",
-      "karma-sourcemap-loader"
+      "karma-sourcemap-loader",
+      "karma-env-preprocessor"
     ],
     reporters: ["progress"],
     port: 9876,

--- a/clients/client-s3/e2e/README.md
+++ b/clients/client-s3/e2e/README.md
@@ -1,0 +1,36 @@
+## Integration test resources
+
+Certain resources need to be created to make sure the integration test
+has backend resources to test against. Follow steps bellow to create them:
+
+1. Create S3 Bucket
+
+   1. Create Bucket with:
+
+   ```console
+   aws s3 mb s3://[BucketName] --region [Region]
+   ```
+
+   1. Put CORS config to the bucket
+
+   ```console
+    aws s3api put-bucket-cors --bucket [BucketName] --cors-configuration '{
+   "CORSRules": [
+    {
+      "AllowedOrigins": ["*"],
+      "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+      "MaxAgeSeconds": 3000,
+      "ExposeHeaders": ["ETag", "Date"],
+      "AllowedHeaders": ["*"]
+    }
+   ]
+   }'
+   ```
+
+   1. supply the bucket name to the test but setting the ENV `AWS_SMOKE_TEST_BUCKET`
+
+1. Run the test with ENV. For example:
+
+   ```console
+   AWS_SMOKE_TEST_REGION=[Region] AWS_SMOKE_TEST_BUCKET=[Bucket] yarn test:e2e
+   ```

--- a/clients/client-s3/karma.conf.js
+++ b/clients/client-s3/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function (config) {
     frameworks: ["mocha", "chai"],
     files: ["e2e/**/*.ispec.ts"],
     preprocessors: {
-      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials"]
+      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"]
     },
     webpackMiddleware: {
       stats: "minimal"
@@ -35,6 +35,7 @@ module.exports = function (config) {
       },
       devtool: "inline-source-map"
     },
+    envPreprocessor: ["AWS_SMOKE_TEST_REGION", "AWS_SMOKE_TEST_BUCKET"],
     plugins: [
       "@aws-sdk/karma-credential-loader",
       "karma-chrome-launcher",
@@ -43,7 +44,8 @@ module.exports = function (config) {
       "karma-chai",
       "karma-webpack",
       "karma-coverage",
-      "karma-sourcemap-loader"
+      "karma-sourcemap-loader",
+      "karma-env-preprocessor"
     ],
     reporters: ["progress"],
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.2",
+    "karma-env-preprocessor": "^0.1.1",
     "karma-firefox-launcher": "^1.3.0",
     "karma-jasmine": "^3.3.1",
     "karma-mocha": "^2.0.1",
@@ -69,9 +70,9 @@
     "puppeteer": "^4.0.0",
     "ts-loader": "^7.0.5",
     "typescript": "~3.8.3",
+    "verdaccio": "^4.7.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
-    "verdaccio": "^4.7.2",
     "yarn": "1.22.4"
   },
   "workspaces": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7409,6 +7409,11 @@ karma-coverage@^2.0.2:
     istanbul-reports "^3.0.0"
     minimatch "^3.0.4"
 
+karma-env-preprocessor@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/karma-env-preprocessor/-/karma-env-preprocessor-0.1.1.tgz#bbe8c87d59c00edb76070bd3c31b4b39d5dc7e15"
+  integrity sha1-u+jIfVnADtt2BwvTwxtLOdXcfhU=
+
 karma-firefox-launcher@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.3.0.tgz#ebcbb1d1ddfada6be900eb8fae25bcf2dcdc8171"


### PR DESCRIPTION
Instead of creating resources(IAM, Identity pools) every time when e2e test suites run, we will call existing resources fixed in test account. This way we achieve low coupling with the test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
