### PR TITLE
chore: prettify *.md files missed in #1185

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ Let’s walk through setting up a project that depends on DynamoDB from the SDK 
 3. Create a new file called index.js, create a DynamoDB service client and send a request.
 
 ```javascript
-const {
-  DynamoDBClient,
-  ListTablesCommand
-} = require("@aws-sdk/client-dynamodb");
+const { DynamoDBClient, ListTablesCommand } = require("@aws-sdk/client-dynamodb");
 
 (async () => {
   const client = new DynamoDBClient({ region: "us-west-2" });
@@ -109,13 +106,13 @@ Here’s an example of adding a custom header using middleware:
 ```javascript
 const client = new DynamoDB({ region: "us-west-2" });
 client.middlewareStack.add(
-  (next, context) => args => {
+  (next, context) => (args) => {
     args.request.headers["Custom-Header"] = "value";
     console.log("\n -- printed from inside middleware -- \n");
     return next(args);
   },
   {
-    step: "build"
+    step: "build",
   }
 );
 await client.listTables({});

--- a/packages/middleware-stack/README.md
+++ b/packages/middleware-stack/README.md
@@ -29,7 +29,7 @@ You can add middleware to specified step with:
 
 ```javascript
 stack.add(middleware, {
-  step: "finalizeRequest"
+  step: "finalizeRequest",
 });
 ```
 
@@ -38,7 +38,7 @@ This approach works for most cases. Sometimes you want your middleware to be exe
 ```javascript
 stack.add(middleware, {
   step: "finalizeRequest",
-  priority: "high"
+  priority: "high",
 });
 ```
 
@@ -51,12 +51,12 @@ In some cases, you might want to execute your middleware before some other known
 ```javascript
 stack.add(middleware, {
   step: "finalizeRequest",
-  name: "myMiddleware"
+  name: "myMiddleware",
 });
 stack.addRelativeTo(anotherMiddleware, {
   step: "finalizeRequest",
   relation: "before", //or 'after'
-  toMiddleware: "myMiddleware"
+  toMiddleware: "myMiddleware",
 });
 ```
 
@@ -92,7 +92,7 @@ If you specify tags for middleware, you can remove multiple middleware at a time
 ```javascript
 stack.add(middleware, {
   step: "finalizeRequest",
-  tags: ["final"]
+  tags: ["final"],
 });
 stack.removeByTag("final");
 ```

--- a/packages/s3-request-presigner/README.md
+++ b/packages/s3-request-presigner/README.md
@@ -14,7 +14,7 @@ const nodeSha256 = require("@aws-sdk/hash-node").Hash;
 const signer = new S3Presigner({
   region: regionProvider,
   credentials: credentialsProvider,
-  sha256: nodeSha256 //if the signer is used in browser, use `browserSha256` then
+  sha256: nodeSha256, //if the signer is used in browser, use `browserSha256` then
 });
 const url = await signer.presign(request);
 ```
@@ -28,7 +28,7 @@ import { Hash as nodeSha256 } from "@aws-sdk/hash-node";
 const signer = new S3RequestPresigner({
   region: regionProvider,
   credentials: credentialsProvider,
-  sha256: nodeSha256 //if the signer is used in browser, use `browserSha256` then
+  sha256: nodeSha256, //if the signer is used in browser, use `browserSha256` then
 });
 const url = await signer.presign(request);
 ```
@@ -40,6 +40,6 @@ the presigner's constructor.
 ```javascript
 //s3 is instantiated from S3Client from @aws-sdk/client-s3-* packages
 const signer = new S3RequestPresigner({
-  ...s3.config
+  ...s3.config,
 });
 ```

--- a/packages/util-create-request/README.md
+++ b/packages/util-create-request/README.md
@@ -26,14 +26,13 @@ JavaScript usage examples:
 
 ```javascript
 const S3Client = require("@aws-sdk/client-s3-node/S3Client").S3Client;
-const GetObject = require("@aws-sdk/client-s3-node/commands/GetObjectCommand")
-  .GetObjectCommand;
+const GetObject = require("@aws-sdk/client-s3-node/commands/GetObjectCommand").GetObjectCommand;
 
 const request = await createRequest(
   new S3Client({}),
   new GetObject({
     Bucket: "bucket",
-    Key: "key"
+    Key: "key",
   })
 );
 /**
@@ -61,7 +60,7 @@ const request = await createRequest<InputTypesUnion, GetObjectInput, Readable>(
   new S3Client({}),
   new GetObjectCommand({
     Bucket: "bucket",
-    Key: "key"
+    Key: "key",
   })
 );
 ```
@@ -78,7 +77,7 @@ const request = await createRequest(
   new DynamoDBClient({}),
   new GetObjectCommand({
     Bucket: "bucket",
-    Key: "key"
+    Key: "key",
   })
 );
 ```


### PR DESCRIPTION
*Issue #, if available:*
Reasons explained in https://github.com/aws/aws-sdk-js-v3/pull/1386

*Description of changes:*
prettify README missed in #1185 done by running the following command in zsh:

```console
$ ./node_modules/.bin/prettier --write **/*.md 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
