### PR TITLE
feat: get partition of given region

### DIFF
--- a/clients/client-accessanalyzer/endpoints.ts
+++ b/clients/client-accessanalyzer/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-acm-pca/endpoints.ts
+++ b/clients/client-acm-pca/endpoints.ts
@@ -40,101 +40,121 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "acm-pca.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "acm-pca.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "acm-pca.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "acm-pca.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "acm-pca.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "acm-pca.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "acm-pca.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "acm-pca.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "acm-pca.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "acm-pca.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "acm-pca.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "acm-pca.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "acm-pca.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "acm-pca.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "acm-pca.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "acm-pca.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "acm-pca.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "acm-pca.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "acm-pca.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "acm-pca.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -142,32 +162,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-acm/endpoints.ts
+++ b/clients/client-acm/endpoints.ts
@@ -40,101 +40,121 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "acm.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "acm.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "acm.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "acm.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "acm.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "acm.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "acm.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "acm.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "acm.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "acm.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "acm.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "acm.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "acm.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "acm.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "acm.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "acm.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "acm.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "acm.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "acm.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "acm.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -142,32 +162,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-alexa-for-business/endpoints.ts
+++ b/clients/client-alexa-for-business/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-1":
       regionInfo = {
         hostname: "a4b.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -47,32 +48,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-amplify/endpoints.ts
+++ b/clients/client-amplify/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-api-gateway/endpoints.ts
+++ b/clients/client-api-gateway/endpoints.ts
@@ -40,116 +40,139 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "apigateway.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "apigateway.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "apigateway.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "apigateway.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "apigateway.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "apigateway.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "apigateway.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "apigateway.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "apigateway.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "apigateway.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "apigateway.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "apigateway.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "apigateway.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "apigateway.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "apigateway.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "apigateway.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "apigateway.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "apigateway.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "apigateway.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "apigateway.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "apigateway.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "apigateway.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "apigateway.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -157,32 +180,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-apigatewaymanagementapi/endpoints.ts
+++ b/clients/client-apigatewaymanagementapi/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-apigatewayv2/endpoints.ts
+++ b/clients/client-apigatewayv2/endpoints.ts
@@ -40,116 +40,139 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "apigateway.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "apigateway.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "apigateway.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "apigateway.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "apigateway.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "apigateway.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "apigateway.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "apigateway.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "apigateway.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "apigateway.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "apigateway.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "apigateway.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "apigateway.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "apigateway.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "apigateway.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "apigateway.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "apigateway.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "apigateway.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "apigateway.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "apigateway.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "apigateway.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "apigateway.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "apigateway.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -157,32 +180,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-app-mesh/endpoints.ts
+++ b/clients/client-app-mesh/endpoints.ts
@@ -40,71 +40,85 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "appmesh.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "appmesh.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "appmesh.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "appmesh.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "appmesh.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "appmesh.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "appmesh.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "appmesh.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "appmesh.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "appmesh.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "appmesh.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "appmesh.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "appmesh.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "appmesh.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -112,32 +126,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-appconfig/endpoints.ts
+++ b/clients/client-appconfig/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-application-auto-scaling/endpoints.ts
+++ b/clients/client-application-auto-scaling/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "application-autoscaling.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "application-autoscaling.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "application-autoscaling.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "application-autoscaling.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "application-autoscaling.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "application-autoscaling.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "application-autoscaling.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "application-autoscaling.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "application-autoscaling.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "application-autoscaling.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "application-autoscaling.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "application-autoscaling.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "application-autoscaling.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "application-autoscaling.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "application-autoscaling.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "application-autoscaling.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "application-autoscaling.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "application-autoscaling.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "application-autoscaling.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "application-autoscaling.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "autoscaling.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "autoscaling.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "application-autoscaling.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "application-autoscaling.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-application-discovery-service/endpoints.ts
+++ b/clients/client-application-discovery-service/endpoints.ts
@@ -40,11 +40,13 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "eu-central-1":
       regionInfo = {
         hostname: "discovery.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "discovery.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -52,32 +54,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-application-insights/endpoints.ts
+++ b/clients/client-application-insights/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-appstream/endpoints.ts
+++ b/clients/client-appstream/endpoints.ts
@@ -40,60 +40,70 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "appstream2.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "appstream2.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "appstream2.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "appstream2.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "appstream2.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "appstream2.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
     case "fips":
       regionInfo = {
         hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "appstream2.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "appstream2.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "appstream",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "appstream2.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "appstream",
       };
       break;
@@ -102,27 +112,32 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "appstream",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
           signingService: "appstream",
         };
       }
@@ -130,6 +145,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "appstream",
         };
       }

--- a/clients/client-appsync/endpoints.ts
+++ b/clients/client-appsync/endpoints.ts
@@ -40,56 +40,67 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "appsync.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "appsync.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "appsync.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "appsync.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "appsync.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "appsync.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "appsync.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "appsync.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "appsync.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "appsync.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "appsync.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -97,32 +108,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-athena/endpoints.ts
+++ b/clients/client-athena/endpoints.ts
@@ -40,96 +40,115 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "athena.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "athena.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "athena.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "athena.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "athena.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "athena.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "athena.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "athena.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "athena.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "athena.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "athena.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "athena.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "athena.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "athena.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "athena.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "athena.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "athena.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "athena.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "athena.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -137,32 +156,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-auto-scaling-plans/endpoints.ts
+++ b/clients/client-auto-scaling-plans/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "autoscaling-plans.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "autoscaling-plans.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "autoscaling-plans.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "autoscaling-plans.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "autoscaling-plans.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "autoscaling-plans.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "autoscaling-plans.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "autoscaling-plans.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "autoscaling-plans.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "autoscaling-plans.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "autoscaling-plans.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "autoscaling-plans.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "autoscaling-plans.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-auto-scaling/endpoints.ts
+++ b/clients/client-auto-scaling/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "autoscaling.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "autoscaling.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "autoscaling.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "autoscaling.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "autoscaling.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "autoscaling.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "autoscaling.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "autoscaling.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "autoscaling.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "autoscaling.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "autoscaling.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "autoscaling.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "autoscaling.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "autoscaling.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "autoscaling.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "autoscaling.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "autoscaling.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "autoscaling.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "autoscaling.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "autoscaling.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "autoscaling.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "autoscaling.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "autoscaling.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "autoscaling.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-backup/endpoints.ts
+++ b/clients/client-backup/endpoints.ts
@@ -40,91 +40,109 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "backup.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "backup.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "backup.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "backup.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "backup.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "backup.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "backup.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "backup.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "backup.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "backup.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "backup.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "backup.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "backup.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "backup.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "backup.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "backup.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "backup.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "backup.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -132,32 +150,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-batch/endpoints.ts
+++ b/clients/client-batch/endpoints.ts
@@ -40,101 +40,121 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "batch.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "batch.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "batch.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "batch.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "batch.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "batch.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "batch.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "batch.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "batch.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "batch.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "batch.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "batch.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "batch.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "batch.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "batch.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "batch.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "batch.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "batch.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "batch.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "batch.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -142,32 +162,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-budgets/endpoints.ts
+++ b/clients/client-budgets/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-global":
       regionInfo = {
         hostname: "budgets.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
@@ -51,21 +52,25 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.

--- a/clients/client-chime/endpoints.ts
+++ b/clients/client-chime/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-global":
       regionInfo = {
         hostname: "service.chime.aws.amazon.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
@@ -51,21 +52,25 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.

--- a/clients/client-cloud9/endpoints.ts
+++ b/clients/client-cloud9/endpoints.ts
@@ -40,36 +40,43 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cloud9.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cloud9.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cloud9.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cloud9.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cloud9.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cloud9.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cloud9.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -77,32 +84,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-clouddirectory/endpoints.ts
+++ b/clients/client-clouddirectory/endpoints.ts
@@ -40,51 +40,61 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-southeast-1":
       regionInfo = {
         hostname: "clouddirectory.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "clouddirectory.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "clouddirectory.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "clouddirectory.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "clouddirectory.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "clouddirectory.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "clouddirectory.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "clouddirectory.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "clouddirectory.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "clouddirectory.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -92,32 +102,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudformation/endpoints.ts
+++ b/clients/client-cloudformation/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "cloudformation.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cloudformation.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "cloudformation.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "cloudformation.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cloudformation.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cloudformation.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "cloudformation.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "cloudformation.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "cloudformation.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cloudformation.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "cloudformation.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cloudformation.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "cloudformation.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "cloudformation.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "cloudformation.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "cloudformation.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cloudformation.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cloudformation.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "cloudformation.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "cloudformation.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "cloudformation.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "cloudformation.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "cloudformation.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cloudformation.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudfront/endpoints.ts
+++ b/clients/client-cloudfront/endpoints.ts
@@ -40,12 +40,14 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-cn-global":
       regionInfo = {
         hostname: "cloudfront.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-northwest-1",
       };
       break;
     case "aws-global":
       regionInfo = {
         hostname: "cloudfront.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
@@ -60,16 +62,19 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.

--- a/clients/client-cloudhsm-v2/endpoints.ts
+++ b/clients/client-cloudhsm-v2/endpoints.ts
@@ -40,120 +40,140 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "cloudhsmv2.ap-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cloudhsmv2.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "cloudhsmv2.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "cloudhsmv2.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cloudhsmv2.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cloudhsmv2.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "cloudhsmv2.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cloudhsmv2.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "cloudhsmv2.eu-north-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cloudhsmv2.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "cloudhsmv2.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "cloudhsmv2.eu-west-3.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "cloudhsmv2.me-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "cloudhsmv2.sa-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cloudhsmv2.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cloudhsmv2.us-east-2.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "cloudhsmv2.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "cloudhsm",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "cloudhsmv2.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "cloudhsm",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "cloudhsmv2.us-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cloudhsmv2.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "cloudhsm",
       };
       break;
@@ -162,27 +182,32 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "cloudhsm",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
           signingService: "cloudhsm",
         };
       }
@@ -190,6 +215,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "cloudhsm",
         };
       }

