### PR TITLE
chore: add pretest:e2e script to make the command build itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:integration-legacy": "cucumber-js --fail-fast",
     "test:integration": "jest --config jest.config.integ.js --passWithNoTests",
     "test:protocols": "yarn build:protocols && lerna run test --scope '@aws-sdk/aws-*'",
+    "pretest:e2e": "yarn build:crypto-dependencies && lerna run --scope '{@aws-sdk/client-cloudformation, @aws-sdk/karma-credential-loader}' --include-dependencies pretest",
     "test:e2e": "node ./tests/e2e/index.js",
     "local-publish": "node ./scripts/verdaccio-publish/index.js"
   },


### PR DESCRIPTION
*Description of changes:*
Add a prehook to `test:e2e` command, to make sure all the command it needs already built when being executed. It makes `test:e2e` command more self-contain(by no requiring manually building the components before running it).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
