### PR TITLE
fix: ignore build folders from codegen folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ dist
 *.iml
 *.iws
 
-codegen/build
+codegen/**/build
 codegen/sdk-codegen/smithy-build.json
 .gradle
 */out/


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1380

*Description of changes:*
ignore build folders from codegen folder

Verified that:
* None of the folders mentioned in https://github.com/aws/aws-sdk-js-v3/issues/1380 are added to git
* changes in files with `build` in them (like `build.gradle.kts`) are added to git

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