--- a/clients/client-cloudhsm/endpoints.ts
+++ b/clients/client-cloudhsm/endpoints.ts
@@ -40,56 +40,67 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cloudhsm.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cloudhsm.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cloudhsm.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "cloudhsm.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cloudhsm.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cloudhsm.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cloudhsm.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cloudhsm.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "cloudhsm.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "cloudhsm.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cloudhsm.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -97,32 +108,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudsearch-domain/endpoints.ts
+++ b/clients/client-cloudsearch-domain/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudsearch/endpoints.ts
+++ b/clients/client-cloudsearch/endpoints.ts
@@ -40,51 +40,61 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cloudsearch.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "cloudsearch.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cloudsearch.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cloudsearch.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cloudsearch.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cloudsearch.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "cloudsearch.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cloudsearch.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "cloudsearch.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cloudsearch.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -92,32 +102,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudtrail/endpoints.ts
+++ b/clients/client-cloudtrail/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "cloudtrail.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cloudtrail.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "cloudtrail.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "cloudtrail.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cloudtrail.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cloudtrail.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "cloudtrail.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "cloudtrail.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "cloudtrail.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cloudtrail.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "cloudtrail.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cloudtrail.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "cloudtrail.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "cloudtrail.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "cloudtrail.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "cloudtrail.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cloudtrail.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cloudtrail.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "cloudtrail.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "cloudtrail.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "cloudtrail.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cloudtrail.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudwatch-events/endpoints.ts
+++ b/clients/client-cloudwatch-events/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "events.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "events.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "events.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "events.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "events.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "events.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "events.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "events.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "events.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "events.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "events.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "events.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "events.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "events.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "events.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "events.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "events.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "events.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "events.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "events.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "events.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "events.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "events.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "events.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudwatch-logs/endpoints.ts
+++ b/clients/client-cloudwatch-logs/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "logs.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "logs.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "logs.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "logs.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "logs.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "logs.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "logs.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "logs.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "logs.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "logs.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "logs.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "logs.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "logs.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "logs.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "logs.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "logs.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "logs.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "logs.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "logs.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "logs.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "logs.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "logs.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "logs.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "logs.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cloudwatch/endpoints.ts
+++ b/clients/client-cloudwatch/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "monitoring.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "monitoring.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "monitoring.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "monitoring.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "monitoring.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "monitoring.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "monitoring.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "monitoring.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "monitoring.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "monitoring.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "monitoring.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "monitoring.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "monitoring.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "monitoring.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "monitoring.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "monitoring.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "monitoring.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "monitoring.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "monitoring.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "monitoring.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "monitoring.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "monitoring.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "monitoring.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "monitoring.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codebuild/endpoints.ts
+++ b/clients/client-codebuild/endpoints.ts
@@ -40,134 +40,160 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "codebuild.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "codebuild.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "codebuild.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "codebuild.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "codebuild.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "codebuild.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "codebuild.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "codebuild.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "codebuild.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "codebuild.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "codebuild.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "codebuild.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "codebuild.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "codebuild.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "codebuild.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "codebuild.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "codebuild.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "codebuild-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "codebuild.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "codebuild-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "codebuild.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "codebuild.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "codebuild.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "codebuild-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "codebuild.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "codebuild-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -176,32 +202,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codecommit/endpoints.ts
+++ b/clients/client-codecommit/endpoints.ts
@@ -40,102 +40,122 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "codecommit.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "codecommit.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "codecommit.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "codecommit.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "codecommit.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "codecommit.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "codecommit.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "codecommit.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "codecommit.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "codecommit.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "codecommit.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips":
       regionInfo = {
         hostname: "codecommit-fips.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ca-central-1",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "codecommit.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "codecommit.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "codecommit.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "codecommit.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "codecommit.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "codecommit.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "codecommit.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "codecommit.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -143,32 +163,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codedeploy/endpoints.ts
+++ b/clients/client-codedeploy/endpoints.ts
@@ -40,151 +40,180 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "codedeploy.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "codedeploy.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "codedeploy.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "codedeploy.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "codedeploy.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "codedeploy.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "codedeploy.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "codedeploy.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "codedeploy.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "codedeploy.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "codedeploy.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "codedeploy.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "codedeploy.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "codedeploy.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "codedeploy.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "codedeploy.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "codedeploy.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "codedeploy-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "codedeploy.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "codedeploy-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "codedeploy.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-east-1-fips":
       regionInfo = {
         hostname: "codedeploy-fips.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "codedeploy.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1-fips":
       regionInfo = {
         hostname: "codedeploy-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "codedeploy.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "codedeploy.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "codedeploy-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "codedeploy.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "codedeploy-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -193,32 +222,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codeguru-reviewer/endpoints.ts
+++ b/clients/client-codeguru-reviewer/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codeguruprofiler/endpoints.ts
+++ b/clients/client-codeguruprofiler/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codepipeline/endpoints.ts
+++ b/clients/client-codepipeline/endpoints.ts
@@ -40,81 +40,97 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "codepipeline.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "codepipeline.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "codepipeline.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "codepipeline.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "codepipeline.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "codepipeline.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "codepipeline.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "codepipeline.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "codepipeline.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "codepipeline.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "codepipeline.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "codepipeline.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "codepipeline.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "codepipeline.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "codepipeline.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "codepipeline.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -122,32 +138,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codestar-connections/endpoints.ts
+++ b/clients/client-codestar-connections/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codestar-notifications/endpoints.ts
+++ b/clients/client-codestar-notifications/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-codestar/endpoints.ts
+++ b/clients/client-codestar/endpoints.ts
@@ -40,61 +40,73 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "codestar.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "codestar.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "codestar.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "codestar.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "codestar.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "codestar.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "codestar.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "codestar.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "codestar.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "codestar.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "codestar.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "codestar.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -102,32 +114,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cognito-identity-provider/endpoints.ts
+++ b/clients/client-cognito-identity-provider/endpoints.ts
@@ -40,61 +40,73 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cognito-idp.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "cognito-idp.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "cognito-idp.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cognito-idp.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cognito-idp.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "cognito-idp.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cognito-idp.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cognito-idp.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "cognito-idp.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cognito-idp.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cognito-idp.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cognito-idp.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -102,32 +114,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cognito-identity/endpoints.ts
+++ b/clients/client-cognito-identity/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cognito-identity.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "cognito-identity.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "cognito-identity.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cognito-identity.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cognito-identity.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "cognito-identity.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "cognito-identity.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cognito-identity.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cognito-identity.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "cognito-identity.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cognito-identity.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cognito-identity.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cognito-identity.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cognito-sync/endpoints.ts
+++ b/clients/client-cognito-sync/endpoints.ts
@@ -40,56 +40,67 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "cognito-sync.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "cognito-sync.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "cognito-sync.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "cognito-sync.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "cognito-sync.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "cognito-sync.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "cognito-sync.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "cognito-sync.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "cognito-sync.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "cognito-sync.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "cognito-sync.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -97,32 +108,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-comprehend/endpoints.ts
+++ b/clients/client-comprehend/endpoints.ts
@@ -40,51 +40,61 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-southeast-1":
       regionInfo = {
         hostname: "comprehend.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "comprehend.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "comprehend.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "comprehend.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "comprehend.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "comprehend.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "comprehend.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "comprehend.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "comprehend.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "comprehend.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -92,32 +102,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-comprehendmedical/endpoints.ts
+++ b/clients/client-comprehendmedical/endpoints.ts
@@ -40,36 +40,43 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-southeast-2":
       regionInfo = {
         hostname: "comprehendmedical.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "comprehendmedical.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "comprehendmedical.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "comprehendmedical.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "comprehendmedical.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "comprehendmedical.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "comprehendmedical.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -77,32 +84,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-compute-optimizer/endpoints.ts
+++ b/clients/client-compute-optimizer/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-config-service/endpoints.ts
+++ b/clients/client-config-service/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "config.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "config.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "config.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "config.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "config.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "config.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "config.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "config.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "config.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "config.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "config.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "config.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "config.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "config.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "config.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "config.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "config.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "config.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "config.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "config.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "config.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "config.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "config.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "config.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-connect/endpoints.ts
+++ b/clients/client-connect/endpoints.ts
@@ -40,26 +40,31 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "connect.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "connect.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "connect.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "connect.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "connect.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -67,32 +72,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-connectparticipant/endpoints.ts
+++ b/clients/client-connectparticipant/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cost-and-usage-report-service/endpoints.ts
+++ b/clients/client-cost-and-usage-report-service/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-1":
       regionInfo = {
         hostname: "cur.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -47,32 +48,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-cost-explorer/endpoints.ts
+++ b/clients/client-cost-explorer/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-global":
       regionInfo = {
         hostname: "ce.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
@@ -51,21 +52,25 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.

--- a/clients/client-data-pipeline/endpoints.ts
+++ b/clients/client-data-pipeline/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "datapipeline.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "datapipeline.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "datapipeline.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "datapipeline.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "datapipeline.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "datapipeline.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-database-migration-service/endpoints.ts
+++ b/clients/client-database-migration-service/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "dms.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "dms.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "dms.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "dms.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "dms.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "dms.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "dms.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "dms.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "dms.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "dms.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "dms.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "dms.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "dms.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "dms.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "dms.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "dms.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "dms.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "dms.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "dms.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "dms.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "dms.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "dms.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "dms.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-dataexchange/endpoints.ts
+++ b/clients/client-dataexchange/endpoints.ts
@@ -40,56 +40,67 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "dataexchange.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "dataexchange.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "dataexchange.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "dataexchange.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "dataexchange.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "dataexchange.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "dataexchange.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "dataexchange.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "dataexchange.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "dataexchange.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "dataexchange.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -97,32 +108,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-datasync/endpoints.ts
+++ b/clients/client-datasync/endpoints.ts
@@ -40,131 +40,156 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "datasync.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "datasync.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "datasync.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "datasync.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "datasync.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "datasync.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "datasync.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "datasync.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "datasync.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "datasync.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "datasync.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "datasync.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips-us-east-1":
       regionInfo = {
         hostname: "datasync-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "fips-us-east-2":
       regionInfo = {
         hostname: "datasync-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "fips-us-gov-west-1":
       regionInfo = {
         hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "fips-us-west-1":
       regionInfo = {
         hostname: "datasync-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "fips-us-west-2":
       regionInfo = {
         hostname: "datasync-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "datasync.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "datasync.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "datasync.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "datasync.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "datasync.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "datasync.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "datasync.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "datasync.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -172,32 +197,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-dax/endpoints.ts
+++ b/clients/client-dax/endpoints.ts
@@ -40,71 +40,85 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "dax.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "dax.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "dax.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "dax.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "dax.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "dax.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "dax.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "dax.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "dax.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "dax.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "dax.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "dax.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "dax.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "dax.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -112,32 +126,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-detective/endpoints.ts
+++ b/clients/client-detective/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-device-farm/endpoints.ts
+++ b/clients/client-device-farm/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-west-2":
       regionInfo = {
         hostname: "devicefarm.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -47,32 +48,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-direct-connect/endpoints.ts
+++ b/clients/client-direct-connect/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "directconnect.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "directconnect.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "directconnect.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "directconnect.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "directconnect.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "directconnect.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "directconnect.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "directconnect.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "directconnect.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "directconnect.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "directconnect.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "directconnect.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "directconnect.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "directconnect.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "directconnect.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "directconnect.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "directconnect.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "directconnect.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "directconnect.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "directconnect.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "directconnect.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "directconnect.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "directconnect.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "directconnect.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-directory-service/endpoints.ts
+++ b/clients/client-directory-service/endpoints.ts
@@ -40,106 +40,127 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "ds.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "ds.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "ds.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "ds.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "ds.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "ds.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "ds.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "ds.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "ds.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "ds.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "ds.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "ds.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "ds.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "ds.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "ds.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "ds.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "ds.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "ds.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "ds.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "ds.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "ds.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -147,32 +168,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-dlm/endpoints.ts
+++ b/clients/client-dlm/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-docdb/endpoints.ts
+++ b/clients/client-docdb/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "rds.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "rds.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "rds.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "rds.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "rds.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "rds.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "rds.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "rds.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "rds.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "rds.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "rds.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "rds.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "rds.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "rds.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "rds.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "rds.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "rds.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "rds.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "rds.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "rds.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "rds.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "rds.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "rds.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "rds.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-dynamodb-streams/endpoints.ts
+++ b/clients/client-dynamodb-streams/endpoints.ts
@@ -40,186 +40,217 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "streams.dynamodb.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "streams.dynamodb.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "streams.dynamodb.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "streams.dynamodb.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "streams.dynamodb.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "streams.dynamodb.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "ca-central-1-fips":
       regionInfo = {
         hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ca-central-1",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "streams.dynamodb.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingService: "dynamodb",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "streams.dynamodb.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingService: "dynamodb",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "streams.dynamodb.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "streams.dynamodb.eu-north-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "streams.dynamodb.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "streams.dynamodb.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "streams.dynamodb.eu-west-3.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "local":
       regionInfo = {
         hostname: "localhost:8000",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "streams.dynamodb.me-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "streams.dynamodb.sa-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "streams.dynamodb.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "streams.dynamodb.us-east-2.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "streams.dynamodb.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "dynamodb",
       };
       break;
     case "us-gov-east-1-fips":
       regionInfo = {
         hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "streams.dynamodb.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "dynamodb",
       };
       break;
     case "us-gov-west-1-fips":
       regionInfo = {
         hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "streams.dynamodb.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
         signingService: "dynamodb",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "streams.dynamodb.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
         signingService: "dynamodb",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "streams.dynamodb.us-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "streams.dynamodb.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "dynamodb",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -228,30 +259,35 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "dynamodb",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
           signingService: "dynamodb",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
           signingService: "dynamodb",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
           signingService: "dynamodb",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
           signingService: "dynamodb",
         };
       }
@@ -259,6 +295,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "dynamodb",
         };
       }

--- a/clients/client-dynamodb/endpoints.ts
+++ b/clients/client-dynamodb/endpoints.ts
@@ -40,168 +40,200 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "dynamodb.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "dynamodb.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "dynamodb.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "dynamodb.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "dynamodb.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "dynamodb.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "dynamodb.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1-fips":
       regionInfo = {
         hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ca-central-1",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "dynamodb.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "dynamodb.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "dynamodb.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "dynamodb.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "dynamodb.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "dynamodb.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "dynamodb.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "local":
       regionInfo = {
         hostname: "localhost:8000",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "dynamodb.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "dynamodb.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "dynamodb.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "dynamodb.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-east-1-fips":
       regionInfo = {
         hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1-fips":
       regionInfo = {
         hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "dynamodb.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "dynamodb.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "dynamodb.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "dynamodb.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -210,32 +242,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ebs/endpoints.ts
+++ b/clients/client-ebs/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ec2-instance-connect/endpoints.ts
+++ b/clients/client-ec2-instance-connect/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ec2/endpoints.ts
+++ b/clients/client-ec2/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "ec2.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "ec2.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "ec2.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "ec2.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "ec2.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "ec2.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "ec2.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "ec2.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "ec2.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "ec2.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "ec2.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "ec2.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "ec2.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "ec2.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "ec2.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "ec2.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "ec2.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "ec2.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "ec2.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "ec2.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "ec2.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "ec2.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "ec2.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "ec2.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ecr/endpoints.ts
+++ b/clients/client-ecr/endpoints.ts
@@ -40,138 +40,161 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "api.ecr.ap-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-east-1",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "api.ecr.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-northeast-1",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "api.ecr.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-northeast-2",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "api.ecr.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-south-1",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "api.ecr.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-1",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "api.ecr.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-2",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "api.ecr.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ca-central-1",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "api.ecr.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-north-1",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "api.ecr.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-northwest-1",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "api.ecr.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-central-1",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "api.ecr.eu-north-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-north-1",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "api.ecr.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-1",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "api.ecr.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-2",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "api.ecr.eu-west-3.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-3",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "api.ecr.me-south-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "me-south-1",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "api.ecr.sa-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "sa-east-1",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "api.ecr.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "api.ecr.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "api.ecr.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "api.ecr.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "api.ecr.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
         signingRegion: "us-iso-east-1",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "api.ecr.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "api.ecr.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -180,32 +203,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ecs/endpoints.ts
+++ b/clients/client-ecs/endpoints.ts
@@ -40,116 +40,139 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "ecs.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "ecs.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "ecs.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "ecs.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "ecs.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "ecs.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "ecs.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "ecs.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "ecs.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "ecs.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "ecs.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "ecs.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "ecs.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "ecs.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "ecs.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "ecs.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "ecs.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "ecs.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "ecs.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "ecs.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "ecs.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "ecs.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "ecs.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -157,32 +180,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-efs/endpoints.ts
+++ b/clients/client-efs/endpoints.ts
@@ -40,96 +40,115 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "elasticfilesystem.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "elasticfilesystem.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "elasticfilesystem.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "elasticfilesystem.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "elasticfilesystem.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "elasticfilesystem.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "elasticfilesystem.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "elasticfilesystem.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "elasticfilesystem.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "elasticfilesystem.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "elasticfilesystem.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "elasticfilesystem.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "elasticfilesystem.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "elasticfilesystem.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "elasticfilesystem.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "elasticfilesystem.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "elasticfilesystem.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "elasticfilesystem.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "elasticfilesystem.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -137,32 +156,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-eks/endpoints.ts
+++ b/clients/client-eks/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-elastic-beanstalk/endpoints.ts
+++ b/clients/client-elastic-beanstalk/endpoints.ts
@@ -40,111 +40,133 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "elasticbeanstalk.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "elasticbeanstalk.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "elasticbeanstalk.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "elasticbeanstalk.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "elasticbeanstalk.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "elasticbeanstalk.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "elasticbeanstalk.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "elasticbeanstalk.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "elasticbeanstalk.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "elasticbeanstalk.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "elasticbeanstalk.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "elasticbeanstalk.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "elasticbeanstalk.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "elasticbeanstalk.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "elasticbeanstalk.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "elasticbeanstalk.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "elasticbeanstalk.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "elasticbeanstalk.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "elasticbeanstalk.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "elasticbeanstalk.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "elasticbeanstalk.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "elasticbeanstalk.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -152,32 +174,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-elastic-inference/endpoints.ts
+++ b/clients/client-elastic-inference/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-elastic-load-balancing-v2/endpoints.ts
+++ b/clients/client-elastic-load-balancing-v2/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "elasticloadbalancing.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "elasticloadbalancing.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "elasticloadbalancing.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-elastic-load-balancing/endpoints.ts
+++ b/clients/client-elastic-load-balancing/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "elasticloadbalancing.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "elasticloadbalancing.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "elasticloadbalancing.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "elasticloadbalancing.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "elasticloadbalancing.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "elasticloadbalancing.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-elastic-transcoder/endpoints.ts
+++ b/clients/client-elastic-transcoder/endpoints.ts
@@ -40,41 +40,49 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "elastictranscoder.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "elastictranscoder.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "elastictranscoder.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "elastictranscoder.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "elastictranscoder.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "elastictranscoder.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "elastictranscoder.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "elastictranscoder.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -82,32 +90,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-elasticache/endpoints.ts
+++ b/clients/client-elasticache/endpoints.ts
@@ -40,127 +40,152 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "elasticache.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "elasticache.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "elasticache.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "elasticache.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "elasticache.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "elasticache.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "elasticache.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "elasticache.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "elasticache.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "elasticache.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "elasticache.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "elasticache.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "elasticache.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "elasticache.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips":
       regionInfo = {
         hostname: "elasticache-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "elasticache.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "elasticache.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "elasticache.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "elasticache.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "elasticache.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "elasticache.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "elasticache.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "elasticache.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "elasticache.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "elasticache.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -168,32 +193,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-elasticsearch-service/endpoints.ts
+++ b/clients/client-elasticsearch-service/endpoints.ts
@@ -40,117 +40,140 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "es.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "es.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "es.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "es.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "es.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "es.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "es.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "es.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "es.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "es.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "es.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "es.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "es.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "es.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips":
       regionInfo = {
         hostname: "es-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "es.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "es.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "es.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "es.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "es.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "es.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "es.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "es.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -158,32 +181,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-emr/endpoints.ts
+++ b/clients/client-emr/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "elasticmapreduce.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "elasticmapreduce.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "elasticmapreduce.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "elasticmapreduce.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "elasticmapreduce.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "elasticmapreduce.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "elasticmapreduce.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "elasticmapreduce.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "elasticmapreduce.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "elasticmapreduce.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "elasticmapreduce.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "elasticmapreduce.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "elasticmapreduce.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "elasticmapreduce.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "elasticmapreduce.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "elasticmapreduce.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "elasticmapreduce.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "elasticmapreduce.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "elasticmapreduce.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "elasticmapreduce.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "elasticmapreduce.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "elasticmapreduce.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-eventbridge/endpoints.ts
+++ b/clients/client-eventbridge/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "events.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "events.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "events.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "events.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "events.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "events.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "events.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "events.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "events.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "events.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "events.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "events.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "events.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "events.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "events.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "events.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "events.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "events.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "events.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "events.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "events.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "events.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "events.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "events.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-firehose/endpoints.ts
+++ b/clients/client-firehose/endpoints.ts
@@ -40,111 +40,133 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "firehose.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "firehose.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "firehose.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "firehose.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "firehose.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "firehose.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "firehose.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "firehose.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "firehose.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "firehose.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "firehose.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "firehose.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "firehose.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "firehose.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "firehose.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "firehose.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "firehose.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "firehose.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "firehose.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "firehose.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "firehose.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "firehose.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -152,32 +174,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-fms/endpoints.ts
+++ b/clients/client-fms/endpoints.ts
@@ -40,81 +40,97 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "fms.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "fms.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "fms.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "fms.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "fms.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "fms.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "fms.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "fms.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "fms.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "fms.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "fms.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "fms.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "fms.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "fms.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "fms.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "fms.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -122,32 +138,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-forecast/endpoints.ts
+++ b/clients/client-forecast/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "forecast.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "forecast.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "forecast.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "forecast.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "forecast.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "forecast.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-forecastquery/endpoints.ts
+++ b/clients/client-forecastquery/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "forecastquery.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "forecastquery.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "forecastquery.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "forecastquery.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "forecastquery.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "forecastquery.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-frauddetector/endpoints.ts
+++ b/clients/client-frauddetector/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-fsx/endpoints.ts
+++ b/clients/client-fsx/endpoints.ts
@@ -40,56 +40,67 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "fsx.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "fsx.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "fsx.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "fsx.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "fsx.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "fsx.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "fsx.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "fsx.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "fsx.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "fsx.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "fsx.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -97,32 +108,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-gamelift/endpoints.ts
+++ b/clients/client-gamelift/endpoints.ts
@@ -40,76 +40,91 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "gamelift.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "gamelift.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "gamelift.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "gamelift.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "gamelift.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "gamelift.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "gamelift.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "gamelift.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "gamelift.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "gamelift.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "gamelift.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "gamelift.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "gamelift.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "gamelift.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "gamelift.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -117,32 +132,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-glacier/endpoints.ts
+++ b/clients/client-glacier/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "glacier.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "glacier.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "glacier.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "glacier.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "glacier.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "glacier.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "glacier.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "glacier.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "glacier.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "glacier.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "glacier.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "glacier.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "glacier.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "glacier.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "glacier.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "glacier.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "glacier.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "glacier.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "glacier.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "glacier.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "glacier.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "glacier.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "glacier.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "glacier.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-global-accelerator/endpoints.ts
+++ b/clients/client-global-accelerator/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-glue/endpoints.ts
+++ b/clients/client-glue/endpoints.ts
@@ -40,106 +40,127 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "glue.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "glue.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "glue.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "glue.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "glue.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "glue.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "glue.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "glue.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "glue.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "glue.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "glue.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "glue.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "glue.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "glue.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "glue.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "glue.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "glue.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "glue.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "glue.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "glue.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "glue.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -147,32 +168,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-greengrass/endpoints.ts
+++ b/clients/client-greengrass/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "greengrass.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "greengrass.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "greengrass.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "greengrass.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "greengrass.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "greengrass.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "greengrass.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "greengrass.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "greengrass.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "greengrass.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "greengrass.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "greengrass.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "greengrass.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-groundstation/endpoints.ts
+++ b/clients/client-groundstation/endpoints.ts
@@ -40,11 +40,13 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-2":
       regionInfo = {
         hostname: "groundstation.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "groundstation.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -52,32 +54,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-guardduty/endpoints.ts
+++ b/clients/client-guardduty/endpoints.ts
@@ -40,119 +40,142 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "guardduty.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "guardduty.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "guardduty.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "guardduty.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "guardduty.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "guardduty.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "guardduty.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "guardduty.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "guardduty.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "guardduty.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "guardduty.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "guardduty.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "guardduty.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "guardduty.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "guardduty.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "guardduty-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "guardduty.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "guardduty-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "guardduty.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "guardduty.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "guardduty-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "guardduty.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "guardduty-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -161,32 +184,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-health/endpoints.ts
+++ b/clients/client-health/endpoints.ts
@@ -40,21 +40,25 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-1":
       regionInfo = {
         hostname: "health.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "health.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "health.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "health.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     // Next, try to match partition endpoints.
@@ -62,32 +66,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iam/endpoints.ts
+++ b/clients/client-iam/endpoints.ts
@@ -40,30 +40,35 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-cn-global":
       regionInfo = {
         hostname: "iam.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-north-1",
       };
       break;
     case "aws-global":
       regionInfo = {
         hostname: "iam.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "aws-iso-b-global":
       regionInfo = {
         hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
         signingRegion: "us-isob-east-1",
       };
       break;
     case "aws-iso-global":
       regionInfo = {
         hostname: "iam.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
         signingRegion: "us-iso-east-1",
       };
       break;
     case "aws-us-gov-global":
       regionInfo = {
         hostname: "iam.us-gov.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;

--- a/clients/client-imagebuilder/endpoints.ts
+++ b/clients/client-imagebuilder/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-inspector/endpoints.ts
+++ b/clients/client-inspector/endpoints.ts
@@ -40,71 +40,85 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "inspector.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "inspector.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "inspector.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "inspector.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "inspector.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "inspector.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "inspector.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "inspector.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "inspector.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "inspector.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "inspector.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "inspector.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "inspector.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "inspector.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -112,32 +126,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iot-1click-devices-service/endpoints.ts
+++ b/clients/client-iot-1click-devices-service/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iot-1click-projects/endpoints.ts
+++ b/clients/client-iot-1click-projects/endpoints.ts
@@ -40,36 +40,43 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "projects.iot1click.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "projects.iot1click.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "projects.iot1click.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "projects.iot1click.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "projects.iot1click.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "projects.iot1click.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "projects.iot1click.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -77,32 +84,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iot-data-plane/endpoints.ts
+++ b/clients/client-iot-data-plane/endpoints.ts
@@ -40,126 +40,147 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "data.iot.ap-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "data.iot.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "data.iot.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "data.iot.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "data.iot.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "data.iot.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "data.iot.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "data.iot.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingService: "iotdata",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "data.iot.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingService: "iotdata",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "data.iot.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "data.iot.eu-north-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "data.iot.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "data.iot.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "data.iot.eu-west-3.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "data.iot.me-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "data.iot.sa-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "data.iot.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "data.iot.us-east-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "data.iot.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "iotdata",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "data.iot.us-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "data.iot.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotdata",
       };
       break;
@@ -168,28 +189,33 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "iotdata",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
           signingService: "iotdata",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
           signingService: "iotdata",
         };
       }
@@ -197,6 +223,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "iotdata",
         };
       }

--- a/clients/client-iot-events-data/endpoints.ts
+++ b/clients/client-iot-events-data/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iot-events/endpoints.ts
+++ b/clients/client-iot-events/endpoints.ts
@@ -40,51 +40,61 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "iotevents.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "iotevents.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "iotevents.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "iotevents.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "iotevents.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "iotevents.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "iotevents.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "iotevents.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "iotevents.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "iotevents.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -92,32 +102,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iot-jobs-data-plane/endpoints.ts
+++ b/clients/client-iot-jobs-data-plane/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iot/endpoints.ts
+++ b/clients/client-iot/endpoints.ts
@@ -40,126 +40,147 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "iot.ap-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "iot.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "iot.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "iot.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "iot.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "iot.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "iot.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "iot.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingService: "execute-api",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "iot.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingService: "execute-api",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "iot.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "iot.eu-north-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "iot.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "iot.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "iot.eu-west-3.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "iot.me-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "iot.sa-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "iot.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "iot.us-east-2.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "iot.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "execute-api",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "iot.us-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "iot.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "execute-api",
       };
       break;
@@ -168,28 +189,33 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "execute-api",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
           signingService: "execute-api",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
           signingService: "execute-api",
         };
       }
@@ -197,6 +223,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "execute-api",
         };
       }

--- a/clients/client-iotanalytics/endpoints.ts
+++ b/clients/client-iotanalytics/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "iotanalytics.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "iotanalytics.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "iotanalytics.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "iotanalytics.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "iotanalytics.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "iotanalytics.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iotsecuretunneling/endpoints.ts
+++ b/clients/client-iotsecuretunneling/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-iotthingsgraph/endpoints.ts
+++ b/clients/client-iotthingsgraph/endpoints.ts
@@ -40,36 +40,42 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "iotthingsgraph.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotthingsgraph",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "iotthingsgraph.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotthingsgraph",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "iotthingsgraph.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotthingsgraph",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "iotthingsgraph.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotthingsgraph",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "iotthingsgraph.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "iotthingsgraph",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "iotthingsgraph.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "iotthingsgraph",
       };
       break;
@@ -78,33 +84,39 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "iotthingsgraph",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "iotthingsgraph",
         };
       }

--- a/clients/client-kafka/endpoints.ts
+++ b/clients/client-kafka/endpoints.ts
@@ -40,86 +40,103 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "kafka.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kafka.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "kafka.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "kafka.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "kafka.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kafka.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "kafka.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kafka.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "kafka.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kafka.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "kafka.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "kafka.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "kafka.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kafka.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "kafka.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "kafka.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kafka.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -127,32 +144,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kendra/endpoints.ts
+++ b/clients/client-kendra/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kinesis-analytics-v2/endpoints.ts
+++ b/clients/client-kinesis-analytics-v2/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kinesisanalytics.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "kinesisanalytics.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "kinesisanalytics.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "kinesisanalytics.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kinesisanalytics.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kinesisanalytics.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "kinesisanalytics.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kinesisanalytics.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "kinesisanalytics.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "kinesisanalytics.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kinesisanalytics.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "kinesisanalytics.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kinesisanalytics.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kinesis-analytics/endpoints.ts
+++ b/clients/client-kinesis-analytics/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kinesisanalytics.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "kinesisanalytics.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "kinesisanalytics.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "kinesisanalytics.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kinesisanalytics.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kinesisanalytics.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "kinesisanalytics.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kinesisanalytics.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "kinesisanalytics.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "kinesisanalytics.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kinesisanalytics.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "kinesisanalytics.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kinesisanalytics.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kinesis-video-archived-media/endpoints.ts
+++ b/clients/client-kinesis-video-archived-media/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kinesisvideo.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kinesisvideo.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kinesisvideo.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kinesisvideo.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kinesis-video-media/endpoints.ts
+++ b/clients/client-kinesis-video-media/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kinesisvideo.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kinesisvideo.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kinesisvideo.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kinesisvideo.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kinesis-video-signaling/endpoints.ts
+++ b/clients/client-kinesis-video-signaling/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kinesisvideo.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kinesisvideo.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kinesisvideo.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kinesisvideo.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kinesis-video/endpoints.ts
+++ b/clients/client-kinesis-video/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kinesisvideo.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kinesisvideo.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kinesisvideo.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kinesisvideo.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kinesisvideo.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kinesis/endpoints.ts
+++ b/clients/client-kinesis/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "kinesis.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kinesis.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "kinesis.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "kinesis.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "kinesis.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kinesis.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "kinesis.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "kinesis.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "kinesis.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kinesis.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "kinesis.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kinesis.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "kinesis.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "kinesis.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "kinesis.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "kinesis.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kinesis.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "kinesis.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "kinesis.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "kinesis.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "kinesis.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "kinesis.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "kinesis.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kinesis.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-kms/endpoints.ts
+++ b/clients/client-kms/endpoints.ts
@@ -40,127 +40,152 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ProdFips":
       regionInfo = {
         hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "ap-east-1":
       regionInfo = {
         hostname: "kms.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "kms.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "kms.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "kms.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "kms.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "kms.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "kms.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "kms.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "kms.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "kms.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "kms.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "kms.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "kms.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "kms.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "kms.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "kms.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "kms.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "kms.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "kms.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "kms.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "kms.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "kms.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "kms.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "kms.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -168,32 +193,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-lakeformation/endpoints.ts
+++ b/clients/client-lakeformation/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "lakeformation.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "lakeformation.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "lakeformation.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "lakeformation.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "lakeformation.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "lakeformation.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "lakeformation.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "lakeformation.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "lakeformation.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "lakeformation.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "lakeformation.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "lakeformation.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "lakeformation.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-lambda/endpoints.ts
+++ b/clients/client-lambda/endpoints.ts
@@ -40,116 +40,139 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "lambda.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "lambda.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "lambda.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "lambda.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "lambda.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "lambda.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "lambda.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "lambda.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "lambda.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "lambda.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "lambda.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "lambda.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "lambda.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "lambda.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "lambda.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "lambda.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "lambda.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "lambda.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "lambda.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "lambda.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "lambda.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "lambda.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "lambda.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -157,32 +180,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-lex-model-building-service/endpoints.ts
+++ b/clients/client-lex-model-building-service/endpoints.ts
@@ -40,18 +40,21 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "eu-west-1":
       regionInfo = {
         hostname: "models.lex.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "lex",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "models.lex.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "lex",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "models.lex.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "lex",
       };
       break;
@@ -60,33 +63,39 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "lex",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "lex",
         };
       }

--- a/clients/client-lex-runtime-service/endpoints.ts
+++ b/clients/client-lex-runtime-service/endpoints.ts
@@ -40,18 +40,21 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "eu-west-1":
       regionInfo = {
         hostname: "runtime.lex.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "lex",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "runtime.lex.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "lex",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "runtime.lex.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "lex",
       };
       break;
@@ -60,33 +63,39 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "lex",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "lex",
         };
       }

--- a/clients/client-license-manager/endpoints.ts
+++ b/clients/client-license-manager/endpoints.ts
@@ -40,111 +40,133 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "license-manager.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "license-manager.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "license-manager.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "license-manager.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "license-manager.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "license-manager.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "license-manager.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "license-manager.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "license-manager.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "license-manager.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "license-manager.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "license-manager.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "license-manager.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "license-manager.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "license-manager.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "license-manager.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "license-manager.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "license-manager.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "license-manager.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "license-manager.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "license-manager.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "license-manager.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -152,32 +174,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-lightsail/endpoints.ts
+++ b/clients/client-lightsail/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "lightsail.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "lightsail.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "lightsail.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "lightsail.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "lightsail.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "lightsail.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "lightsail.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "lightsail.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "lightsail.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "lightsail.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "lightsail.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "lightsail.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "lightsail.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-machine-learning/endpoints.ts
+++ b/clients/client-machine-learning/endpoints.ts
@@ -40,11 +40,13 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "eu-west-1":
       regionInfo = {
         hostname: "machinelearning.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "machinelearning.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -52,32 +54,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-macie/endpoints.ts
+++ b/clients/client-macie/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-managedblockchain/endpoints.ts
+++ b/clients/client-managedblockchain/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-marketplace-catalog/endpoints.ts
+++ b/clients/client-marketplace-catalog/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-marketplace-commerce-analytics/endpoints.ts
+++ b/clients/client-marketplace-commerce-analytics/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-1":
       regionInfo = {
         hostname: "marketplacecommerceanalytics.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -47,32 +48,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-marketplace-entitlement-service/endpoints.ts
+++ b/clients/client-marketplace-entitlement-service/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-1":
       regionInfo = {
         hostname: "entitlement.marketplace.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
@@ -48,33 +49,39 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "aws-marketplace",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "aws-marketplace",
         };
       }

--- a/clients/client-marketplace-metering/endpoints.ts
+++ b/clients/client-marketplace-metering/endpoints.ts
@@ -40,120 +40,140 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "metering.marketplace.ap-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "metering.marketplace.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "metering.marketplace.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "metering.marketplace.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "metering.marketplace.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "metering.marketplace.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "metering.marketplace.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "metering.marketplace.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "metering.marketplace.eu-north-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "metering.marketplace.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "metering.marketplace.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "metering.marketplace.eu-west-3.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "metering.marketplace.me-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "metering.marketplace.sa-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "metering.marketplace.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "metering.marketplace.us-east-2.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "metering.marketplace.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "aws-marketplace",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "metering.marketplace.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingService: "aws-marketplace",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "metering.marketplace.us-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "metering.marketplace.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "aws-marketplace",
       };
       break;
@@ -162,27 +182,32 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "aws-marketplace",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
           signingService: "aws-marketplace",
         };
       }
@@ -190,6 +215,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "aws-marketplace",
         };
       }

--- a/clients/client-mediaconnect/endpoints.ts
+++ b/clients/client-mediaconnect/endpoints.ts
@@ -40,76 +40,91 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "mediaconnect.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "mediaconnect.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "mediaconnect.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "mediaconnect.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "mediaconnect.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "mediaconnect.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "mediaconnect.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "mediaconnect.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "mediaconnect.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "mediaconnect.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "mediaconnect.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "mediaconnect.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "mediaconnect.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "mediaconnect.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "mediaconnect.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -117,32 +132,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mediaconvert/endpoints.ts
+++ b/clients/client-mediaconvert/endpoints.ts
@@ -40,87 +40,104 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "mediaconvert.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "mediaconvert.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "mediaconvert.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "mediaconvert.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "mediaconvert.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "mediaconvert.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "subscribe.mediaconvert.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-northwest-1",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "mediaconvert.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "mediaconvert.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "mediaconvert.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "mediaconvert.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "mediaconvert.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "mediaconvert.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "mediaconvert.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "mediaconvert.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "mediaconvert.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "mediaconvert.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -128,32 +145,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-medialive/endpoints.ts
+++ b/clients/client-medialive/endpoints.ts
@@ -40,71 +40,85 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "medialive.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "medialive.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "medialive.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "medialive.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "medialive.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "medialive.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "medialive.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "medialive.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "medialive.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "medialive.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "medialive.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "medialive.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "medialive.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "medialive.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -112,32 +126,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mediapackage-vod/endpoints.ts
+++ b/clients/client-mediapackage-vod/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mediapackage/endpoints.ts
+++ b/clients/client-mediapackage/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "mediapackage.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "mediapackage.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "mediapackage.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "mediapackage.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "mediapackage.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "mediapackage.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "mediapackage.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "mediapackage.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "mediapackage.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "mediapackage.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "mediapackage.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "mediapackage.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "mediapackage.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mediastore-data/endpoints.ts
+++ b/clients/client-mediastore-data/endpoints.ts
@@ -40,41 +40,49 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "data.mediastore.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "data.mediastore.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "data.mediastore.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "data.mediastore.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "data.mediastore.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "data.mediastore.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "data.mediastore.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "data.mediastore.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -82,32 +90,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mediastore/endpoints.ts
+++ b/clients/client-mediastore/endpoints.ts
@@ -40,41 +40,49 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "mediastore.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "mediastore.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "mediastore.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "mediastore.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "mediastore.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "mediastore.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "mediastore.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "mediastore.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -82,32 +90,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mediatailor/endpoints.ts
+++ b/clients/client-mediatailor/endpoints.ts
@@ -40,36 +40,43 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "api.mediatailor.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "api.mediatailor.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "api.mediatailor.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "api.mediatailor.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "api.mediatailor.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "api.mediatailor.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "api.mediatailor.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -77,32 +84,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-migration-hub/endpoints.ts
+++ b/clients/client-migration-hub/endpoints.ts
@@ -40,11 +40,13 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "eu-central-1":
       regionInfo = {
         hostname: "mgh.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "mgh.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -52,32 +54,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-migrationhub-config/endpoints.ts
+++ b/clients/client-migrationhub-config/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mobile/endpoints.ts
+++ b/clients/client-mobile/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mq/endpoints.ts
+++ b/clients/client-mq/endpoints.ts
@@ -40,95 +40,113 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "mq.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "mq.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "mq.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "mq.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "mq.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "mq.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "mq.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "mq.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "mq.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "mq.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips-us-east-1":
       regionInfo = {
         hostname: "mq-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "fips-us-east-2":
       regionInfo = {
         hostname: "mq-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "fips-us-west-1":
       regionInfo = {
         hostname: "mq-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "fips-us-west-2":
       regionInfo = {
         hostname: "mq-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "mq.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "mq.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "mq.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "mq.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -136,32 +154,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-mturk/endpoints.ts
+++ b/clients/client-mturk/endpoints.ts
@@ -40,11 +40,13 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "sandbox":
       regionInfo = {
         hostname: "mturk-requester-sandbox.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "mturk-requester.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -52,32 +54,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-neptune/endpoints.ts
+++ b/clients/client-neptune/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "rds.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "rds.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "rds.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "rds.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "rds.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "rds.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "rds.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "rds.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "rds.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "rds.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "rds.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "rds.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "rds.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "rds.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "rds.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "rds.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "rds.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "rds.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "rds.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "rds.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "rds.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "rds.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "rds.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "rds.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-networkmanager/endpoints.ts
+++ b/clients/client-networkmanager/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-opsworks/endpoints.ts
+++ b/clients/client-opsworks/endpoints.ts
@@ -40,76 +40,91 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "opsworks.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "opsworks.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "opsworks.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "opsworks.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "opsworks.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "opsworks.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "opsworks.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "opsworks.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "opsworks.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "opsworks.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "opsworks.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "opsworks.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "opsworks.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "opsworks.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "opsworks.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -117,32 +132,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-opsworkscm/endpoints.ts
+++ b/clients/client-opsworkscm/endpoints.ts
@@ -40,46 +40,55 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "opsworks-cm.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "opsworks-cm.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "opsworks-cm.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "opsworks-cm.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "opsworks-cm.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "opsworks-cm.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "opsworks-cm.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "opsworks-cm.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "opsworks-cm.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -87,32 +96,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-organizations/endpoints.ts
+++ b/clients/client-organizations/endpoints.ts
@@ -40,12 +40,14 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-global":
       regionInfo = {
         hostname: "organizations.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "aws-us-gov-global":
       regionInfo = {
         hostname: "organizations.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
@@ -57,16 +59,19 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {

--- a/clients/client-outposts/endpoints.ts
+++ b/clients/client-outposts/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-personalize-events/endpoints.ts
+++ b/clients/client-personalize-events/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-personalize-runtime/endpoints.ts
+++ b/clients/client-personalize-runtime/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-personalize/endpoints.ts
+++ b/clients/client-personalize/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-pi/endpoints.ts
+++ b/clients/client-pi/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-pinpoint-email/endpoints.ts
+++ b/clients/client-pinpoint-email/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-south-1":
       regionInfo = {
         hostname: "email.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "email.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "email.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "email.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "email.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "email.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-pinpoint-sms-voice/endpoints.ts
+++ b/clients/client-pinpoint-sms-voice/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-pinpoint/endpoints.ts
+++ b/clients/client-pinpoint/endpoints.ts
@@ -40,36 +40,42 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-south-1":
       regionInfo = {
         hostname: "pinpoint.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "mobiletargeting",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "pinpoint.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingService: "mobiletargeting",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "pinpoint.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingService: "mobiletargeting",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "pinpoint.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingService: "mobiletargeting",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "pinpoint.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "mobiletargeting",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "pinpoint.us-west-2.amazonaws.com",
+        partition: "aws",
         signingService: "mobiletargeting",
       };
       break;
@@ -78,33 +84,39 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "mobiletargeting",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "mobiletargeting",
         };
       }

--- a/clients/client-polly/endpoints.ts
+++ b/clients/client-polly/endpoints.ts
@@ -40,91 +40,109 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "polly.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "polly.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "polly.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "polly.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "polly.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "polly.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "polly.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "polly.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "polly.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "polly.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "polly.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "polly.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "polly.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "polly.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "polly.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "polly.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "polly.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "polly.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -132,32 +150,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-pricing/endpoints.ts
+++ b/clients/client-pricing/endpoints.ts
@@ -40,12 +40,14 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-south-1":
       regionInfo = {
         hostname: "api.pricing.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingService: "pricing",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "api.pricing.us-east-1.amazonaws.com",
+        partition: "aws",
         signingService: "pricing",
       };
       break;
@@ -54,33 +56,39 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "pricing",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
           signingService: "pricing",
         };
       }

--- a/clients/client-qldb-session/endpoints.ts
+++ b/clients/client-qldb-session/endpoints.ts
@@ -40,46 +40,55 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "session.qldb.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "session.qldb.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "session.qldb.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "session.qldb.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "session.qldb.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "session.qldb.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "session.qldb.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "session.qldb.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "session.qldb.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -87,32 +96,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-qldb/endpoints.ts
+++ b/clients/client-qldb/endpoints.ts
@@ -40,46 +40,55 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "qldb.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "qldb.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "qldb.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "qldb.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "qldb.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "qldb.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "qldb.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "qldb.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "qldb.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -87,32 +96,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-quicksight/endpoints.ts
+++ b/clients/client-quicksight/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ram/endpoints.ts
+++ b/clients/client-ram/endpoints.ts
@@ -40,91 +40,109 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "ram.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "ram.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "ram.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "ram.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "ram.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "ram.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "ram.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "ram.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "ram.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "ram.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "ram.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "ram.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "ram.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "ram.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "ram.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "ram.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "ram.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "ram.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -132,32 +150,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-rds-data/endpoints.ts
+++ b/clients/client-rds-data/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-rds/endpoints.ts
+++ b/clients/client-rds/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "rds.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "rds.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "rds.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "rds.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "rds.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "rds.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "rds.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "rds.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "rds.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "rds.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "rds.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "rds.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "rds.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "rds.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "rds.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "rds.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "rds.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "rds.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "rds.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "rds.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "rds.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "rds.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "rds.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "rds.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-redshift/endpoints.ts
+++ b/clients/client-redshift/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "redshift.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "redshift.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "redshift.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "redshift.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "redshift.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "redshift.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "redshift.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "redshift.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "redshift.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "redshift.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "redshift.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "redshift.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "redshift.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "redshift.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "redshift.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "redshift.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "redshift.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "redshift.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "redshift.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "redshift.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "redshift.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "redshift.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "redshift.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "redshift.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-rekognition/endpoints.ts
+++ b/clients/client-rekognition/endpoints.ts
@@ -40,66 +40,79 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "rekognition.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "rekognition.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "rekognition.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "rekognition.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "rekognition.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "rekognition.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "rekognition.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "rekognition.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "rekognition.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "rekognition.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "rekognition.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "rekognition.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "rekognition.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -107,32 +120,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-resource-groups-tagging-api/endpoints.ts
+++ b/clients/client-resource-groups-tagging-api/endpoints.ts
@@ -40,111 +40,133 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "tagging.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "tagging.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "tagging.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "tagging.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "tagging.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "tagging.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "tagging.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "tagging.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "tagging.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "tagging.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "tagging.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "tagging.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "tagging.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "tagging.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "tagging.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "tagging.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "tagging.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "tagging.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "tagging.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "tagging.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "tagging.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "tagging.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -152,32 +174,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-resource-groups/endpoints.ts
+++ b/clients/client-resource-groups/endpoints.ts
@@ -40,137 +40,163 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "resource-groups.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "resource-groups.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "resource-groups.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "resource-groups.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "resource-groups.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "resource-groups.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "resource-groups.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "resource-groups.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "resource-groups.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "resource-groups.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "resource-groups.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "resource-groups.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips-us-east-1":
       regionInfo = {
         hostname: "resource-groups-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "fips-us-east-2":
       regionInfo = {
         hostname: "resource-groups-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "fips-us-gov-east-1":
       regionInfo = {
         hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "fips-us-gov-west-1":
       regionInfo = {
         hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "fips-us-west-1":
       regionInfo = {
         hostname: "resource-groups-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "fips-us-west-2":
       regionInfo = {
         hostname: "resource-groups-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "resource-groups.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "resource-groups.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "resource-groups.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "resource-groups.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "resource-groups.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "resource-groups.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -178,32 +204,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-robomaker/endpoints.ts
+++ b/clients/client-robomaker/endpoints.ts
@@ -40,36 +40,43 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "robomaker.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "robomaker.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "robomaker.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "robomaker.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "robomaker.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "robomaker.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "robomaker.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -77,32 +84,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-route-53-domains/endpoints.ts
+++ b/clients/client-route-53-domains/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-1":
       regionInfo = {
         hostname: "route53domains.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -47,32 +48,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-route-53/endpoints.ts
+++ b/clients/client-route-53/endpoints.ts
@@ -40,18 +40,21 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-global":
       regionInfo = {
         hostname: "route53.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "aws-iso-global":
       regionInfo = {
         hostname: "route53.c2s.ic.gov",
+        partition: "aws-iso",
         signingRegion: "us-iso-east-1",
       };
       break;
     case "aws-us-gov-global":
       regionInfo = {
         hostname: "route53.us-gov.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
@@ -63,6 +66,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
@@ -71,6 +75,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {

--- a/clients/client-route53resolver/endpoints.ts
+++ b/clients/client-route53resolver/endpoints.ts
@@ -40,81 +40,97 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "route53resolver.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "route53resolver.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "route53resolver.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "route53resolver.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "route53resolver.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "route53resolver.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "route53resolver.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "route53resolver.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "route53resolver.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "route53resolver.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "route53resolver.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "route53resolver.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "route53resolver.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "route53resolver.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "route53resolver.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "route53resolver.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -122,32 +138,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-s3-control/endpoints.ts
+++ b/clients/client-s3-control/endpoints.ts
@@ -40,156 +40,182 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "s3-control.ap-northeast-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-northeast-1",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "s3-control.ap-northeast-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-northeast-2",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "s3-control.ap-south-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-south-1",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "s3-control.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-1",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "s3-control.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-2",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "s3-control.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ca-central-1",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "s3-control.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-north-1",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "s3-control.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-northwest-1",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "s3-control.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-central-1",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "s3-control.eu-north-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-north-1",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "s3-control.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-1",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "s3-control.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-2",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "s3-control.eu-west-3.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-3",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "s3-control.sa-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "sa-east-1",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "s3-control.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "s3-control-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "s3-control.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "s3-control-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "s3-control.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "us-gov-east-1-fips":
       regionInfo = {
         hostname: "s3-control-fips.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "s3-control.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-gov-west-1-fips":
       regionInfo = {
         hostname: "s3-control-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "s3-control.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "s3-control-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "s3-control.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "s3-control-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -198,32 +224,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-s3/endpoints.ts
+++ b/clients/client-s3/endpoints.ts
@@ -40,133 +40,159 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "s3.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "s3.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "s3.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "s3.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "s3.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "s3.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "s3.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "s3.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "s3.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "s3.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "s3.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "s3.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "s3.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "s3.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips-us-gov-west-1":
       regionInfo = {
         hostname: "s3-fips-us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "s3.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "s3-external-1":
       regionInfo = {
         hostname: "s3-external-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "s3.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "s3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "s3.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "s3.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "s3.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "s3.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "s3.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "s3.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "s3.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -174,32 +200,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sagemaker-a2i-runtime/endpoints.ts
+++ b/clients/client-sagemaker-a2i-runtime/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sagemaker-runtime/endpoints.ts
+++ b/clients/client-sagemaker-runtime/endpoints.ts
@@ -40,124 +40,148 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "runtime.sagemaker.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "runtime.sagemaker.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "runtime.sagemaker.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "runtime.sagemaker.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "runtime.sagemaker.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "runtime.sagemaker.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "runtime.sagemaker.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "runtime.sagemaker.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "runtime.sagemaker.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "runtime.sagemaker.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "runtime.sagemaker.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "runtime.sagemaker.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "runtime.sagemaker.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "runtime.sagemaker.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "runtime.sagemaker.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "runtime-fips.sagemaker.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "runtime.sagemaker.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "runtime-fips.sagemaker.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "runtime.sagemaker.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "runtime.sagemaker.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "runtime-fips.sagemaker.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "runtime.sagemaker.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "runtime-fips.sagemaker.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -166,32 +190,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sagemaker/endpoints.ts
+++ b/clients/client-sagemaker/endpoints.ts
@@ -40,124 +40,148 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "api.sagemaker.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "api.sagemaker.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "api.sagemaker.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "api.sagemaker.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "api.sagemaker.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "api.sagemaker.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "api.sagemaker.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "api.sagemaker.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "api.sagemaker.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "api.sagemaker.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "api.sagemaker.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "api.sagemaker.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "api.sagemaker.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "api.sagemaker.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "api.sagemaker.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "api.sagemaker.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "api.sagemaker.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "api.sagemaker.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "api.sagemaker.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -166,32 +190,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-savingsplans/endpoints.ts
+++ b/clients/client-savingsplans/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-global":
       regionInfo = {
         hostname: "savingsplans.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
@@ -51,21 +52,25 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.

--- a/clients/client-schemas/endpoints.ts
+++ b/clients/client-schemas/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-secrets-manager/endpoints.ts
+++ b/clients/client-secrets-manager/endpoints.ts
@@ -40,136 +40,162 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "secretsmanager.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "secretsmanager.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "secretsmanager.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "secretsmanager.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "secretsmanager.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "secretsmanager.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "secretsmanager.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "secretsmanager.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "secretsmanager.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "secretsmanager.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "secretsmanager.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "secretsmanager.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "secretsmanager.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "secretsmanager.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "secretsmanager.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "secretsmanager-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "secretsmanager.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "secretsmanager-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "secretsmanager.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-east-1-fips":
       regionInfo = {
         hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-east-1",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "secretsmanager.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1-fips":
       regionInfo = {
         hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "secretsmanager.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "secretsmanager-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "secretsmanager.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "secretsmanager-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -178,32 +204,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-securityhub/endpoints.ts
+++ b/clients/client-securityhub/endpoints.ts
@@ -40,91 +40,109 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "securityhub.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "securityhub.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "securityhub.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "securityhub.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "securityhub.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "securityhub.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "securityhub.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "securityhub.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "securityhub.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "securityhub.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "securityhub.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "securityhub.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "securityhub.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "securityhub.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "securityhub.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "securityhub.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "securityhub.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "securityhub.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -132,32 +150,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-serverlessapplicationrepository/endpoints.ts
+++ b/clients/client-serverlessapplicationrepository/endpoints.ts
@@ -40,101 +40,121 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "serverlessrepo.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "serverlessrepo.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "serverlessrepo.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "serverlessrepo.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "serverlessrepo.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "serverlessrepo.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "serverlessrepo.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "serverlessrepo.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "serverlessrepo.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "serverlessrepo.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "serverlessrepo.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "serverlessrepo.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "serverlessrepo.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "serverlessrepo.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "serverlessrepo.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "serverlessrepo.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "serverlessrepo.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "serverlessrepo.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "serverlessrepo.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "serverlessrepo.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -142,32 +162,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-service-catalog/endpoints.ts
+++ b/clients/client-service-catalog/endpoints.ts
@@ -40,115 +40,137 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "servicecatalog.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "servicecatalog.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "servicecatalog.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "servicecatalog.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "servicecatalog.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "servicecatalog.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "servicecatalog.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "servicecatalog.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "servicecatalog.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "servicecatalog.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "servicecatalog.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "servicecatalog.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "servicecatalog.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "servicecatalog-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "servicecatalog.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "servicecatalog-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "servicecatalog.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1-fips":
       regionInfo = {
         hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "servicecatalog.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "servicecatalog-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "servicecatalog.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "servicecatalog-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -157,32 +179,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-service-quotas/endpoints.ts
+++ b/clients/client-service-quotas/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-servicediscovery/endpoints.ts
+++ b/clients/client-servicediscovery/endpoints.ts
@@ -40,91 +40,109 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "servicediscovery.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "servicediscovery.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "servicediscovery.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "servicediscovery.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "servicediscovery.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "servicediscovery.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "servicediscovery.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "servicediscovery.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "servicediscovery.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "servicediscovery.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "servicediscovery.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "servicediscovery.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "servicediscovery.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "servicediscovery.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "servicediscovery.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "servicediscovery.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "servicediscovery.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "servicediscovery.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -132,32 +150,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ses/endpoints.ts
+++ b/clients/client-ses/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-south-1":
       regionInfo = {
         hostname: "email.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "email.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "email.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "email.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "email.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "email.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sesv2/endpoints.ts
+++ b/clients/client-sesv2/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-south-1":
       regionInfo = {
         hostname: "email.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "email.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "email.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "email.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "email.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "email.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sfn/endpoints.ts
+++ b/clients/client-sfn/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "states.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "states.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "states.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "states.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "states.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "states.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "states.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "states.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "states.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "states.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "states.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "states.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "states.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "states.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "states.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "states.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "states.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "states.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "states.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "states.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "states.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "states.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "states.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "states.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-shield/endpoints.ts
+++ b/clients/client-shield/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "us-east-1":
       regionInfo = {
         hostname: "shield.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -47,32 +48,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-signer/endpoints.ts
+++ b/clients/client-signer/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sms/endpoints.ts
+++ b/clients/client-sms/endpoints.ts
@@ -40,111 +40,133 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "sms.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "sms.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "sms.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "sms.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "sms.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "sms.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "sms.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "sms.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "sms.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "sms.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "sms.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "sms.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "sms.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "sms.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "sms.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "sms.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "sms.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "sms.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "sms.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "sms.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "sms.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "sms.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -152,32 +174,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-snowball/endpoints.ts
+++ b/clients/client-snowball/endpoints.ts
@@ -40,101 +40,121 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "snowball.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "snowball.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "snowball.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "snowball.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "snowball.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "snowball.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "snowball.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "snowball.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "snowball.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "snowball.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "snowball.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "snowball.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "snowball.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "snowball.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "snowball.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "snowball.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "snowball.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "snowball.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "snowball.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "snowball.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -142,32 +162,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sns/endpoints.ts
+++ b/clients/client-sns/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "sns.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "sns.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "sns.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "sns.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "sns.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "sns.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "sns.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "sns.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "sns.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "sns.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "sns.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "sns.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "sns.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "sns.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "sns.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "sns.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "sns.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "sns.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "sns.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "sns.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "sns.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "sns.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "sns.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "sns.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sqs/endpoints.ts
+++ b/clients/client-sqs/endpoints.ts
@@ -40,145 +40,173 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "sqs.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "sqs.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "sqs.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "sqs.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "sqs.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "sqs.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "sqs.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "sqs.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "sqs.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "sqs.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "sqs.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "sqs.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "sqs.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "sqs.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "fips-us-east-1":
       regionInfo = {
         hostname: "sqs-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "fips-us-east-2":
       regionInfo = {
         hostname: "sqs-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "fips-us-west-1":
       regionInfo = {
         hostname: "sqs-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "fips-us-west-2":
       regionInfo = {
         hostname: "sqs-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "sqs.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "sqs.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "sqs.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "sqs.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "sqs.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "sqs.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "sqs.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "sqs.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "sqs.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "sqs.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -186,32 +214,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-ssm/endpoints.ts
+++ b/clients/client-ssm/endpoints.ts
@@ -40,111 +40,133 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "ssm.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "ssm.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "ssm.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "ssm.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "ssm.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "ssm.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "ssm.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "ssm.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "ssm.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "ssm.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "ssm.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "ssm.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "ssm.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "ssm.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "ssm.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "ssm.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "ssm.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "ssm.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "ssm.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "ssm.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "ssm.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "ssm.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -152,32 +174,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sso-oidc/endpoints.ts
+++ b/clients/client-sso-oidc/endpoints.ts
@@ -40,54 +40,63 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-southeast-1":
       regionInfo = {
         hostname: "oidc.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-1",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "oidc.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-2",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "oidc.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ca-central-1",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "oidc.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-central-1",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "oidc.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-1",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "oidc.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-2",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "oidc.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "oidc.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "oidc.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -96,32 +105,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sso/endpoints.ts
+++ b/clients/client-sso/endpoints.ts
@@ -40,54 +40,63 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-southeast-1":
       regionInfo = {
         hostname: "portal.sso.ap-southeast-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-1",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "portal.sso.ap-southeast-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "ap-southeast-2",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "portal.sso.ca-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "ca-central-1",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "portal.sso.eu-central-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-central-1",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "portal.sso.eu-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-1",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "portal.sso.eu-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "eu-west-2",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "portal.sso.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "portal.sso.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "portal.sso.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -96,32 +105,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-storage-gateway/endpoints.ts
+++ b/clients/client-storage-gateway/endpoints.ts
@@ -40,101 +40,121 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "storagegateway.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "storagegateway.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "storagegateway.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "storagegateway.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "storagegateway.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "storagegateway.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "storagegateway.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "storagegateway.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "storagegateway.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "storagegateway.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "storagegateway.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "storagegateway.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "storagegateway.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "storagegateway.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "storagegateway.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "storagegateway.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "storagegateway.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "storagegateway.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "storagegateway.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "storagegateway.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -142,32 +162,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-sts/endpoints.ts
+++ b/clients/client-sts/endpoints.ts
@@ -40,150 +40,179 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "sts.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "sts.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "sts.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "sts.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "sts.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "sts.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "aws-global":
       regionInfo = {
         hostname: "sts.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "sts.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "sts.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "sts.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "sts.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "sts.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "sts.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "sts.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "sts.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "sts.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "sts.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "sts.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "sts-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "sts.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "sts-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "sts.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "sts.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "sts.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "sts.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "sts.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1-fips":
       regionInfo = {
         hostname: "sts-fips.us-west-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "sts.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "sts-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -192,32 +221,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-support/endpoints.ts
+++ b/clients/client-support/endpoints.ts
@@ -40,24 +40,28 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-cn-global":
       regionInfo = {
         hostname: "support.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-north-1",
       };
       break;
     case "aws-global":
       regionInfo = {
         hostname: "support.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "aws-iso-b-global":
       regionInfo = {
         hostname: "support.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
         signingRegion: "us-isob-east-1",
       };
       break;
     case "aws-iso-global":
       regionInfo = {
         hostname: "support.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
         signingRegion: "us-iso-east-1",
       };
       break;
@@ -66,32 +70,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-swf/endpoints.ts
+++ b/clients/client-swf/endpoints.ts
@@ -40,121 +40,145 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "swf.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "swf.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "swf.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "swf.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "swf.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "swf.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "swf.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "swf.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "swf.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "swf.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "swf.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "swf.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "swf.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "swf.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "swf.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "swf.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "swf.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "swf.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-east-1":
       regionInfo = {
         hostname: "swf.us-gov-east-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "swf.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "swf.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-isob-east-1":
       regionInfo = {
         hostname: "swf.us-isob-east-1.sc2s.sgov.gov",
+        partition: "aws-iso-b",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "swf.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "swf.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -162,32 +186,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-textract/endpoints.ts
+++ b/clients/client-textract/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-transcribe-streaming/endpoints.ts
+++ b/clients/client-transcribe-streaming/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-southeast-2":
       regionInfo = {
         hostname: "transcribestreaming.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "transcribestreaming.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "transcribestreaming.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "transcribestreaming.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "transcribestreaming.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "transcribestreaming.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-transcribe/endpoints.ts
+++ b/clients/client-transcribe/endpoints.ts
@@ -40,103 +40,123 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "transcribe.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "transcribe.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "transcribe.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "transcribe.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "transcribe.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "transcribe.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "transcribe.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-north-1":
       regionInfo = {
         hostname: "cn.transcribe.cn-north-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-north-1",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "cn.transcribe.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
         signingRegion: "cn-northwest-1",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "transcribe.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "transcribe.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "transcribe.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "transcribe.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "transcribe.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "transcribe.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "transcribe.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "transcribe.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "transcribe.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "transcribe.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "transcribe.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -144,32 +164,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-transfer/endpoints.ts
+++ b/clients/client-transfer/endpoints.ts
@@ -40,81 +40,97 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "transfer.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "transfer.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "transfer.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "transfer.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "transfer.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "transfer.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "transfer.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "transfer.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "transfer.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "transfer.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "transfer.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "transfer.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "transfer.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "transfer.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "transfer.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "transfer.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -122,32 +138,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-translate/endpoints.ts
+++ b/clients/client-translate/endpoints.ts
@@ -40,79 +40,94 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "translate.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "translate.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "translate.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "translate.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "translate.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "translate.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "translate.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "translate.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1-fips":
       regionInfo = {
         hostname: "translate-fips.us-east-1.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "translate.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2-fips":
       regionInfo = {
         hostname: "translate-fips.us-east-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-2",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "translate.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-gov-west-1-fips":
       regionInfo = {
         hostname: "translate-fips.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
         signingRegion: "us-gov-west-1",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "translate.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2-fips":
       regionInfo = {
         hostname: "translate-fips.us-west-2.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-west-2",
       };
       break;
@@ -121,32 +136,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-waf-regional/endpoints.ts
+++ b/clients/client-waf-regional/endpoints.ts
@@ -40,86 +40,103 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "waf-regional.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "waf-regional.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "waf-regional.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "waf-regional.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "waf-regional.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "waf-regional.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "waf-regional.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "waf-regional.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "waf-regional.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "waf-regional.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "waf-regional.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "waf-regional.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "waf-regional.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "waf-regional.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "waf-regional.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "waf-regional.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "waf-regional.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -127,32 +144,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-waf/endpoints.ts
+++ b/clients/client-waf/endpoints.ts
@@ -40,6 +40,7 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "aws-global":
       regionInfo = {
         hostname: "waf.amazonaws.com",
+        partition: "aws",
         signingRegion: "us-east-1",
       };
       break;
@@ -51,21 +52,25 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.

--- a/clients/client-wafv2/endpoints.ts
+++ b/clients/client-wafv2/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-workdocs/endpoints.ts
+++ b/clients/client-workdocs/endpoints.ts
@@ -40,31 +40,37 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "workdocs.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "workdocs.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "workdocs.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "workdocs.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "workdocs.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "workdocs.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -72,32 +78,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-worklink/endpoints.ts
+++ b/clients/client-worklink/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-workmail/endpoints.ts
+++ b/clients/client-workmail/endpoints.ts
@@ -40,16 +40,19 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "eu-west-1":
       regionInfo = {
         hostname: "workmail.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "workmail.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "workmail.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -57,32 +60,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-workmailmessageflow/endpoints.ts
+++ b/clients/client-workmailmessageflow/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-workspaces/endpoints.ts
+++ b/clients/client-workspaces/endpoints.ts
@@ -40,71 +40,85 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-northeast-1":
       regionInfo = {
         hostname: "workspaces.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "workspaces.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "workspaces.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "workspaces.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "workspaces.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "cn-northwest-1":
       regionInfo = {
         hostname: "workspaces.cn-northwest-1.amazonaws.com.cn",
+        partition: "aws-cn",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "workspaces.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "workspaces.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "workspaces.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "workspaces.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "workspaces.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-gov-west-1":
       regionInfo = {
         hostname: "workspaces.us-gov-west-1.amazonaws.com",
+        partition: "aws-us-gov",
       };
       break;
     case "us-iso-east-1":
       regionInfo = {
         hostname: "workspaces.us-iso-east-1.c2s.ic.gov",
+        partition: "aws-iso",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "workspaces.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -112,32 +126,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/clients/client-xray/endpoints.ts
+++ b/clients/client-xray/endpoints.ts
@@ -40,91 +40,109 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
     case "ap-east-1":
       regionInfo = {
         hostname: "xray.ap-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-1":
       regionInfo = {
         hostname: "xray.ap-northeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-northeast-2":
       regionInfo = {
         hostname: "xray.ap-northeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-south-1":
       regionInfo = {
         hostname: "xray.ap-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-1":
       regionInfo = {
         hostname: "xray.ap-southeast-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ap-southeast-2":
       regionInfo = {
         hostname: "xray.ap-southeast-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "ca-central-1":
       regionInfo = {
         hostname: "xray.ca-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-central-1":
       regionInfo = {
         hostname: "xray.eu-central-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-north-1":
       regionInfo = {
         hostname: "xray.eu-north-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-1":
       regionInfo = {
         hostname: "xray.eu-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-2":
       regionInfo = {
         hostname: "xray.eu-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "eu-west-3":
       regionInfo = {
         hostname: "xray.eu-west-3.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "me-south-1":
       regionInfo = {
         hostname: "xray.me-south-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "sa-east-1":
       regionInfo = {
         hostname: "xray.sa-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-1":
       regionInfo = {
         hostname: "xray.us-east-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-east-2":
       regionInfo = {
         hostname: "xray.us-east-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-1":
       regionInfo = {
         hostname: "xray.us-west-1.amazonaws.com",
+        partition: "aws",
       };
       break;
     case "us-west-2":
       regionInfo = {
         hostname: "xray.us-west-2.amazonaws.com",
+        partition: "aws",
       };
       break;
     // Next, try to match partition endpoints.
@@ -132,32 +150,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -80,6 +80,7 @@ export interface RegionInfo {
   path?: string;
   signingService?: string;
   signingRegion?: string;
+  partition?: string;
 }
 
 /**

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -77,10 +77,10 @@ export interface UrlParser {
  */
 export interface RegionInfo {
   hostname: string;
+  partition: string;
   path?: string;
   signingService?: string;
   signingRegion?: string;
-  partition?: string;
 }
 
 /**

--- a/protocol_tests/aws-ec2/endpoints.ts
+++ b/protocol_tests/aws-ec2/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/protocol_tests/aws-json/endpoints.ts
+++ b/protocol_tests/aws-json/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/protocol_tests/aws-query/endpoints.ts
+++ b/protocol_tests/aws-query/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/protocol_tests/aws-restjson/endpoints.ts
+++ b/protocol_tests/aws-restjson/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }

--- a/protocol_tests/aws-restxml/endpoints.ts
+++ b/protocol_tests/aws-restxml/endpoints.ts
@@ -42,32 +42,38 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
       if (AWS_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
       if (AWS_CN_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_CN_TEMPLATE.replace("{region}", region),
+          partition: "aws-cn",
         };
       }
       if (AWS_ISO_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso",
         };
       }
       if (AWS_ISO_B_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_ISO_B_TEMPLATE.replace("{region}", region),
+          partition: "aws-iso-b",
         };
       }
       if (AWS_US_GOV_REGIONS.has(region)) {
         regionInfo = {
           hostname: AWS_US_GOV_TEMPLATE.replace("{region}", region),
+          partition: "aws-us-gov",
         };
       }
       // Finally, assume it's an AWS partition endpoint.
       if (regionInfo === undefined) {
         regionInfo = {
           hostname: AWS_TEMPLATE.replace("{region}", region),
+          partition: "aws",
         };
       }
   }


### PR DESCRIPTION
*Description of changes:*
This change generate a new `partition` to the return value of `regionInfoProvider`. Which this change, user can infer which partion does the supplied region belong to. This feature is useful when the SDK needs to validate whether the request is made to intended partition.

The last commit is the code generation. To see the actual changes, you can ignore the laster commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
