### PR TITLE
fix: removeSync in case of directory in copy-to-clients

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { join } = require("path");
-const { copySync, ensureDirSync } = require("fs-extra");
+const { copySync, removeSync } = require("fs-extra");
 const { readdirSync, lstatSync, readFileSync, existsSync, writeFileSync } = require("fs");
 
 const getOverwritablePredicate = (packageName) => (pathName) => {
@@ -96,8 +96,7 @@ const copyToClients = async (sourceDir, destinationDir) => {
         pinDependencies(mergedManifest);
         writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2).concat(`\n`));
       } else if (overwritablePredicate(packageSub) || !existsSync(destSubPath)) {
-        //Overwrite the directories and files that are overwritable, or not yet exists
-        if (lstatSync(packageSubPath).isDirectory()) ensureDirSync(destSubPath);
+        if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
         copySync(packageSubPath, destSubPath, {
           overwrite: true,
         });


### PR DESCRIPTION
*Issue #, if available:*
Internal issue JS-2016

*Description of changes:*
removeSync in case of directory in copy-to-clients

As detailed in internal issue JS-2016, the current copy-to-clients script doesn't remove commands which could have been removed from models. This PR ensures that the directories are deleted before individual files are copied over. The command `ensureDirSync` doesn't need to be run, as `copySync` would create the directory.

*Testing:*
Verified that the files `GetPredictionCommand.ts` and `PutModelCommand.ts` were removed while generating client for frauddetector using updated models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
