### PR TITLE
feat: refactor middleware stack

### DIFF
--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
@@ -35,12 +35,12 @@ describe("fromCognitoIdentity", () => {
       expiration,
     });
 
-    expect(send.mock.calls[0][0]).toEqual(
-      new GetCredentialsForIdentityCommand({
-        IdentityId: identityId,
-        CustomRoleArn: "myArn",
-      })
-    );
+    const sendParam = send.mock.calls[0][0];
+    expect(sendParam).toEqual(expect.any(GetCredentialsForIdentityCommand));
+    expect(sendParam.input).toEqual({
+      IdentityId: identityId,
+      CustomRoleArn: "myArn",
+    });
   });
 
   it("should resolve logins to string tokens and pass them to the service", async () => {
@@ -54,16 +54,16 @@ describe("fromCognitoIdentity", () => {
       },
     })();
 
-    expect(send.mock.calls[0][0]).toEqual(
-      new GetCredentialsForIdentityCommand({
-        IdentityId: identityId,
-        CustomRoleArn: "myArn",
-        Logins: {
-          myDomain: "token",
-          "www.amazon.com": "expiring nonce",
-        },
-      })
-    );
+    const sendParam = send.mock.calls[0][0];
+    expect(sendParam).toEqual(expect.any(GetCredentialsForIdentityCommand));
+    expect(sendParam.input).toMatchObject({
+      IdentityId: identityId,
+      CustomRoleArn: "myArn",
+      Logins: {
+        myDomain: "token",
+        "www.amazon.com": "expiring nonce",
+      },
+    });
   });
 
   it("should convert a GetCredentialsForIdentity response without credentials to a provider error", async () => {

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
@@ -56,7 +56,10 @@ describe("fromCognitoIdentityPool", () => {
     });
 
     expect(send.mock.calls.length).toBe(1);
-    expect(send.mock.calls[0][0]).toEqual(new GetIdCommand({ IdentityPoolId: identityPoolId }));
+    expect(send.mock.calls[0][0]).toEqual(expect.any(GetIdCommand));
+    expect(send.mock.calls[0][0].input).toEqual({
+      IdentityPoolId: identityPoolId,
+    });
 
     expect((fromCognitoIdentity as any).mock.calls.length).toBe(1);
     expect((fromCognitoIdentity as any).mock.calls[0][0]).toEqual({
@@ -76,15 +79,14 @@ describe("fromCognitoIdentityPool", () => {
       },
     })();
 
-    expect(send.mock.calls[0][0]).toEqual(
-      new GetIdCommand({
-        IdentityPoolId: identityPoolId,
-        Logins: {
-          myDomain: "token",
-          "www.amazon.com": "expiring nonce",
-        },
-      })
-    );
+    expect(send.mock.calls[0][0]).toEqual(expect.any(GetIdCommand));
+    expect(send.mock.calls[0][0].input).toEqual({
+      IdentityPoolId: identityPoolId,
+      Logins: {
+        myDomain: "token",
+        "www.amazon.com": "expiring nonce",
+      },
+    });
   });
 
   it("should not invoke GetId a second time once an identityID has been fetched", async () => {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~3.4.0"
+    "typescript": "~3.9.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
@@ -1,4 +1,4 @@
-import { MiddlewareStack } from "@aws-sdk/middleware-stack";
+import { constructStack } from "@aws-sdk/middleware-stack";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
 import { bucketEndpointMiddleware, bucketEndpointMiddlewareOptions } from "./bucketEndpointMiddleware";
@@ -130,7 +130,7 @@ describe("bucketEndpointMiddleware", () => {
   });
 
   it("should be inserted before 'hostheaderMiddleware' if exists", async () => {
-    const stack = new MiddlewareStack();
+    const stack = constructStack();
     const mockHostheaderMiddleware = (next: any) => (args: any) => {
       args.request.arr.push("two");
       return next(args);

--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
@@ -2,12 +2,11 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 import {
   BuildHandler,
   BuildHandlerArguments,
-  BuildHandlerOptions,
   BuildHandlerOutput,
   BuildMiddleware,
   MetadataBearer,
   Pluggable,
-  RelativeLocation,
+  RelativeMiddlewareOptions,
 } from "@aws-sdk/types";
 
 import { bucketHostname } from "./bucketHostname";
@@ -49,8 +48,7 @@ export function bucketEndpointMiddleware(options: BucketEndpointResolvedConfig):
   };
 }
 
-export const bucketEndpointMiddlewareOptions: BuildHandlerOptions & RelativeLocation<any, any> = {
-  step: "build",
+export const bucketEndpointMiddlewareOptions: RelativeMiddlewareOptions = {
   tags: ["BUCKET_ENDPOINT"],
   name: "bucketEndpointMiddleware",
   relation: "before",

--- a/packages/middleware-eventstream/src/handling-middleware.ts
+++ b/packages/middleware-eventstream/src/handling-middleware.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { FinalizeRequestHandlerOptions, FinalizeRequestMiddleware, RelativeLocation } from "@aws-sdk/types";
+import { FinalizeRequestMiddleware, RelativeMiddlewareOptions } from "@aws-sdk/types";
 
 import { EventStreamResolvedConfig } from "./configuration";
 
@@ -11,8 +11,7 @@ export const eventStreamHandlingMiddleware = (
   return options.eventStreamPayloadHandler.handle(next, args, context);
 };
 
-export const eventStreamHandlingMiddlewareOptions: FinalizeRequestHandlerOptions & RelativeLocation<any, any> = {
-  step: "finalizeRequest",
+export const eventStreamHandlingMiddlewareOptions: RelativeMiddlewareOptions = {
   tags: ["EVENT_STREAM", "SIGNATURE", "HANDLE"],
   name: "eventStreamHandlingMiddleware",
   relation: "after",

--- a/packages/middleware-sdk-s3-control/src/prepend-account-id.ts
+++ b/packages/middleware-sdk-s3-control/src/prepend-account-id.ts
@@ -2,12 +2,11 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 import {
   BuildHandler,
   BuildHandlerArguments,
-  BuildHandlerOptions,
   BuildHandlerOutput,
   BuildMiddleware,
   MetadataBearer,
   Pluggable,
-  RelativeLocation,
+  RelativeMiddlewareOptions,
 } from "@aws-sdk/types";
 
 export function prependAccountIdMiddleware(): BuildMiddleware<any, any> {
@@ -40,8 +39,7 @@ export function prependAccountIdMiddleware(): BuildMiddleware<any, any> {
   };
 }
 
-export const prependAccountIdMiddlewareOptions: BuildHandlerOptions & RelativeLocation<any, any> = {
-  step: "build",
+export const prependAccountIdMiddlewareOptions: RelativeMiddlewareOptions = {
   tags: ["PREPEND_ACCOUNT_ID_MIDDLEWARE"],
   name: "prependAccountIdMiddleware",
   relation: "before",

--- a/packages/middleware-sdk-transcribe-streaming/src/middleware-endpoint.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/middleware-endpoint.ts
@@ -2,9 +2,8 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 import {
   BuildHandler,
   BuildHandlerArguments,
-  BuildHandlerOptions,
   BuildMiddleware,
-  RelativeLocation,
+  RelativeMiddlewareOptions,
   RequestHandler,
 } from "@aws-sdk/types";
 
@@ -54,8 +53,7 @@ export const websocketURLMiddleware = (options: {
   return next(args);
 };
 
-export const websocketURLMiddlewareOptions: BuildHandlerOptions & RelativeLocation<any, any> = {
-  step: "build",
+export const websocketURLMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "websocketURLMiddleware",
   tags: ["WEBSOCKET", "EVENT_STREAM"],
   relation: "after",

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -3,10 +3,9 @@ import {
   FinalizeHandler,
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,
-  FinalizeRequestHandlerOptions,
   FinalizeRequestMiddleware,
   Pluggable,
-  RelativeLocation,
+  RelativeMiddlewareOptions,
 } from "@aws-sdk/types";
 
 import { AwsAuthResolvedConfig } from "./configurations";
@@ -43,9 +42,8 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
     };
 }
 
-export const awsAuthMiddlewareOptions: FinalizeRequestHandlerOptions & RelativeLocation<any, any> = {
+export const awsAuthMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "awsAuthMiddleware",
-  step: "finalizeRequest",
   tags: ["SIGNATURE", "AWSAUTH"],
   relation: "after",
   toMiddleware: "retryMiddleware",

--- a/packages/middleware-stack/src/MiddlewareStack.spec.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.spec.ts
@@ -11,7 +11,7 @@ import {
   Pluggable,
 } from "@aws-sdk/types";
 
-import { MiddlewareStack } from "./MiddlewareStack";
+import { constructStack } from "./MiddlewareStack";
 
 type input = Array<string>;
 type output = object;
@@ -29,7 +29,7 @@ function getConcatMiddleware(message: string): MiddlewareType<input, output> {
 
 describe("MiddlewareStack", () => {
   it("should resolve the stack into a composed handler", async () => {
-    const stack = new MiddlewareStack<input, output>();
+    const stack = constructStack<input, output>();
     const secondMW = getConcatMiddleware("second") as InitializeMiddleware<input, output>;
     stack.add(secondMW, { name: "second" });
     stack.addRelativeTo(getConcatMiddleware("first") as InitializeMiddleware<input, output>, {
@@ -75,7 +75,7 @@ describe("MiddlewareStack", () => {
   });
 
   it("should allow adding middleware relatively", async () => {
-    const stack = new MiddlewareStack<input, output>();
+    const stack = constructStack<input, output>();
     type MW = InitializeMiddleware<input, output>;
     stack.addRelativeTo(getConcatMiddleware("H") as MW, {
       name: "H",
@@ -145,7 +145,7 @@ describe("MiddlewareStack", () => {
   });
 
   it("should allow cloning", async () => {
-    const stack = new MiddlewareStack<input, output>();
+    const stack = constructStack<input, output>();
     const secondMiddleware = getConcatMiddleware("second") as InitializeMiddleware<input, output>;
     stack.add(secondMiddleware);
     stack.add(getConcatMiddleware("first") as InitializeMiddleware<input, output>, {
@@ -174,14 +174,14 @@ describe("MiddlewareStack", () => {
   });
 
   it("should allow combining stacks", async () => {
-    const stack = new MiddlewareStack<input, output>();
+    const stack = constructStack<input, output>();
     stack.add(getConcatMiddleware("first") as InitializeMiddleware<input, output>);
     stack.add(getConcatMiddleware("second") as InitializeMiddleware<input, output>, {
       name: "second",
       priority: "low",
     });
 
-    const secondStack = new MiddlewareStack<input, output>();
+    const secondStack = constructStack<input, output>();
     secondStack.add(getConcatMiddleware("fourth") as FinalizeRequestMiddleware<input, output>, {
       step: "build",
       priority: "low",
@@ -209,7 +209,7 @@ describe("MiddlewareStack", () => {
   });
 
   it("should allow the removal of middleware by constructor identity", async () => {
-    const stack = new MiddlewareStack<input, output>();
+    const stack = constructStack<input, output>();
     stack.add(getConcatMiddleware("don't remove me") as InitializeMiddleware<input, output>, { name: "notRemove" });
     stack.addRelativeTo(getConcatMiddleware("remove me!") as InitializeMiddleware<input, output>, {
       relation: "after",
@@ -231,7 +231,7 @@ describe("MiddlewareStack", () => {
   });
 
   it("should allow the removal of middleware by tag", async () => {
-    const stack = new MiddlewareStack<input, output>();
+    const stack = constructStack<input, output>();
     stack.add(getConcatMiddleware("not removed") as InitializeMiddleware<input, output>, {
       name: "not removed",
       tags: ["foo", "bar"],
@@ -256,7 +256,7 @@ describe("MiddlewareStack", () => {
   });
 
   it("should apply customizations from pluggables", async () => {
-    const stack = new MiddlewareStack<input, output>();
+    const stack = constructStack<input, output>();
     const plugin: Pluggable<input, output> = {
       applyToStack: (stack) => {
         stack.addRelativeTo(getConcatMiddleware("second") as InitializeMiddleware<input, output>, {

--- a/packages/middleware-stack/src/MiddlewareStack.spec.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.spec.ts
@@ -13,16 +13,14 @@ type input = Array<string>;
 type output = object;
 
 //return tagged union to make compiler happy
-function getConcatMiddleware(message: string) {
-  return (next: FinalizeHandler<input, output>): InitializeHandler<input, output> => {
-    return (args: any) =>
-      next({
-        ...args,
-        input: args.input.concat(message),
-        request: undefined as any,
-      });
-  };
-}
+const getConcatMiddleware = (message: string) => (
+  next: FinalizeHandler<input, output>
+): InitializeHandler<input, output> => (args: any) =>
+  next({
+    ...args,
+    input: args.input.concat(message),
+    request: undefined as any,
+  });
 
 describe("MiddlewareStack", () => {
   describe("add", () => {

--- a/packages/middleware-stack/src/MiddlewareStack.spec.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.spec.ts
@@ -1,13 +1,9 @@
 import {
-  BuildMiddleware,
   DeserializeHandlerArguments,
   DeserializeMiddleware,
+  FinalizeHandler,
   FinalizeHandlerArguments,
-  FinalizeRequestMiddleware,
-  Handler,
-  InitializeHandlerOutput,
-  InitializeMiddleware,
-  MiddlewareType,
+  InitializeHandler,
   Pluggable,
 } from "@aws-sdk/types";
 
@@ -17,261 +13,315 @@ type input = Array<string>;
 type output = object;
 
 //return tagged union to make compiler happy
-function getConcatMiddleware(message: string): MiddlewareType<input, output> {
-  return (next: Handler<input, output>): Handler<input, output> => {
-    return (args: any): Promise<InitializeHandlerOutput<output>> =>
+function getConcatMiddleware(message: string) {
+  return (next: FinalizeHandler<input, output>): InitializeHandler<input, output> => {
+    return (args: any) =>
       next({
         ...args,
         input: args.input.concat(message),
+        request: undefined as any,
       });
   };
 }
 
 describe("MiddlewareStack", () => {
-  it("should resolve the stack into a composed handler", async () => {
-    const stack = constructStack<input, output>();
-    const secondMW = getConcatMiddleware("second") as InitializeMiddleware<input, output>;
-    stack.add(secondMW, { name: "second" });
-    stack.addRelativeTo(getConcatMiddleware("first") as InitializeMiddleware<input, output>, {
-      relation: "before",
-      toMiddleware: "second",
-    });
-    stack.add(getConcatMiddleware("fourth") as BuildMiddleware<input, output>, {
-      step: "build",
-      name: "fourth",
-    });
-    stack.add(getConcatMiddleware("third") as BuildMiddleware<input, output>, {
-      step: "build",
-      priority: "high",
-    });
-    stack.add(getConcatMiddleware("fifth") as FinalizeRequestMiddleware<input, output>, {
-      step: "finalizeRequest",
-      name: "fifth",
-    });
-    stack.add(getConcatMiddleware("seventh") as FinalizeRequestMiddleware<input, output>, { step: "finalizeRequest" });
-    stack.addRelativeTo(getConcatMiddleware("sixth") as FinalizeRequestMiddleware<input, output>, {
-      step: "finalizeRequest",
-      relation: "after",
-      toMiddleware: "fifth",
-    });
-    stack.add(getConcatMiddleware("ninth") as DeserializeMiddleware<input, output>, {
-      priority: "low",
-      step: "deserialize",
-    });
-    stack.addRelativeTo(getConcatMiddleware("eighth") as DeserializeMiddleware<input, output>, {
-      step: "deserialize",
-      relation: "before",
-      toMiddleware: "doesnt_exist",
-    });
-    const inner = jest.fn();
+  describe("add", () => {
+    it("should sort middleware based on step, priority, and ording of adding", async () => {
+      const stack = constructStack<input, output>();
+      const bMW = getConcatMiddleware("B");
+      stack.add(bMW, { name: "B" });
+      stack.add(getConcatMiddleware("A"), {
+        priority: "high",
+      });
+      stack.add(getConcatMiddleware("D"), {
+        step: "build",
+        name: "D",
+      });
+      stack.add(getConcatMiddleware("C"), {
+        step: "build",
+        priority: "high",
+      });
+      stack.add(getConcatMiddleware("E"), {
+        step: "finalizeRequest",
+      });
+      stack.add(getConcatMiddleware("F"), { step: "finalizeRequest" });
+      stack.add(getConcatMiddleware("G") as DeserializeMiddleware<input, output>, {
+        priority: "low",
+        step: "deserialize",
+      });
+      const inner = jest.fn();
 
-    const composed = stack.resolve(inner, {} as any);
-    await composed({ input: [] });
+      const composed = stack.resolve(inner, {} as any);
+      await composed({ input: [] });
 
-    expect(inner.mock.calls.length).toBe(1);
-    expect(inner).toBeCalledWith({
-      input: ["first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth"],
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({
+        input: ["A", "B", "C", "D", "E", "F", "G"],
+      });
     });
   });
 
-  it("should allow adding middleware relatively", async () => {
-    const stack = constructStack<input, output>();
-    type MW = InitializeMiddleware<input, output>;
-    stack.addRelativeTo(getConcatMiddleware("H") as MW, {
-      name: "H",
-      relation: "after",
-      toMiddleware: "G",
-    });
-    stack.addRelativeTo(getConcatMiddleware("A") as MW, {
-      name: "A",
-      relation: "after",
-      toMiddleware: "nonExist",
-    });
-    stack.addRelativeTo(getConcatMiddleware("C") as MW, {
-      name: "C",
-      relation: "after",
-      toMiddleware: "A",
-    });
-    stack.addRelativeTo(getConcatMiddleware("B") as MW, {
-      name: "B",
-      relation: "after",
-      toMiddleware: "A",
-    });
-    stack.addRelativeTo(getConcatMiddleware("D") as MW, {
-      name: "D",
-      relation: "after",
-      toMiddleware: "C",
-    });
-    stack.add(getConcatMiddleware("G") as MW, {
-      name: "G",
-      priority: "low",
-    });
-    stack.addRelativeTo(getConcatMiddleware("E") as MW, {
-      name: "E",
-      relation: "before",
-      toMiddleware: "F",
-    });
-    stack.addRelativeTo(getConcatMiddleware("F") as MW, {
-      name: "F",
-      relation: "before",
-      toMiddleware: "G",
-    });
-    stack.addRelativeTo(getConcatMiddleware("I") as MW, {
-      name: "I",
-      relation: "before",
-      toMiddleware: "J",
-    });
-    stack.addRelativeTo(getConcatMiddleware("J") as MW, {
-      name: "J",
-      relation: "after",
-      toMiddleware: "I",
-    });
-    const inner = jest.fn();
-
-    const composed = stack.resolve(inner, {} as any);
-    await composed({ input: [] });
-
-    expect(inner.mock.calls.length).toBe(1);
-    const concatenated = inner.mock.calls[0][0].input;
-    expect(concatenated.indexOf("H")).toBeGreaterThan(concatenated.indexOf("G"));
-    expect(concatenated.indexOf("C")).toBeGreaterThan(concatenated.indexOf("A"));
-    expect(concatenated.indexOf("B")).toBeGreaterThan(concatenated.indexOf("A"));
-    expect(concatenated.indexOf("D")).toBeGreaterThan(concatenated.indexOf("C"));
-    expect(concatenated.indexOf("E")).toBeLessThan(concatenated.indexOf("F"));
-    expect(concatenated.indexOf("F")).toBeLessThan(concatenated.indexOf("G"));
-    expect(concatenated.indexOf("I")).toBeLessThan(concatenated.indexOf("J"));
-    expect(concatenated.indexOf("J")).toBeGreaterThan(concatenated.indexOf("I"));
-    expect(concatenated.indexOf("H")).toBeGreaterThan(concatenated.indexOf("G"));
-  });
-
-  it("should allow cloning", async () => {
-    const stack = constructStack<input, output>();
-    const secondMiddleware = getConcatMiddleware("second") as InitializeMiddleware<input, output>;
-    stack.add(secondMiddleware);
-    stack.add(getConcatMiddleware("first") as InitializeMiddleware<input, output>, {
-      name: "first",
-      priority: "high",
-    });
-
-    const secondStack = stack.clone();
-
-    const inner = jest.fn(({ input }: DeserializeHandlerArguments<input>) => {
-      expect(input).toEqual(["first", "second"]);
-      return Promise.resolve({ response: {} });
-    });
-    await secondStack.resolve(inner, {} as any)({ input: [] });
-    expect(inner.mock.calls.length).toBe(1);
-    expect(() => secondStack.add(secondMiddleware, { name: "first" })).toThrowError(
-      "Duplicated middleware name 'first'"
-    );
-    expect(() =>
-      secondStack.addRelativeTo(getConcatMiddleware("first") as InitializeMiddleware<input, output>, {
-        name: "first",
+  describe("addRelativeTo", () => {
+    it("should allow adding middleware relatively based relation and order of adding", async () => {
+      const stack = constructStack<input, output>();
+      stack.addRelativeTo(getConcatMiddleware("H"), {
+        name: "H",
+        relation: "after",
+        toMiddleware: "G",
+      });
+      stack.add(getConcatMiddleware("A"), {
+        name: "A",
+      });
+      stack.addRelativeTo(getConcatMiddleware("C"), {
+        name: "C",
+        relation: "after",
+        toMiddleware: "A",
+      });
+      stack.addRelativeTo(getConcatMiddleware("B"), {
+        name: "B",
+        relation: "after",
+        toMiddleware: "A",
+      });
+      stack.addRelativeTo(getConcatMiddleware("D"), {
+        name: "D",
+        relation: "after",
+        toMiddleware: "C",
+      });
+      stack.add(getConcatMiddleware("G"), {
+        name: "G",
+        priority: "low",
+      });
+      stack.addRelativeTo(getConcatMiddleware("E"), {
+        name: "E",
         relation: "before",
-        toMiddleware: "first",
-      })
-    ).toThrowError("Duplicated middleware name 'first'");
+        toMiddleware: "F",
+      });
+      stack.addRelativeTo(getConcatMiddleware("F"), {
+        name: "F",
+        relation: "before",
+        toMiddleware: "G",
+      });
+      const inner = jest.fn();
+      const composed = stack.resolve(inner, {} as any);
+      await composed({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: ["A", "B", "C", "D", "E", "F", "G", "H"] });
+    });
+
+    it("should add relative middleware within the scope of adjacent absolute middleware", async () => {
+      const stack = constructStack<input, output>();
+      stack.addRelativeTo(getConcatMiddleware("B"), {
+        name: "B",
+        relation: "after",
+        toMiddleware: "A",
+      });
+      stack.add(getConcatMiddleware("A"), { name: "A" });
+      stack.addRelativeTo(getConcatMiddleware("C"), {
+        name: "C",
+        relation: "before",
+        toMiddleware: "D",
+      });
+      stack.add(getConcatMiddleware("D"), { name: "D" });
+      const inner = jest.fn();
+      const composed = stack.resolve(inner, {} as any);
+      await composed({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: ["A", "B", "C", "D"] });
+    });
+
+    it("should not add self-referenced relative middleware", async () => {
+      const stack = constructStack<input, output>();
+      stack.addRelativeTo(getConcatMiddleware("A"), {
+        name: "A",
+        relation: "before",
+        toMiddleware: "B",
+      });
+      stack.addRelativeTo(getConcatMiddleware("B"), {
+        name: "B",
+        relation: "before",
+        toMiddleware: "C",
+      });
+      stack.addRelativeTo(getConcatMiddleware("C"), {
+        name: "C",
+        relation: "after",
+        toMiddleware: "A",
+      });
+      const inner = jest.fn();
+      const composed = stack.resolve(inner, {} as any);
+      await composed({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: [] });
+    });
+
+    it("should throw if add middleware relative to non-exist middleware", async () => {
+      expect.assertions(1);
+      const stack = constructStack<input, output>();
+      stack.addRelativeTo(getConcatMiddleware("foo"), {
+        name: "foo",
+        relation: "before",
+        toMiddleware: "non_exist",
+      });
+      const inner = jest.fn();
+      try {
+        stack.resolve(inner, {} as any);
+      } catch (e) {
+        expect(e.message).toBe("non_exist is not found when adding foo middleware before non_exist");
+      }
+    });
   });
 
-  it("should allow combining stacks", async () => {
-    const stack = constructStack<input, output>();
-    stack.add(getConcatMiddleware("first") as InitializeMiddleware<input, output>);
-    stack.add(getConcatMiddleware("second") as InitializeMiddleware<input, output>, {
-      name: "second",
-      priority: "low",
+  describe("clone", () => {
+    it("should allow cloning", async () => {
+      const stack = constructStack<input, output>();
+      const bMiddleware = getConcatMiddleware("B");
+      stack.add(bMiddleware);
+      stack.add(getConcatMiddleware("A"), {
+        name: "A",
+        priority: "high",
+      });
+      const secondStack = stack.clone();
+      const inner = jest.fn();
+      await secondStack.resolve(inner, {} as any)({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: ["A", "B"] });
+      // validate adding middleware to cloned stack won't affect the original stack.
+      inner.mockClear();
+      secondStack.add(getConcatMiddleware("C"));
+      await secondStack.resolve(inner, {} as any)({ input: [] });
+      expect(inner).toBeCalledWith({ input: ["A", "B", "C"] });
+      inner.mockClear();
+      await stack.resolve(inner, {} as any)({ input: [] });
+      expect(inner).toBeCalledWith({ input: ["A", "B"] });
     });
-
-    const secondStack = constructStack<input, output>();
-    secondStack.add(getConcatMiddleware("fourth") as FinalizeRequestMiddleware<input, output>, {
-      step: "build",
-      priority: "low",
-    });
-    secondStack.addRelativeTo(getConcatMiddleware("third") as FinalizeRequestMiddleware<input, output>, {
-      step: "build",
-      relation: "after",
-      toMiddleware: "second",
-    });
-
-    const inner = jest.fn(({ input }: DeserializeHandlerArguments<input>) => {
-      expect(input).toEqual(["first", "second", "third", "fourth"]);
-      return Promise.resolve({ response: {} });
-    });
-    await stack.concat(secondStack).resolve(inner, {} as any)({ input: [] });
-
-    expect(inner.mock.calls.length).toBe(1);
-
-    secondStack.add(getConcatMiddleware("second") as FinalizeRequestMiddleware<input, output>, {
-      step: "build",
-      priority: "high",
-      name: "second",
-    });
-    expect(() => stack.concat(secondStack)).toThrow("Duplicated middleware name 'second'");
   });
 
-  it("should allow the removal of middleware by constructor identity", async () => {
-    const stack = constructStack<input, output>();
-    stack.add(getConcatMiddleware("don't remove me") as InitializeMiddleware<input, output>, { name: "notRemove" });
-    stack.addRelativeTo(getConcatMiddleware("remove me!") as InitializeMiddleware<input, output>, {
-      relation: "after",
-      toMiddleware: "notRemove",
-      name: "toRemove",
+  describe("concat", () => {
+    it("should allow combining stacks", async () => {
+      const stack = constructStack<input, output>();
+      stack.add(getConcatMiddleware("A"));
+      stack.add(getConcatMiddleware("B"), {
+        name: "B",
+        priority: "low",
+      });
+
+      const secondStack = constructStack<input, output>();
+      secondStack.add(getConcatMiddleware("D"), {
+        step: "build",
+        priority: "low",
+      });
+      secondStack.addRelativeTo(getConcatMiddleware("C"), {
+        relation: "after",
+        toMiddleware: "B",
+      });
+
+      const inner = jest.fn();
+      await stack.concat(secondStack).resolve(inner, {} as any)({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: ["A", "B", "C", "D"] });
     });
 
-    await stack.resolve(({ input }: FinalizeHandlerArguments<Array<string>>) => {
-      expect(input.sort()).toEqual(["don't remove me", "remove me!"]);
-      return Promise.resolve({ response: {} });
-    }, {} as any)({ input: [] });
-
-    stack.remove("toRemove");
-
-    await stack.resolve(({ input }: FinalizeHandlerArguments<Array<string>>) => {
-      expect(input).toEqual(["don't remove me"]);
-      return Promise.resolve({ response: {} });
-    }, {} as any)({ input: [] });
+    it("should not touch the stack of the concat() caller or the parameter", async () => {
+      const stack = constructStack<input, output>();
+      stack.add(getConcatMiddleware("A"));
+      const secondStack = constructStack<input, output>();
+      secondStack.add(getConcatMiddleware("B"));
+      const inner = jest.fn();
+      await stack.concat(secondStack).resolve(inner, {} as any)({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: ["A", "B"] });
+      inner.mockClear();
+      await secondStack.resolve(inner, {} as any)({ input: [] });
+      expect(inner).toBeCalledWith({ input: ["B"] });
+      inner.mockClear();
+      await stack.resolve(inner, {} as any)({ input: [] });
+      expect(inner).toBeCalledWith({ input: ["A"] });
+    });
   });
 
-  it("should allow the removal of middleware by tag", async () => {
-    const stack = constructStack<input, output>();
-    stack.add(getConcatMiddleware("not removed") as InitializeMiddleware<input, output>, {
-      name: "not removed",
-      tags: ["foo", "bar"],
+  describe("remove", () => {
+    it("should remove middleware by name", async () => {
+      const stack = constructStack<input, output>();
+      stack.add(getConcatMiddleware("don't remove me"), { name: "notRemove" });
+      stack.addRelativeTo(getConcatMiddleware("remove me!"), {
+        relation: "after",
+        toMiddleware: "notRemove",
+        name: "toRemove",
+      });
+
+      await stack.resolve(({ input }: FinalizeHandlerArguments<Array<string>>) => {
+        expect(input.sort()).toEqual(["don't remove me", "remove me!"]);
+        return Promise.resolve({ response: {} });
+      }, {} as any)({ input: [] });
+
+      stack.remove("toRemove");
+
+      const inner = jest.fn();
+      await stack.resolve(inner, {} as any)({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: ["don't remove me"] });
     });
-    stack.addRelativeTo(getConcatMiddleware("remove me!") as InitializeMiddleware<input, output>, {
-      relation: "after",
-      toMiddleware: "not removed",
-      tags: ["foo", "bar", "baz"],
+
+    it("should remove middleware by reference", async () => {
+      const stack = constructStack<input, output>();
+      const mw = getConcatMiddleware("remove all references of me");
+      stack.add(mw, { name: "toRemove1" });
+      stack.add(getConcatMiddleware("don't remove me!"));
+      stack.add(mw, { name: "toRemove2" });
+      stack.remove(mw);
+
+      const inner = jest.fn();
+      await stack.resolve(inner, {} as any)({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+      expect(inner).toBeCalledWith({ input: ["don't remove me!"] });
     });
-
-    await stack.resolve(({ input }: FinalizeHandlerArguments<Array<string>>) => {
-      expect(input.sort()).toEqual(["not removed", "remove me!"]);
-      return Promise.resolve({ response: {} });
-    }, {} as any)({ input: [] });
-
-    stack.removeByTag("baz");
-
-    await stack.resolve(({ input }: DeserializeHandlerArguments<Array<string>>) => {
-      expect(input).toEqual(["not removed"]);
-      return Promise.resolve({ response: {} });
-    }, {} as any)({ input: [] });
   });
 
-  it("should apply customizations from pluggables", async () => {
-    const stack = constructStack<input, output>();
-    const plugin: Pluggable<input, output> = {
-      applyToStack: (stack) => {
-        stack.addRelativeTo(getConcatMiddleware("second") as InitializeMiddleware<input, output>, {
-          relation: "after",
-          toMiddleware: "first",
-        });
-        stack.add(getConcatMiddleware("first") as InitializeMiddleware<input, output>, { name: "first" });
-      },
-    };
-    stack.use(plugin);
-    const inner = jest.fn(({ input }: DeserializeHandlerArguments<input>) => {
-      expect(input).toEqual(["first", "second"]);
-      return Promise.resolve({ response: {} });
+  describe("removeByTag", () => {
+    it("should allow the removal of middleware by tag", async () => {
+      const stack = constructStack<input, output>();
+      stack.add(getConcatMiddleware("not removed"), {
+        name: "not removed",
+        tags: ["foo", "bar"],
+      });
+      stack.addRelativeTo(getConcatMiddleware("remove me!"), {
+        relation: "after",
+        toMiddleware: "not removed",
+        tags: ["foo", "bar", "baz"],
+      });
+
+      await stack.resolve(({ input }: FinalizeHandlerArguments<Array<string>>) => {
+        expect(input.sort()).toEqual(["not removed", "remove me!"]);
+        return Promise.resolve({ response: {} });
+      }, {} as any)({ input: [] });
+
+      stack.removeByTag("baz");
+
+      await stack.resolve(({ input }: DeserializeHandlerArguments<Array<string>>) => {
+        expect(input).toEqual(["not removed"]);
+        return Promise.resolve({ response: {} });
+      }, {} as any)({ input: [] });
     });
-    await stack.resolve(inner, {} as any)({ input: [] });
-    expect(inner.mock.calls.length).toBe(1);
+  });
+
+  describe("use", () => {
+    it("should apply customizations from pluggables", async () => {
+      const stack = constructStack<input, output>();
+      const plugin: Pluggable<input, output> = {
+        applyToStack: (stack) => {
+          stack.addRelativeTo(getConcatMiddleware("second"), {
+            relation: "after",
+            toMiddleware: "first",
+          });
+          stack.add(getConcatMiddleware("first"), { name: "first" });
+        },
+      };
+      stack.use(plugin);
+      const inner = jest.fn(({ input }: DeserializeHandlerArguments<input>) => {
+        expect(input).toEqual(["first", "second"]);
+        return Promise.resolve({ response: {} });
+      });
+      await stack.resolve(inner, {} as any)({ input: [] });
+      expect(inner.mock.calls.length).toBe(1);
+    });
   });
 });

--- a/packages/middleware-stack/src/MiddlewareStack.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.ts
@@ -4,7 +4,7 @@ import {
   Handler,
   HandlerExecutionContext,
   HandlerOptions,
-  MiddlewareStack as IMiddlewareStack,
+  MiddlewareStack,
   MiddlewareType,
   Pluggable,
   Priority,
@@ -12,28 +12,14 @@ import {
   Step,
 } from "@aws-sdk/types";
 
-import {
-  MiddlewareEntry,
-  NamedMiddlewareEntriesMap,
-  NamedRelativeEntriesMap,
-  NormalizedRelativeEntry,
-  NormalizingEntryResult,
-  RelativeMiddlewareAnchor,
-  RelativeMiddlewareEntry,
-} from "./types";
+import { AbsoluteMiddlewareEntry, MiddlewareEntry, Normalized, RelativeMiddlewareEntry } from "./types";
 
-export function constructStack<Input extends object, Output extends object>(): IMiddlewareStack<Input, Output> {
-  const absoluteEntries: Array<MiddlewareEntry<Input, Output>> = [];
-  const relativeEntries: Array<RelativeMiddlewareEntry<Input, Output>> = [];
-  const entriesNameMap: {
-    [middlewareName: string]: MiddlewareEntry<Input, Output> | RelativeMiddlewareEntry<Input, Output>;
-  } = {};
+export function constructStack<Input extends object, Output extends object>(): MiddlewareStack<Input, Output> {
+  let absoluteEntries: AbsoluteMiddlewareEntry<Input, Output>[] = [];
+  let relativeEntries: RelativeMiddlewareEntry<Input, Output>[] = [];
+  const entriesNameSet: Set<string> = new Set();
 
-  const sort = (
-    entries: Array<MiddlewareEntry<Input, Output> | NormalizedRelativeEntry<Input, Output>>
-  ): Array<MiddlewareEntry<Input, Output> | NormalizedRelativeEntry<Input, Output>> =>
-    //reverse before sorting so that middleware of same step will execute in
-    //the order of being added
+  const sort = <T extends AbsoluteMiddlewareEntry<Input, Output>>(entries: T[]): T[] =>
     entries.sort(
       (a, b) =>
         stepWeights[b.step] - stepWeights[a.step] ||
@@ -41,47 +27,55 @@ export function constructStack<Input extends object, Output extends object>(): I
     );
 
   const removeByName = (toRemove: string): boolean => {
-    for (let i = absoluteEntries.length - 1; i >= 0; i--) {
-      if (absoluteEntries[i].name && absoluteEntries[i].name === toRemove) {
-        absoluteEntries.splice(i, 1);
-        delete entriesNameMap[toRemove];
-        return true;
+    let isRemoved = false;
+    const filterCb = (entry: MiddlewareEntry<Input, Output>): boolean => {
+      if (entry.name && entry.name === toRemove) {
+        isRemoved = false;
+        entriesNameSet.delete(toRemove);
+        return false;
       }
-    }
-    for (let i = relativeEntries.length - 1; i >= 0; i--) {
-      if (relativeEntries[i].name && relativeEntries[i].name === toRemove) {
-        relativeEntries.splice(i, 1);
-        delete entriesNameMap[toRemove];
-        return true;
-      }
-    }
-    return false;
+      return true;
+    };
+    absoluteEntries = absoluteEntries.filter(filterCb);
+    relativeEntries = relativeEntries.filter(filterCb);
+    return isRemoved;
   };
 
   const removeByReference = (toRemove: MiddlewareType<Input, Output>): boolean => {
-    for (let i = absoluteEntries.length - 1; i >= 0; i--) {
-      if (absoluteEntries[i].middleware === toRemove) {
-        const { name } = absoluteEntries[i];
-        if (name) delete entriesNameMap[name];
-        absoluteEntries.splice(i, 1);
-        return true;
+    let isRemoved = false;
+    const filterCb = (entry: MiddlewareEntry<Input, Output>): boolean => {
+      if (entry.middleware === toRemove) {
+        isRemoved = true;
+        if (entry.name) entriesNameSet.delete(entry.name);
+        return false;
       }
-    }
-    for (let i = relativeEntries.length - 1; i >= 0; i--) {
-      if (relativeEntries[i].middleware === toRemove) {
-        const { name } = relativeEntries[i];
-        if (name) delete entriesNameMap[name];
-        relativeEntries.splice(i, 1);
-        return true;
+      return true;
+    };
+    absoluteEntries = absoluteEntries.filter(filterCb);
+    relativeEntries = relativeEntries.filter(filterCb);
+    return isRemoved;
+  };
+
+  const removeByTag = (toRemove: string): boolean => {
+    let isRemoved = false;
+    const filterCb = (entry: MiddlewareEntry<Input, Output>): boolean => {
+      const { tags, name } = entry;
+      if (tags && tags.includes(toRemove)) {
+        if (name) entriesNameSet.delete(name);
+        isRemoved = true;
+        return false;
       }
-    }
-    return false;
+      return true;
+    };
+    absoluteEntries = absoluteEntries.filter(filterCb);
+    relativeEntries = relativeEntries.filter(filterCb);
+    return isRemoved;
   };
 
   const cloneTo = <InputType extends Input, OutputType extends Output>(
-    toStack: IMiddlewareStack<InputType, OutputType>
-  ): IMiddlewareStack<InputType, OutputType> => {
-    const clone = toStack || constructStack<InputType, OutputType>();
+    toStack: MiddlewareStack<InputType, OutputType>
+  ): MiddlewareStack<InputType, OutputType> => {
+    const clone = toStack;
     absoluteEntries.forEach((entry) => {
       //@ts-ignore
       clone.add(entry.middleware, { ...entry });
@@ -93,149 +87,87 @@ export function constructStack<Input extends object, Output extends object>(): I
     return clone;
   };
 
-  /**
-   * Resolve relative middleware entries to multiple double linked lists
-   * depicting the relative location of middleware. Only middleware that have
-   * direct or transitive relation will form a linked list.
-   *
-   * This function normalizes relative middleware into 2 categories of linked
-   * lists. (1) linked list that have absolute-located middleware on one end.
-   * These middleware will be resolved accordingly before or after the absolute-
-   * located middleware. (2) Linked list that have no absolute-located middleware
-   * on any end. They will be resolved to corresponding step with normal priority
-   *
-   * The 2 types of linked list will return as a tuple
-   */
-  const normalizeRelativeEntries = (): NormalizingEntryResult<Input, Output> => {
-    const absoluteMiddlewareNamesMap = absoluteEntries
-      .filter((entry) => entry.name)
-      .reduce((accumulator, entry) => {
-        accumulator[entry.name!] = entry;
-        return accumulator;
-      }, {} as NamedMiddlewareEntriesMap<Input, Output>);
-    const normalized = relativeEntries.map(
-      (entry) =>
-        ({
-          ...entry,
-          priority: null,
-          next: undefined,
-          prev: undefined,
-        } as NormalizedRelativeEntry<Input, Output>)
-    );
-    const relativeMiddlewareNamesMap = normalized
-      .filter((entry) => entry.name)
-      .reduce((accumulator, entry) => {
-        accumulator[entry.name!] = entry;
-        return accumulator;
-      }, {} as NamedRelativeEntriesMap<Input, Output>);
-
-    const anchors: RelativeMiddlewareAnchor<Input, Output> = {};
-    for (let i = 0; i < relativeEntries.length; i++) {
-      const { prev, next } = relativeEntries[i];
-      const resolvedCurr = normalized[i];
-      //either prev or next is set
-      if (prev) {
-        if (absoluteMiddlewareNamesMap[prev] && absoluteMiddlewareNamesMap[prev].step === resolvedCurr.step) {
-          if (!anchors[prev]) anchors[prev] = {};
-          resolvedCurr.next = anchors[prev].next;
-          if (anchors[prev].next) anchors[prev].next!.prev = resolvedCurr;
-          anchors[prev].next = resolvedCurr;
-        } else if (relativeMiddlewareNamesMap[prev] && relativeMiddlewareNamesMap[prev].step === resolvedCurr.step) {
-          const resolvedPrev = relativeMiddlewareNamesMap[prev];
-          if (resolvedPrev.next === resolvedCurr) continue;
-          resolvedCurr.next = resolvedPrev.next;
-          resolvedPrev.next = resolvedCurr;
-          if (resolvedCurr.next) resolvedCurr.next.prev = resolvedCurr;
-          resolvedCurr.prev = resolvedPrev;
-        }
-      } else if (next) {
-        if (absoluteMiddlewareNamesMap[next] && absoluteMiddlewareNamesMap[next].step === resolvedCurr.step) {
-          if (!anchors[next]) anchors[next] = {};
-          resolvedCurr.prev = anchors[next].prev;
-          if (anchors[next].prev) anchors[next].prev!.next = resolvedCurr;
-          anchors[next].prev = resolvedCurr;
-        } else if (relativeMiddlewareNamesMap[next] && relativeMiddlewareNamesMap[next].step === resolvedCurr.step) {
-          const resolvedNext = relativeMiddlewareNamesMap[next];
-          if (resolvedNext.prev === resolvedCurr) continue;
-          resolvedCurr.prev = resolvedNext.prev;
-          resolvedNext.prev = resolvedCurr;
-          if (resolvedCurr.prev) resolvedCurr.prev.next = resolvedCurr;
-          resolvedCurr.next = resolvedNext;
-        }
+  const expandRelativeMiddlewareList = (
+    from: Normalized<MiddlewareEntry<Input, Output>, Input, Output>
+  ): MiddlewareEntry<Input, Output>[] => {
+    const expandedMiddleareList: MiddlewareEntry<Input, Output>[] = [];
+    from.before.forEach((entry) => {
+      if (entry.before.length === 0 && entry.after.length === 0) {
+        expandedMiddleareList.push(entry);
+      } else {
+        expandedMiddleareList.push(...expandRelativeMiddlewareList(entry));
       }
-    }
-    // get the head of the relative middleware linked list that have
-    // no transitive relation to absolute middleware.
-    const orphanedRelativeEntries: Array<NormalizedRelativeEntry<Input, Output>> = [];
-    const visited: WeakSet<NormalizedRelativeEntry<Input, Output>> = new WeakSet();
-    for (const anchorName of Object.keys(anchors)) {
-      let { prev, next } = anchors[anchorName];
-      while (prev) {
-        visited.add(prev);
-        prev = prev.prev;
+    });
+    expandedMiddleareList.push(from);
+    from.after.reverse().forEach((entry) => {
+      if (entry.before.length === 0 && entry.after.length === 0) {
+        expandedMiddleareList.push(entry);
+      } else {
+        expandedMiddleareList.push(...expandRelativeMiddlewareList(entry));
       }
-      while (next) {
-        visited.add(next);
-        next = next.next;
-      }
-    }
-    for (let i = 0; i < normalized.length; i++) {
-      let entry: NormalizedRelativeEntry<Input, Output> | undefined = normalized[i];
-      if (visited.has(entry)) continue;
-      if (!entry.prev) orphanedRelativeEntries.push(entry);
-      while (entry && !visited.has(entry)) {
-        visited.add(entry);
-        entry = entry.next;
-      }
-    }
-    return [orphanedRelativeEntries, anchors];
+    });
+    return expandedMiddleareList;
   };
 
   /**
    * Get a final list of middleware in the order of being executed in the resolved handler.
-   * If relative entries list is not empty, those entries will be added to final middleware
-   * list with rules below:
-   * 1. if `toMiddleware` exists in the specific `step`, the middleware will be inserted before
-   *     or after the specified `toMiddleware`
-   * 2. if `toMiddleware` doesn't exist in the specific `step`, the middleware will be appended
-   *     to specific `step` with priority of `normal`
    */
   const getMiddlewareList = (): Array<MiddlewareType<Input, Output>> => {
-    const middlewareList: Array<MiddlewareType<Input, Output>> = [];
-    const [orphanedRelativeEntries, anchors] = normalizeRelativeEntries();
-    let entryList = [...absoluteEntries, ...orphanedRelativeEntries];
-    entryList = sort(entryList);
-    for (const entry of entryList) {
-      const defaultAnchorValue = { prev: undefined, next: undefined };
-      const { prev, next } = entry.name ? anchors[entry.name] || defaultAnchorValue : defaultAnchorValue;
-      let relativeEntry = prev;
-      //reverse relative entry linked list and add to ordered handler list
-      while (relativeEntry?.prev) {
-        relativeEntry = relativeEntry.prev;
+    const normalizedAbsoluteEntries: Normalized<AbsoluteMiddlewareEntry<Input, Output>, Input, Output>[] = [];
+    const normalizedRelativeEntries: Normalized<RelativeMiddlewareEntry<Input, Output>, Input, Output>[] = [];
+    const normalizedEntriesNameMap: {
+      [middlewareName: string]: Normalized<MiddlewareEntry<Input, Output>, Input, Output>;
+    } = {};
+    absoluteEntries.forEach((entry) => {
+      const normalizedEntry = {
+        ...entry,
+        before: [],
+        after: [],
+      };
+      if (normalizedEntry.name) normalizedEntriesNameMap[normalizedEntry.name] = normalizedEntry;
+      normalizedAbsoluteEntries.push(normalizedEntry);
+    });
+    relativeEntries.forEach((entry) => {
+      const normalizedEntry = {
+        ...entry,
+        before: [],
+        after: [],
+      };
+      if (normalizedEntry.name) normalizedEntriesNameMap[normalizedEntry.name] = normalizedEntry;
+      normalizedRelativeEntries.push(normalizedEntry);
+    });
+    normalizedRelativeEntries.forEach((entry) => {
+      if (entry.toMiddleware) {
+        const toMiddleware = normalizedEntriesNameMap[entry.toMiddleware];
+        if (toMiddleware === undefined) {
+          throw new Error(
+            `${entry.toMiddleware} is not found when adding ${entry.name || "anonymous"} middleware ${entry.relation} ${
+              entry.toMiddleware
+            }`
+          );
+        }
+        if (entry.relation === "after") {
+          toMiddleware.after.push(entry);
+        }
+        if (entry.relation === "before") {
+          toMiddleware.before.push(entry);
+        }
       }
-      while (relativeEntry) {
-        middlewareList.push(relativeEntry.middleware);
-        relativeEntry = relativeEntry.next;
-      }
-      middlewareList.push(entry.middleware);
-      let orphanedEntry = entry as any;
-      while ((orphanedEntry as any).next) {
-        middlewareList.push((orphanedEntry as any).next.middleware);
-        orphanedEntry = (orphanedEntry as any).next;
-      }
-      relativeEntry = next;
-      while (relativeEntry) {
-        middlewareList.push(relativeEntry.middleware);
-        relativeEntry = relativeEntry.next;
-      }
-    }
-    return middlewareList.reverse();
+    });
+    const mainChain = sort(normalizedAbsoluteEntries)
+      .map(expandRelativeMiddlewareList)
+      .reduce((wholeList, expendedMiddlewareList) => {
+        // TODO: Replace it with Array.flat();
+        wholeList.push(...expendedMiddlewareList);
+        return wholeList;
+      }, [] as MiddlewareEntry<Input, Output>[]);
+    return mainChain.map((entry) => entry.middleware);
   };
 
   const stack = {
     add: (middleware: MiddlewareType<Input, Output>, options: HandlerOptions & AbsoluteLocation = {}) => {
       const { name, step = "initialize", tags, priority = "normal" } = options;
-      const entry: MiddlewareEntry<Input, Output> = {
+      const entry: AbsoluteMiddlewareEntry<Input, Output> = {
         name,
         step,
         tags,
@@ -243,35 +175,32 @@ export function constructStack<Input extends object, Output extends object>(): I
         middleware,
       };
       if (name) {
-        if (Object.prototype.hasOwnProperty.call(entriesNameMap, name)) {
+        if (entriesNameSet.has(name)) {
           throw new Error(`Duplicated middleware name '${name}'`);
         }
-        entriesNameMap[name] = entry;
+        entriesNameSet.add(name);
       }
       absoluteEntries.push(entry);
     },
-    addRelativeTo: (
-      middleware: MiddlewareType<Input, Output>,
-      options: HandlerOptions & RelativeLocation<Input, Output>
-    ) => {
+    addRelativeTo: (middleware: MiddlewareType<Input, Output>, options: HandlerOptions & RelativeLocation) => {
       const { step = "initialize", name, tags, relation, toMiddleware } = options;
       const entry: RelativeMiddlewareEntry<Input, Output> = {
         middleware,
         step,
         name,
         tags,
-        next: relation === "before" ? toMiddleware : undefined,
-        prev: relation === "after" ? toMiddleware : undefined,
+        relation,
+        toMiddleware,
       };
       if (name) {
-        if (Object.prototype.hasOwnProperty.call(entriesNameMap, name)) {
+        if (entriesNameSet.has(name)) {
           throw new Error(`Duplicated middleware name '${name}'`);
         }
-        entriesNameMap[name] = entry;
+        entriesNameSet.add(name);
       }
       relativeEntries.push(entry);
     },
-    clone: (): IMiddlewareStack<Input, Output> => cloneTo(constructStack<Input, Output>()),
+    clone: (base?: MiddlewareStack<Input, Output>) => cloneTo(base || constructStack<Input, Output>()),
     use: (plugin: Pluggable<Input, Output>) => {
       plugin.applyToStack(stack);
     },
@@ -279,34 +208,15 @@ export function constructStack<Input extends object, Output extends object>(): I
       if (typeof toRemove === "string") return removeByName(toRemove);
       else return removeByReference(toRemove);
     },
-    removeByTag: (toRemove: string): boolean => {
-      let removed = false;
-      for (let i = absoluteEntries.length - 1; i >= 0; i--) {
-        const { tags, name } = absoluteEntries[i];
-        if (tags && tags.indexOf(toRemove) > -1) {
-          absoluteEntries.splice(i, 1);
-          if (name) delete entriesNameMap[name];
-          removed = true;
-        }
-      }
-      for (let i = relativeEntries.length - 1; i >= 0; i--) {
-        const { tags, name } = relativeEntries[i];
-        if (tags && tags.indexOf(toRemove) > -1) {
-          relativeEntries.splice(i, 1);
-          if (name) delete entriesNameMap[name];
-          removed = true;
-        }
-      }
-      return removed;
-    },
+    removeByTag,
     concat: <InputType extends Input, OutputType extends Output>(
-      from: IMiddlewareStack<InputType, OutputType>
-    ): IMiddlewareStack<InputType, OutputType> => cloneTo(from.clone()),
+      from: MiddlewareStack<InputType, OutputType>
+    ): MiddlewareStack<InputType, OutputType> => from.clone(cloneTo(constructStack<InputType, OutputType>())),
     resolve: <InputType extends Input, OutputType extends Output>(
       handler: DeserializeHandler<InputType, OutputType>,
       context: HandlerExecutionContext
     ): Handler<InputType, OutputType> => {
-      for (const middleware of getMiddlewareList()) {
+      for (const middleware of getMiddlewareList().reverse()) {
         handler = middleware(handler as Handler<Input, OutputType>, context) as any;
       }
       return handler as Handler<InputType, OutputType>;

--- a/packages/middleware-stack/src/types.ts
+++ b/packages/middleware-stack/src/types.ts
@@ -1,16 +1,28 @@
-import { HandlerOptions, MiddlewareType, Priority, Step } from "@aws-sdk/types";
+import { AbsoluteLocation, HandlerOptions, MiddlewareType, Priority, RelativeLocation, Step } from "@aws-sdk/types";
+
 export interface MiddlewareEntry<Input extends object, Output extends object> extends HandlerOptions {
-  step: Step;
   middleware: MiddlewareType<Input, Output>;
+}
+
+export interface AbsoluteMiddlewareEntry<Input extends object, Output extends object>
+  extends MiddlewareEntry<Input, Output>,
+    AbsoluteLocation {
+  step: Step;
   priority: Priority;
 }
 
-export interface RelativeMiddlewareEntry<Input extends object, Output extends object> extends HandlerOptions {
-  step: Step;
-  middleware: MiddlewareType<Input, Output>;
-  next?: string;
-  prev?: string;
-}
+export interface RelativeMiddlewareEntry<Input extends object, Output extends object>
+  extends MiddlewareEntry<Input, Output>,
+    RelativeLocation {}
+
+export type Normalized<
+  T extends MiddlewareEntry<Input, Output>,
+  Input extends object = {},
+  Output extends object = {}
+> = T & {
+  after: Normalized<RelativeMiddlewareEntry<Input, Output>, Input, Output>[];
+  before: Normalized<RelativeMiddlewareEntry<Input, Output>, Input, Output>[];
+};
 
 export interface NormalizedRelativeEntry<Input extends object, Output extends object> extends HandlerOptions {
   step: Step;
@@ -23,19 +35,3 @@ export interface NormalizedRelativeEntry<Input extends object, Output extends ob
 export type NamedMiddlewareEntriesMap<Input extends object, Output extends object> = {
   [key: string]: MiddlewareEntry<Input, Output>;
 };
-
-export type NamedRelativeEntriesMap<Input extends object, Output extends object> = {
-  [key: string]: NormalizedRelativeEntry<Input, Output>;
-};
-
-export type RelativeMiddlewareAnchor<Input extends object, Output extends object> = {
-  [name: string]: {
-    prev?: NormalizedRelativeEntry<Input, Output>;
-    next?: NormalizedRelativeEntry<Input, Output>;
-  };
-};
-
-export type NormalizingEntryResult<Input extends object, Output extends object> = [
-  Array<NormalizedRelativeEntry<Input, Output>>,
-  RelativeMiddlewareAnchor<Input, Output>
-];

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -1,4 +1,4 @@
-import { MiddlewareStack } from "@aws-sdk/middleware-stack";
+import { constructStack } from "@aws-sdk/middleware-stack";
 import { Client as IClient, Command, MetadataBearer, RequestHandler } from "@aws-sdk/types";
 
 export interface SmithyConfiguration<HandlerOptions> {
@@ -14,7 +14,7 @@ export class Client<
   ClientOutput extends MetadataBearer,
   ResolvedClientConfiguration extends SmithyResolvedConfiguration<HandlerOptions>
 > implements IClient<ClientInput, ClientOutput, ResolvedClientConfiguration> {
-  public middlewareStack = new MiddlewareStack<ClientInput, ClientOutput>();
+  public middlewareStack = constructStack<ClientInput, ClientOutput>();
   readonly config: ResolvedClientConfiguration;
   constructor(config: ResolvedClientConfiguration) {
     this.config = config;

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -1,4 +1,4 @@
-import { MiddlewareStack } from "@aws-sdk/middleware-stack";
+import { constructStack } from "@aws-sdk/middleware-stack";
 import { Command as ICommand, Handler, MetadataBearer, MiddlewareStack as IMiddlewareStack } from "@aws-sdk/types";
 
 export abstract class Command<
@@ -9,9 +9,9 @@ export abstract class Command<
   ClientOutput extends MetadataBearer = any
 > implements ICommand<ClientInput, Input, ClientOutput, Output, ResolvedClientConfiguration> {
   abstract input: Input;
-  readonly middlewareStack: IMiddlewareStack<Input, Output> = new MiddlewareStack<Input, Output>();
+  readonly middlewareStack: IMiddlewareStack<Input, Output> = constructStack<Input, Output>();
   abstract resolveMiddleware(
-    stack: MiddlewareStack<ClientInput, ClientOutput>,
+    stack: IMiddlewareStack<ClientInput, ClientOutput>,
     configuration: ResolvedClientConfiguration,
     options: any
   ): Handler<Input, Output>;

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -218,7 +218,7 @@ export interface AbsoluteLocation {
 
 export type Relation = "before" | "after";
 
-export interface RelativeLocation<Input extends object, Output extends object> {
+export interface RelativeLocation {
   /**
    * Specify the relation to be before or after a know middleware.
    */
@@ -229,6 +229,8 @@ export interface RelativeLocation<Input extends object, Output extends object> {
    */
   toMiddleware: string;
 }
+
+export type RelativeMiddlewareOptions = RelativeLocation & Omit<HandlerOptions, "step">;
 
 export interface InitializeHandlerOptions extends HandlerOptions {
   step?: "initialize";
@@ -259,32 +261,33 @@ export interface DeserializeHandlerOptions extends HandlerOptions {
  *    `priority` options to `high` or `low`.
  * 2. Adding middleware to location relative to known middleware with `addRelativeTo()`.
  *    This is useful when given middleware must be executed before or after specific
- *    middleware(`toMiddleware`). If specified `toMiddleware` is not found, given
- *    middleware will be added to given step with normal priority.
- *    Note `toMiddleware` can only be added to middleware stack staticly using
- *    `add()` API.
+ *    middleware(`toMiddleware`). You can add a middleware relatively to another
+ *    middleware which also added relatively. But eventually, this relative middleware
+ *    chain **must** be 'anchored' by a middleware that added using `add()` API
+ *    with absolute `step` and `priority`. This mothod will throw if specified
+ *    `toMiddleware` is not found.
  */
 export interface MiddlewareStack<Input extends object, Output extends object> {
   /**
-   * Add middleware to the list to be executed during the "initialize" step,
+   * Add middleware to the stack to be executed during the "initialize" step,
    * optionally specifying a priority, tags and name
    */
   add(middleware: InitializeMiddleware<Input, Output>, options?: InitializeHandlerOptions & AbsoluteLocation): void;
 
   /**
-   * Add middleware to the list to be executed during the "serialize" step,
+   * Add middleware to the stack to be executed during the "serialize" step,
    * optionally specifying a priority, tags and name
    */
   add(middleware: SerializeMiddleware<Input, Output>, options: SerializeHandlerOptions & AbsoluteLocation): void;
 
   /**
-   * Add middleware to the list to be executed during the "build" step,
+   * Add middleware to the stack to be executed during the "build" step,
    * optionally specifying a priority, tags and name
    */
   add(middleware: BuildMiddleware<Input, Output>, options: BuildHandlerOptions & AbsoluteLocation): void;
 
   /**
-   * Add middleware to the list to be executed during the "finalizeRequest" step,
+   * Add middleware to the stack to be executed during the "finalizeRequest" step,
    * optionally specifying a priority, tags and name
    */
   add(
@@ -293,65 +296,16 @@ export interface MiddlewareStack<Input extends object, Output extends object> {
   ): void;
 
   /**
-   * Add middleware to the list to be executed during the "deserialize" step,
+   * Add middleware to the stack to be executed during the "deserialize" step,
    * optionally specifying a priority, tags and name
    */
   add(middleware: DeserializeMiddleware<Input, Output>, options: DeserializeHandlerOptions & AbsoluteLocation): void;
 
   /**
-   * Add middleware to location relative to a known middleware in 'initialize' step.
-   * Require setting `relation` (to `before` or `after`) and `toMiddleware` to
-   * identify the location of inserted middleware
-   * optionally specifying tags and name
+   * Add middleware to a stack position before or after a known middleware，optionally
+   * specifying name and tags.
    */
-  addRelativeTo(
-    middleware: InitializeMiddleware<Input, Output>,
-    options: InitializeHandlerOptions & RelativeLocation<Input, Output>
-  ): void;
-
-  /**
-   * Add middleware to location relative to a known middleware in 'serialize' step.
-   * Require setting `relation` (to `before` or `after`) and `toMiddleware` to
-   * identify the location of inserted middleware
-   * optionally specifying tags and name
-   */
-  addRelativeTo(
-    middleware: SerializeMiddleware<Input, Output>,
-    options: SerializeHandlerOptions & RelativeLocation<Input, Output>
-  ): void;
-
-  /**
-   * Add middleware to location relative to a known middleware in 'build' step.
-   * Require setting `relation` (to `before` or `after`) and `toMiddleware` to
-   * identify the location of inserted middleware
-   * optionally specifying tags and name
-   */
-  addRelativeTo(
-    middleware: BuildMiddleware<Input, Output>,
-    options: BuildHandlerOptions & RelativeLocation<Input, Output>
-  ): void;
-
-  /**
-   * Add middleware to location relative to a known middleware in 'finalizeRequest' step.
-   * Require setting `relation` (to `before` or `after`) and `toMiddleware` to
-   * identify the location of inserted middleware
-   * optionally specifying tags and name
-   */
-  addRelativeTo(
-    middleware: FinalizeRequestMiddleware<Input, Output>,
-    options: FinalizeRequestHandlerOptions & RelativeLocation<Input, Output>
-  ): void;
-
-  /**
-   * Add middleware to location relative to a known middleware in 'deserialize' step.
-   * Require setting `relation` (to `before` or `after`) and `toMiddleware` to
-   * identify the location of inserted middleware
-   * optionally specifying tags and name
-   */
-  addRelativeTo(
-    middleware: DeserializeMiddleware<Input, Output>,
-    options: DeserializeHandlerOptions & RelativeLocation<Input, Output>
-  ): void;
+  addRelativeTo(middleware: MiddlewareType<Input, Output>, options: RelativeMiddlewareOptions): void;
 
   /**
    * Apply a customization function to mutate the middleware stack, often
@@ -360,10 +314,12 @@ export interface MiddlewareStack<Input extends object, Output extends object> {
   use(pluggable: Pluggable<Input, Output>): void;
 
   /**
-   * Create a shallow clone of this list. Step bindings and handler priorities
+   * Create a shallow clone of this stack. Step bindings and handler priorities
    * and tags are preserved in the copy.
+   * Users can optionally supply a base stack that will be merged into the clone
+   * output but its middleware will take preference.
    */
-  clone(): MiddlewareStack<Input, Output>;
+  clone(base?: MiddlewareStack<Input, Output>): MiddlewareStack<Input, Output>;
 
   /**
    * Removes middleware from the stack.
@@ -383,8 +339,8 @@ export interface MiddlewareStack<Input extends object, Output extends object> {
   removeByTag(toRemove: string): boolean;
 
   /**
-   * Create a list containing the middlewares in this list as well as the
-   * middlewares in the `from` list. Neither source is modified, and step
+   * Create a stack containing the middlewares in this stack as well as the
+   * middlewares in the `from` stack. Neither source is modified, and step
    * bindings and handler priorities and tags are preserved in the copy.
    */
   concat<InputType extends Input, OutputType extends Output>(

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -267,7 +267,7 @@ export interface DeserializeHandlerOptions extends HandlerOptions {
  *    with absolute `step` and `priority`. This mothod will throw if specified
  *    `toMiddleware` is not found.
  */
-export interface MiddlewareStack<Input extends object, Output extends object> {
+export interface MiddlewareStack<Input extends object, Output extends object> extends Pluggable<Input, Output> {
   /**
    * Add middleware to the stack to be executed during the "initialize" step,
    * optionally specifying a priority, tags and name
@@ -316,10 +316,8 @@ export interface MiddlewareStack<Input extends object, Output extends object> {
   /**
    * Create a shallow clone of this stack. Step bindings and handler priorities
    * and tags are preserved in the copy.
-   * Users can optionally supply a base stack that will be merged into the clone
-   * output but its middleware will take preference.
    */
-  clone(base?: MiddlewareStack<Input, Output>): MiddlewareStack<Input, Output>;
+  clone(): MiddlewareStack<Input, Output>;
 
   /**
    * Removes middleware from the stack.

--- a/packages/util-create-request/src/foo.fixture.ts
+++ b/packages/util-create-request/src/foo.fixture.ts
@@ -1,7 +1,7 @@
-import { MiddlewareStack } from "@aws-sdk/middleware-stack";
+import { constructStack } from "@aws-sdk/middleware-stack";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { Client, Command } from "@aws-sdk/smithy-client";
-import { MetadataBearer } from "@aws-sdk/types";
+import { MetadataBearer, MiddlewareStack } from "@aws-sdk/types";
 
 export interface OperationInput {
   String: string;
@@ -22,14 +22,14 @@ const input: OperationInput = { String: "input" };
 
 export const fooClient: Client<any, InputTypesUnion, OutputTypesUnion, any> = {
   config: {},
-  middlewareStack: new MiddlewareStack<InputTypesUnion, OutputTypesUnion>(),
+  middlewareStack: constructStack<InputTypesUnion, OutputTypesUnion>(),
   send: (command: Command<InputTypesUnion, OutputTypesUnion, any, OperationInput, OperationOutput>) =>
     command.resolveMiddleware(this.middlewareStack, this.config, undefined)({ input }),
   destroy: () => {},
 };
 
 export const operationCommand: Command<InputTypesUnion, OutputTypesUnion, any, OperationInput, OperationOutput> = {
-  middlewareStack: new MiddlewareStack<object, OutputTypesUnion>(),
+  middlewareStack: constructStack<object, OutputTypesUnion>(),
   input: {} as any,
   resolveMiddleware: (stack: MiddlewareStack<InputTypesUnion, OutputTypesUnion>) => {
     const concatStack = stack.concat(operationCommand.middlewareStack);

--- a/packages/util-create-request/src/index.ts
+++ b/packages/util-create-request/src/index.ts
@@ -1,4 +1,3 @@
-import { MiddlewareStack } from "@aws-sdk/middleware-stack";
 import { Client, Command } from "@aws-sdk/smithy-client";
 import { BuildMiddleware, HttpRequest, MetadataBearer } from "@aws-sdk/types";
 
@@ -22,7 +21,7 @@ export async function createRequest<
     priority: "low",
   });
 
-  const handler = command.resolveMiddleware(clientStack as MiddlewareStack<any, any>, client.config, undefined);
+  const handler = command.resolveMiddleware(clientStack, client.config, undefined);
 
   //@ts-ignore
   return await handler(command).then((output) => output.output.request);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11754,11 +11754,6 @@ typescript@3.7.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
-typescript@~3.4.0:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
-
 typescript@~3.9.3:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"


### PR DESCRIPTION
*Issue #, if available:*
#1377 

*Description of changes:*
* This change refactors the middleware stack class into a factory. So that the private data are stored in closure instead of class "private" members. Now, you can instantiate a middleware stack by `constructStack<Input, Output>();` instead of `new MiddlewareStack<Input, Output>()`.

* Remove `step` from the `addRelativeTo` options. This way the position of the middleware is solely depend on the `toMiddleware` and `relation`(before or after).

* Refactor the middleware stack resolution implementation. Now the resolution algorithm is easier to follow & maintain.

/cc @trivikr 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
