### PR TITLE
fix: move retry defaults to middleware-retry

### DIFF
--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -18,7 +18,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-gamma.2",
-    "@aws-sdk/retry-config-provider": "1.0.0-gamma.1",
     "@aws-sdk/service-error-classification": "1.0.0-gamma.2",
     "@aws-sdk/types": "1.0.0-gamma.2",
     "react-native-get-random-values": "^1.4.0",

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -4,7 +4,7 @@ import { v4 } from "uuid";
 
 import { DEFAULT_RETRY_DELAY_BASE, INITIAL_RETRY_TOKENS, THROTTLING_RETRY_DELAY_BASE } from "./constants";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
-import { RetryQuota, StandardRetryStrategy, DEFAULT_MAX_ATTEMPTS } from "./defaultStrategy";
+import { DEFAULT_MAX_ATTEMPTS, RetryQuota, StandardRetryStrategy } from "./defaultStrategy";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
 

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -1,11 +1,10 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/retry-config-provider";
 import { isThrottlingError } from "@aws-sdk/service-error-classification";
 import { v4 } from "uuid";
 
 import { DEFAULT_RETRY_DELAY_BASE, INITIAL_RETRY_TOKENS, THROTTLING_RETRY_DELAY_BASE } from "./constants";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
-import { RetryQuota, StandardRetryStrategy } from "./defaultStrategy";
+import { RetryQuota, StandardRetryStrategy, DEFAULT_MAX_ATTEMPTS } from "./defaultStrategy";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
 

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -1,5 +1,4 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/retry-config-provider";
 import { isThrottlingError } from "@aws-sdk/service-error-classification";
 import { SdkError } from "@aws-sdk/smithy-client";
 import { FinalizeHandler, FinalizeHandlerArguments, MetadataBearer, Provider, RetryStrategy } from "@aws-sdk/types";
@@ -9,6 +8,17 @@ import { DEFAULT_RETRY_DELAY_BASE, INITIAL_RETRY_TOKENS, THROTTLING_RETRY_DELAY_
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
+
+/**
+ * The default value for how many HTTP requests an SDK should make for a
+ * single SDK operation invocation before giving up
+ */
+export const DEFAULT_MAX_ATTEMPTS = "3";
+
+/**
+ * The default retry algorithm to use.
+ */
+export const DEFAULT_RETRY_MODE = "standard";
 
 /**
  * Determines whether an error is retryable based on the number of retries

--- a/packages/retry-config-provider/package.json
+++ b/packages/retry-config-provider/package.json
@@ -22,6 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/middleware-retry": "1.0.0-gamma.2",
     "@aws-sdk/property-provider": "1.0.0-gamma.2",
     "@aws-sdk/shared-ini-file-loader": "1.0.0-gamma.2",
     "@aws-sdk/types": "1.0.0-gamma.2",

--- a/packages/retry-config-provider/src/defaultProvider.spec.ts
+++ b/packages/retry-config-provider/src/defaultProvider.spec.ts
@@ -1,10 +1,9 @@
 import { chain, fromStatic, memoize } from "@aws-sdk/property-provider";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 
 import {
   CONFIG_MAX_ATTEMPTS,
   CONFIG_RETRY_MODE,
-  DEFAULT_MAX_ATTEMPTS,
-  DEFAULT_RETRY_MODE,
   ENV_MAX_ATTEMPTS,
   ENV_RETRY_MODE,
   maxAttemptsProvider,

--- a/packages/retry-config-provider/src/defaultProvider.spec.ts
+++ b/packages/retry-config-provider/src/defaultProvider.spec.ts
@@ -1,5 +1,5 @@
-import { chain, fromStatic, memoize } from "@aws-sdk/property-provider";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
+import { chain, fromStatic, memoize } from "@aws-sdk/property-provider";
 
 import {
   CONFIG_MAX_ATTEMPTS,

--- a/packages/retry-config-provider/src/defaultProvider.ts
+++ b/packages/retry-config-provider/src/defaultProvider.ts
@@ -1,6 +1,6 @@
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { chain, fromStatic, memoize } from "@aws-sdk/property-provider";
 import { Provider } from "@aws-sdk/types";
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 
 import { fromEnv } from "./fromEnv";
 import { fromSharedConfigFiles, SharedConfigInit } from "./fromSharedConfigFiles";

--- a/packages/retry-config-provider/src/defaultProvider.ts
+++ b/packages/retry-config-provider/src/defaultProvider.ts
@@ -1,16 +1,15 @@
 import { chain, fromStatic, memoize } from "@aws-sdk/property-provider";
 import { Provider } from "@aws-sdk/types";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 
 import { fromEnv } from "./fromEnv";
 import { fromSharedConfigFiles, SharedConfigInit } from "./fromSharedConfigFiles";
 
 export const ENV_MAX_ATTEMPTS = "AWS_MAX_ATTEMPTS";
 export const CONFIG_MAX_ATTEMPTS = "max_attempts";
-export const DEFAULT_MAX_ATTEMPTS = "3";
 
 export const ENV_RETRY_MODE = "AWS_RETRY_MODE";
 export const CONFIG_RETRY_MODE = "retry_mode";
-export const DEFAULT_RETRY_MODE = "standard";
 
 const defaultProvider = (
   configuration: SharedConfigInit = {},


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1352

*Description of changes:*
move retry defaults to middleware-retry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
