### PR TITLE
chore: prettify JS code missed in #1185

### DIFF
--- a/clients/client-cognito-identity/karma.conf.js
+++ b/clients/client-cognito-identity/karma.conf.js
@@ -4,14 +4,14 @@ module.exports = function (config) {
     frameworks: ["mocha", "chai"],
     files: ["e2e/**/*.ispec.ts"],
     preprocessors: {
-      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"]
+      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"],
     },
     webpackMiddleware: {
-      stats: "minimal"
+      stats: "minimal",
     },
     webpack: {
       resolve: {
-        extensions: [".ts", ".js"]
+        extensions: [".ts", ".js"],
       },
       mode: "development",
       module: {
@@ -24,21 +24,18 @@ module.exports = function (config) {
                 options: {
                   configFile: "tsconfig.json",
                   compilerOptions: {
-                    rootDir: "./"
-                  }
-                }
-              }
+                    rootDir: "./",
+                  },
+                },
+              },
             ],
-            exclude: /node_modules/
-          }
-        ]
+            exclude: /node_modules/,
+          },
+        ],
       },
-      devtool: "inline-source-map"
+      devtool: "inline-source-map",
     },
-    envPreprocessor: [
-      "AWS_SMOKE_TEST_REGION",
-      "AWS_SMOKE_TEST_IDENTITY_POOL_ID"
-    ],
+    envPreprocessor: ["AWS_SMOKE_TEST_REGION", "AWS_SMOKE_TEST_IDENTITY_POOL_ID"],
     plugins: [
       "@aws-sdk/karma-credential-loader",
       "karma-chrome-launcher",
@@ -48,7 +45,7 @@ module.exports = function (config) {
       "karma-webpack",
       "karma-coverage",
       "karma-sourcemap-loader",
-      "karma-env-preprocessor"
+      "karma-env-preprocessor",
     ],
     reporters: ["progress"],
     port: 9876,
@@ -59,11 +56,11 @@ module.exports = function (config) {
     customLaunchers: {
       FirefoxHeadless: {
         base: "Firefox",
-        flags: ["-headless"]
-      }
+        flags: ["-headless"],
+      },
     },
     singleRun: true,
     concurrency: Infinity,
-    exclude: ["**/*.d.ts", "*.spec.ts"]
+    exclude: ["**/*.d.ts", "*.spec.ts"],
   });
 };

--- a/clients/client-s3/karma.conf.js
+++ b/clients/client-s3/karma.conf.js
@@ -4,14 +4,14 @@ module.exports = function (config) {
     frameworks: ["mocha", "chai"],
     files: ["e2e/**/*.ispec.ts"],
     preprocessors: {
-      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"]
+      "e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"],
     },
     webpackMiddleware: {
-      stats: "minimal"
+      stats: "minimal",
     },
     webpack: {
       resolve: {
-        extensions: [".ts", ".js"]
+        extensions: [".ts", ".js"],
       },
       mode: "development",
       module: {
@@ -24,16 +24,16 @@ module.exports = function (config) {
                 options: {
                   configFile: "tsconfig.json",
                   compilerOptions: {
-                    rootDir: "./"
-                  }
-                }
-              }
+                    rootDir: "./",
+                  },
+                },
+              },
             ],
-            exclude: /node_modules/
-          }
-        ]
+            exclude: /node_modules/,
+          },
+        ],
       },
-      devtool: "inline-source-map"
+      devtool: "inline-source-map",
     },
     envPreprocessor: ["AWS_SMOKE_TEST_REGION", "AWS_SMOKE_TEST_BUCKET"],
     plugins: [
@@ -45,7 +45,7 @@ module.exports = function (config) {
       "karma-webpack",
       "karma-coverage",
       "karma-sourcemap-loader",
-      "karma-env-preprocessor"
+      "karma-env-preprocessor",
     ],
     reporters: ["progress"],
     port: 9876,
@@ -56,11 +56,11 @@ module.exports = function (config) {
     customLaunchers: {
       FirefoxHeadless: {
         base: "Firefox",
-        flags: ["-headless"]
-      }
+        flags: ["-headless"],
+      },
     },
     singleRun: true,
     concurrency: Infinity,
-    exclude: ["**/*.d.ts", "*.spec.ts"]
+    exclude: ["**/*.d.ts", "*.spec.ts"],
   });
 };

--- a/clients/client-transcribe-streaming/jest.config.js
+++ b/clients/client-transcribe-streaming/jest.config.js
@@ -8,6 +8,6 @@ module.exports = {
     "/node_modules/",
     "/commands/",
     "/protocols/", // protocols tested in protocol protocol_tests folder
-    "endpoints" // endpoint tested in tests/functional/endpoints
-  ]
+    "endpoints", // endpoint tested in tests/functional/endpoints
+  ],
 };

--- a/clients/client-transcribe-streaming/jest.integ.config.js
+++ b/clients/client-transcribe-streaming/jest.integ.config.js
@@ -2,5 +2,5 @@ const base = require("../../jest.config.base.js");
 
 module.exports = {
   ...base,
-  testMatch: ["**/*.integ.spec.js"]
+  testMatch: ["**/*.integ.spec.js"],
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
-    "type-enum": [2, "always", ["feat", "fix", "docs", "test", "chore"]]
-  }
+    "type-enum": [2, "always", ["feat", "fix", "docs", "test", "chore"]],
+  },
 };

