### PR TITLE
fix: add dist to tsconfig exclude

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     }
   },
   "include": ["packages/"],
-  "exclude": ["node_modules/", "packages/*/build/"]
+  "exclude": ["node_modules/", "packages/*/dist/", "packages/*/node_modules/"]
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1345
Tsconfig ignores the build, not the dist

*Description of changes:*

Before:
real    11m44.230s
user    73m58.100s
sys     3m42.993s

After:
real    4m20.136s
user    27m12.105s
sys     2m21.304s

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
