### PR TITLE
Copy tweaks in s3-request-presigner README

### DIFF
--- a/packages/s3-request-presigner/README.md
+++ b/packages/s3-request-presigner/README.md
@@ -19,7 +19,7 @@ const signer = new S3Presigner({
 const url = await signer.presign(request);
 ```
 
-Typescript Example:
+ES6 Example:
 
 ```javascript
 import { S3RequestPresigner } from "@aws-sdk/s3-request-presigner";
@@ -33,8 +33,8 @@ const signer = new S3RequestPresigner({
 const url = await signer.presign(request);
 ```
 
-To avoid redundant construction parameters when instantiate the s3 presigner,
-you can simply spread the configurations of an existing s3 clients and supply to
+To avoid redundant construction parameters when instantiating the s3 presigner,
+you can simply spread the configuration of an existing s3 client and supply it to
 the presigner's constructor.
 
 ```javascript


### PR DESCRIPTION
* Signify that the second example is ES6-specific -- not Typescript
* Minor grammar corrections:
    * "when instantiating" vs. "when instantiate"
    * "the configuration of an" vs. "the configurations of an"
    * "an existing client" vs. "an existing clients"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
