### PR TITLE
fix: increase cucumber default timeout to 300s

### DIFF
--- a/features/extra/hooks.js
+++ b/features/extra/hooks.js
@@ -16,7 +16,7 @@ const {
   setWorldConstructor
 } = require("cucumber");
 
-setDefaultTimeout(180 * 1000);
+setDefaultTimeout(300 * 1000);
 setWorldConstructor(require("./world.js").World);
 
 Before(function (scenario, callback) {


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-1910

*Description of changes:*
Increase cucumber default timeout to 300s as some integration tests are failing intermittently

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
