### PR TITLE
chore: fix prettier formatting missed while linting in #1350

### DIFF
--- a/packages/config-resolver/src/EndpointsConfig.ts
+++ b/packages/config-resolver/src/EndpointsConfig.ts
@@ -1,4 +1,4 @@
-import { Endpoint, Provider, RegionInfo,RegionInfoProvider, UrlParser } from "@aws-sdk/types";
+import { Endpoint, Provider, RegionInfo, RegionInfoProvider, UrlParser } from "@aws-sdk/types";
 
 export function normalizeEndpoint(
   endpoint?: string | Endpoint | Provider<Endpoint>,

--- a/packages/middleware-host-header/src/index.ts
+++ b/packages/middleware-host-header/src/index.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { AbsoluteLocation, BuildHandlerOptions, BuildMiddleware, Pluggable,RequestHandler } from "@aws-sdk/types";
+import { AbsoluteLocation, BuildHandlerOptions, BuildMiddleware, Pluggable, RequestHandler } from "@aws-sdk/types";
 
 export interface HostHeaderInputConfig {}
 interface PreviouslyResolved {

--- a/packages/middleware-retry/src/retryMiddleware.spec.ts
+++ b/packages/middleware-retry/src/retryMiddleware.spec.ts
@@ -1,4 +1,4 @@
-import { FinalizeHandlerArguments,MiddlewareStack, RetryStrategy } from "@aws-sdk/types";
+import { FinalizeHandlerArguments, MiddlewareStack, RetryStrategy } from "@aws-sdk/types";
 
 import { getRetryPlugin, retryMiddleware, retryMiddlewareOptions } from "./retryMiddleware";
 

--- a/packages/middleware-sdk-transcribe-streaming/src/signer.spec.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/signer.spec.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { RequestPresigningArguments,RequestSigningArguments } from "@aws-sdk/types";
+import { RequestPresigningArguments, RequestSigningArguments } from "@aws-sdk/types";
 
 import { SignatureV4 } from "./signer";
 

--- a/packages/middleware-stack/src/types.ts
+++ b/packages/middleware-stack/src/types.ts
@@ -1,4 +1,4 @@
-import { HandlerOptions, MiddlewareType, Priority,Step } from "@aws-sdk/types";
+import { HandlerOptions, MiddlewareType, Priority, Step } from "@aws-sdk/types";
 export interface MiddlewareEntry<Input extends object, Output extends object> extends HandlerOptions {
   step: Step;
   middleware: MiddlewareType<Input, Output>;

--- a/packages/protocol-http/src/httpRequest.ts
+++ b/packages/protocol-http/src/httpRequest.ts
@@ -1,4 +1,4 @@
-import { Endpoint, HeaderBag, HttpMessage, HttpRequest as IHttpRequest,QueryParameterBag } from "@aws-sdk/types";
+import { Endpoint, HeaderBag, HttpMessage, HttpRequest as IHttpRequest, QueryParameterBag } from "@aws-sdk/types";
 
 type HttpRequestOptions = Partial<HttpMessage> & Partial<Endpoint> & { method?: string };
 

--- a/packages/signature-v4/src/getCanonicalHeaders.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.ts
@@ -1,4 +1,4 @@
-import { HeaderBag,HttpRequest } from "@aws-sdk/types";
+import { HeaderBag, HttpRequest } from "@aws-sdk/types";
 
 import { ALWAYS_UNSIGNABLE_HEADERS, PROXY_HEADER_PATTERN, SEC_HEADER_PATTERN } from "./constants";
 

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -1,5 +1,5 @@
 import { MiddlewareStack } from "@aws-sdk/middleware-stack";
-import { Client as IClient,Command, MetadataBearer, RequestHandler } from "@aws-sdk/types";
+import { Client as IClient, Command, MetadataBearer, RequestHandler } from "@aws-sdk/types";
 
 export interface SmithyConfiguration<HandlerOptions> {
   requestHandler: RequestHandler<any, any, HandlerOptions>;


### PR DESCRIPTION
*Issue #, if available:*
Prettify command was run to check if any TS files were missed similar to https://github.com/aws/aws-sdk-js-v3/pull/1386
But it caught prettify changes missed in https://github.com/aws/aws-sdk-js-v3/pull/1350

*Description of changes:*
fix prettier formatting missed while linting in #1350, achieved by running following command in zsh:
```console
$ ./node_modules/.bin/prettier --write **/*.ts
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
