### PR TITLE
chore(deps-dev): add @aws-sdk/client-documentation-generator in clients

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -62,6 +62,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -62,6 +62,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -62,6 +62,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@aws-sdk/client-iam": "1.0.0-gamma.5",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -63,6 +63,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -63,6 +63,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -63,6 +63,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.7.5",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.7.5",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -62,6 +62,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -63,6 +63,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -64,6 +64,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -76,6 +76,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.7.5",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -63,6 +63,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -61,6 +61,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -69,6 +69,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -60,6 +60,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -62,6 +62,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -61,6 +61,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -62,6 +62,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -62,6 +62,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -64,6 +64,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-documentation-generator": "1.0.0-gamma.3",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1412
CodeGen: https://github.com/awslabs/smithy-typescript/pull/195

*Description of changes:*
add @aws-sdk/client-documentation-generator in clients, which is required to be added as a devDependency to generate docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
