### PR TITLE
chore(deps-dev): bump typedoc to 0.17.8

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -69,7 +69,7 @@
     "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -68,7 +68,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -67,7 +67,7 @@
     "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -67,7 +67,7 @@
     "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -69,7 +69,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -82,7 +82,7 @@
     "jest": "^25.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -65,7 +65,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -73,7 +73,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -64,7 +64,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   }
 }

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -13,7 +13,8 @@
     "pretty": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "target": "ES2015"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -66,7 +66,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -67,7 +67,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -69,7 +69,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "tslib": "^1.8.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.8",
     "typescript": "~3.9.3"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,13 +1771,6 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/fs-extra@^5.0.3":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.1.0.tgz#2a325ef97901504a3828718c390d34b8426a10a1"
-  integrity sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/fs-extra@^8.0.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.1.tgz#1e49f22d09aa46e19b51c0b013cb63d0d923a068"
@@ -1785,7 +1778,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@*", "@types/glob@^7.1.1":
+"@types/glob@^7.1.1":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.2.tgz#06ca26521353a545d94a0adc74f38a59d232c987"
   integrity sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==
@@ -1799,18 +1792,6 @@
   integrity sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
   dependencies:
     "@types/node" "*"
-
-"@types/handlebars@^4.0.38":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
-  integrity sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==
-  dependencies:
-    handlebars "*"
-
-"@types/highlight.js@^9.12.3":
-  version "9.12.4"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
-  integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
@@ -1845,17 +1826,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/lodash@^4.14.110":
-  version "4.14.156"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.156.tgz#cbe30909c89a1feeb7c60803e785344ea0ec82d1"
-  integrity sha512-l2AgHXcKUwx2DsvP19wtRPqZ4NkONjmorOdq4sMcxIjqdIuuV/ULo2ftuv4NUpevwfW7Ju/UKLqo0ZXuEt/8lQ==
-
-"@types/marked@^0.4.0":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.4.2.tgz#64a89e53ea37f61cc0f3ee1732c555c2dbf6452f"
-  integrity sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==
-
-"@types/minimatch@*", "@types/minimatch@3.0.3":
+"@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -1904,14 +1875,6 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.2.tgz#5bb52ee68d0f8efa9cc0099920e56be6cc4e37f3"
   integrity sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
-
-"@types/shelljs@^0.8.0":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.8.tgz#e439c69929b88a2c8123c1a55e09eb708315addf"
-  integrity sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==
-  dependencies:
-    "@types/glob" "*"
-    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2816,13 +2779,6 @@ babel-preset-jest@^26.1.0:
   dependencies:
     babel-plugin-jest-hoist "^26.1.0"
     babel-preset-current-node-syntax "^0.1.2"
-
-backbone@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
-  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
-  dependencies:
-    underscore ">=1.8.3"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -5371,15 +5327,6 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -5751,7 +5698,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@*, handlebars@4.7.6, handlebars@^4.0.6, handlebars@^4.7.0, handlebars@^4.7.6:
+handlebars@4.7.6, handlebars@^4.7.6:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
@@ -5886,10 +5833,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^9.13.1, highlight.js@^9.17.1:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+highlight.js@^10.0.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.1.2.tgz#c20db951ba1c22c055010648dfffd7b2a968e00c"
+  integrity sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -7391,11 +7338,6 @@ jmespath@^0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
-jquery@^3.4.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8130,7 +8072,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1:
+lodash@4.17.15, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8297,15 +8239,15 @@ marked@0.7.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
-marked@0.8.2, marked@^0.8.0:
+marked@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
   integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
-marked@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
-  integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
+marked@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
+  integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -10588,7 +10530,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.2, shelljs@^0.8.3:
+shelljs@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -11689,70 +11631,28 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
-  integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
-
-typedoc-default-themes@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz#c214ce5bbcc6045558448a8fd422b90e3e9b6782"
-  integrity sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==
+typedoc-default-themes@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz#743380a80afe62c5ef92ca1bd4abe2ac596be4d2"
+  integrity sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==
   dependencies:
-    backbone "^1.4.0"
-    jquery "^3.4.1"
     lunr "^2.3.8"
-    underscore "^1.9.1"
 
-typedoc@^0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.14.2.tgz#769f457f4f9e4bdb8b5f3b177c86b6a31d8c3dc3"
-  integrity sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==
+typedoc@^0.17.8:
+  version "0.17.8"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.17.8.tgz#96b67e9454aa7853bfc4dc9a55c8a07adfd5478e"
+  integrity sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==
   dependencies:
-    "@types/fs-extra" "^5.0.3"
-    "@types/handlebars" "^4.0.38"
-    "@types/highlight.js" "^9.12.3"
-    "@types/lodash" "^4.14.110"
-    "@types/marked" "^0.4.0"
-    "@types/minimatch" "3.0.3"
-    "@types/shelljs" "^0.8.0"
-    fs-extra "^7.0.0"
-    handlebars "^4.0.6"
-    highlight.js "^9.13.1"
-    lodash "^4.17.10"
-    marked "^0.4.0"
-    minimatch "^3.0.0"
-    progress "^2.0.0"
-    shelljs "^0.8.2"
-    typedoc-default-themes "^0.5.0"
-    typescript "3.2.x"
-
-typedoc@^0.15.0:
-  version "0.15.8"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.15.8.tgz#d83195445a718d173e0d5c73b5581052cb47d4d9"
-  integrity sha512-a0zypcvfIFsS7Gqpf2MkC1+jNND3K1Om38pbDdy/gYWX01NuJZhC5+O0HkIp0oRIZOo7PWrA5+fC24zkANY28Q==
-  dependencies:
-    "@types/minimatch" "3.0.3"
     fs-extra "^8.1.0"
-    handlebars "^4.7.0"
-    highlight.js "^9.17.1"
+    handlebars "^4.7.6"
+    highlight.js "^10.0.0"
     lodash "^4.17.15"
-    marked "^0.8.0"
+    lunr "^2.3.8"
+    marked "1.0.0"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.3"
-    typedoc-default-themes "^0.6.3"
-    typescript "3.7.x"
-
-typescript@3.2.x:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
-
-typescript@3.7.x:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+    shelljs "^0.8.4"
+    typedoc-default-themes "^0.10.2"
 
 typescript@~3.9.3:
   version "3.9.6"
@@ -11786,11 +11686,6 @@ unbzip2-stream@^1.3.3:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
-
-underscore@>=1.8.3, underscore@^1.9.1:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
-  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
*Issue #, if available:*
Updating as current version of typedoc depends on old version of TypeScript
```console
$ yarn list typescript
yarn list v1.22.4
warning Filtering by arguments is deprecated. Please use the pattern option instead.
├─ @aws-sdk/client-documentation-generator@1.0.0-gamma.3
│  └─ typedoc@0.14.2
│     └─ typescript@3.2.4
├─ @aws-sdk/karma-credential-loader@1.0.0-gamma.3
│  └─ typescript@3.9.6
├─ typedoc@0.15.8
│  └─ typescript@3.7.5
└─ typescript@3.9.6
```

*Description of changes:*
bump typedoc to 0.17.8

<details>
<summary>Zip file of client-s3 docs</summary>

[client-s3-docs.zip](https://github.com/aws/aws-sdk-js-v3/files/4998352/client-s3-docs.zip)

</details>

<details>
<summary>Screenshot</summary>

![CreateBucketRequest](https://user-images.githubusercontent.com/16024985/88872299-b518f000-d1ce-11ea-9409-726b5d3db8f4.png)

</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
