### PR TITLE
fix: get maxAttempts from maxAttemptsProvider

### DIFF
--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -18,7 +18,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-gamma.2",
-    "@aws-sdk/retry-config-provider": "1.0.0-gamma.1",
     "@aws-sdk/service-error-classification": "1.0.0-gamma.2",
     "@aws-sdk/types": "1.0.0-gamma.2",
     "react-native-get-random-values": "^1.4.0",

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -6,7 +6,6 @@ import { StandardRetryStrategy, RetryQuota } from "./defaultStrategy";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { v4 } from "uuid";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/retry-config-provider";
 
 jest.mock("@aws-sdk/service-error-classification");
 jest.mock("./delayDecider");
@@ -474,46 +473,6 @@ describe("defaultStrategy", () => {
       }
 
       expect(next).toHaveBeenCalledTimes(maxAttempts);
-      ((isInstance as unknown) as jest.Mock).mockReturnValue(false);
-    });
-  });
-
-  describe("defaults maxAttempts to DEFAULT_MAX_ATTEMPTS", () => {
-    it("when maxAttemptsProvider throws error", async () => {
-      const { isInstance } = HttpRequest;
-      ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
-
-      next = jest.fn((args) => {
-        expect(args.request.headers["amz-sdk-request"]).toBe(`attempt=1; max=${DEFAULT_MAX_ATTEMPTS}`);
-        return Promise.resolve({
-          response: "mockResponse",
-          output: { $metadata: {} },
-        });
-      });
-
-      const retryStrategy = new StandardRetryStrategy(() => Promise.reject("ERROR"));
-      await retryStrategy.retry(next, { request: { headers: {} } } as any);
-
-      expect(next).toHaveBeenCalledTimes(1);
-      ((isInstance as unknown) as jest.Mock).mockReturnValue(false);
-    });
-
-    it("when parseInt fails on maxAttemptsProvider", async () => {
-      const { isInstance } = HttpRequest;
-      ((isInstance as unknown) as jest.Mock).mockReturnValue(true);
-
-      next = jest.fn((args) => {
-        expect(args.request.headers["amz-sdk-request"]).toBe(`attempt=1; max=${DEFAULT_MAX_ATTEMPTS}`);
-        return Promise.resolve({
-          response: "mockResponse",
-          output: { $metadata: {} },
-        });
-      });
-
-      const retryStrategy = new StandardRetryStrategy(() => Promise.resolve("not-a-number"));
-      await retryStrategy.retry(next, { request: { headers: {} } } as any);
-
-      expect(next).toHaveBeenCalledTimes(1);
       ((isInstance as unknown) as jest.Mock).mockReturnValue(false);
     });
   });


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1352

*Description of changes:*
Get maxAttempts from maxAttemptsProvider, as it returns default value as per https://github.com/aws/aws-sdk-js-v3/pull/1341

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
