### PR TITLE
fix: run jest tests from all folders in cjs

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -2,6 +2,6 @@ module.exports = {
   // remove testMatch once we move to ts-jest
   testMatch: [
     "**/__tests__/**/*.js?(x)",
-    "**/dist/cjs/?(*.)+(spec|test).js?(x)"
+    "**/dist/cjs/**/?(*.)+(spec|test).js?(x)"
   ]
 };


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1323

*Description of changes:*
run jest tests from all folders in cjs

```console
$ cd packages/credential-provider-imds
$ yarn test  

yarn run v1.22.4
$ yarn build:cjs
$ tsc -p tsconfig.cjs.json
$ jest
 PASS  dist/cjs/fromContainerMetadata.spec.js
 PASS  dist/cjs/fromInstanceMetadata.spec.js
 PASS  dist/cjs/remoteProvider/httpGet.spec.js
 PASS  dist/cjs/remoteProvider/ImdsCredentials.spec.js
 PASS  dist/cjs/remoteProvider/retry.spec.js
 PASS  dist/cjs/remoteProvider/RemoteProviderInit.spec.js

Test Suites: 6 passed, 6 total
Tests:       33 passed, 33 total
Snapshots:   0 total
Time:        1.147s
Ran all test suites.
Done in 2.99s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
