### PR TITLE
feat: lint and fix on precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test:integration": "jest --config jest.config.integ.js --passWithNoTests",
     "test:protocols": "yarn build:protocols && lerna run test --scope '@aws-sdk/aws-*'",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
-    "test:e2e": "node ./tests/e2e/index.js",
-    "lint": "eslint 'packages/**/src/**/*.ts' --fix"
+    "test:e2e": "node ./tests/e2e/index.js"
   },
   "repository": {
     "type": "git",
@@ -103,6 +102,10 @@
     }
   },
   "lint-staged": {
+    "packages/**/src/**/*.ts": [
+      "eslint --fix",
+      "prettier --write"
+    ],
     "**/*.{ts,js,md,json}": "prettier --write"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/1367

*Description of changes:*
lint and fix on precommit

Verified by enduring that linter is run on precommit for `packages/**/src/**/*.ts`
(prevents creating an empty commit in the case tested):

<details>
<summary>Click to Expand</summary>

<img width="746" alt="Screen Shot 2020-07-13 at 11 20 41 AM" src="https://user-images.githubusercontent.com/16024985/87339286-3d26a680-c4fb-11ea-9fbf-e5ab93499435.png">

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
