### PR TITLE
fix(eventstream-serde-browser): set `module` to dist output

### DIFF
--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
-  "module": "./build/index.js",
+  "module": "./dist/es/index.js",
   "types": "./dist/cjs/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",


### PR DESCRIPTION
*Description of changes:*
The `module` property of `eventstream-serde-browser/package.json` was not set to `./dist/es/index.js`, which is what Typescript (`tsconfig.es.json`) is configured to output the ES bundle to. This pull request updates it.

**Question:** should I version bump the package as well?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
