### PR TITLE
fix(middleware-sdk-transcribe-streaming): unsign the non host headers

### DIFF
--- a/packages/middleware-sdk-transcribe-streaming/src/signer.spec.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/signer.spec.ts
@@ -1,0 +1,48 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { SignatureV4 } from "./signer";
+describe("transcribe streaming", () => {
+  describe("WebSocket request signer", () => {
+    const toSign = new HttpRequest({
+      headers: {
+        "x-amz-foo": "foo",
+        bar: "bar",
+        "amz-sdk-invocation-id": "123",
+        "amz-sdk-request": "attempt=1",
+        host: "aws.amazon.com"
+      },
+      body: "hello world",
+      query: {
+        prop1: "A",
+        prop2: "B"
+      }
+    });
+    beforeEach(() => {
+      jest.mock("@aws-sdk/protocol-http");
+      ((HttpRequest as any) as jest.Mock).mockReturnValue({
+        isInstance: () => true
+      });
+    });
+    it("should invoke base SigV4 signer correctly", async () => {
+      expect.assertions(5);
+      const mockBaseSigner = {
+        presign: jest
+          .fn()
+          .mockImplementation(request => Promise.resolve(request))
+      };
+      const signer = new SignatureV4({ signer: mockBaseSigner as any });
+      const signed = await signer.sign(toSign);
+      expect(toSign).toMatchObject(signed);
+      expect(mockBaseSigner.presign).toBeCalled();
+      // The request's body should not be presigned
+      expect(mockBaseSigner.presign.mock.calls[0][0].body).toEqual("");
+      expect(
+        mockBaseSigner.presign.mock.calls[0][1]!.unsignableHeaders
+      ).toBeDefined();
+      const unsignableHeaders: Set<string> = mockBaseSigner.presign.mock
+        .calls[0][1]!.unsignableHeaders;
+      expect([...unsignableHeaders.entries()].map(([value]) => value)).toEqual(
+        Object.keys(toSign.headers).filter(a => a !== "host")
+      );
+    });
+  });
+});

--- a/packages/middleware-sdk-transcribe-streaming/src/signer.spec.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/signer.spec.ts
@@ -2,28 +2,22 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 import { SignatureV4 } from "./signer";
 describe("transcribe streaming", () => {
   describe("WebSocket request signer", () => {
-    const toSign = new HttpRequest({
-      headers: {
-        "x-amz-foo": "foo",
-        bar: "bar",
-        "amz-sdk-invocation-id": "123",
-        "amz-sdk-request": "attempt=1",
-        host: "aws.amazon.com"
-      },
-      body: "hello world",
-      query: {
-        prop1: "A",
-        prop2: "B"
-      }
-    });
-    beforeEach(() => {
-      jest.mock("@aws-sdk/protocol-http");
-      ((HttpRequest as any) as jest.Mock).mockReturnValue({
-        isInstance: () => true
-      });
-    });
     it("should invoke base SigV4 signer correctly", async () => {
       expect.assertions(5);
+      const toSign = new HttpRequest({
+        headers: {
+          "x-amz-foo": "foo",
+          bar: "bar",
+          "amz-sdk-invocation-id": "123",
+          "amz-sdk-request": "attempt=1",
+          host: "aws.amazon.com"
+        },
+        body: "hello world",
+        query: {
+          prop1: "A",
+          prop2: "B"
+        }
+      });
       const mockBaseSigner = {
         presign: jest
           .fn()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Transcribe streaming's WebSocket request omits the request headers. So we should not sign any header other than `host`. Because if the header is signed, but not sent to the service, the signature is mismatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
