### PR TITLE
feat: lint all ts files in packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:protocols": "yarn build:protocols && lerna run test --scope '@aws-sdk/aws-*'",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "test:e2e": "node ./tests/e2e/index.js",
-    "lint": "eslint 'packages/**/src/*.ts' --fix"
+    "lint": "eslint 'packages/**/src/**/*.ts' --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
@@ -1,5 +1,6 @@
-import { fromImdsCredentials, ImdsCredentials, isImdsCredentials } from "./ImdsCredentials";
 import { Credentials } from "@aws-sdk/types";
+
+import { fromImdsCredentials, ImdsCredentials, isImdsCredentials } from "./ImdsCredentials";
 
 const creds: ImdsCredentials = Object.freeze({
   AccessKeyId: "foo",
@@ -30,7 +31,7 @@ describe("isImdsCredentials", () => {
   });
 
   it("should reject scalar values", () => {
-    for (let scalar of ["string", 1, true, null, void 0]) {
+    for (const scalar of ["string", 1, true, null, void 0]) {
       expect(isImdsCredentials(scalar)).toBe(false);
     }
   });

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -1,14 +1,15 @@
-import * as nock from "nock";
-import { createServer } from "http";
-import { httpRequest } from "./httpRequest";
 import { ProviderError } from "@aws-sdk/property-provider";
+import { createServer } from "http";
+import * as nock from "nock";
+
+import { httpRequest } from "./httpRequest";
 
 describe("httpRequest", () => {
   let port: number;
   const host = "localhost";
   const path = "/";
 
-  const getOpenPort = async (candidatePort: number = 4321): Promise<number> => {
+  const getOpenPort = async (candidatePort = 4321): Promise<number> => {
     try {
       return new Promise<number>((resolve, reject) => {
         const server = createServer();

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -1,6 +1,6 @@
-import { Buffer } from "buffer";
-import { request, IncomingMessage, RequestOptions } from "http";
 import { ProviderError } from "@aws-sdk/property-provider";
+import { Buffer } from "buffer";
+import { IncomingMessage, request, RequestOptions } from "http";
 
 /**
  * @internal

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -8,7 +8,7 @@ import { IncomingMessage, request, RequestOptions } from "http";
 export function httpRequest(options: RequestOptions): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const req = request({ method: "GET", ...options });
-    req.on("error", (err) => {
+    req.on("error", () => {
       reject(new ProviderError("Unable to connect to instance metadata service"));
     });
 

--- a/packages/eventstream-serde-universal/src/fixtures/MockEventMessageSource.fixture.ts
+++ b/packages/eventstream-serde-universal/src/fixtures/MockEventMessageSource.fixture.ts
@@ -19,6 +19,7 @@ export class MockEventMessageSource extends Readable {
   }
 
   _read() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     if (this.readCount === this.data.length) {
       if (this.throwError) {

--- a/packages/node-http-handler/src/stream-collector/index.ts
+++ b/packages/node-http-handler/src/stream-collector/index.ts
@@ -1,5 +1,6 @@
-import { Readable } from "stream";
 import { StreamCollector } from "@aws-sdk/types";
+import { Readable } from "stream";
+
 import { Collector } from "./collector";
 
 export const streamCollector: StreamCollector = (stream: Readable): Promise<Uint8Array> =>

--- a/packages/node-http-handler/src/stream-collector/readable.mock.ts
+++ b/packages/node-http-handler/src/stream-collector/readable.mock.ts
@@ -16,6 +16,7 @@ export class ReadFromBuffers extends Readable {
     this.errorAfter = typeof options.errorAfter === "number" ? options.errorAfter : -1;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _read(size: number) {
     if (this.errorAfter !== -1 && this.errorAfter === this.numBuffersRead) {
       this.emit("error", new Error("Mock Error"));

--- a/packages/node-http-handler/src/stream-collector/readable.mock.ts
+++ b/packages/node-http-handler/src/stream-collector/readable.mock.ts
@@ -7,7 +7,7 @@ export interface ReadFromBuffersOptions extends ReadableOptions {
 
 export class ReadFromBuffers extends Readable {
   private buffersToRead: Buffer[];
-  private numBuffersRead: number = 0;
+  private numBuffersRead = 0;
 
   private errorAfter: number;
   constructor(options: ReadFromBuffersOptions) {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1350 was linting files directly in the src folder and not child folders

*Description of changes:*
lint all ts files in packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
