### PR TITLE
feat(credential-provider-imds): update httpGet to accept options.method

### DIFF
--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -29,6 +29,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
+    "nock": "^13.0.2",
     "typescript": "~3.8.3"
   },
   "types": "./dist/cjs/index.d.ts"

--- a/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
@@ -4,21 +4,21 @@ import {
   ENV_CMDS_RELATIVE_URI,
   fromContainerMetadata
 } from "./fromContainerMetadata";
-import { httpGet } from "./remoteProvider/httpGet";
+import { httpRequest } from "./remoteProvider/httpRequest";
 import {
   fromImdsCredentials,
   ImdsCredentials
 } from "./remoteProvider/ImdsCredentials";
 
-const mockHttpGet = <any>httpGet;
-jest.mock("./remoteProvider/httpGet", () => ({ httpGet: jest.fn() }));
+const mockHttpRequest = <any>httpRequest;
+jest.mock("./remoteProvider/httpRequest", () => ({ httpRequest: jest.fn() }));
 
 const relativeUri = process.env[ENV_CMDS_RELATIVE_URI];
 const fullUri = process.env[ENV_CMDS_FULL_URI];
 const authToken = process.env[ENV_CMDS_AUTH_TOKEN];
 
 beforeEach(() => {
-  mockHttpGet.mockReset();
+  mockHttpRequest.mockReset();
   delete process.env[ENV_CMDS_RELATIVE_URI];
   delete process.env[ENV_CMDS_FULL_URI];
   delete process.env[ENV_CMDS_AUTH_TOKEN];
@@ -53,12 +53,12 @@ describe("fromContainerMetadata", () => {
     const token = "Basic abcd";
     process.env[ENV_CMDS_FULL_URI] = "http://localhost:8080/path";
     process.env[ENV_CMDS_AUTH_TOKEN] = token;
-    mockHttpGet.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
+    mockHttpRequest.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
 
     await fromContainerMetadata()();
 
-    expect(mockHttpGet.mock.calls.length).toBe(1);
-    const [options = {}] = mockHttpGet.mock.calls[0];
+    expect(mockHttpRequest.mock.calls.length).toBe(1);
+    const [options = {}] = mockHttpRequest.mock.calls[0];
     expect(options.headers).toMatchObject({
       Authorization: token
     });
@@ -70,7 +70,7 @@ describe("fromContainerMetadata", () => {
     });
 
     it("should resolve credentials by fetching them from the container metadata service", async () => {
-      mockHttpGet.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
+      mockHttpRequest.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
 
       expect(await fromContainerMetadata()()).toEqual(
         fromImdsCredentials(creds)
@@ -80,38 +80,42 @@ describe("fromContainerMetadata", () => {
     it("should retry the fetching operation up to maxRetries times", async () => {
       const maxRetries = 5;
       for (let i = 0; i < maxRetries - 1; i++) {
-        mockHttpGet.mockReturnValueOnce(Promise.reject("No!"));
+        mockHttpRequest.mockReturnValueOnce(Promise.reject("No!"));
       }
-      mockHttpGet.mockReturnValueOnce(Promise.resolve(JSON.stringify(creds)));
+      mockHttpRequest.mockReturnValueOnce(
+        Promise.resolve(JSON.stringify(creds))
+      );
 
       expect(await fromContainerMetadata({ maxRetries })()).toEqual(
         fromImdsCredentials(creds)
       );
-      expect(mockHttpGet.mock.calls.length).toEqual(maxRetries);
+      expect(mockHttpRequest.mock.calls.length).toEqual(maxRetries);
     });
 
     it("should retry responses that receive invalid response values", async () => {
       for (let key of Object.keys(creds)) {
         const invalidCreds: any = { ...creds };
         delete invalidCreds[key];
-        mockHttpGet.mockReturnValueOnce(
+        mockHttpRequest.mockReturnValueOnce(
           Promise.resolve(JSON.stringify(invalidCreds))
         );
       }
-      mockHttpGet.mockReturnValueOnce(Promise.resolve(JSON.stringify(creds)));
+      mockHttpRequest.mockReturnValueOnce(
+        Promise.resolve(JSON.stringify(creds))
+      );
 
       await fromContainerMetadata({ maxRetries: 100 })();
-      expect(mockHttpGet.mock.calls.length).toEqual(
+      expect(mockHttpRequest.mock.calls.length).toEqual(
         Object.keys(creds).length + 1
       );
     });
 
-    it("should pass relevant configuration to httpGet", async () => {
+    it("should pass relevant configuration to httpRequest", async () => {
       const timeout = Math.ceil(Math.random() * 1000);
-      mockHttpGet.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
+      mockHttpRequest.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
       await fromContainerMetadata({ timeout })();
-      expect(mockHttpGet.mock.calls.length).toEqual(1);
-      expect(mockHttpGet.mock.calls[0][0]).toEqual({
+      expect(mockHttpRequest.mock.calls.length).toEqual(1);
+      expect(mockHttpRequest.mock.calls[0][0]).toEqual({
         hostname: "169.254.170.2",
         path: process.env[ENV_CMDS_RELATIVE_URI],
         timeout
@@ -120,20 +124,20 @@ describe("fromContainerMetadata", () => {
   });
 
   describe(ENV_CMDS_FULL_URI, () => {
-    it("should pass relevant configuration to httpGet", async () => {
+    it("should pass relevant configuration to httpRequest", async () => {
       process.env[ENV_CMDS_FULL_URI] = "http://localhost:8080/path";
 
       const timeout = Math.ceil(Math.random() * 1000);
-      mockHttpGet.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
+      mockHttpRequest.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
       await fromContainerMetadata({ timeout })();
-      expect(mockHttpGet.mock.calls.length).toEqual(1);
+      expect(mockHttpRequest.mock.calls.length).toEqual(1);
       const {
         protocol,
         hostname,
         path,
         port,
         timeout: actualTimeout
-      } = mockHttpGet.mock.calls[0][0];
+      } = mockHttpRequest.mock.calls[0][0];
       expect(protocol).toBe("http:");
       expect(hostname).toBe("localhost");
       expect(path).toBe("/path");
@@ -146,10 +150,10 @@ describe("fromContainerMetadata", () => {
       process.env[ENV_CMDS_FULL_URI] = "http://localhost:8080/path";
 
       const timeout = Math.ceil(Math.random() * 1000);
-      mockHttpGet.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
+      mockHttpRequest.mockReturnValue(Promise.resolve(JSON.stringify(creds)));
       await fromContainerMetadata({ timeout })();
-      expect(mockHttpGet.mock.calls.length).toEqual(1);
-      expect(mockHttpGet.mock.calls[0][0]).toEqual({
+      expect(mockHttpRequest.mock.calls.length).toEqual(1);
+      expect(mockHttpRequest.mock.calls[0][0]).toEqual({
         hostname: "169.254.170.2",
         path: "foo",
         timeout

--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -3,7 +3,7 @@ import {
   RemoteProviderInit,
   providerConfigFromInit
 } from "./remoteProvider/RemoteProviderInit";
-import { httpGet } from "./remoteProvider/httpGet";
+import { httpRequest } from "./remoteProvider/httpRequest";
 import {
   fromImdsCredentials,
   isImdsCredentials
@@ -53,7 +53,7 @@ function requestFromEcsImds(
     options.headers = headers;
   }
 
-  return httpGet({
+  return httpRequest({
     ...options,
     timeout
   }).then(buffer => buffer.toString());

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -3,7 +3,7 @@ import {
   RemoteProviderInit,
   providerConfigFromInit
 } from "./remoteProvider/RemoteProviderInit";
-import { httpGet } from "./remoteProvider/httpGet";
+import { httpRequest } from "./remoteProvider/httpRequest";
 import {
   fromImdsCredentials,
   isImdsCredentials
@@ -27,7 +27,7 @@ export const fromInstanceMetadata = (
       await retry<string>(
         async () =>
           (
-            await httpGet({ host: IMDS_IP, path: IMDS_PATH, timeout })
+            await httpRequest({ host: IMDS_IP, path: IMDS_PATH, timeout })
           ).toString(),
         maxRetries
       )
@@ -36,7 +36,7 @@ export const fromInstanceMetadata = (
     return retry(async () => {
       const credsResponse = JSON.parse(
         (
-          await httpGet({
+          await httpRequest({
             host: IMDS_IP,
             path: IMDS_PATH + profile,
             timeout

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -11,6 +11,9 @@ import {
 import { retry } from "./remoteProvider/retry";
 import { ProviderError } from "@aws-sdk/property-provider";
 
+const IMDS_IP = "169.254.169.254";
+const IMDS_PATH = "/latest/meta-data/iam/security-credentials/";
+
 /**
  * Creates a credential provider that will source credentials from the EC2
  * Instance Metadata Service
@@ -22,14 +25,23 @@ export const fromInstanceMetadata = (
   return async () => {
     const profile = (
       await retry<string>(
-        async () => await requestFromEc2Imds(timeout),
+        async () =>
+          (
+            await httpGet({ host: IMDS_IP, path: IMDS_PATH, timeout })
+          ).toString(),
         maxRetries
       )
     ).trim();
 
     return retry(async () => {
       const credsResponse = JSON.parse(
-        await requestFromEc2Imds(timeout, profile)
+        (
+          await httpGet({
+            host: IMDS_IP,
+            path: IMDS_PATH + profile,
+            timeout
+          })
+        ).toString()
       );
       if (!isImdsCredentials(credsResponse)) {
         throw new ProviderError(
@@ -40,19 +52,4 @@ export const fromInstanceMetadata = (
       return fromImdsCredentials(credsResponse);
     }, maxRetries);
   };
-};
-
-const IMDS_IP = "169.254.169.254";
-const IMDS_PATH = "latest/meta-data/iam/security-credentials";
-
-const requestFromEc2Imds = async (
-  timeout: number,
-  path?: string
-): Promise<string> => {
-  const buffer = await httpGet({
-    host: IMDS_IP,
-    path: `/${IMDS_PATH}/${path ? path : ""}`,
-    timeout
-  });
-  return buffer.toString();
 };

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -1,18 +1,37 @@
 import * as nock from "nock";
+import { createServer } from "http";
 import { httpRequest } from "./httpRequest";
 
 describe("httpRequest", () => {
+  let port: number;
   const host = "localhost";
   const path = "/";
+
+  const getOpenPort = async (candidatePort: number = 4321): Promise<number> => {
+    try {
+      return new Promise<number>((resolve, reject) => {
+        const server = createServer();
+        server.on("error", () => reject());
+        server.listen(candidatePort);
+        server.close(() => resolve(candidatePort));
+      });
+    } catch (e) {
+      return await getOpenPort(candidatePort + 1);
+    }
+  };
+
+  beforeAll(async () => {
+    port = await getOpenPort();
+  });
 
   describe("returns response", () => {
     it("defaults to method GET", async () => {
       const expectedResponse = "expectedResponse";
-      const scope = nock("http://" + host)
+      const scope = nock(`http://${host}:${port}`)
         .get(path)
         .reply(200, expectedResponse);
 
-      const response = await httpRequest({ host, path });
+      const response = await httpRequest({ host, path, port });
       expect(response.toString()).toStrictEqual(expectedResponse);
 
       scope.done();
@@ -21,11 +40,11 @@ describe("httpRequest", () => {
     it("uses method passed in options", async () => {
       const method = "POST";
       const expectedResponse = "expectedResponse";
-      const scope = nock("http://" + host)
+      const scope = nock(`http://${host}:${port}`)
         .post(path)
         .reply(200, expectedResponse);
 
-      const response = await httpRequest({ host, path, method });
+      const response = await httpRequest({ host, path, port, method });
       expect(response.toString()).toStrictEqual(expectedResponse);
 
       scope.done();

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -52,14 +52,14 @@ describe("httpRequest", () => {
     addMatcher("/", expectedResponse);
 
     expect(
-      (await httpRequest(`http://localhost:${port}/`)).toString("utf8")
+      (await httpRequest({ host: "localhost", port })).toString("utf8")
     ).toEqual(expectedResponse);
   });
 
   it("should reject the promise with a non-terminal error if a 404 status code is received", async () => {
     addMatcher("/fizz", "buzz");
 
-    await httpRequest(`http://localhost:${port}/foo`).then(
+    await httpRequest({ host: "localhost", path: "/foo", port }).then(
       () => {
         throw new Error("The promise should have been rejected");
       },
@@ -72,7 +72,7 @@ describe("httpRequest", () => {
   it("should reject the promise with a non-terminal error if the remote server cannot be contacted", async () => {
     server.close();
 
-    await httpRequest(`http://localhost:${port}/foo`).then(
+    await httpRequest({ host: "localhost", path: "/foo", port }).then(
       () => {
         throw new Error("The promise should have been rejected");
       },

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -1,5 +1,5 @@
 import { createServer } from "http";
-import { httpGet } from "./httpGet";
+import { httpRequest } from "./httpRequest";
 import { ProviderError } from "@aws-sdk/property-provider";
 
 let matchers: { [url: string]: string } = {};
@@ -46,20 +46,20 @@ afterAll(() => {
 
 beforeEach(clearMatchers);
 
-describe("httpGet", () => {
+describe("httpRequest", () => {
   it("should respond with a promise fulfilled with the http response", async () => {
     const expectedResponse = "foo bar baz";
     addMatcher("/", expectedResponse);
 
     expect(
-      (await httpGet(`http://localhost:${port}/`)).toString("utf8")
+      (await httpRequest(`http://localhost:${port}/`)).toString("utf8")
     ).toEqual(expectedResponse);
   });
 
   it("should reject the promise with a non-terminal error if a 404 status code is received", async () => {
     addMatcher("/fizz", "buzz");
 
-    await httpGet(`http://localhost:${port}/foo`).then(
+    await httpRequest(`http://localhost:${port}/foo`).then(
       () => {
         throw new Error("The promise should have been rejected");
       },
@@ -72,7 +72,7 @@ describe("httpGet", () => {
   it("should reject the promise with a non-terminal error if the remote server cannot be contacted", async () => {
     server.close();
 
-    await httpGet(`http://localhost:${port}/foo`).then(
+    await httpRequest(`http://localhost:${port}/foo`).then(
       () => {
         throw new Error("The promise should have been rejected");
       },

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -1,6 +1,7 @@
 import * as nock from "nock";
 import { createServer } from "http";
 import { httpRequest } from "./httpRequest";
+import { ProviderError } from "@aws-sdk/property-provider";
 
 describe("httpRequest", () => {
   let port: number;
@@ -46,6 +47,20 @@ describe("httpRequest", () => {
 
       const response = await httpRequest({ host, path, port, method });
       expect(response.toString()).toStrictEqual(expectedResponse);
+
+      scope.done();
+    });
+  });
+
+  describe("throws error", () => {
+    it("when request throws error", async () => {
+      const scope = nock(`http://${host}:${port}`)
+        .get(path)
+        .replyWithError("error");
+
+      await expect(httpRequest({ host, path, port })).rejects.toStrictEqual(
+        new ProviderError("Unable to connect to instance metadata service")
+      );
 
       scope.done();
     });

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -5,15 +5,30 @@ describe("httpRequest", () => {
   const host = "localhost";
   const path = "/";
 
-  it("returns response", async () => {
-    const expectedResponse = "expectedResponse";
-    const scope = nock("http://" + host)
-      .get(path)
-      .reply(200, expectedResponse);
+  describe("returns response", () => {
+    it("defaults to method GET", async () => {
+      const expectedResponse = "expectedResponse";
+      const scope = nock("http://" + host)
+        .get(path)
+        .reply(200, expectedResponse);
 
-    const response = await httpRequest({ host, path });
-    expect(response.toString()).toStrictEqual(expectedResponse);
+      const response = await httpRequest({ host, path });
+      expect(response.toString()).toStrictEqual(expectedResponse);
 
-    scope.done();
+      scope.done();
+    });
+
+    it("uses method passed in options", async () => {
+      const method = "POST";
+      const expectedResponse = "expectedResponse";
+      const scope = nock("http://" + host)
+        .post(path)
+        .reply(200, expectedResponse);
+
+      const response = await httpRequest({ host, path, method });
+      expect(response.toString()).toStrictEqual(expectedResponse);
+
+      scope.done();
+    });
   });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -1,84 +1,19 @@
-import { createServer } from "http";
+import * as nock from "nock";
 import { httpRequest } from "./httpRequest";
-import { ProviderError } from "@aws-sdk/property-provider";
-
-let matchers: { [url: string]: string } = {};
-
-function addMatcher(url: string, toReturn: string): void {
-  matchers[url] = toReturn;
-}
-
-function clearMatchers(): void {
-  matchers = {};
-}
-
-function getOpenPort(candidatePort: number = 4321): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    const server = createServer();
-    server.on("error", () => reject());
-    server.listen(candidatePort);
-    server.close(() => resolve(candidatePort));
-  }).catch(() => getOpenPort(candidatePort + 1));
-}
-
-let port: number;
-
-const server = createServer((request, response) => {
-  const { url = "" } = request;
-  if (url in matchers) {
-    response.statusCode = 200;
-    response.end(matchers[url]);
-  } else {
-    response.statusCode = 404;
-    response.end("Not found");
-  }
-});
-
-beforeAll(async done => {
-  port = await getOpenPort();
-  server.listen(port);
-  done();
-});
-
-afterAll(() => {
-  server.close();
-});
-
-beforeEach(clearMatchers);
 
 describe("httpRequest", () => {
-  it("should respond with a promise fulfilled with the http response", async () => {
-    const expectedResponse = "foo bar baz";
-    addMatcher("/", expectedResponse);
+  const host = "localhost";
+  const path = "/";
 
-    expect(
-      (await httpRequest({ host: "localhost", port })).toString("utf8")
-    ).toEqual(expectedResponse);
-  });
+  it("returns response", async () => {
+    const expectedResponse = "expectedResponse";
+    const scope = nock("http://" + host)
+      .get(path)
+      .reply(200, expectedResponse);
 
-  it("should reject the promise with a non-terminal error if a 404 status code is received", async () => {
-    addMatcher("/fizz", "buzz");
+    const response = await httpRequest({ host, path });
+    expect(response.toString()).toStrictEqual(expectedResponse);
 
-    await httpRequest({ host: "localhost", path: "/foo", port }).then(
-      () => {
-        throw new Error("The promise should have been rejected");
-      },
-      (err: any) => {
-        expect((err as ProviderError).tryNextLink).toBe(true);
-      }
-    );
-  });
-
-  it("should reject the promise with a non-terminal error if the remote server cannot be contacted", async () => {
-    server.close();
-
-    await httpRequest({ host: "localhost", path: "/foo", port }).then(
-      () => {
-        throw new Error("The promise should have been rejected");
-      },
-      (err: any) => {
-        expect((err as ProviderError).tryNextLink).toBe(true);
-      }
-    );
+    scope.done();
   });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -5,7 +5,7 @@ import { ProviderError } from "@aws-sdk/property-provider";
 /**
  * @internal
  */
-export function httpGet(options: RequestOptions | string): Promise<Buffer> {
+export function httpRequest(options: RequestOptions | string): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const request = get(options);
     request.on("error", err => {

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -5,16 +5,16 @@ import { ProviderError } from "@aws-sdk/property-provider";
 /**
  * @internal
  */
-export function httpRequest(options: RequestOptions | string): Promise<Buffer> {
+export function httpRequest(options: RequestOptions): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const request = get(options);
-    request.on("error", err => {
+    const req = get(options);
+    req.on("error", err => {
       reject(
         new ProviderError("Unable to connect to instance metadata service")
       );
     });
 
-    request.on("response", (res: IncomingMessage) => {
+    req.on("response", (res: IncomingMessage) => {
       const { statusCode = 400 } = res;
       if (statusCode < 200 || 300 <= statusCode) {
         reject(

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer";
-import { get, IncomingMessage, RequestOptions } from "http";
+import { request, IncomingMessage, RequestOptions } from "http";
 import { ProviderError } from "@aws-sdk/property-provider";
 
 /**
@@ -7,7 +7,7 @@ import { ProviderError } from "@aws-sdk/property-provider";
  */
 export function httpRequest(options: RequestOptions): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const req = get(options);
+    const req = request({ method: "GET", ...options });
     req.on("error", err => {
       reject(
         new ProviderError("Unable to connect to instance metadata service")
@@ -32,5 +32,7 @@ export function httpRequest(options: RequestOptions): Promise<Buffer> {
         resolve(Buffer.concat(chunks));
       });
     });
+
+    req.end();
   });
 }

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -17,11 +17,11 @@ export function httpRequest(options: RequestOptions): Promise<Buffer> {
     req.on("response", (res: IncomingMessage) => {
       const { statusCode = 400 } = res;
       if (statusCode < 200 || 300 <= statusCode) {
-        reject(
-          new ProviderError(
-            "Error response received from instance metadata service"
-          )
+        const error = new ProviderError(
+          "Error response received from instance metadata service"
         );
+        (error as any).statusCode = statusCode;
+        reject(error);
       }
 
       const chunks: Array<Buffer> = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -7976,6 +7976,16 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
+nock@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.2.tgz#3e50f88348edbb90cce1bbbf0a3ea6a068993983"
+  integrity sha512-Wm8H22iT3UKPDf138tmgJ0NRfCLd9f2LByki9T2mGHnB66pEqvJh3gV/up1ZufZF24n7/pDYyLGybdqOzF3JIw==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
+
 node-fetch-npm@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz#6507d0e17a9ec0be3bec516958a497cec54bf5a4"
@@ -8845,6 +8855,11 @@ promzard@^0.3.0:
   integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
   dependencies:
     read "1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
*Issue #, if available:*
Required for PUT operation in signed IMDS workflow (internal JS-1903)

*Description of changes:*
* update httpGet to accept options.method
* uses nock for simplifying http request tests
* populates statusCode in ProviderError, as it would be consumed in signed IMDS workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
