### PR TITLE
fix: add region validation using DNS Host label regex

### DIFF
--- a/packages/config-resolver/src/EndpointsConfig.spec.ts
+++ b/packages/config-resolver/src/EndpointsConfig.spec.ts
@@ -85,9 +85,29 @@ describe("EndpointsConfig", () => {
       describe("throws error", () => {
         const error = new Error("error");
 
-        it("if region throws error", () => {
-          region.mockRejectedValueOnce(error);
-          return expect(resolveEndpointsConfig(input).endpoint()).rejects.toStrictEqual(error);
+        describe("if region", () => {
+          it("throws error", () => {
+            region.mockRejectedValueOnce(error);
+            return expect(resolveEndpointsConfig(input).endpoint()).rejects.toStrictEqual(error);
+          });
+
+          it("is invalid", () => {
+            [
+              "",
+              "has_underscore",
+              "-starts-with-dash",
+              "ends-with-dash-",
+              "-starts-and-ends-with-dash-",
+              "-",
+              "c0nt@in$-$ymb01$",
+              "0123456789012345678901234567890123456789012345678901234567890123", // 64 characters
+            ].forEach((invalidRegion) => {
+              region.mockResolvedValueOnce(invalidRegion);
+              return expect(resolveEndpointsConfig(input).endpoint()).rejects.toStrictEqual(
+                new Error("Invalid region in client config")
+              );
+            });
+          });
         });
 
         describe("if regionInfoProvider", () => {

--- a/packages/config-resolver/src/EndpointsConfig.ts
+++ b/packages/config-resolver/src/EndpointsConfig.ts
@@ -45,9 +45,16 @@ const normalizeEndpoint = (input: EndpointsInputConfig & PreviouslyResolved): Pr
 const getEndPointFromRegion = async (input: EndpointsInputConfig & PreviouslyResolved) => {
   const { tls = true } = input;
   const region = await input.region();
+
+  const dnsHostRegex = new RegExp(/^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])$/);
+  if (!dnsHostRegex.test(region)) {
+    throw new Error("Invalid region in client config");
+  }
+
   const { hostname } = (await input.regionInfoProvider(region)) ?? {};
   if (!hostname) {
     throw new Error("Cannot resolve hostname from client config");
   }
+
   return input.urlParser(`${tls ? "https:" : "http:"}//${hostname}`);
 };


### PR DESCRIPTION
*Issue #, if available:*
From v2: https://github.com/aws/aws-sdk-js/pull/3368
Internal issue JS-1834

*Description of changes:*
adds region validation using DNS Host label regex

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
