### PR TITLE
chore(deps-dev): bump @types/jest to 26.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@commitlint/config-conventional": "^9.0.1",
     "@types/chai-as-promised": "^7.1.2",
     "@types/fs-extra": "^8.0.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.4.0",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-utf8-browser": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-utf8-node": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typedoc": "^0.14.2",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "tslib": "^1.8.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -24,7 +24,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -26,7 +26,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -26,7 +26,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -27,7 +27,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@aws-sdk/shared-ini-file-loader": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -28,7 +28,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "1.0.0-gamma.1",
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.4.0"
   },

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@aws-sdk/util-utf8-browser": "1.0.0-gamma.1",
     "@aws-sdk/util-utf8-node": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -24,7 +24,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@aws-sdk/abort-controller": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "typescript": "~3.8.3"
   }
 }

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-hex-encoding": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-hex-encoding": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -17,7 +17,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/util-base64-node": "1.0.0-gamma.1",
     "@aws-sdk/util-base64-browser": "1.0.0-gamma.1",
     "@aws-sdk/util-hex-encoding": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@aws-sdk/smithy-client": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -24,7 +24,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -25,7 +25,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -29,7 +29,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.0.3",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -26,7 +26,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -28,7 +28,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/retry-config-provider/package.json
+++ b/packages/retry-config-provider/package.json
@@ -28,7 +28,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@aws-sdk/hash-node": "1.0.0-gamma.1",
     "@aws-sdk/protocol-http": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-sdk/smithy-client": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -24,7 +24,7 @@
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/util-hex-encoding": "1.0.0-gamma.1",
     "@aws-sdk/util-utf8-node": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -5,7 +5,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -29,7 +29,7 @@
     "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
     "@aws-sdk/protocol-http": "1.0.0-gamma.1",
     "@aws-sdk/util-buffer-from": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/url-parser-browser/package.json
+++ b/packages/url-parser-browser/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/url-parser-node/package.json
+++ b/packages/url-parser-node/package.json
@@ -23,7 +23,7 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -18,7 +18,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.3",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -17,7 +17,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   }

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "1.0.0-gamma.1",
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -21,7 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -6,7 +6,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.4",
+    "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~3.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,15 +699,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
@@ -1674,17 +1665,10 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^24.0.12":
-  version "24.9.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
-  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
-  dependencies:
-    jest-diff "^24.3.0"
-
-"@types/jest@^25.1.4":
-  version "25.2.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
-  integrity sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==
+"@types/jest@^26.0.4":
+  version "26.0.4"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.4.tgz#d2e513e85aca16992816f192582b5e67b0b15efb"
+  integrity sha512-4fQNItvelbNA9+sFgU+fhJo8ZFF+AS4Egk3GWwCW2jFtViukXbnztccafAdLhzE/0EiCogljtQQXP8aQ9J7sFg==
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
@@ -1766,13 +1750,6 @@
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
-
-"@types/yargs@^13.0.0":
-  version "13.0.9"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.9.tgz#44028e974343c7afcf3960f1a2b1099c39a7b5e1"
-  integrity sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.5"
@@ -2204,7 +2181,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -4085,11 +4062,6 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
-
-diff-sequences@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -6299,16 +6271,6 @@ jest-config@^26.1.0:
     micromatch "^4.0.2"
     pretty-format "^26.1.0"
 
-jest-diff@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
 jest-diff@^25.2.1:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -6369,11 +6331,6 @@ jest-environment-node@^26.1.0:
     "@jest/types" "^26.1.0"
     jest-mock "^26.1.0"
     jest-util "^26.1.0"
-
-jest-get-type@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
-  integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
 jest-get-type@^25.2.6:
   version "25.2.6"
@@ -8815,16 +8772,6 @@ prettier@2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
-pretty-format@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
@@ -9083,7 +9030,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-is@^16.12.0, react-is@^16.8.4:
+react-is@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
*Issue #, if available:*
Replacement for https://github.com/aws/aws-sdk-js-v3/pull/1327

*Description of changes:*
bump @types/jest to 26.0.4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