--- a/features/autoscaling/step_definitions/autoscaling.js
+++ b/features/autoscaling/step_definitions/autoscaling.js
@@ -6,14 +6,11 @@ Before({ tags: "@autoscaling" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a launch configuration with name {string}", function (
-  name,
-  callback
-) {
+Given("I create a launch configuration with name {string}", function (name, callback) {
   const params = {
     ImageId: "ami-1624987f",
     InstanceType: "m1.small",
-    LaunchConfigurationName: name
+    LaunchConfigurationName: name,
   };
   this.request(null, "createLaunchConfiguration", params, callback, false);
 });
@@ -22,13 +19,8 @@ Given("I describe launch configurations", function (callback) {
   this.request(null, "describeLaunchConfigurations", {}, callback);
 });
 
-Then("the list should contain the launch configuration {string}", function (
-  name,
-  callback
-) {
-  this.assert.contains(this.data.LaunchConfigurations, function (
-    configuration
-  ) {
+Then("the list should contain the launch configuration {string}", function (name, callback) {
+  this.assert.contains(this.data.LaunchConfigurations, function (configuration) {
     return configuration.LaunchConfigurationName === name;
   });
   callback();

--- a/features/cloudformation/step_definitions/cloudformation.js
+++ b/features/cloudformation/step_definitions/cloudformation.js
@@ -6,16 +6,13 @@ Before({ tags: "@cloudformation" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a CloudFormation stack with name prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a CloudFormation stack with name prefix {string}", function (prefix, callback) {
   this.stackName = this.uniqueName(prefix);
   this.templateBody = '{"Resources":{"member":{"Type":"AWS::SQS::Queue"}}}';
   const params = {
     TemplateBody: this.templateBody,
     StackName: this.stackName,
-    EnableTerminationProtection: true
+    EnableTerminationProtection: true,
   };
   this.request(null, "createStack", params, callback, false);
 });

--- a/features/cloudfront/step_definitions/cloudfront.js
+++ b/features/cloudfront/step_definitions/cloudfront.js
@@ -4,7 +4,7 @@ const { Before, Given } = require("cucumber");
 const createParams = {
   CallerReference: "",
   Aliases: {
-    Quantity: 0
+    Quantity: 0,
   },
   DefaultRootObject: "",
   Origins: {
@@ -15,41 +15,41 @@ const createParams = {
         CustomOriginConfig: {
           HTTPPort: 80,
           HTTPSPort: 443,
-          OriginProtocolPolicy: "match-viewer"
-        }
-      }
+          OriginProtocolPolicy: "match-viewer",
+        },
+      },
     ],
-    Quantity: 1
+    Quantity: 1,
   },
   DefaultCacheBehavior: {
     TargetOriginId: "origin",
     ForwardedValues: {
       QueryString: false,
       Cookies: {
-        Forward: "all"
-      }
+        Forward: "all",
+      },
     },
     TrustedSigners: {
       Items: [],
       Enabled: false,
-      Quantity: 0
+      Quantity: 0,
     },
     ViewerProtocolPolicy: "allow-all",
-    MinTTL: 0
+    MinTTL: 0,
   },
   CacheBehaviors: {
     Items: [],
-    Quantity: 0
+    Quantity: 0,
   },
   Comment: "",
   Logging: {
     Enabled: false,
     Bucket: "invalidbucket.s3.amazonaws.com",
     Prefix: "prefix",
-    IncludeCookies: false
+    IncludeCookies: false,
   },
   PriceClass: "PriceClass_All",
-  Enabled: false
+  Enabled: false,
 };
 
 Before({ tags: "@cloudfront" }, function (scenario, callback) {
@@ -58,21 +58,11 @@ Before({ tags: "@cloudfront" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a CloudFront distribution with name prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a CloudFront distribution with name prefix {string}", function (prefix, callback) {
   this.cfName = this.uniqueName(prefix);
   this.cfCreateParams.CallerReference = this.cfName;
-  this.cfCreateParams.Origins.Items[0].Id =
-    this.cfName === "" ? "origin" : "InvalidOrigin";
-  this.request(
-    null,
-    "createDistribution",
-    { DistributionConfig: this.cfCreateParams },
-    callback,
-    false
-  );
+  this.cfCreateParams.Origins.Items[0].Id = this.cfName === "" ? "origin" : "InvalidOrigin";
+  this.request(null, "createDistribution", { DistributionConfig: this.cfCreateParams }, callback, false);
 });
 
 Given("I list CloudFront distributions", function (callback) {

--- a/features/cloudsearch/step_definitions/cloudsearch.js
+++ b/features/cloudsearch/step_definitions/cloudsearch.js
@@ -6,16 +6,7 @@ Before({ tags: "@cloudsearch" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a domain with name prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a domain with name prefix {string}", function (prefix, callback) {
   this.domainName = this.uniqueName(prefix);
-  this.request(
-    null,
-    "createDomain",
-    { DomainName: this.domainName },
-    callback,
-    false
-  );
+  this.request(null, "createDomain", { DomainName: this.domainName }, callback, false);
 });

--- a/features/cloudtrail/step_definitions/cloudtrail.js
+++ b/features/cloudtrail/step_definitions/cloudtrail.js
@@ -11,11 +11,5 @@ Given("I describe trails", function (callback) {
 });
 
 Given("I create a trail with an invalid name", function (callback) {
-  this.request(
-    null,
-    "createTrail",
-    { Name: "", S3BucketName: "" },
-    callback,
-    false
-  );
+  this.request(null, "createTrail", { Name: "", S3BucketName: "" }, callback, false);
 });

--- a/features/cloudwatch/step_definitions/cloudwatch.js
+++ b/features/cloudwatch/step_definitions/cloudwatch.js
@@ -6,10 +6,7 @@ Before({ tags: "@cloudwatch" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a CloudWatch alarm with prefix {string}", function (
-  name,
-  callback
-) {
+Given("I create a CloudWatch alarm with prefix {string}", function (name, callback) {
   const timestamp = new Date().getTime();
   this.cloudWatchAlarm = {
     AlarmName: name,
@@ -19,24 +16,15 @@ Given("I create a CloudWatch alarm with prefix {string}", function (
     EvaluationPeriods: 5,
     Period: 60,
     Statistic: "Average",
-    Threshold: 50.0
+    Threshold: 50.0,
   };
 
   this.cloudWatchAlarm.AlarmName += "-" + timestamp;
 
-  this.request(
-    null,
-    "putMetricAlarm",
-    this.cloudWatchAlarm,
-    callback,
-    undefined
-  );
+  this.request(null, "putMetricAlarm", this.cloudWatchAlarm, callback, undefined);
 });
 
-Given("I create a CloudWatch alarm with name {string}", function (
-  name,
-  callback
-) {
+Given("I create a CloudWatch alarm with name {string}", function (name, callback) {
   const timestamp = new Date().getTime();
   this.cloudWatchAlarm = {
     AlarmName: name,
@@ -46,7 +34,7 @@ Given("I create a CloudWatch alarm with name {string}", function (
     EvaluationPeriods: 5,
     Period: 60,
     Statistic: "Average",
-    Threshold: 50.0
+    Threshold: 50.0,
   };
 
   this.request(null, "putMetricAlarm", this.cloudWatchAlarm, callback, false);
@@ -55,7 +43,7 @@ Given("I create a CloudWatch alarm with name {string}", function (
 Given("I list the CloudWatch alarms", function (callback) {
   const params = {
     MetricName: this.cloudWatchAlarm.MetricName,
-    Namespace: this.cloudWatchAlarm.Namespace
+    Namespace: this.cloudWatchAlarm.Namespace,
   };
   this.request(null, "describeAlarmsForMetric", params, callback);
 });
@@ -69,10 +57,5 @@ Then("the list should contain the CloudWatch alarm", function (callback) {
 });
 
 Then("I delete the CloudWatch alarm", function (callback) {
-  this.request(
-    null,
-    "deleteAlarms",
-    { AlarmNames: [this.cloudWatchAlarm.AlarmName] },
-    callback
-  );
+  this.request(null, "deleteAlarms", { AlarmNames: [this.cloudWatchAlarm.AlarmName] }, callback);
 });

--- a/features/cloudwatchevents/step_definitions/cloudwatchevents.js
+++ b/features/cloudwatchevents/step_definitions/cloudwatchevents.js
@@ -1,6 +1,4 @@
-const {
-  CloudWatchEvents
-} = require("../../../clients/client-cloudwatch-events");
+const { CloudWatchEvents } = require("../../../clients/client-cloudwatch-events");
 const { Before } = require("cucumber");
 
 Before({ tags: "@cloudwatchevents" }, function (scenario, callback) {

--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -6,19 +6,10 @@ Before({ tags: "@cloudwatchlogs" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a CloudWatch logGroup with prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a CloudWatch logGroup with prefix {string}", function (prefix, callback) {
   const expectErr = prefix === "" ? false : undefined;
   this.logGroupName = this.uniqueName(prefix);
-  this.request(
-    null,
-    "createLogGroup",
-    { logGroupName: this.logGroupName },
-    callback,
-    expectErr
-  );
+  this.request(null, "createLogGroup", { logGroupName: this.logGroupName }, callback, expectErr);
 });
 
 Given("I list the CloudWatch logGroups", function (callback) {
@@ -34,10 +25,5 @@ Then("the list should contain the CloudWatch logGroup", function (callback) {
 });
 
 Then("I delete the CloudWatch logGroup", function (callback) {
-  this.request(
-    null,
-    "deleteLogGroup",
-    { logGroupName: this.logGroupName },
-    callback
-  );
+  this.request(null, "deleteLogGroup", { logGroupName: this.logGroupName }, callback);
 });

--- a/features/cognitoidentity/step_definitions/cognitoidentity.js
+++ b/features/cognitoidentity/step_definitions/cognitoidentity.js
@@ -6,33 +6,20 @@ Before({ tags: "@cognitoidentity" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a Cognito identity pool with prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a Cognito identity pool with prefix {string}", function (prefix, callback) {
   const expectError = prefix === "" ? false : undefined;
   const params = {
     IdentityPoolName: this.uniqueName(prefix, ""),
-    AllowUnauthenticatedIdentities: true
+    AllowUnauthenticatedIdentities: true,
   };
   this.request(null, "createIdentityPool", params, callback, expectError);
 });
 
 Given("I describe the Cognito identity pool ID", function (callback) {
   this.identityPoolId = this.data.IdentityPoolId;
-  this.request(
-    null,
-    "describeIdentityPool",
-    { IdentityPoolId: this.data.IdentityPoolId },
-    callback
-  );
+  this.request(null, "describeIdentityPool", { IdentityPoolId: this.data.IdentityPoolId }, callback);
 });
 
 Then("I delete the Cognito identity pool", function (callback) {
-  this.request(
-    null,
-    "deleteIdentityPool",
-    { IdentityPoolId: this.identityPoolId },
-    callback
-  );
+  this.request(null, "deleteIdentityPool", { IdentityPoolId: this.identityPoolId }, callback);
 });

--- a/features/cognitosync/step_definitions/cognitosync.js
+++ b/features/cognitosync/step_definitions/cognitosync.js
@@ -10,10 +10,11 @@ Given("I list Cognito identity pool usage", function (callback) {
   this.request(null, "listIdentityPoolUsage", {}, callback);
 });
 
-Given(
-  "I list Cognito data sets with identity pool id {string} and identity id {string}",
-  function (idpid, idid, callback) {
-    const params = { IdentityPoolId: idpid, IdentityId: idid };
-    this.request(null, "listDatasets", params, callback, false);
-  }
-);
+Given("I list Cognito data sets with identity pool id {string} and identity id {string}", function (
+  idpid,
+  idid,
+  callback
+) {
+  const params = { IdentityPoolId: idpid, IdentityId: idid };
+  this.request(null, "listDatasets", params, callback, false);
+});

--- a/features/datapipeline/step_definitions/datapipeline.js
+++ b/features/datapipeline/step_definitions/datapipeline.js
@@ -6,13 +6,10 @@ Before({ tags: "@datapipeline" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a Data Pipeline with name prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a Data Pipeline with name prefix {string}", function (prefix, callback) {
   const params = {
     name: this.uniqueName(prefix),
-    uniqueId: this.uniqueName("aws-js-sdk")
+    uniqueId: this.uniqueName("aws-js-sdk"),
   };
   this.request(null, "createPipeline", params, callback, false);
 });

--- a/features/directconnect/step_definitions/directconnect.js
+++ b/features/directconnect/step_definitions/directconnect.js
@@ -6,14 +6,11 @@ Before({ tags: "@directconnect" }, function (scenario, callback) {
   callback();
 });
 
-Given(
-  "I create a Direct Connect connection with an invalid location",
-  function (callback) {
-    const params = {
-      bandwidth: "1Gbps",
-      location: "INVALID_LOCATION",
-      connectionName: this.uniqueName("aws-sdk-js")
-    };
-    this.request(null, "createConnection", params, callback, false);
-  }
-);
+Given("I create a Direct Connect connection with an invalid location", function (callback) {
+  const params = {
+    bandwidth: "1Gbps",
+    location: "INVALID_LOCATION",
+    connectionName: this.uniqueName("aws-sdk-js"),
+  };
+  this.request(null, "createConnection", params, callback, false);
+});

--- a/features/directoryservice/step_definitions/directoryservice.js
+++ b/features/directoryservice/step_definitions/directoryservice.js
@@ -1,6 +1,4 @@
-const {
-  DirectoryService
-} = require("../../../clients/client-directory-service");
+const { DirectoryService } = require("../../../clients/client-directory-service");
 const { Before } = require("cucumber");
 
 Before({ tags: "@directoryservice" }, function (scenario, callback) {

--- a/features/dms/step_definitions/dms.js
+++ b/features/dms/step_definitions/dms.js
@@ -1,6 +1,4 @@
-const {
-  DatabaseMigrationService
-} = require("../../../clients/client-database-migration-service");
+const { DatabaseMigrationService } = require("../../../clients/client-database-migration-service");
 const { Before } = require("cucumber");
 
 Before({ tags: "@dms" }, function (scenario, callback) {

--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -7,7 +7,7 @@ const { DynamoDB } = require("../../../clients/client-dynamodb");
  */
 function waitForTableExists(world, callback) {
   const params = {
-    TableName: world.tableName
+    TableName: world.tableName,
   };
 
   const maxAttempts = 25;
@@ -37,7 +37,7 @@ function waitForTableExists(world, callback) {
  */
 function waitForTableNotExists(world, callback) {
   const params = {
-    TableName: world.tableName
+    TableName: world.tableName,
   };
 
   const maxAttempts = 25;
@@ -64,7 +64,7 @@ const { Before, Given, Then, When } = require("cucumber");
 
 Before({ tags: "@dynamodb" }, function (scenario, next) {
   this.service = new DynamoDB({
-    maxRetries: 2
+    maxRetries: 2,
   });
   next();
 });
@@ -74,7 +74,7 @@ function createTable(world, callback) {
     TableName: world.tableName,
     AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
     KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-    BillingMode: "PAY_PER_REQUEST"
+    BillingMode: "PAY_PER_REQUEST",
   };
 
   world.service.createTable(params, function (err, data) {
@@ -126,19 +126,14 @@ When("I put a recursive item", function (next) {
       data: {
         M: {
           attr1: {
-            L: [{ S: "value1" }, { L: [{ M: { attr12: { S: "value2" } } }] }]
+            L: [{ S: "value1" }, { L: [{ M: { attr12: { S: "value2" } } }] }],
           },
           attr2: {
-            L: [
-              { B: new Uint8Array([0]) },
-              { B: new Uint8Array([1]) },
-              { NULL: true },
-              { BOOL: true }
-            ]
-          }
-        }
-      }
-    }
+            L: [{ B: new Uint8Array([0]) }, { B: new Uint8Array([1]) }, { NULL: true }, { BOOL: true }],
+          },
+        },
+      },
+    },
   };
   this.request(null, "putItem", params, next);
 });
@@ -148,11 +143,7 @@ Then("the item with id {string} should exist", function (key, next) {
   this.request(null, "getItem", params, next);
 });
 
-Then("it should have attribute {string} containing {string}", function (
-  attr,
-  value,
-  next
-) {
+Then("it should have attribute {string} containing {string}", function (attr, value, next) {
   this.assert.equal(jmespath.search(this.data.Item, attr), value);
   next();
 });
@@ -170,10 +161,7 @@ Then("the table should eventually not exist", function (callback) {
   waitForTableNotExists(this, callback);
 });
 
-Given("my first request is corrupted with CRC checking (ON|OFF)", function (
-  toggle,
-  callback
-) {
+Given("my first request is corrupted with CRC checking (ON|OFF)", function (toggle, callback) {
   const world = this;
   this.service.config.dynamoDbCrc32 = toggle == "ON" ? true : false;
   const req = this.service.listTables();
@@ -196,16 +184,12 @@ Given("my first request is corrupted with CRC checking (ON|OFF)", function (
 });
 
 Then("the request should( not)? be retried", function (retry, callback) {
-  if (retry && this.data.$metadata.retries > 0)
-    callback(new Error("Request was incorrectly retried"));
-  if (!retry && this.data.$metadata.retries == 0)
-    callback(new Error("Request was incorrectly retried"));
+  if (retry && this.data.$metadata.retries > 0) callback(new Error("Request was incorrectly retried"));
+  if (!retry && this.data.$metadata.retries == 0) callback(new Error("Request was incorrectly retried"));
   callback();
 });
 
-Given("all of my requests are corrupted with CRC checking ON", function (
-  callback
-) {
+Given("all of my requests are corrupted with CRC checking ON", function (callback) {
   const world = this;
   const req = this.service.listTables();
   req.removeAllListeners("httpData");
@@ -221,31 +205,21 @@ Given("all of my requests are corrupted with CRC checking ON", function (
 });
 
 When("the request is retried the maximum number of times", function (callback) {
-  if (this.data.$metadata.retries != 2)
-    callback(new Error("Incorrect retry count"));
+  if (this.data.$metadata.retries != 2) callback(new Error("Incorrect retry count"));
   callback();
 });
 
-Then("the request should( not)? fail with a CRC checking error", function (
-  failed,
-  callback
-) {
+Then("the request should( not)? fail with a CRC checking error", function (failed, callback) {
   if (failed && this.error) callback(this.error);
-  if (!failed && !this.error)
-    callback(new Error("Did not fail when should have"));
+  if (!failed && !this.error) callback(new Error("Did not fail when should have"));
   callback();
 });
 
-Given(
-  "I try to delete an item with key {string} from table {string}",
-  function (key, table, callback) {
-    const params = { TableName: table, Key: { id: { S: key } } };
-    this.request(null, "deleteItem", params, callback, false);
-  }
-);
+Given("I try to delete an item with key {string} from table {string}", function (key, table, callback) {
+  const params = { TableName: table, Key: { id: { S: key } } };
+  this.request(null, "deleteItem", params, callback, false);
+});
 
-Given("I try to delete a table with an empty table parameter", function (
-  callback
-) {
+Given("I try to delete a table with an empty table parameter", function (callback) {
   this.request(null, "deleteTable", { TableName: "" }, callback, false);
 });

--- a/features/ec2/step_definitions/ec2.js
+++ b/features/ec2/step_definitions/ec2.js
@@ -19,11 +19,7 @@ const waitForVolumeAvailable = (ec2, volumeId, callback) => {
         if (data.Volumes[0].State === "available") {
           callback();
         } else if (data.Volumes[0].State === "deleted") {
-          callback(
-            new Error(
-              `VolumeId ${data.Volumes[i].VolumeId} is in failure state`
-            )
-          );
+          callback(new Error(`VolumeId ${data.Volumes[i].VolumeId} is in failure state`));
         } else {
           setTimeout(function () {
             checkForVolumeAvailable();
@@ -49,11 +45,7 @@ Given("I describe EC2 regions {string}", function (regions, callback) {
   this.request(null, "describeRegions", { RegionNames: regions }, callback);
 });
 
-Then("the EC2 endpoint for {string} should be {string}", function (
-  region,
-  endpoint,
-  callback
-) {
+Then("the EC2 endpoint for {string} should be {string}", function (region, endpoint, callback) {
   this.assert.contains(this.data.Regions, function (region) {
     return region.Endpoint === endpoint;
   });
@@ -61,18 +53,10 @@ Then("the EC2 endpoint for {string} should be {string}", function (
 });
 
 Given("I describe the EC2 instance {string}", function (instanceId, callback) {
-  this.request(
-    null,
-    "describeInstances",
-    { InstanceIds: [instanceId] },
-    callback,
-    false
-  );
+  this.request(null, "describeInstances", { InstanceIds: [instanceId] }, callback, false);
 });
 
-Given("I attempt to copy an encrypted snapshot across regions", function (
-  callback
-) {
+Given("I attempt to copy an encrypted snapshot across regions", function (callback) {
   const self = this;
   let volId, srcSnapId, dstSnapId, params;
   const sourceRegion = "us-west-2";
@@ -89,7 +73,7 @@ Given("I attempt to copy an encrypted snapshot across regions", function (
   params = {
     AvailabilityZone: sourceRegion + "a",
     Size: 10,
-    Encrypted: true
+    Encrypted: true,
   };
   srcEc2.createVolume(params, function (err, data) {
     if (err) {
@@ -114,7 +98,7 @@ Given("I attempt to copy an encrypted snapshot across regions", function (
         setTimeout(function () {
           params = {
             SourceRegion: sourceRegion,
-            SourceSnapshotId: srcSnapId
+            SourceSnapshotId: srcSnapId,
           };
           dstEc2.copySnapshot(params, function (err, data) {
             if (data) dstSnapId = data.SnapshotId;

--- a/features/elasticache/step_definitions/elasticache.js
+++ b/features/elasticache/step_definitions/elasticache.js
@@ -6,15 +6,12 @@ Before({ tags: "@elasticache" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a cache parameter group with name prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a cache parameter group with name prefix {string}", function (prefix, callback) {
   this.cacheGroupName = this.uniqueName(prefix);
   const params = {
     Description: "Description",
     CacheParameterGroupName: this.cacheGroupName,
-    CacheParameterGroupFamily: "memcached1.4"
+    CacheParameterGroupFamily: "memcached1.4",
   };
   this.request(null, "createCacheParameterGroup", params, callback, false);
 });
@@ -27,7 +24,7 @@ Given("the cache parameter group name is in the result", function (callback) {
 
 Given("I describe the cache parameter groups", function (callback) {
   const params = {
-    CacheParameterGroupName: this.cacheGroupName
+    CacheParameterGroupName: this.cacheGroupName,
   };
   this.request(null, "describeCacheParameterGroups", params, callback);
 });
@@ -40,7 +37,7 @@ Then("the cache parameter group should be described", function (callback) {
 
 Then("I delete the cache parameter group", function (callback) {
   const params = {
-    CacheParameterGroupName: this.cacheGroupName
+    CacheParameterGroupName: this.cacheGroupName,
   };
   this.request(null, "deleteCacheParameterGroup", params, callback);
 });

--- a/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
+++ b/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
@@ -1,6 +1,4 @@
-const {
-  ElasticBeanstalk
-} = require("../../../clients/client-elastic-beanstalk");
+const { ElasticBeanstalk } = require("../../../clients/client-elastic-beanstalk");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elasticbeanstalk" }, function (scenario, callback) {
@@ -8,49 +6,35 @@ Before({ tags: "@elasticbeanstalk" }, function (scenario, callback) {
   callback();
 });
 
-Given(
-  "I create an Elastic Beanstalk application with name prefix {string}",
-  function (prefix, callback) {
-    this.appName = this.uniqueName(prefix);
-    const params = { ApplicationName: this.appName };
-    this.request(null, "createApplication", params, callback, false);
-  }
-);
+Given("I create an Elastic Beanstalk application with name prefix {string}", function (prefix, callback) {
+  this.appName = this.uniqueName(prefix);
+  const params = { ApplicationName: this.appName };
+  this.request(null, "createApplication", params, callback, false);
+});
 
-Given(
-  "I create an Elastic Beanstalk application version with label {string}",
-  function (label, callback) {
-    this.appVersion = label;
-    const params = {
-      ApplicationName: this.appName,
-      VersionLabel: this.appVersion
-    };
-    this.request(null, "createApplicationVersion", params, callback);
-  }
-);
+Given("I create an Elastic Beanstalk application version with label {string}", function (label, callback) {
+  this.appVersion = label;
+  const params = {
+    ApplicationName: this.appName,
+    VersionLabel: this.appVersion,
+  };
+  this.request(null, "createApplicationVersion", params, callback);
+});
 
 Given("I describe the Elastic Beanstalk application", function (callback) {
   const params = { ApplicationNames: [this.appName] };
   this.request(null, "describeApplications", params, callback);
 });
 
-Then(
-  "the result should contain the Elastic Beanstalk application version",
-  function (callback) {
-    this.assert.deepEqual(this.data.Applications[0].Versions, [
-      this.appVersion
-    ]);
-    callback();
-  }
-);
+Then("the result should contain the Elastic Beanstalk application version", function (callback) {
+  this.assert.deepEqual(this.data.Applications[0].Versions, [this.appVersion]);
+  callback();
+});
 
-Then(
-  "the result should contain the Elastic Beanstalk application name",
-  function (callback) {
-    this.assert.equal(this.data.Applications[0].ApplicationName, this.appName);
-    callback();
-  }
-);
+Then("the result should contain the Elastic Beanstalk application name", function (callback) {
+  this.assert.equal(this.data.Applications[0].ApplicationName, this.appName);
+  callback();
+});
 
 Then("I delete the Elastic Beanstalk application", function (callback) {
   const params = { ApplicationName: this.appName };

--- a/features/elastictranscoder/step_definitions/elastictranscoder.js
+++ b/features/elastictranscoder/step_definitions/elastictranscoder.js
@@ -1,6 +1,4 @@
-const {
-  ElasticTranscoder
-} = require("../../../clients/client-elastic-transcoder");
+const { ElasticTranscoder } = require("../../../clients/client-elastic-transcoder");
 const { S3 } = require("../../../clients/client-s3");
 const { IAM } = require("../../../clients/client-iam");
 const { Before, Given, Then } = require("cucumber");
@@ -12,32 +10,29 @@ Before({ tags: "@elastictranscoder" }, function (scenario, callback) {
   callback();
 });
 
-Given(
-  "I create an Elastic Transcoder pipeline with name prefix {string}",
-  function (prefix, callback) {
-    this.pipelineName = this.uniqueName(prefix);
-    const params = {
-      Name: this.pipelineName,
-      InputBucket: this.bucket,
-      OutputBucket: this.bucket,
-      Role: this.iamRoleArn,
-      Notifications: {
-        Progressing: "",
-        Completed: "",
-        Warning: "",
-        Error: ""
-      }
-    };
+Given("I create an Elastic Transcoder pipeline with name prefix {string}", function (prefix, callback) {
+  this.pipelineName = this.uniqueName(prefix);
+  const params = {
+    Name: this.pipelineName,
+    InputBucket: this.bucket,
+    OutputBucket: this.bucket,
+    Role: this.iamRoleArn,
+    Notifications: {
+      Progressing: "",
+      Completed: "",
+      Warning: "",
+      Error: "",
+    },
+  };
 
-    const world = this;
-    const next = function () {
-      if (world.data) world.pipelineId = world.data.Pipeline.Id;
-      callback();
-    };
+  const world = this;
+  const next = function () {
+    if (world.data) world.pipelineId = world.data.Pipeline.Id;
+    callback();
+  };
 
-    this.request(null, "createPipeline", params, next, false);
-  }
-);
+  this.request(null, "createPipeline", params, next, false);
+});
 
 Given("I list pipelines", function (callback) {
   this.request(null, "listPipelines", {}, callback);
@@ -57,7 +52,7 @@ Then("I pause the pipeline", function (callback) {
     "updatePipelineStatus",
     {
       Id: this.pipelineId,
-      Status: "Paused"
+      Status: "Paused",
     },
     callback
   );
@@ -68,7 +63,7 @@ Then("I read the pipeline", function (callback) {
     null,
     "readPipeline",
     {
-      Id: this.pipelineId
+      Id: this.pipelineId,
     },
     callback
   );
@@ -84,7 +79,7 @@ Then("I delete the pipeline", function (callback) {
     null,
     "deletePipeline",
     {
-      Id: this.pipelineId
+      Id: this.pipelineId,
     },
     callback
   );

--- a/features/elb/step_definitions/elb.js
+++ b/features/elb/step_definitions/elb.js
@@ -1,6 +1,4 @@
-const {
-  ElasticLoadBalancing
-} = require("../../../clients/client-elastic-load-balancing");
+const { ElasticLoadBalancing } = require("../../../clients/client-elastic-load-balancing");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elb" }, function (scenario, callback) {
@@ -8,10 +6,7 @@ Before({ tags: "@elb" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a load balancer with name prefix {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a load balancer with name prefix {string}", function (prefix, callback) {
   this.loadBalancerName = prefix + "-" + new Date().getTime();
 
   const params = {
@@ -20,19 +15,17 @@ Given("I create a load balancer with name prefix {string}", function (
       {
         Protocol: "TCP",
         LoadBalancerPort: 80,
-        InstancePort: 80
-      }
+        InstancePort: 80,
+      },
     ],
-    AvailabilityZones: ["us-east-1a"]
+    AvailabilityZones: ["us-east-1a"],
   };
   this.request(null, "createLoadBalancer", params, callback, false);
 });
 
-Given("I describe load balancers with the load balancer name", function (
-  callback
-) {
+Given("I describe load balancers with the load balancer name", function (callback) {
   const params = {
-    LoadBalancerNames: [this.loadBalancerName]
+    LoadBalancerNames: [this.loadBalancerName],
   };
   this.request(null, "describeLoadBalancers", params, callback);
 });
@@ -45,7 +38,7 @@ Then("the load balancer should be in the list", function (callback) {
 
 Then("I delete the load balancer", function (callback) {
   const params = {
-    LoadBalancerName: this.loadBalancerName
+    LoadBalancerName: this.loadBalancerName,
   };
   this.request(null, "deleteLoadBalancer", params, callback);
 });

--- a/features/elbv2/step_definitions/elbv2.js
+++ b/features/elbv2/step_definitions/elbv2.js
@@ -1,6 +1,4 @@
-const {
-  ElasticLoadBalancingv2
-} = require("../../../clients/client-elastic-load-balancing-v2");
+const { ElasticLoadBalancingv2 } = require("../../../clients/client-elastic-load-balancing-v2");
 const { Before } = require("cucumber");
 
 Before({ tags: "@elbv2" }, function (scenario, callback) {

--- a/features/es/step_definitions/es.js
+++ b/features/es/step_definitions/es.js
@@ -1,6 +1,4 @@
-const {
-  ElasticsearchService
-} = require("../../../clients/client-elasticsearch-service");
+const { ElasticsearchService } = require("../../../clients/client-elasticsearch-service");
 const { Before } = require("cucumber");
 
 Before({ tags: "@es" }, function (scenario, callback) {

--- a/features/extra/assertions.js
+++ b/features/extra/assertions.js
@@ -1,10 +1,7 @@
 const assert = require("assert");
 
 assert.match = function assertMatches(string, matcher, message) {
-  assert.ok(
-    string.match(matcher),
-    message || "Expected " + string + " to match " + matcher
-  );
+  assert.ok(string.match(matcher), message || "Expected " + string + " to match " + matcher);
 };
 
 assert.contains = function assertContains(list, matcher, message) {
@@ -21,16 +18,11 @@ assert.contains = function assertContains(list, matcher, message) {
   assert.fail(list, matcher, message, "does not contain");
 };
 
-assert.compare = function assertComparison(
-  actual,
-  operator,
-  expected,
-  message
-) {
+assert.compare = function assertComparison(actual, operator, expected, message) {
   const compare = actual + " " + operator + " " + expected;
   assert.ok(eval(compare), message || compare);
 };
 
 module.exports = {
-  assert: assert
+  assert: assert,
 };

--- a/features/extra/cleanup.js
+++ b/features/extra/cleanup.js
@@ -50,7 +50,7 @@ const deleteFixtures = function () {
 /*
  * Delete objects and then bucket.
  */
-const cleanBucket = async bucket => {
+const cleanBucket = async (bucket) => {
   await deleteObjects(bucket);
   await deleteBucket(bucket);
 };
@@ -58,7 +58,7 @@ const cleanBucket = async bucket => {
 /*
  * Delete bucket
  */
-const deleteBucket = async bucket => {
+const deleteBucket = async (bucket) => {
   const s3 = new S3({ maxRetries: 100 });
   return s3.deleteBucket({ Bucket: bucket });
 };
@@ -66,10 +66,10 @@ const deleteBucket = async bucket => {
 /**
  * Delete objects.
  */
-const deleteObjects = async bucket => {
+const deleteObjects = async (bucket) => {
   const s3 = new S3({ maxRetries: 100 });
   const params = {
-    Bucket: bucket
+    Bucket: bucket,
   };
 
   const data = await s3.listObjects(params);

--- a/features/extra/helpers.js
+++ b/features/extra/helpers.js
@@ -85,13 +85,7 @@ module.exports = {
           extra.call(world, world.data);
           next.call(world);
         } else if (extra !== false && err) {
-          world.unexpectedError(
-            svc.config.signingName,
-            operation,
-            world.error.name,
-            world.error.message,
-            next
-          );
+          world.unexpectedError(svc.config.signingName, operation, world.error.name, world.error.message, next);
         } else {
           next.call(world);
         }
@@ -107,9 +101,7 @@ module.exports = {
    * operation failed.
    */
   unexpectedError: function unexpectedError(svc, op, name, msg, next) {
-    next.fail(
-      new Error(`Received unexpected error from ${svc}.${op}, ${name}: ${msg}`)
-    );
+    next.fail(new Error(`Received unexpected error from ${svc}.${op}, ${name}: ${msg}`));
   },
 
   /**
@@ -247,5 +239,5 @@ module.exports = {
       });
     };
     checkForBucketNotExists();
-  }
+  },
 };

--- a/features/extra/hooks.js
+++ b/features/extra/hooks.js
@@ -7,14 +7,7 @@ const isType = (obj, type) => {
   return Object.prototype.toString.call(obj) === "[object " + type + "]";
 };
 
-const {
-  Before,
-  Given,
-  Then,
-  When,
-  setDefaultTimeout,
-  setWorldConstructor
-} = require("cucumber");
+const { Before, Given, Then, When, setDefaultTimeout, setWorldConstructor } = require("cucumber");
 
 setDefaultTimeout(300 * 1000);
 setWorldConstructor(require("./world.js").World);
@@ -28,12 +21,8 @@ Before(function (scenario, callback) {
 Given("I create a shared bucket", function (callback) {
   if (this.sharedBucket) return callback();
 
-  const bucket = (this.sharedBucket = this.uniqueName(
-    "aws-sdk-js-shared-integration"
-  ));
-  this.request("s3", "createBucket", { Bucket: this.sharedBucket }, function (
-    err
-  ) {
+  const bucket = (this.sharedBucket = this.uniqueName("aws-sdk-js-shared-integration"));
+  this.request("s3", "createBucket", { Bucket: this.sharedBucket }, function (err) {
     this.cacheBucketName(this.sharedBucket);
     if (err) {
       callback(err);
@@ -48,10 +37,7 @@ Given("I create a shared bucket", function (callback) {
 
 Given("I create a bucket", function (callback) {
   const bucket = (this.bucket = this.uniqueName("aws-sdk-js-integration"));
-  this.request("s3", "createBucket", { Bucket: this.bucket }, function (
-    err,
-    data
-  ) {
+  this.request("s3", "createBucket", { Bucket: this.bucket }, function (err, data) {
     if (err) {
       return callback(err);
     }
@@ -77,11 +63,7 @@ Given("I run the {string} operation", function (operation, callback) {
   this.request(null, operation, {}, callback, false);
 });
 
-Given("I run the {string} operation with params:", function (
-  operation,
-  params,
-  callback
-) {
+Given("I run the {string} operation with params:", function (operation, params, callback) {
   this.request(null, operation, JSON.parse(params), callback, false);
 });
 
@@ -92,28 +74,19 @@ Then("the request should be successful", function (callback) {
 
 Then("the value at {string} should be a list", function (path, callback) {
   const value = jmespath.search(this.data, path);
-  this.assert.ok(
-    Array.isArray(value),
-    "expected " + util.inspect(value) + " to be a list"
-  );
+  this.assert.ok(Array.isArray(value), "expected " + util.inspect(value) + " to be a list");
   callback();
 });
 
 Then("the value at {string} should be a number", function (path, callback) {
   const value = jmespath.search(this.data, path);
-  this.assert.ok(
-    typeof value === "number",
-    "expected " + util.inspect(value) + " to be a number"
-  );
+  this.assert.ok(typeof value === "number", "expected " + util.inspect(value) + " to be a number");
   callback();
 });
 
 Then("the value at {string} should be a string", function (path, callback) {
   const value = jmespath.search(this.data, path);
-  this.assert.ok(
-    typeof value === "string",
-    "expected " + util.inspect(value) + " to be a string"
-  );
+  this.assert.ok(typeof value === "string", "expected " + util.inspect(value) + " to be a string");
   callback();
 });
 
@@ -148,46 +121,44 @@ Then("I should get the error:", function (table, callback) {
   callback();
 });
 
-Given("I have a {string} service in the {string} region", function (
-  svc,
-  region,
-  callback
-) {
+Given("I have a {string} service in the {string} region", function (svc, region, callback) {
   this.service = new this.service.constructor({ region: region });
   callback();
 });
 
-Given(
-  /^I paginate the "([^"]*)" operation(?: with limit (\d+))?(?: and max pages (\d+))?$/,
-  function (operation, limit, maxPages, callback) {
-    limit = parseInt(limit);
-    if (maxPages) maxPages = parseInt(maxPages);
+Given(/^I paginate the "([^"]*)" operation(?: with limit (\d+))?(?: and max pages (\d+))?$/, function (
+  operation,
+  limit,
+  maxPages,
+  callback
+) {
+  limit = parseInt(limit);
+  if (maxPages) maxPages = parseInt(maxPages);
 
-    const world = this;
-    this.numPages = 0;
-    this.numMarkers = 0;
-    this.operation = operation;
-    this.paginationConfig = this.service.paginationConfig(operation);
-    this.params = this.params || {};
+  const world = this;
+  this.numPages = 0;
+  this.numMarkers = 0;
+  this.operation = operation;
+  this.paginationConfig = this.service.paginationConfig(operation);
+  this.params = this.params || {};
 
-    const marker = this.paginationConfig.outputToken;
-    if (this.paginationConfig.limitKey) {
-      this.params[this.paginationConfig.limitKey] = limit;
-    }
-    this.service[operation](this.params).eachPage(function (err, data) {
-      if (err) callback(err);
-      else if (data === null) callback();
-      else if (maxPages && world.numPages === maxPages) {
-        callback();
-        return false;
-      } else {
-        if (data[marker]) world.numMarkers++;
-        world.numPages++;
-        world.data = data;
-      }
-    });
+  const marker = this.paginationConfig.outputToken;
+  if (this.paginationConfig.limitKey) {
+    this.params[this.paginationConfig.limitKey] = limit;
   }
-);
+  this.service[operation](this.params).eachPage(function (err, data) {
+    if (err) callback(err);
+    else if (data === null) callback();
+    else if (maxPages && world.numPages === maxPages) {
+      callback();
+      return false;
+    } else {
+      if (data[marker]) world.numMarkers++;
+      world.numPages++;
+      world.data = data;
+    }
+  });
+});
 
 Then("I should get more than one page", function (callback) {
   this.assert.compare(this.numPages, ">", 1);
@@ -215,23 +186,21 @@ Then("the last page should not contain a marker", function (callback) {
   callback();
 });
 
-Then(
-  "the result at {word} should contain a property {word} with a(n) {word}",
-  function (wrapper, property, type, callback) {
-    if (type === "Array" || type === "Date") {
-      this.assert.equal(isType(this.data[wrapper][property], type), true);
-    } else {
-      this.assert.equal(typeof this.data[wrapper][property], type);
-    }
-    callback();
-  }
-);
-
-Then("the result should contain a property {word} with a(n) {word}", function (
+Then("the result at {word} should contain a property {word} with a(n) {word}", function (
+  wrapper,
   property,
   type,
   callback
 ) {
+  if (type === "Array" || type === "Date") {
+    this.assert.equal(isType(this.data[wrapper][property], type), true);
+  } else {
+    this.assert.equal(typeof this.data[wrapper][property], type);
+  }
+  callback();
+});
+
+Then("the result should contain a property {word} with a(n) {word}", function (property, type, callback) {
   if (type === "Array" || type === "Date") {
     this.assert.equal(isType(this.data[property], type), true);
   } else {

--- a/features/iam/step_definitions/iam.js
+++ b/features/iam/step_definitions/iam.js
@@ -24,7 +24,7 @@ Given("I create an IAM user with the username", function (callback) {
     "iam",
     "createUser",
     {
-      UserName: this.iamUser
+      UserName: this.iamUser,
     },
     next,
     false
@@ -48,16 +48,13 @@ Then("I delete the IAM user", function (callback) {
     "iam",
     "deleteUser",
     {
-      UserName: this.iamUser
+      UserName: this.iamUser,
     },
     callback
   );
 });
 
-Given("I create an IAM role with name prefix {string}", function (
-  name,
-  callback
-) {
+Given("I create an IAM role with name prefix {string}", function (name, callback) {
   this.iamRoleName = this.uniqueName(name);
 
   const world = this;
@@ -67,7 +64,7 @@ Given("I create an IAM role with name prefix {string}", function (
     '"Action":["sts:AssumeRole"]}]}';
   const params = {
     RoleName: this.iamRoleName,
-    AssumeRolePolicyDocument: assumeRolePolicyDocument
+    AssumeRolePolicyDocument: assumeRolePolicyDocument,
   };
   const next = function () {
     world.iamRoleArn = world.data.Role.Arn;
@@ -88,7 +85,7 @@ Then("I delete the IAM role", function (callback) {
     "iam",
     "deleteRole",
     {
-      RoleName: this.iamRoleName
+      RoleName: this.iamRoleName,
     },
     callback
   );

--- a/features/kinesis/step_definitions/kinesis.js
+++ b/features/kinesis/step_definitions/kinesis.js
@@ -7,11 +7,5 @@ Before({ tags: "@kinesis" }, function (scenario, callback) {
 });
 
 Given("I try to describe a stream in Kinesis", function (callback) {
-  this.request(
-    null,
-    "describeStream",
-    { StreamName: "XXINVALIDXX" },
-    callback,
-    false
-  );
+  this.request(null, "describeStream", { StreamName: "XXINVALIDXX" }, callback, false);
 });

--- a/features/opsworks/step_definitions/opsworks.js
+++ b/features/opsworks/step_definitions/opsworks.js
@@ -8,11 +8,9 @@ Before({ tags: "@opsworks" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create an OpsWorks user profile with the IAM user ARN", function (
-  callback
-) {
+Given("I create an OpsWorks user profile with the IAM user ARN", function (callback) {
   const params = {
-    IamUserArn: this.iamUserArn
+    IamUserArn: this.iamUserArn,
   };
   this.request(null, "createUserProfile", params, callback, false);
 });
@@ -24,7 +22,7 @@ Given("the IAM user ARN is in the result", function (callback) {
 
 Given("I describe the OpsWorks user profiles", function (callback) {
   const params = {
-    IamUserArns: [this.iamUserArn]
+    IamUserArns: [this.iamUserArn],
   };
   this.request(null, "describeUserProfiles", params, callback);
 });
@@ -39,16 +37,14 @@ Then("the name should be equal to the IAM username", function (callback) {
   callback();
 });
 
-Then("the SSH username should be equal to the IAM username", function (
-  callback
-) {
+Then("the SSH username should be equal to the IAM username", function (callback) {
   this.assert.equal(this.data.UserProfiles[0].SshUsername, this.iamUser);
   callback();
 });
 
 Then("I delete the OpsWorks user profile", function (callback) {
   const params = {
-    IamUserArn: this.iamUserArn
+    IamUserArn: this.iamUserArn,
   };
   this.request(null, "deleteUserProfile", params, callback, false);
 });

--- a/features/pinpoint/step_definitions/pinpoint.js
+++ b/features/pinpoint/step_definitions/pinpoint.js
@@ -9,8 +9,8 @@ Before({ tags: "@pinpoint" }, function (scenario, callback) {
 Given("I create an application", function (callback) {
   const params = {
     CreateApplicationRequest: {
-      Name: this.uniqueName("aws-sdk-js-integration")
-    }
+      Name: this.uniqueName("aws-sdk-js-integration"),
+    },
   };
   this.request(null, "createApp", params, function (err, data) {
     if (err) {
@@ -21,16 +21,13 @@ Given("I create an application", function (callback) {
   });
 });
 
-Given('I run the "putEvents" operation with EventsRequest:', function (
-  eventsRequest,
-  callback
-) {
+Given('I run the "putEvents" operation with EventsRequest:', function (eventsRequest, callback) {
   this.request(
     null,
     "putEvents",
     {
       ApplicationId: this.applicationId,
-      EventsRequest: JSON.parse(eventsRequest)
+      EventsRequest: JSON.parse(eventsRequest),
     },
     callback,
     false
@@ -42,7 +39,7 @@ Given("I delete the application", function (callback) {
     null,
     "deleteApp",
     {
-      ApplicationId: this.applicationId
+      ApplicationId: this.applicationId,
     },
     callback,
     false

--- a/features/rds/step_definitions/rds.js
+++ b/features/rds/step_definitions/rds.js
@@ -7,24 +7,16 @@ Before({ tags: "@rds" }, function (scenario, callback) {
   callback();
 });
 
-Given("I create a RDS security group with prefix name {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a RDS security group with prefix name {string}", function (prefix, callback) {
   this.dbGroupName = this.uniqueName(prefix);
   const params = {
     DBSecurityGroupDescription: "Description",
-    DBSecurityGroupName: this.dbGroupName
+    DBSecurityGroupName: this.dbGroupName,
   };
   this.request(null, "createDBSecurityGroup", params, callback, false);
 });
 
-Then("the value at {string} should contain {string} with {string}", function (
-  path,
-  key,
-  value,
-  callback
-) {
+Then("the value at {string} should contain {string} with {string}", function (path, key, value, callback) {
   const member = jmespath.search(this.data, path);
   let containDefault = false;
   member.forEach(function (config) {
@@ -32,53 +24,45 @@ Then("the value at {string} should contain {string} with {string}", function (
       containDefault = true;
     }
   });
-  this.assert.ok(
-    containDefault === true,
-    `No ${path} has member key ${key} of the value ${value}`
-  );
+  this.assert.ok(containDefault === true, `No ${path} has member key ${key} of the value ${value}`);
   callback();
 });
 
-Given(
-  "I paginate the {string} operation asynchronously with limit {int}",
-  function (operation, limit, callback) {
-    const maxPages = 3;
-    limit = parseInt(limit);
+Given("I paginate the {string} operation asynchronously with limit {int}", function (operation, limit, callback) {
+  const maxPages = 3;
+  limit = parseInt(limit);
 
-    const world = this;
-    this.numPages = 0;
-    this.numMarkers = 0;
-    this.operation = operation;
-    this.paginationConfig = this.service.paginationConfig(operation);
-    this.params = this.params || {};
-    this.finishedPagination = false;
+  const world = this;
+  this.numPages = 0;
+  this.numMarkers = 0;
+  this.operation = operation;
+  this.paginationConfig = this.service.paginationConfig(operation);
+  this.params = this.params || {};
+  this.finishedPagination = false;
 
-    const marker = this.paginationConfig.outputToken;
-    if (this.paginationConfig.limitKey) {
-      this.params[this.paginationConfig.limitKey] = limit;
-    }
-    this.service[operation](this.params).eachPage(function (err, data, done) {
-      process.nextTick(function () {
-        if (err) callback(err);
-        else if (data === null || world.numPages === maxPages) {
-          world.finishedPagination = true;
-          callback();
-          return false;
-        } else {
-          if (data[marker]) world.numMarkers++;
-          world.numPages++;
-          world.data = data;
-        }
-
-        done(); // start getting next page
-      });
-    });
+  const marker = this.paginationConfig.outputToken;
+  if (this.paginationConfig.limitKey) {
+    this.params[this.paginationConfig.limitKey] = limit;
   }
-);
+  this.service[operation](this.params).eachPage(function (err, data, done) {
+    process.nextTick(function () {
+      if (err) callback(err);
+      else if (data === null || world.numPages === maxPages) {
+        world.finishedPagination = true;
+        callback();
+        return false;
+      } else {
+        if (data[marker]) world.numMarkers++;
+        world.numPages++;
+        world.data = data;
+      }
 
-Then("I should be able to asynchronously paginate all pages", function (
-  callback
-) {
+      done(); // start getting next page
+    });
+  });
+});
+
+Then("I should be able to asynchronously paginate all pages", function (callback) {
   this.assert.equal(this.finishedPagination, true);
   callback();
 });

--- a/features/redshift/step_definitions/redshift.js
+++ b/features/redshift/step_definitions/redshift.js
@@ -6,15 +6,12 @@ Before({ tags: "@redshift" }, function (scenario, callback) {
   callback();
 });
 
-Given(
-  "I create a Redshift cluster parameter group with prefix name {string}",
-  function (prefix, callback) {
-    this.parameterGroupName = this.uniqueName(prefix);
-    const params = {
-      Description: "Description",
-      ParameterGroupName: this.parameterGroupName,
-      ParameterGroupFamily: "redshift-1.0"
-    };
-    this.request(null, "createClusterParameterGroup", params, callback, false);
-  }
-);
+Given("I create a Redshift cluster parameter group with prefix name {string}", function (prefix, callback) {
+  this.parameterGroupName = this.uniqueName(prefix);
+  const params = {
+    Description: "Description",
+    ParameterGroupName: this.parameterGroupName,
+    ParameterGroupFamily: "redshift-1.0",
+  };
+  this.request(null, "createClusterParameterGroup", params, callback, false);
+});

--- a/features/route53/step_definitions/route53.js
+++ b/features/route53/step_definitions/route53.js
@@ -6,17 +6,14 @@ Before({ tags: "@route53" }, function (scenario, callback) {
   callback();
 });
 
-When("I create a Route53 hosted zone with name prefix {string}", function (
-  prefix,
-  callback
-) {
+When("I create a Route53 hosted zone with name prefix {string}", function (prefix, callback) {
   this.zoneName = "zone1.example.com";
   const params = {
     Name: this.zoneName,
     CallerReference: this.uniqueName(prefix),
     HostedZoneConfig: {
-      Comment: "A comment about the zone"
-    }
+      Comment: "A comment about the zone",
+    },
   };
   this.request(null, "createHostedZone", params, callback, false);
 });
@@ -41,7 +38,7 @@ When("I get information about the Route53 change ID", function (callback) {
     null,
     "getChange",
     {
-      Id: this.changeInfoId
+      Id: this.changeInfoId,
     },
     callback
   );
@@ -57,7 +54,7 @@ When("I get information about the Route53 hosted zone ID", function (callback) {
     null,
     "getHostedZone",
     {
-      Id: this.hostedZoneId
+      Id: this.hostedZoneId,
     },
     callback
   );
@@ -74,23 +71,20 @@ Then("I delete the Route53 hosted zone", function (callback) {
     null,
     "deleteHostedZone",
     {
-      Id: this.hostedZoneId
+      Id: this.hostedZoneId,
     },
     callback
   );
 });
 
-When("I create a Route53 TCP health check with name prefix {string}", function (
-  prefix,
-  callback
-) {
+When("I create a Route53 TCP health check with name prefix {string}", function (prefix, callback) {
   const params = {
     CallerReference: this.uniqueName(prefix),
     HealthCheckConfig: {
       IPAddress: "192.0.43.10", // example.com
       Port: 80,
-      Type: "TCP"
-    }
+      Type: "TCP",
+    },
   };
   this.request(null, "createHealthCheck", params, callback);
 });
@@ -107,22 +101,19 @@ Then("the result should contain the health check ID", function (callback) {
 
 When("I get information about the health check ID", function (callback) {
   const params = {
-    HealthCheckId: this.healthCheckId
+    HealthCheckId: this.healthCheckId,
   };
   this.request(null, "getHealthCheck", params, callback);
 });
 
-Then(
-  "the result should contain the previous health check information",
-  function (callback) {
-    this.assert.deepEqual(this.data.HealthCheck, this.healthCheckInfo);
-    callback();
-  }
-);
+Then("the result should contain the previous health check information", function (callback) {
+  this.assert.deepEqual(this.data.HealthCheck, this.healthCheckInfo);
+  callback();
+});
 
 Then("I delete the Route53 TCP health check", function (callback) {
   const params = {
-    HealthCheckId: this.healthCheckId
+    HealthCheckId: this.healthCheckId,
   };
   this.request(null, "deleteHealthCheck", params, callback);
 });

--- a/features/route53domains/step_definitions/route53domains.js
+++ b/features/route53domains/step_definitions/route53domains.js
@@ -10,15 +10,13 @@ Given("I list Route53 domains", function (callback) {
   this.request(null, "listDomains", {}, callback);
 });
 
-Given("I try to register a Route53 domain with invalid parameters", function (
-  callback
-) {
+Given("I try to register a Route53 domain with invalid parameters", function (callback) {
   const params = {
     DomainName: "example.com",
     DurationInYears: 1,
     AdminContact: {},
     RegistrantContact: {},
-    TechContact: {}
+    TechContact: {},
   };
   this.request(null, "registerDomain", params, callback, false);
 });

--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -3,32 +3,30 @@ const { Given, Then, When } = require("cucumber");
 
 Given("I am using the S3 {string} region", function (region, callback) {
   this.s3 = new S3({
-    region: region
+    region: region,
   });
   callback();
 });
 
-Given(
-  "I am using the S3 {string} region with signatureVersion {string}",
-  function (region, signatureVersion, callback) {
-    this.s3 = new S3({
-      region: region,
-      signatureVersion: signatureVersion
-    });
-    callback();
-  }
-);
-
-When("I create a bucket with the location constraint {string}", function (
-  location,
+Given("I am using the S3 {string} region with signatureVersion {string}", function (
+  region,
+  signatureVersion,
   callback
 ) {
+  this.s3 = new S3({
+    region: region,
+    signatureVersion: signatureVersion,
+  });
+  callback();
+});
+
+When("I create a bucket with the location constraint {string}", function (location, callback) {
   const bucket = (this.bucket = this.uniqueName("aws-sdk-js-integration"));
   const params = {
     Bucket: this.bucket,
     CreateBucketConfiguration: {
-      LocationConstraint: location
-    }
+      LocationConstraint: location,
+    },
   };
   this.request("s3", "createBucket", params, function (err, data) {
     if (err) {
@@ -37,21 +35,18 @@ When("I create a bucket with the location constraint {string}", function (
     this.waitForBucketExists(
       this.s3,
       {
-        Bucket: bucket
+        Bucket: bucket,
       },
       callback
     );
   });
 });
 
-Then("the bucket should have a location constraint of {string}", function (
-  loc,
-  callback
-) {
+Then("the bucket should have a location constraint of {string}", function (loc, callback) {
   const self = this;
   self.s3.getBucketLocation(
     {
-      Bucket: self.bucket
+      Bucket: self.bucket,
     },
     function (err, data) {
       if (err) callback(err);
@@ -61,62 +56,51 @@ Then("the bucket should have a location constraint of {string}", function (
   );
 });
 
-When(
-  "I put a transition lifecycle configuration on the bucket with prefix {string}",
-  function (prefix, callback) {
-    const params = {
-      Bucket: this.bucket,
-      LifecycleConfiguration: {
-        Rules: [
-          {
-            Filter: {
-              Prefix: prefix
+When("I put a transition lifecycle configuration on the bucket with prefix {string}", function (prefix, callback) {
+  const params = {
+    Bucket: this.bucket,
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          Filter: {
+            Prefix: prefix,
+          },
+          Status: "Enabled",
+          Transitions: [
+            {
+              Days: 0,
+              StorageClass: "GLACIER",
             },
-            Status: "Enabled",
-            Transitions: [
-              {
-                Days: 0,
-                StorageClass: "GLACIER"
-              }
-            ]
-          }
-        ]
-      }
-    };
-    this.request("s3", "putBucketLifecycleConfiguration", params, callback);
-  }
-);
+          ],
+        },
+      ],
+    },
+  };
+  this.request("s3", "putBucketLifecycleConfiguration", params, callback);
+});
 
-When("I get the transition lifecycle configuration on the bucket", function (
-  callback
-) {
+When("I get the transition lifecycle configuration on the bucket", function (callback) {
   this.eventually(callback, function (next) {
     this.request(
       "s3",
       "getBucketLifecycleConfiguration",
       {
-        Bucket: this.bucket
+        Bucket: this.bucket,
       },
       next
     );
   });
 });
 
-Then(
-  "the lifecycle configuration should have transition days of {int}",
-  function (days, callback) {
-    this.assert.equal(this.data.Rules[0].Transitions[0].Days, 0);
-    callback();
-  }
-);
+Then("the lifecycle configuration should have transition days of {int}", function (days, callback) {
+  this.assert.equal(this.data.Rules[0].Transitions[0].Days, 0);
+  callback();
+});
 
-Then(
-  "the lifecycle configuration should have transition storage class of {string}",
-  function (value, callback) {
-    this.assert.equal(this.data.Rules[0].Transitions[0].StorageClass, value);
-    callback();
-  }
-);
+Then("the lifecycle configuration should have transition storage class of {string}", function (value, callback) {
+  this.assert.equal(this.data.Rules[0].Transitions[0].StorageClass, value);
+  callback();
+});
 
 When("I put a bucket CORS configuration", function (callback) {
   const params = {
@@ -128,10 +112,10 @@ When("I put a bucket CORS configuration", function (callback) {
           AllowedOrigins: ["http://example.com"],
           AllowedHeaders: ["*"],
           ExposeHeaders: ["x-amz-server-side-encryption"],
-          MaxAgeSeconds: 5000
-        }
-      ]
-    }
+          MaxAgeSeconds: 5000,
+        },
+      ],
+    },
   };
   this.request("s3", "putBucketCors", params, callback);
 });
@@ -141,43 +125,28 @@ When("I get the bucket CORS configuration", function (callback) {
     "s3",
     "getBucketCors",
     {
-      Bucket: this.bucket
+      Bucket: this.bucket,
     },
     callback
   );
 });
 
-Then("the AllowedMethods list should inclue {string}", function (
-  value,
-  callback
-) {
-  this.assert.equal(
-    this.data.CORSRules[0].AllowedMethods.sort().join(" "),
-    "DELETE POST PUT"
-  );
+Then("the AllowedMethods list should inclue {string}", function (value, callback) {
+  this.assert.equal(this.data.CORSRules[0].AllowedMethods.sort().join(" "), "DELETE POST PUT");
   callback();
 });
 
-Then("the AllowedOrigin value should equal {string}", function (
-  value,
-  callback
-) {
+Then("the AllowedOrigin value should equal {string}", function (value, callback) {
   this.assert.equal(this.data.CORSRules[0].AllowedOrigins[0], value);
   callback();
 });
 
-Then("the AllowedHeader value should equal {string}", function (
-  value,
-  callback
-) {
+Then("the AllowedHeader value should equal {string}", function (value, callback) {
   this.assert.equal(this.data.CORSRules[0].AllowedHeaders[0], value);
   callback();
 });
 
-Then("the ExposeHeader value should equal {string}", function (
-  value,
-  callback
-) {
+Then("the ExposeHeader value should equal {string}", function (value, callback) {
   this.assert.equal(this.data.CORSRules[0].ExposeHeaders[0], value);
   callback();
 });
@@ -187,21 +156,17 @@ Then("the MaxAgeSeconds value should equal {int}", function (value, callback) {
   callback();
 });
 
-When("I put a bucket tag with key {string} and value {string}", function (
-  key,
-  value,
-  callback
-) {
+When("I put a bucket tag with key {string} and value {string}", function (key, value, callback) {
   const params = {
     Bucket: this.bucket,
     Tagging: {
       TagSet: [
         {
           Key: key,
-          Value: value
-        }
-      ]
-    }
+          Value: value,
+        },
+      ],
+    },
   };
 
   this.request("s3", "putBucketTagging", params, callback);
@@ -212,50 +177,44 @@ When("I get the bucket tagging", function (callback) {
     "s3",
     "getBucketTagging",
     {
-      Bucket: this.bucket
+      Bucket: this.bucket,
     },
     callback
   );
 });
 
-Then(
-  "the first tag in the tag set should have key and value {string}, {string}",
-  function (key, value, callback) {
-    this.assert.equal(this.data.TagSet[0].Key, key);
-    this.assert.equal(this.data.TagSet[0].Value, value);
-    callback();
-  }
-);
+Then("the first tag in the tag set should have key and value {string}, {string}", function (key, value, callback) {
+  this.assert.equal(this.data.TagSet[0].Key, key);
+  this.assert.equal(this.data.TagSet[0].Value, value);
+  callback();
+});
 
-When(
-  "I create a bucket with a DNS compatible name that contains a dot",
-  function (callback) {
-    const bucket = (this.bucket = this.uniqueName("aws-sdk-js.integration"));
-    this.request(
-      "s3",
-      "createBucket",
-      {
-        Bucket: this.bucket
-      },
-      function (err, data) {
-        if (err) {
-          return callback(err);
-        }
-        this.waitForBucketExists(
-          this.s3,
-          {
-            Bucket: bucket
-          },
-          callback
-        );
+When("I create a bucket with a DNS compatible name that contains a dot", function (callback) {
+  const bucket = (this.bucket = this.uniqueName("aws-sdk-js.integration"));
+  this.request(
+    "s3",
+    "createBucket",
+    {
+      Bucket: this.bucket,
+    },
+    function (err, data) {
+      if (err) {
+        return callback(err);
       }
-    );
-  }
-);
+      this.waitForBucketExists(
+        this.s3,
+        {
+          Bucket: bucket,
+        },
+        callback
+      );
+    }
+  );
+});
 
 Given("I force path style requests", function (callback) {
   this.s3 = new S3({
-    forcePathStyle: true
+    forcePathStyle: true,
   });
   callback();
 });
@@ -272,15 +231,11 @@ Then("the bucket name should not be in the request host", function (callback) {
   callback();
 });
 
-When("I put {string} to the key {string} in the bucket", function (
-  data,
-  key,
-  next
-) {
+When("I put {string} to the key {string} in the bucket", function (data, key, next) {
   const params = {
     Bucket: this.bucket,
     Key: key,
-    Body: data
+    Body: data,
   };
   this.request("s3", "putObject", params, next, false);
 });
@@ -288,7 +243,7 @@ When("I put {string} to the key {string} in the bucket", function (
 When("I get the key {string} in the bucket", function (key, next) {
   const params = {
     Bucket: this.bucket,
-    Key: key
+    Key: key,
   };
   this.request("s3", "getObject", params, next, false);
 });
@@ -296,32 +251,25 @@ When("I get the key {string} in the bucket", function (key, next) {
 Then("I delete the object {string} from the bucket", function (key, next) {
   const params = {
     Bucket: this.bucket,
-    Key: key
+    Key: key,
   };
   this.request("s3", "deleteObject", params, next);
 });
 
-When(
-  /^I put a (small|large) buffer to the key "([^"]*)" in the bucket$/,
-  function (size, key, next) {
-    const body = this.createBuffer(size);
-    const params = {
-      Bucket: this.bucket,
-      Key: key,
-      Body: body
-    };
-    this.request("s3", "putObject", params, next);
-  }
-);
-
-Then(/^the object "([^"]*)" should (not )?exist in the bucket$/, function (
-  key,
-  shouldNotExist,
-  next
-) {
+When(/^I put a (small|large) buffer to the key "([^"]*)" in the bucket$/, function (size, key, next) {
+  const body = this.createBuffer(size);
   const params = {
     Bucket: this.bucket,
-    Key: key
+    Key: key,
+    Body: body,
+  };
+  this.request("s3", "putObject", params, next);
+});
+
+Then(/^the object "([^"]*)" should (not )?exist in the bucket$/, function (key, shouldNotExist, next) {
+  const params = {
+    Bucket: this.bucket,
+    Key: key,
   };
   this.eventually(next, function (retry) {
     retry.condition = function () {

--- a/features/s3/step_definitions/hooks.js
+++ b/features/s3/step_definitions/hooks.js
@@ -3,7 +3,7 @@ const { Before } = require("cucumber");
 
 Before({ tags: "@s3" }, function (scenario, callback) {
   this.service = this.s3 = new S3({
-    maxRetries: 100
+    maxRetries: 100,
   });
   callback();
 });

--- a/features/s3/step_definitions/proxy.js
+++ b/features/s3/step_definitions/proxy.js
@@ -8,8 +8,8 @@ Before({ tags: "@s3 or @proxy" }, function (scenario, callback) {
 
   this.service = this.s3 = new S3({
     httpOptions: {
-      proxy: "http://localhost:" + this.proxyPort
-    }
+      proxy: "http://localhost:" + this.proxyPort,
+    },
   });
 
   callback();
@@ -30,7 +30,7 @@ function setupProxyServer() {
       port: uri.port || 80,
       method: req.method,
       path: uri.path,
-      headers: req.headers
+      headers: req.headers,
     };
     options.headers.host = uri.hostname;
 

--- a/features/ses/step_definitions/ses.js
+++ b/features/ses/step_definitions/ses.js
@@ -21,7 +21,7 @@ When("I ask to verify the email address {string}", function (email, next) {
     null,
     "verifyEmailAddress",
     {
-      EmailAddress: email
+      EmailAddress: email,
     },
     next,
     function () {

--- a/features/sns/step_definitions/sns.js
+++ b/features/sns/step_definitions/sns.js
@@ -12,7 +12,7 @@ Given("I create an SNS topic with name {string}", function (name, callback) {
     null,
     "createTopic",
     {
-      Name: name
+      Name: name,
     },
     callback,
     function (data) {
@@ -38,7 +38,7 @@ Then("I delete the SNS topic", function (callback) {
     null,
     "deleteTopic",
     {
-      TopicArn: this.topicArn
+      TopicArn: this.topicArn,
     },
     callback
   );
@@ -49,7 +49,7 @@ Given("I get SNS topic attributes with an invalid ARN", function (callback) {
     null,
     "getTopicAttributes",
     {
-      TopicArn: "INVALID"
+      TopicArn: "INVALID",
     },
     callback,
     false

--- a/features/sqs/step_definitions/messages.js
+++ b/features/sqs/step_definitions/messages.js
@@ -1,12 +1,7 @@
 const { Then, When } = require("cucumber");
 
 When("I send the message {string}", function (message, callback) {
-  this.request(
-    null,
-    "sendMessage",
-    { QueueUrl: this.queueUrl, MessageBody: message },
-    callback
-  );
+  this.request(null, "sendMessage", { QueueUrl: this.queueUrl, MessageBody: message }, callback);
 });
 
 Then("the result should include a message ID", function (callback) {
@@ -14,55 +9,43 @@ Then("the result should include a message ID", function (callback) {
   callback();
 });
 
-Then("the result should have an MD5 digest of {string}", function (
-  digest,
-  callback
-) {
+Then("the result should have an MD5 digest of {string}", function (digest, callback) {
   this.assert.equal(this.data.MD5OfMessageBody, digest);
   callback();
 });
 
-Then(
-  "I should eventually be able to receive {string} from the queue",
-  function (message, callback) {
-    this.eventually(callback, function (next) {
-      next.condition = function () {
-        return this.data.Messages[0].Body === message;
-      };
-      this.request(null, "receiveMessage", { QueueUrl: this.queueUrl }, next);
-    });
-  }
-);
+Then("I should eventually be able to receive {string} from the queue", function (message, callback) {
+  this.eventually(callback, function (next) {
+    next.condition = function () {
+      return this.data.Messages[0].Body === message;
+    };
+    this.request(null, "receiveMessage", { QueueUrl: this.queueUrl }, next);
+  });
+});
 
-When("I send the message {string} with a binary attribute", function (
-  message,
-  callback
-) {
+When("I send the message {string} with a binary attribute", function (message, callback) {
   const params = {
     QueueUrl: this.queueUrl,
     MessageBody: message,
     MessageAttributes: {
-      binary: { DataType: "Binary", BinaryValue: Buffer.from([1, 2, 3]) }
-    }
+      binary: { DataType: "Binary", BinaryValue: Buffer.from([1, 2, 3]) },
+    },
   };
   this.request(null, "sendMessage", params, callback);
 });
 
-Then(
-  "I should eventually be able to receive {string} from the queue with a binary attribute",
-  function (message, callback) {
-    this.eventually(callback, function (next) {
-      next.condition = function () {
-        return (
-          this.data.Messages[0].MessageAttributes.binary.BinaryValue.toString() ===
-          "1,2,3"
-        );
-      };
-      const params = {
-        QueueUrl: this.queueUrl,
-        MessageAttributeNames: ["binary"]
-      };
-      this.request(null, "receiveMessage", params, next);
-    });
-  }
-);
+Then("I should eventually be able to receive {string} from the queue with a binary attribute", function (
+  message,
+  callback
+) {
+  this.eventually(callback, function (next) {
+    next.condition = function () {
+      return this.data.Messages[0].MessageAttributes.binary.BinaryValue.toString() === "1,2,3";
+    };
+    const params = {
+      QueueUrl: this.queueUrl,
+      MessageAttributeNames: ["binary"],
+    };
+    this.request(null, "receiveMessage", params, next);
+  });
+});

--- a/features/sqs/step_definitions/queues.js
+++ b/features/sqs/step_definitions/queues.js
@@ -1,9 +1,6 @@
 const { Given, Then } = require("cucumber");
 
-Given("I create a queue with the prefix name {string}", function (
-  prefix,
-  callback
-) {
+Given("I create a queue with the prefix name {string}", function (prefix, callback) {
   const name = this.uniqueName(prefix);
   this.request(null, "createQueue", { QueueName: name }, callback, function () {
     this.queueUrl = this.data.QueueUrl;
@@ -11,9 +8,7 @@ Given("I create a queue with the prefix name {string}", function (
   });
 });
 
-Then("list queues should eventually return the queue urls", function (
-  callback
-) {
+Then("list queues should eventually return the queue urls", function (callback) {
   this.eventually(
     callback,
     function (next) {

--- a/features/sqs/step_definitions/sqs.js
+++ b/features/sqs/step_definitions/sqs.js
@@ -3,7 +3,7 @@ const { Before } = require("cucumber");
 
 Before({ tags: "@sqs" }, function (scenario, callback) {
   this.service = new SQS({
-    region: "us-east-1"
+    region: "us-east-1",
   });
   this.createdQueues = [];
   callback();

--- a/features/storagegateway/step_definitions/storagegateway.js
+++ b/features/storagegateway/step_definitions/storagegateway.js
@@ -11,7 +11,7 @@ When("I try to activate a Storage Gateway", function (callback) {
     ActivationKey: "INVALIDKEY",
     GatewayName: this.uniqueName("aws-sdk-js"),
     GatewayTimezone: "GMT-5:00",
-    GatewayRegion: "us-east-1"
+    GatewayRegion: "us-east-1",
   };
   this.request(null, "activateGateway", params, callback, false);
 });

--- a/features/sts/step_definitions/sts.js
+++ b/features/sts/step_definitions/sts.js
@@ -6,15 +6,12 @@ Before({ tags: "@sts" }, function (scenario, callback) {
   callback();
 });
 
-Given("I get an STS session token with a duration of {int} seconds", function (
-  duration,
-  callback
-) {
+Given("I get an STS session token with a duration of {int} seconds", function (duration, callback) {
   this.request(
     null,
     "getSessionToken",
     {
-      DurationSeconds: parseInt(duration)
+      DurationSeconds: parseInt(duration),
     },
     callback,
     false
@@ -25,7 +22,7 @@ Given("I try to assume role with web identity", function (callback) {
   const params = {
     RoleArn: "arn:aws:iam::123456789:role/WebIdentity",
     RoleSessionName: "name",
-    WebIdentityToken: "token"
+    WebIdentityToken: "token",
   };
   this.request(null, "assumeRoleWithWebIdentity", params, callback, false);
 });
@@ -36,7 +33,7 @@ Given("I try to assume role with SAML", function (callback) {
   const params = {
     RoleArn: arn,
     PrincipalArn: arn,
-    SAMLAssertion: token
+    SAMLAssertion: token,
   };
   this.request(null, "assumeRoleWithSAML", params, callback, false);
 });

--- a/features/support/step_definitions/support.js
+++ b/features/support/step_definitions/support.js
@@ -10,32 +10,26 @@ Given("I describe Support services", function (callback) {
   this.request(null, "describeServices", {}, callback);
 });
 
-Then(
-  "the Supported services list should contain a service with code {string}",
-  function (code, callback) {
-    this.assert.contains(this.data.services, function (svc) {
-      return svc.code == code;
-    });
-    callback();
-  }
-);
+Then("the Supported services list should contain a service with code {string}", function (code, callback) {
+  this.assert.contains(this.data.services, function (svc) {
+    return svc.code == code;
+  });
+  callback();
+});
 
-Then(
-  "the Supported services list should contain a service with name {string}",
-  function (name, callback) {
-    this.assert.contains(this.data.services, function (svc) {
-      return svc.name == name;
-    });
-    callback();
-  }
-);
+Then("the Supported services list should contain a service with name {string}", function (name, callback) {
+  this.assert.contains(this.data.services, function (svc) {
+    return svc.name == name;
+  });
+  callback();
+});
 
 Given("I create a case with an invalid category", function (callback) {
   const params = {
     subject: "Subject",
     serviceCode: "INVALID-CODE",
     categoryCode: "INVALID-CATEGORY",
-    communicationBody: "Communication"
+    communicationBody: "Communication",
   };
 
   this.request(null, "createCase", params, callback, false);

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,7 +1,4 @@
 module.exports = {
   // remove testMatch once we move to ts-jest
-  testMatch: [
-    "**/__tests__/**/*.js?(x)",
-    "**/dist/cjs/**/?(*.)+(spec|test).js?(x)"
-  ]
+  testMatch: ["**/__tests__/**/*.js?(x)", "**/dist/cjs/**/?(*.)+(spec|test).js?(x)"],
 };

--- a/jest.config.integ.js
+++ b/jest.config.integ.js
@@ -4,5 +4,5 @@ module.exports = {
   ...base,
   projects: ["<rootDir>/clients/*/jest.integ.config.js"],
   testPathIgnorePatterns: ["/node_modules/"],
-  coveragePathIgnorePatterns: ["/node_modules/", "/__fixtures__/"]
+  coveragePathIgnorePatterns: ["/node_modules/", "/__fixtures__/"],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,12 +5,8 @@ module.exports = {
   projects: [
     "<rootDir>/protocol_tests/*/jest.config.js",
     "<rootDir>/packages/*/jest.config.js",
-    "<rootDir>/clients/*/jest.config.js"
+    "<rootDir>/clients/*/jest.config.js",
   ],
   testPathIgnorePatterns: ["/node_modules/", "<rootDir>/clients/client-.*"],
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "<rootDir>/clients/client-.*",
-    "/__fixtures__/"
-  ]
+  coveragePathIgnorePatterns: ["/node_modules/", "<rootDir>/clients/client-.*", "/__fixtures__/"],
 };

--- a/packages/abort-controller/jest.config.js
+++ b/packages/abort-controller/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/body-checksum-browser/jest.config.js
+++ b/packages/body-checksum-browser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/body-checksum-node/jest.config.js
+++ b/packages/body-checksum-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/chunked-blob-reader-native/jest.config.js
+++ b/packages/chunked-blob-reader-native/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/chunked-blob-reader/jest.config.js
+++ b/packages/chunked-blob-reader/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/chunked-stream-reader-node/jest.config.js
+++ b/packages/chunked-stream-reader-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/config-resolver/jest.config.js
+++ b/packages/config-resolver/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/credential-provider-cognito-identity/jest.config.js
+++ b/packages/credential-provider-cognito-identity/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   //only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/packages/credential-provider-env/jest.config.js
+++ b/packages/credential-provider-env/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/credential-provider-imds/jest.config.js
+++ b/packages/credential-provider-imds/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/credential-provider-ini/jest.config.js
+++ b/packages/credential-provider-ini/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/credential-provider-node/jest.config.js
+++ b/packages/credential-provider-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/credential-provider-process/jest.config.js
+++ b/packages/credential-provider-process/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/eventstream-handler-node/jest.config.js
+++ b/packages/eventstream-handler-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/eventstream-marshaller/jest.config.js
+++ b/packages/eventstream-marshaller/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/eventstream-marshaller/scripts/buildTestVectorsFixture.js
+++ b/packages/eventstream-marshaller/scripts/buildTestVectorsFixture.js
@@ -12,7 +12,7 @@ const HEADER_TYPES = [
   "binary",
   "string",
   "timestamp",
-  "uuid"
+  "uuid",
 ];
 
 const vectorsDir = join(dirname(__dirname), "test_vectors");
@@ -25,20 +25,16 @@ for (const dirName of ["positive", "negative"]) {
   for (const vectorName of readdirSync(encodedVectorsDir)) {
     vectors += `    ${vectorName}: {
         expectation: '${dirName === "positive" ? "success" : "failure"}',
-        encoded: Uint8Array.from([${readFileSync(
-          join(encodedVectorsDir, vectorName)
-        )
-          .map(byte => byte.toString(10))
+        encoded: Uint8Array.from([${readFileSync(join(encodedVectorsDir, vectorName))
+          .map((byte) => byte.toString(10))
           .join(", ")}]),
 `;
 
     if (dirName === "positive") {
-      const decoded = JSON.parse(
-        readFileSync(join(decodedVectorsDir, vectorName))
-      );
+      const decoded = JSON.parse(readFileSync(join(decodedVectorsDir, vectorName)));
       const headers = decoded.headers
         .map(
-          declaration =>
+          (declaration) =>
             `               '${declaration.name}': {
                     type: '${HEADER_TYPES[declaration.type]}',
                     value: ${headerValue(declaration.type, declaration.value)},
@@ -84,17 +80,12 @@ function headerValue(type, vectorRepresentation) {
       return `new Date(${vectorRepresentation})`;
     case 9:
       const hex = Buffer.from(vectorRepresentation, "base64").toString("hex");
-      return `'${hex.substr(0, 8)}-${hex.substr(8, 4)}-${hex.substr(
-        12,
-        4
-      )}-${hex.substr(16, 4)}-${hex.substr(20)}'`;
+      return `'${hex.substr(0, 8)}-${hex.substr(8, 4)}-${hex.substr(12, 4)}-${hex.substr(16, 4)}-${hex.substr(20)}'`;
     default:
       return vectorRepresentation;
   }
 }
 
 function writeBuffer(buffer) {
-  return `Uint8Array.from([${buffer
-    .map(byte => byte.toString(10))
-    .join(", ")}])`;
+  return `Uint8Array.from([${buffer.map((byte) => byte.toString(10)).join(", ")}])`;
 }

--- a/packages/eventstream-serde-node/jest.config.js
+++ b/packages/eventstream-serde-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/eventstream-serde-universal/jest.config.js
+++ b/packages/eventstream-serde-universal/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/fetch-http-handler/jest.config.js
+++ b/packages/fetch-http-handler/jest.config.js
@@ -2,5 +2,5 @@ const base = require("../../jest.config.base.js");
 
 module.exports = {
   ...base,
-  testPathIgnorePatterns: ["/node_modules/", "(.*).browser.spec.js"]
+  testPathIgnorePatterns: ["/node_modules/", "(.*).browser.spec.js"],
 };

--- a/packages/fetch-http-handler/karma.conf.js
+++ b/packages/fetch-http-handler/karma.conf.js
@@ -7,26 +7,26 @@ module.exports = function (config) {
       "src/stream-collector.browser.spec.ts",
       "src/fetch-http-handler.ts",
       "src/fetch-http-handler.browser.spec.ts",
-      "src/request-timeout.ts"
+      "src/request-timeout.ts",
     ],
     exclude: ["**/*.d.ts"],
     preprocessors: {
-      "**/*.ts": "karma-typescript"
+      "**/*.ts": "karma-typescript",
     },
     reporters: ["progress", "karma-typescript"],
     browsers: ["ChromeHeadlessNoSandbox"],
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox"]
-      }
+        flags: ["--no-sandbox"],
+      },
     },
     karmaTypescriptConfig: {
       tsconfig: "./tsconfig.json",
       bundlerOptions: {
-        addNodeGlobals: false
-      }
+        addNodeGlobals: false,
+      },
     },
-    singleRun: true
+    singleRun: true,
   });
 };

--- a/packages/hash-blob-browser/jest.config.js
+++ b/packages/hash-blob-browser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/hash-blob-browser/karma.conf.js
+++ b/packages/hash-blob-browser/karma.conf.js
@@ -5,22 +5,22 @@ module.exports = function (config) {
     files: ["src/**/*.ts"],
     exclude: ["**/*.d.ts"],
     preprocessors: {
-      "**/*.ts": "karma-typescript"
+      "**/*.ts": "karma-typescript",
     },
     reporters: ["progress", "karma-typescript"],
     browsers: ["ChromeHeadlessNoSandbox"],
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox"]
-      }
+        flags: ["--no-sandbox"],
+      },
     },
     karmaTypescriptConfig: {
       tsconfig: "./tsconfig.json",
       bundlerOptions: {
-        addNodeGlobals: false
-      }
+        addNodeGlobals: false,
+      },
     },
-    singleRun: true
+    singleRun: true,
   });
 };

--- a/packages/hash-node/jest.config.js
+++ b/packages/hash-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/hash-stream-node/jest.config.js
+++ b/packages/hash-stream-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/is-array-buffer/jest.config.js
+++ b/packages/is-array-buffer/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/karma-credential-loader/jest.config.js
+++ b/packages/karma-credential-loader/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/md5-js/jest.config.js
+++ b/packages/md5-js/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-apply-body-checksum/jest.config.js
+++ b/packages/middleware-apply-body-checksum/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-bucket-endpoint/jest.config.js
+++ b/packages/middleware-bucket-endpoint/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-content-length/jest.config.js
+++ b/packages/middleware-content-length/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-eventstream/jest.config.js
+++ b/packages/middleware-eventstream/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-expect-continue/jest.config.js
+++ b/packages/middleware-expect-continue/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-header-default/jest.config.js
+++ b/packages/middleware-header-default/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-host-header/jest.config.js
+++ b/packages/middleware-host-header/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-location-constraint/jest.config.js
+++ b/packages/middleware-location-constraint/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-retry/jest.config.js
+++ b/packages/middleware-retry/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-api-gateway/jest.config.js
+++ b/packages/middleware-sdk-api-gateway/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-ec2/jest.config.js
+++ b/packages/middleware-sdk-ec2/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-glacier/jest.config.js
+++ b/packages/middleware-sdk-glacier/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-machinelearning/jest.config.js
+++ b/packages/middleware-sdk-machinelearning/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-rds/jest.config.js
+++ b/packages/middleware-sdk-rds/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-route53/jest.config.js
+++ b/packages/middleware-sdk-route53/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-s3-control/jest.config.js
+++ b/packages/middleware-sdk-s3-control/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-s3/jest.config.js
+++ b/packages/middleware-sdk-s3/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-sqs/jest.config.js
+++ b/packages/middleware-sdk-sqs/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-sdk-transcribe-streaming/jest.config.js
+++ b/packages/middleware-sdk-transcribe-streaming/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   //only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/packages/middleware-signing/jest.config.js
+++ b/packages/middleware-signing/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-ssec/jest.config.js
+++ b/packages/middleware-ssec/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/middleware-stack/jest.config.js
+++ b/packages/middleware-stack/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/node-http-handler/jest.config.js
+++ b/packages/node-http-handler/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/property-provider/jest.config.js
+++ b/packages/property-provider/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/protocol-http/jest.config.js
+++ b/packages/protocol-http/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/querystring-builder/jest.config.js
+++ b/packages/querystring-builder/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/querystring-parser/jest.config.js
+++ b/packages/querystring-parser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/region-provider/jest.config.js
+++ b/packages/region-provider/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/retry-config-provider/jest.config.js
+++ b/packages/retry-config-provider/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/s3-request-presigner/jest.config.js
+++ b/packages/s3-request-presigner/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/service-error-classification/jest.config.js
+++ b/packages/service-error-classification/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/sha256-tree-hash/jest.config.js
+++ b/packages/sha256-tree-hash/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/shared-ini-file-loader/jest.config.js
+++ b/packages/shared-ini-file-loader/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/signature-v4/jest.config.js
+++ b/packages/signature-v4/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   //only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/packages/smithy-client/jest.config.js
+++ b/packages/smithy-client/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/url-parser-browser/jest.config.js
+++ b/packages/url-parser-browser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/url-parser-node/jest.config.js
+++ b/packages/url-parser-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-base64-browser/jest.config.js
+++ b/packages/util-base64-browser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-base64-node/jest.config.js
+++ b/packages/util-base64-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-body-length-browser/jest.config.js
+++ b/packages/util-body-length-browser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-body-length-node/jest.config.js
+++ b/packages/util-body-length-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-buffer-from/jest.config.js
+++ b/packages/util-buffer-from/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-create-request/jest.config.js
+++ b/packages/util-create-request/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-format-url/jest.config.js
+++ b/packages/util-format-url/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-hex-encoding/jest.config.js
+++ b/packages/util-hex-encoding/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-locate-window/jest.config.js
+++ b/packages/util-locate-window/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-uri-escape/jest.config.js
+++ b/packages/util-uri-escape/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-user-agent-browser/jest.config.js
+++ b/packages/util-user-agent-browser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-user-agent-node/jest.config.js
+++ b/packages/util-user-agent-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-utf8-browser/jest.config.js
+++ b/packages/util-utf8-browser/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/util-utf8-node/jest.config.js
+++ b/packages/util-utf8-node/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/packages/xml-builder/jest.config.js
+++ b/packages/xml-builder/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base.js");
 
 module.exports = {
-  ...base
+  ...base,
 };

--- a/protocol_tests/aws-ec2/jest.config.js
+++ b/protocol_tests/aws-ec2/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   // Only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/protocol_tests/aws-json/jest.config.js
+++ b/protocol_tests/aws-json/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   // Only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/protocol_tests/aws-query/jest.config.js
+++ b/protocol_tests/aws-query/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   // Only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/protocol_tests/aws-restjson/jest.config.js
+++ b/protocol_tests/aws-restjson/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   // Only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/protocol_tests/aws-restxml/jest.config.js
+++ b/protocol_tests/aws-restxml/jest.config.js
@@ -3,5 +3,5 @@ const base = require("../../jest.config.base.js");
 module.exports = {
   ...base,
   // Only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
 };

--- a/scripts/generate-clients/code-gen-dir.js
+++ b/scripts/generate-clients/code-gen-dir.js
@@ -2,28 +2,15 @@ const { join, normalize } = require("path");
 
 const CODE_GEN_ROOT = normalize(join(__dirname, "..", "..", "codegen"));
 
-const getCodeGenDirRoot = dir => join(CODE_GEN_ROOT, dir);
+const getCodeGenDirRoot = (dir) => join(CODE_GEN_ROOT, dir);
 const CODE_GEN_SDK_ROOT = getCodeGenDirRoot("sdk-codegen");
 const CODE_GEN_PROTOCOL_TESTS_ROOT = getCodeGenDirRoot("protocol-test-codegen");
 
 const TEMP_CODE_GEN_INPUT_DIR = normalize(join(__dirname, ".aws-models"));
 
-const getCodeGenOutputDir = dir =>
-  normalize(
-    join(
-      __dirname,
-      "..",
-      "..",
-      "codegen",
-      dir,
-      "build",
-      "smithyprojections",
-      dir
-    )
-  );
-const CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR = getCodeGenOutputDir(
-  "protocol-test-codegen"
-);
+const getCodeGenOutputDir = (dir) =>
+  normalize(join(__dirname, "..", "..", "codegen", dir, "build", "smithyprojections", dir));
+const CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR = getCodeGenOutputDir("protocol-test-codegen");
 const CODE_GEN_SDK_OUTPUT_DIR = getCodeGenOutputDir("sdk-codegen");
 
 module.exports = {
@@ -32,5 +19,5 @@ module.exports = {
   CODE_GEN_PROTOCOL_TESTS_ROOT,
   CODE_GEN_SDK_OUTPUT_DIR,
   CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR,
-  TEMP_CODE_GEN_INPUT_DIR
+  TEMP_CODE_GEN_INPUT_DIR,
 };

--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -2,14 +2,10 @@ const path = require("path");
 const { emptyDirSync } = require("fs-extra");
 const { copyFileSync, readdirSync, lstatSync } = require("fs");
 const { spawnProcess } = require("./spawn-process");
-const {
-  CODE_GEN_ROOT,
-  CODE_GEN_SDK_ROOT,
-  TEMP_CODE_GEN_INPUT_DIR
-} = require("./code-gen-dir");
+const { CODE_GEN_ROOT, CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR } = require("./code-gen-dir");
 const Glob = require("glob");
 
-const generateClients = async models => {
+const generateClients = async (models) => {
   let designatedModels = false;
   if (typeof models === "string") {
     //`models` is a folder path
@@ -20,21 +16,18 @@ const generateClients = async models => {
       const modelPath = path.join(models, modelFileName);
       if (!lstatSync(modelPath).isFile()) continue;
       console.log(`copying model ${modelFileName}...`);
-      copyFileSync(
-        modelPath,
-        path.join(TEMP_CODE_GEN_INPUT_DIR, modelFileName)
-      );
+      copyFileSync(modelPath, path.join(TEMP_CODE_GEN_INPUT_DIR, modelFileName));
     }
   } else if (Array.isArray(models)) {
     //`models` is a list of globs
     designatedModels = true;
     emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
-    models.forEach(pattern => {
+    models.forEach((pattern) => {
       const files = Glob.sync(pattern, {
         realpath: true,
-        absolute: true
+        absolute: true,
       });
-      files.forEach(file => {
+      files.forEach((file) => {
         if (!lstatSync(file).isFile()) return;
         const name = path.basename(file);
         console.log(`copying model ${name}...`);
@@ -46,30 +39,21 @@ const generateClients = async models => {
   }
   const options = [":sdk-codegen:clean", ":sdk-codegen:build"];
   if (designatedModels) {
-    options.push(
-      `-PmodelsDirProp=${path.relative(
-        CODE_GEN_SDK_ROOT,
-        TEMP_CODE_GEN_INPUT_DIR
-      )}`
-    );
+    options.push(`-PmodelsDirProp=${path.relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR)}`);
   }
 
   await spawnProcess("./gradlew", options, {
-    cwd: CODE_GEN_ROOT
+    cwd: CODE_GEN_ROOT,
   });
 };
 
 const generateProtocolTests = async () => {
-  await spawnProcess(
-    "./gradlew",
-    [":protocol-test-codegen:clean", ":protocol-test-codegen:build"],
-    {
-      cwd: CODE_GEN_ROOT
-    }
-  );
+  await spawnProcess("./gradlew", [":protocol-test-codegen:clean", ":protocol-test-codegen:build"], {
+    cwd: CODE_GEN_ROOT,
+  });
 };
 
 module.exports = {
   generateClients,
-  generateProtocolTests
+  generateProtocolTests,
 };

--- a/scripts/generate-clients/code-prettify.js
+++ b/scripts/generate-clients/code-prettify.js
@@ -1,12 +1,9 @@
 const { spawnProcess } = require("./spawn-process");
 
-const prettifyCode = async dir => {
-  await spawnProcess("./node_modules/.bin/prettier", [
-    "--write",
-    `${dir}/**/*.{ts,js,md,json}`
-  ]);
+const prettifyCode = async (dir) => {
+  await spawnProcess("./node_modules/.bin/prettier", ["--write", `${dir}/**/*.{ts,js,md,json}`]);
 };
 
 module.exports = {
-  prettifyCode
+  prettifyCode,
 };

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -6,16 +6,12 @@ const { copyToClients } = require("./copy-to-clients");
 const {
   CODE_GEN_SDK_OUTPUT_DIR,
   CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR,
-  TEMP_CODE_GEN_INPUT_DIR
+  TEMP_CODE_GEN_INPUT_DIR,
 } = require("./code-gen-dir");
 const { prettifyCode } = require("./code-prettify");
 
-const SDK_CLIENTS_DIR = path.normalize(
-  path.join(__dirname, "..", "..", "clients")
-);
-const PROTOCOL_TESTS_CLIENTS_DIR = path.normalize(
-  path.join(__dirname, "..", "..", "protocol_tests")
-);
+const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
+const PROTOCOL_TESTS_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "protocol_tests"));
 
 const { models, globs, output: clientsDir } = yargs
   .alias("m", "models")
@@ -40,10 +36,7 @@ const { models, globs, output: clientsDir } = yargs
     await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
 
     await copyToClients(CODE_GEN_SDK_OUTPUT_DIR, clientsDir);
-    await copyToClients(
-      CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR,
-      PROTOCOL_TESTS_CLIENTS_DIR
-    );
+    await copyToClients(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);
 
     emptyDirSync(CODE_GEN_SDK_OUTPUT_DIR);
     emptyDirSync(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);

--- a/scripts/generate-clients/spawn-process.js
+++ b/scripts/generate-clients/spawn-process.js
@@ -4,14 +4,14 @@ const spawnProcess = (command, args = [], options = {}) =>
   new Promise((resolve, reject) => {
     try {
       const ls = spawn(command, args, options);
-      ls.stdout.on("data", data => {
+      ls.stdout.on("data", (data) => {
         console.log(data.toString());
       });
-      ls.stderr.on("data", data => {
+      ls.stderr.on("data", (data) => {
         console.error(`stderr: ${data.toString()}`);
       });
 
-      ls.on("close", code => {
+      ls.on("close", (code) => {
         console.log(`child process exited with code ${code}`);
         resolve();
       });

--- a/scripts/verdaccio-publish/index.js
+++ b/scripts/verdaccio-publish/index.js
@@ -9,11 +9,7 @@ const pipeStdIo = { stdio: [process.stdin, process.stdout, process.stderr] };
 execSync("rm -rf verdaccio/storage/@aws-sdk");
 
 // Start verdaccio in the background
-const verdaccio = spawn(
-  "npx",
-  ["verdaccio", "-c", "verdaccio/config.yaml"],
-  pipeStdIo
-).on("error", e => {
+const verdaccio = spawn("npx", ["verdaccio", "-c", "verdaccio/config.yaml"], pipeStdIo).on("error", (e) => {
   throw e;
 });
 
@@ -36,9 +32,9 @@ const args = [
   "--ignore-scripts",
   "--no-verify-access",
   "--dist-tag",
-  "ci"
+  "ci",
 ];
-spawn("npx", args, pipeStdIo).on("close", code => {
+spawn("npx", args, pipeStdIo).on("close", (code) => {
   // Rollback the changes caused by the version bumping
   execSync("git checkout -- clients/*/package.json");
   execSync("git checkout -- packages/*/package.json");

--- a/tests/functional/endpoints/fixtures.js
+++ b/tests/functional/endpoints/fixtures.js
@@ -41,7 +41,7 @@ module.exports.KNOWN_REGIONS = {
     // sts: "sts.amazonaws.com",
     swf: "swf.ap-northeast-1.amazonaws.com",
     workspaces: "workspaces.ap-northeast-1.amazonaws.com",
-    "rds-data": "rds-data.ap-northeast-1.amazonaws.com"
+    "rds-data": "rds-data.ap-northeast-1.amazonaws.com",
   },
   "ap-southeast-1": {
     //autoscaling: "autoscaling.ap-southeast-1.amazonaws.com",
@@ -74,7 +74,7 @@ module.exports.KNOWN_REGIONS = {
     // sts: "sts.amazonaws.com",
     swf: "swf.ap-southeast-1.amazonaws.com",
     workspaces: "workspaces.ap-southeast-1.amazonaws.com",
-    "rds-data": "rds-data.ap-southeast-1.amazonaws.com"
+    "rds-data": "rds-data.ap-southeast-1.amazonaws.com",
   },
   "ap-southeast-2": {
     //autoscaling: "autoscaling.ap-southeast-2.amazonaws.com",
@@ -110,7 +110,7 @@ module.exports.KNOWN_REGIONS = {
     // sts: "sts.amazonaws.com",
     swf: "swf.ap-southeast-2.amazonaws.com",
     workspaces: "workspaces.ap-southeast-2.amazonaws.com",
-    "rds-data": "rds-data.ap-southeast-2.amazonaws.com"
+    "rds-data": "rds-data.ap-southeast-2.amazonaws.com",
   },
   "aws-us-gov-global": {
     //iam: "iam.us-gov.amazonaws.com"
@@ -138,7 +138,7 @@ module.exports.KNOWN_REGIONS = {
     "dynamodb-streams": "streams.dynamodb.cn-north-1.amazonaws.com.cn",
     // sts: "sts.cn-north-1.amazonaws.com.cn",
     swf: "swf.cn-north-1.amazonaws.com.cn",
-    "rds-data": "rds-data.cn-north-1.amazonaws.com.cn"
+    "rds-data": "rds-data.cn-north-1.amazonaws.com.cn",
   },
   "eu-central-1": {
     //autoscaling: "autoscaling.eu-central-1.amazonaws.com",
@@ -168,7 +168,7 @@ module.exports.KNOWN_REGIONS = {
     "storage-gateway": "storagegateway.eu-central-1.amazonaws.com",
     "dynamodb-streams": "streams.dynamodb.eu-central-1.amazonaws.com",
     // sts: "sts.amazonaws.com",
-    swf: "swf.eu-central-1.amazonaws.com"
+    swf: "swf.eu-central-1.amazonaws.com",
   },
   "eu-west-1": {
     "api-gateway": "apigateway.eu-west-1.amazonaws.com",
@@ -212,7 +212,7 @@ module.exports.KNOWN_REGIONS = {
     "dynamodb-streams": "streams.dynamodb.eu-west-1.amazonaws.com",
     // sts: "sts.amazonaws.com",
     swf: "swf.eu-west-1.amazonaws.com",
-    workspaces: "workspaces.eu-west-1.amazonaws.com"
+    workspaces: "workspaces.eu-west-1.amazonaws.com",
   },
   "fips-us-gov-west-1": {
     //s3: "s3-fips-us-gov-west-1.amazonaws.com"
@@ -243,7 +243,7 @@ module.exports.KNOWN_REGIONS = {
     "storage-gateway": "storagegateway.sa-east-1.amazonaws.com",
     "dynamodb-streams": "streams.dynamodb.sa-east-1.amazonaws.com",
     // sts: "sts.amazonaws.com",
-    swf: "swf.sa-east-1.amazonaws.com"
+    swf: "swf.sa-east-1.amazonaws.com",
   },
   "us-east-1": {
     "api-gateway": "apigateway.us-east-1.amazonaws.com",
@@ -299,7 +299,7 @@ module.exports.KNOWN_REGIONS = {
     support: "support.us-east-1.amazonaws.com",
     swf: "swf.us-east-1.amazonaws.com",
     workspaces: "workspaces.us-east-1.amazonaws.com",
-    waf: "waf.amazonaws.com"
+    waf: "waf.amazonaws.com",
   },
   "us-gov-west-1": {
     //autoscaling: "autoscaling.us-gov-west-1.amazonaws.com",
@@ -321,7 +321,7 @@ module.exports.KNOWN_REGIONS = {
     //sns: "sns.us-gov-west-1.amazonaws.com",
     // sqs: "us-gov-west-1.queue.amazonaws.com",
     // sts: "sts.us-gov-west-1.amazonaws.com",
-    swf: "swf.us-gov-west-1.amazonaws.com"
+    swf: "swf.us-gov-west-1.amazonaws.com",
   },
   "us-west-1": {
     //autoscaling: "autoscaling.us-west-1.amazonaws.com",
@@ -351,7 +351,7 @@ module.exports.KNOWN_REGIONS = {
     "storage-gateway": "storagegateway.us-west-1.amazonaws.com",
     "dynamodb-streams": "streams.dynamodb.us-west-1.amazonaws.com",
     // sts: "sts.amazonaws.com",
-    swf: "swf.us-west-1.amazonaws.com"
+    swf: "swf.us-west-1.amazonaws.com",
   },
   "us-west-2": {
     "api-gateway": "apigateway.us-west-2.amazonaws.com",
@@ -395,6 +395,6 @@ module.exports.KNOWN_REGIONS = {
     "dynamodb-streams": "streams.dynamodb.us-west-2.amazonaws.com",
     // sts: "sts.amazonaws.com",
     swf: "swf.us-west-2.amazonaws.com",
-    workspaces: "workspaces.us-west-2.amazonaws.com"
-  }
+    workspaces: "workspaces.us-west-2.amazonaws.com",
+  },
 };

--- a/tests/functional/jest.config.js
+++ b/tests/functional/jest.config.js
@@ -1,5 +1,5 @@
 const base = require("../../jest.config.base");
 module.exports = {
   ...base,
-  testMatch: ["./**/?(*.)+(spec|test).js?(x)"]
+  testMatch: ["./**/?(*.)+(spec|test).js?(x)"],
 };

--- a/tests/functional/signing-names/fixtures.js
+++ b/tests/functional/signing-names/fixtures.js
@@ -1,5 +1,5 @@
 module.exports.SIGNING_NAMES = {
   "us-west-2": {
-    "rds-data": undefined
-  }
+    "rds-data": undefined,
+  },
 };

--- a/tests/functional/signing-names/index.spec.js
+++ b/tests/functional/signing-names/index.spec.js
@@ -4,9 +4,7 @@ const { getRegionInfoProvider } = require("../util/regioninfo-provider");
 describe("signing names for know regions", () => {
   for (const region of Object.keys(SIGNING_NAMES)) {
     describe(region, () => {
-      for (const [service, signingName] of Object.entries(
-        SIGNING_NAMES[region]
-      )) {
+      for (const [service, signingName] of Object.entries(SIGNING_NAMES[region])) {
         it(`${service} should infer signing name ${signingName}`, () => {
           const regionInfoProvider = getRegionInfoProvider(service);
           expect(regionInfoProvider(region).signingService).toBe(signingName);

--- a/tests/functional/util/regioninfo-provider.js
+++ b/tests/functional/util/regioninfo-provider.js
@@ -1,14 +1,5 @@
 const { join } = require("path");
-module.exports.getRegionInfoProvider = fromService => {
-  const path = join(
-    "..",
-    "..",
-    "..",
-    "clients",
-    `client-${fromService}`,
-    "dist",
-    "cjs",
-    "endpoints"
-  );
+module.exports.getRegionInfoProvider = (fromService) => {
+  const path = join("..", "..", "..", "clients", `client-${fromService}`, "dist", "cjs", "endpoints");
   return require(path).defaultRegionInfoProvider;
 };


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1185

*Description of changes:*
prettify JS code missed in #1185

The command run in `./node_modules/.bin/prettier --write **/*.{ts,js,md,json}` for prettifying code did not prettify JavaScript files. This appears to be an issue with bash process

```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3

$ ps -p $$
  PID TTY          TIME CMD
 1179 pts/0    00:00:00 bash

$ ./node_modules/.bin/prettier --write **/*.js
[error] No matching files. Patterns: node_modules/asn1.js node_modules/big.js node_modules/bn.js node_modules/decimal.js node_modules/des.js node_modules/hash.js node_modules/highlight.js node_modules/ipaddr.js node_modules/md5.js node_modules/sha.js
```

When zsh was used, it was able to prettify JS files:
```console
zsh> pwd
/home/trivikr/workspace/aws-sdk-js-v3

zsh> ps -p $$
  PID TTY          TIME CMD
31103 pts/0    00:00:00 zsh

zsh> ./node_modules/.bin/prettier --write **/*.js
clients/client-cognito-identity/karma.conf.js 38ms
clients/client-s3/karma.conf.js 12ms
....
```

bash process was used in PR #1185 as zsh was giving `argument list too long` error
```console
$ ./node_modules/.bin/prettier --write **/*.{ts,js,md,json}
zsh: argument list too long: ./node_modules/.bin/prettier
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
