### PR TITLE
feat(eventstream-serde-universal): omit unknown event type

### DIFF
--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
@@ -41,7 +41,9 @@ export function getUnmarshalledStream<T extends { [key: string]: any }>(
           const event = {
             [message.headers[":event-type"].value as string]: message
           };
-          yield await options.deserializer(event);
+          const deserialized = await options.deserializer(event);
+          if (deserialized.$unknown) continue;
+          yield deserialized;
         } else {
           throw Error(
             `Unrecognizable event type: ${message.headers[":event-type"].value}`


### PR DESCRIPTION
When an event returns from response event stream is not defined in the model. The deserialize will parse it as `{$unknown: {Event: Payload}}`. In this case, the downstream event stream should omit this event, instead of emitting an event with name `$unknown`. 

This PR implements the change and unit test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
