### PR TITLE
fix: remove `Blob` usage

### DIFF
--- a/packages/fetch-http-handler/src/stream-collector.ts
+++ b/packages/fetch-http-handler/src/stream-collector.ts
@@ -2,17 +2,13 @@ import { StreamCollector } from "@aws-sdk/types";
 import { fromBase64 } from "@aws-sdk/util-base64-browser";
 
 //reference: https://snack.expo.io/r1JCSWRGU
-export const streamCollector: StreamCollector =
-  // `Blob` does not exist on Cloudflare Workers.
-  typeof Blob === "undefined"
-    ? collectStream
-    : (stream: Blob | ReadableStream): Promise<Uint8Array> => {
-        if (stream instanceof Blob) {
-          return collectBlob(stream);
-        }
+export const streamCollector: StreamCollector = (stream: Blob | ReadableStream): Promise<Uint8Array> => {
+  if (typeof Blob === "function" && stream instanceof Blob) {
+    return collectBlob(stream);
+  }
 
-        return collectStream(stream);
-      };
+  return collectStream(stream as ReadableStream);
+};
 
 async function collectBlob(blob: Blob): Promise<Uint8Array> {
   const base64 = await readToBase64(blob);

--- a/packages/fetch-http-handler/src/stream-collector.ts
+++ b/packages/fetch-http-handler/src/stream-collector.ts
@@ -2,13 +2,17 @@ import { StreamCollector } from "@aws-sdk/types";
 import { fromBase64 } from "@aws-sdk/util-base64-browser";
 
 //reference: https://snack.expo.io/r1JCSWRGU
-export const streamCollector: StreamCollector = (stream: Blob | ReadableStream): Promise<Uint8Array> => {
-  if (stream instanceof Blob) {
-    return collectBlob(stream);
-  }
+export const streamCollector: StreamCollector =
+  // `Blob` does not exist on Cloudflare Workers.
+  typeof Blob === "undefined"
+    ? collectStream
+    : (stream: Blob | ReadableStream): Promise<Uint8Array> => {
+        if (stream instanceof Blob) {
+          return collectBlob(stream);
+        }
 
-  return collectStream(stream);
-};
+        return collectStream(stream);
+      };
 
 async function collectBlob(blob: Blob): Promise<Uint8Array> {
   const base64 = await readToBase64(blob);

--- a/packages/util-body-length-browser/src/index.ts
+++ b/packages/util-body-length-browser/src/index.ts
@@ -1,6 +1,22 @@
 export function calculateBodyLength(body: any): number | undefined {
   if (typeof body === "string") {
-    return new Blob([body]).size;
+    let len = body.length;
+
+    // Source: https://github.com/DylanPiercey/byte-length
+    for (let i = len; i--; ) {
+      const code = body.charCodeAt(i);
+      if (0xdc00 <= code && code <= 0xdfff) {
+        i--;
+      }
+
+      if (0x7f < code && code <= 0x7ff) {
+        len++;
+      } else if (0x7ff < code && code <= 0xffff) {
+        len += 2;
+      }
+    }
+
+    return len;
   } else if (typeof body.byteLength === "number") {
     // handles Uint8Array, ArrayBuffer, Buffer, and ArrayBufferView
     return body.byteLength;

--- a/packages/util-body-length-browser/src/index.ts
+++ b/packages/util-body-length-browser/src/index.ts
@@ -2,18 +2,10 @@ export function calculateBodyLength(body: any): number | undefined {
   if (typeof body === "string") {
     let len = body.length;
 
-    // Source: https://github.com/DylanPiercey/byte-length
-    for (let i = len; i--; ) {
+    for (let i = len - 1; i >= 0; i--) {
       const code = body.charCodeAt(i);
-      if (0xdc00 <= code && code <= 0xdfff) {
-        i--;
-      }
-
-      if (0x7f < code && code <= 0x7ff) {
-        len++;
-      } else if (0x7ff < code && code <= 0xffff) {
-        len += 2;
-      }
+      if (code > 0x7f && code <= 0x7ff) len++;
+      else if (code > 0x7ff && code <= 0xffff) len += 2;
     }
 
     return len;


### PR DESCRIPTION
*Issue #, if available:* Closes https://github.com/aws/aws-sdk-js-v3/issues/1378.

*Description of changes:* Removes `Blob` constructor usage from code paths where it's not necessary. I also found a past perf test when I was looking for alternative solutions to getting the string length and `Blob` is at least 130x slower than a for loop. Using `TextEncoder` would be even faster, but I'm assuming we want IE11 support natively without any polyfills.

Perf test: https://jsperf.com/utf-8-byte-length/36
Other possible solutions: https://stackoverflow.com/questions/5515869/string-length-in-bytes-in-javascript

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
