### PR TITLE
feat(middleware-sdk-s3): bucket name validator skips ARN bucket name

### DIFF
--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/util-arn-parser": "1.0.0-gamma.1",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-s3/src/validate-bucket-name.ts
+++ b/packages/middleware-sdk-s3/src/validate-bucket-name.ts
@@ -7,6 +7,7 @@ import {
   MetadataBearer,
   Pluggable,
 } from "@aws-sdk/types";
+import { validate } from "@aws-sdk/util-arn-parser";
 
 export function validateBucketNameMiddleware(): InitializeMiddleware<any, any> {
   return <Output extends MetadataBearer>(
@@ -14,9 +15,11 @@ export function validateBucketNameMiddleware(): InitializeMiddleware<any, any> {
   ): InitializeHandler<any, Output> => async (
     args: InitializeHandlerArguments<any>
   ): Promise<InitializeHandlerOutput<Output>> => {
-    const { input } = args;
-    if (typeof input.Bucket === "string" && input.Bucket.indexOf("/") >= 0) {
-      const err = new Error(`Bucket name shouldn't contain '/', received '${input.Bucket}'`);
+    const {
+      input: { Bucket },
+    } = args;
+    if (typeof Bucket === "string" && !validate(Bucket) && Bucket.indexOf("/") >= 0) {
+      const err = new Error(`Bucket name shouldn't contain '/', received '${Bucket}'`);
       err.name = "InvalidBucketName";
       throw err;
     }

--- a/packages/middleware-sdk-s3/src/validate-bucket-name.ts
+++ b/packages/middleware-sdk-s3/src/validate-bucket-name.ts
@@ -7,7 +7,7 @@ import {
   MetadataBearer,
   Pluggable,
 } from "@aws-sdk/types";
-import { validate } from "@aws-sdk/util-arn-parser";
+import { validate as validateArn } from "@aws-sdk/util-arn-parser";
 
 export function validateBucketNameMiddleware(): InitializeMiddleware<any, any> {
   return <Output extends MetadataBearer>(
@@ -18,7 +18,7 @@ export function validateBucketNameMiddleware(): InitializeMiddleware<any, any> {
     const {
       input: { Bucket },
     } = args;
-    if (typeof Bucket === "string" && !validate(Bucket) && Bucket.indexOf("/") >= 0) {
+    if (typeof Bucket === "string" && !validateArn(Bucket) && Bucket.indexOf("/") >= 0) {
       const err = new Error(`Bucket name shouldn't contain '/', received '${Bucket}'`);
       err.name = "InvalidBucketName";
       throw err;

--- a/packages/util-arn-parser/src/index.spec.ts
+++ b/packages/util-arn-parser/src/index.spec.ts
@@ -4,6 +4,7 @@ describe("validate", () => {
   it("should validate whether input is a qualified resource ARN", () => {
     expect(validate("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint")).toBe(true);
     expect(validate("arn:aws:s3:us-east-1:123456789012:accesspoint:myendpoint")).toBe(true);
+    expect(validate("arn:aws:s3:us-east-1:123456789012:accesspoint/myendpoint")).toBe(true);
     expect(validate("arn:aws-cn:s3:cn-north-1:123456789012:accesspoint:myendpoint")).toBe(true);
     expect(validate("arn:aws:sns:us-west-2:123456789012:myTopic")).toBe(true);
     expect(validate("some:random:string:separated:by:colons")).toBe(false);


### PR DESCRIPTION
*Description of changes:*
S3 bucket name validation middleware validates there's no `/` exists in bucket name. But is the bucket name is an ARN, this validation should not fail. 
This validation functionality should not be part of `@aws-sdk/middleware-bucket-endpoint` because this validation is applied to all the S3 operations, whereas later has some exceptions like `createBucket()`, `deleteBucket()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
