### PR TITLE
chore: remove unused configuration from integ tests

### DIFF
--- a/features/extra/world.js
+++ b/features/extra/world.js
@@ -1,14 +1,4 @@
 const world = require("./helpers");
-const fs = require("fs");
-const path = require("path");
-
-try {
-  world.config = JSON.parse(fs.readFileSync(path.resolve("./configuration")));
-} catch (e) {
-} finally {
-  process.env["CONFIGURED_REGION"] = "us-west-2";
-}
-
 const WorldConstructor = function WorldConstructor() {
   return world;
 };


### PR DESCRIPTION
*Issue #, if available:*
Was noticed while investigating https://github.com/aws/aws-sdk-js-v3/issues/1338

*Description of changes:*

The environment variable `CONFIGURED_REGION` is used in v2 for setting up global AWS config, and it's not required in v3 integ tests
* v2 code which sets env var `CONFIGURED_REGION` https://github.com/aws/aws-sdk-js/blob/cc29728c1c4178969ebabe3bbe6b6f3159436394/features/extra/world.js#L8
* v2 code which uses env var `CONFIGURED_REGION` https://github.com/aws/aws-sdk-js/blob/cc29728c1c4178969ebabe3bbe6b6f3159436394/features/extra/cleanup.js#L106-L108
* In v3, the region is explicitly set where required during client creation
  * Explicitly in JavaScript https://github.com/aws/aws-sdk-js-v3/blob/4bc605be4eda41b47ecf44bdea31d289f88aa699/features/inspector/step_definitions/inspector.js#L4-L7
  * In scenario https://github.com/aws/aws-sdk-js-v3/blob/c96f35f972c44706a391bb07e0a897e73b8d6dfe/features/s3/buckets.feature#L13

The file configuration:
* is used in v2 integ tests
  * Defined at https://github.com/aws/aws-sdk-js/blob/cc29728c1c4178969ebabe3bbe6b6f3159436394/configuration.sample
  * Consumed in https://github.com/aws/aws-sdk-js/blob/cc29728c1c4178969ebabe3bbe6b6f3159436394/features/extra/world.js#L6
* In v3, the file was removed in https://github.com/aws/aws-sdk-js-v3/pull/1088

Verified that integration tests are successful
```console
$ yarn test:integration-legacy
yarn run v1.22.4
$ cucumber-js --fail-fast
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

153 scenarios (153 passed)
534 steps (534 passed)
1m00.378s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
