### PR TITLE
fix: use fromStatic to return default config values

### DIFF
--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -18,6 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-gamma.1",
+    "@aws-sdk/retry-config-provider": "1.0.0-gamma.0",
     "@aws-sdk/service-error-classification": "1.0.0-gamma.1",
     "@aws-sdk/types": "1.0.0-gamma.1",
     "react-native-get-random-values": "^1.4.0",

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -10,6 +10,7 @@ import { StandardRetryStrategy, RetryQuota } from "./defaultStrategy";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { v4 } from "uuid";
+import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/retry-config-provider";
 
 jest.mock("@aws-sdk/service-error-classification", () => ({
   isThrottlingError: jest.fn().mockReturnValue(true)
@@ -616,15 +617,14 @@ describe("defaultStrategy", () => {
     });
   });
 
-  describe("defaults maxAttempts to 3", () => {
+  describe("defaults maxAttempts to DEFAULT_MAX_ATTEMPTS", () => {
     it("when maxAttemptsProvider throws error", async () => {
-      const maxAttempts = 3;
       const { isInstance } = HttpRequest;
       ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
 
       next = jest.fn(args => {
         expect(args.request.headers["amz-sdk-request"]).toBe(
-          `attempt=1; max=${maxAttempts}`
+          `attempt=1; max=${DEFAULT_MAX_ATTEMPTS}`
         );
         return Promise.resolve({
           response: "mockResponse",
@@ -642,13 +642,12 @@ describe("defaultStrategy", () => {
     });
 
     it("when parseInt fails on maxAttemptsProvider", async () => {
-      const maxAttempts = 3;
       const { isInstance } = HttpRequest;
       ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
 
       next = jest.fn(args => {
         expect(args.request.headers["amz-sdk-request"]).toBe(
-          `attempt=1; max=${maxAttempts}`
+          `attempt=1; max=${DEFAULT_MAX_ATTEMPTS}`
         );
         return Promise.resolve({
           response: "mockResponse",

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -17,6 +17,7 @@ import {
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { v4 } from "uuid";
+import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/retry-config-provider";
 
 /**
  * Determines whether an error is retryable based on the number of retries
@@ -92,14 +93,16 @@ export class StandardRetryStrategy implements RetryStrategy {
   }
 
   private async getMaxAttempts() {
-    let maxAttemptsStr;
+    let maxAttemptsStr: string;
     try {
       maxAttemptsStr = await this.maxAttemptsProvider();
     } catch (error) {
-      maxAttemptsStr = "3";
+      maxAttemptsStr = DEFAULT_MAX_ATTEMPTS;
     }
     const maxAttempts = parseInt(maxAttemptsStr);
-    return Number.isNaN(maxAttempts) ? 3 : maxAttempts;
+    return Number.isNaN(maxAttempts)
+      ? parseInt(DEFAULT_MAX_ATTEMPTS)
+      : maxAttempts;
   }
 
   async retry<Input extends object, Ouput extends MetadataBearer>(

--- a/packages/retry-config-provider/src/defaultProvider.ts
+++ b/packages/retry-config-provider/src/defaultProvider.ts
@@ -16,9 +16,15 @@ export const DEFAULT_RETRY_MODE = "standard";
 
 const defaultProvider = (
   configuration: SharedConfigInit = {},
-  envVarName: string,
-  configKey: string,
-  defaultValue: string
+  {
+    envVarName,
+    configKey,
+    defaultValue
+  }: {
+    envVarName: string;
+    configKey: string;
+    defaultValue: string;
+  }
 ): Provider<string> =>
   memoize(
     chain(
@@ -31,19 +37,17 @@ const defaultProvider = (
 export const maxAttemptsProvider = (
   configuration: SharedConfigInit = {}
 ): Provider<string> =>
-  defaultProvider(
-    configuration,
-    ENV_MAX_ATTEMPTS,
-    CONFIG_MAX_ATTEMPTS,
-    DEFAULT_MAX_ATTEMPTS
-  );
+  defaultProvider(configuration, {
+    envVarName: ENV_MAX_ATTEMPTS,
+    configKey: CONFIG_MAX_ATTEMPTS,
+    defaultValue: DEFAULT_MAX_ATTEMPTS
+  });
 
 export const retryModeProvider = (
   configuration: SharedConfigInit = {}
 ): Provider<string> =>
-  defaultProvider(
-    configuration,
-    ENV_RETRY_MODE,
-    CONFIG_RETRY_MODE,
-    DEFAULT_RETRY_MODE
-  );
+  defaultProvider(configuration, {
+    envVarName: ENV_RETRY_MODE,
+    configKey: CONFIG_RETRY_MODE,
+    defaultValue: DEFAULT_RETRY_MODE
+  });

--- a/packages/retry-config-provider/src/defaultProvider.ts
+++ b/packages/retry-config-provider/src/defaultProvider.ts
@@ -3,30 +3,47 @@ import {
   SharedConfigInit,
   fromSharedConfigFiles
 } from "./fromSharedConfigFiles";
-import { chain, memoize } from "@aws-sdk/property-provider";
+import { chain, memoize, fromStatic } from "@aws-sdk/property-provider";
 import { Provider } from "@aws-sdk/types";
 
 export const ENV_MAX_ATTEMPTS = "AWS_MAX_ATTEMPTS";
 export const CONFIG_MAX_ATTEMPTS = "max_attempts";
+export const DEFAULT_MAX_ATTEMPTS = "3";
 
 export const ENV_RETRY_MODE = "AWS_RETRY_MODE";
 export const CONFIG_RETRY_MODE = "retry_mode";
+export const DEFAULT_RETRY_MODE = "standard";
 
 const defaultProvider = (
   configuration: SharedConfigInit = {},
   envVarName: string,
-  configKey: string
+  configKey: string,
+  defaultValue: string
 ): Provider<string> =>
   memoize(
-    chain(fromEnv(envVarName), fromSharedConfigFiles(configuration, configKey))
+    chain(
+      fromEnv(envVarName),
+      fromSharedConfigFiles(configuration, configKey),
+      fromStatic(defaultValue)
+    )
   );
 
 export const maxAttemptsProvider = (
   configuration: SharedConfigInit = {}
 ): Provider<string> =>
-  defaultProvider(configuration, ENV_MAX_ATTEMPTS, CONFIG_MAX_ATTEMPTS);
+  defaultProvider(
+    configuration,
+    ENV_MAX_ATTEMPTS,
+    CONFIG_MAX_ATTEMPTS,
+    DEFAULT_MAX_ATTEMPTS
+  );
 
 export const retryModeProvider = (
   configuration: SharedConfigInit = {}
 ): Provider<string> =>
-  defaultProvider(configuration, ENV_RETRY_MODE, CONFIG_RETRY_MODE);
+  defaultProvider(
+    configuration,
+    ENV_RETRY_MODE,
+    CONFIG_RETRY_MODE,
+    DEFAULT_RETRY_MODE
+  );


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-1909

*Description of changes:*
use fromStatic to return default config values

Verified that integration tests no longer throw `No max_attempts found for profile default in SDK configuration files` error:

On master:
```console
$ yarn test:integration-legacy --tags @acm
yarn run v1.22.4
$ cucumber-js --fail-fast --tags @acm
.(node:5683) UnhandledPromiseRejectionWarning: Error: No max_attempts found for profile default in SDK configuration files
    at new ProviderError (/local/home/trivikr/workspace/aws-sdk-js-v3/packages/property-provider/dist/cjs/ProviderError.js:17:28)
    at /local/home/trivikr/workspace/aws-sdk-js-v3/packages/retry-config-provider/dist/cjs/fromSharedConfigFiles.js:23:27
    at step (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/tslib/tslib.js:141:27)
    at Object.next (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/tslib/tslib.js:122:57)
    at fulfilled (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/tslib/tslib.js:112:62)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:5683) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 7)
(node:5683) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
.(node:5683) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 7)
....(node:5683) UnhandledPromiseRejectionWarning: Error: No max_attempts found for profile default in SDK configuration files
    at new ProviderError (/local/home/trivikr/workspace/aws-sdk-js-v3/packages/property-provider/dist/cjs/ProviderError.js:17:28)
    at /local/home/trivikr/workspace/aws-sdk-js-v3/packages/retry-config-provider/dist/cjs/fromSharedConfigFiles.js:23:27
    at step (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/tslib/tslib.js:141:27)
    at Object.next (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/tslib/tslib.js:122:57)
    at fulfilled (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/tslib/tslib.js:112:62)
(node:5683) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 14)
.(node:5683) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 14)
..

2 scenarios (2 passed)
5 steps (5 passed)
0m00.055s
Done in 2.38s.
```

On PR branch:
```console
$ yarn test:integration-legacy --tags @acm
yarn run v1.22.4
$ cucumber-js --fail-fast --tags @acm
.........

2 scenarios (2 passed)
5 steps (5 passed)
0m00.152s
Done in 2.45s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
