### PR TITLE
chore: update integ test resources stack name

### DIFF
--- a/tests/e2e/get-integ-test-resources.js
+++ b/tests/e2e/get-integ-test-resources.js
@@ -5,7 +5,7 @@ exports.getIntegTestResources = async () => {
   const region = await client.config.region();
 
   const { StackResources: stackResources } = await client.send(
-    new DescribeStackResourcesCommand({ StackName: "IntegTestResourcesStack" })
+    new DescribeStackResourcesCommand({ StackName: "SdkReleaseV3IntegTestResourcesStack" })
   );
 
   const identityPoolId = stackResources.filter((resource) => resource.ResourceType === "AWS::Cognito::IdentityPool")[0]


### PR DESCRIPTION
*Description of changes:*
This is a very minor change. We need to change the stack name here because the integ test resources stack name on backend is changed. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
