### PR TITLE
chore(deps-dev): bump prettier to 2.1.0

### DIFF
--- a/clients/client-transcribe-streaming/README.md
+++ b/clients/client-transcribe-streaming/README.md
@@ -206,9 +206,9 @@ If you are using `async...await` style code, you are able to catch the errors wi
 categories of exceptions can be thrown:
 
 - Immediate exceptions thrown before transcription is started, like signature
-exceptions, invalid parameters exceptions, and network errors;
+  exceptions, invalid parameters exceptions, and network errors;
 - Streaming exceptions that happens after transcription is
-started, like `InternalFailureException` or `ConflictException`.
+  started, like `InternalFailureException` or `ConflictException`.
 
 For immediate exceptions, the SDK client will retry the request if the error is retryable, like network errors. You can
 config the client to behave as you intend to.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "lerna": "3.22.1",
     "lint-staged": "^10.0.1",
     "mocha": "^8.0.1",
-    "prettier": "2.0.5",
+    "prettier": "2.1.0",
     "puppeteer": "^5.1.0",
     "ts-loader": "^7.0.5",
     "typescript": "~4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9566,10 +9566,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+prettier@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.0.tgz#5a9789f767a243118c60f3e56d95cb6544914fbb"
+  integrity sha512-lz28cCbA1cDFHVuY8vvj6QuqOwIpyIfPUYkSl8AZ/vxH8qBXMMjE2knfLHCrZCmUsK/H1bg1P0tOo0dJkTJHvw==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"


### PR DESCRIPTION
*Issue #, if available:*
* Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/1456 for TypeScript 4.0 support
* Prettier 2.1 announcement blog post https://prettier.io/blog/2020/08/24/2.1.0.html

*Description of changes:*
chore(deps-dev): bump prettier to 2.1.0

Ran following commands to get files formatted with prettier 2.1.0:
* `./node_modules/.bin/prettier --write **/*.{ts,js,md,json}`
* `yarn generate-clients`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
