### PR TITLE
chore: set workspace TypeScript version in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.rulers": [80, 120]
+  "editor.rulers": [80, 120],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Set workspace TypeScript version in VSCode settings so that VSCode uses workspace version all the time:
* TS in v3 was updated to 4.0 soon after the release on 8/20 in https://github.com/aws/aws-sdk-js-v3/pull/1456, but latest VSCode version 1.48.1 doesn't support 4.0 https://code.visualstudio.com/updates/v1_48#_typescript-40-support
* In future, if TS version updates get delayed for some reason than VSCode should use the version from the workspace by default.

Documentation: https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-newer-typescript-versions

Screenshots:

<details>
<summary>Before</summary>

![code](https://user-images.githubusercontent.com/16024985/91189594-7a0fbc80-e6a7-11ea-894a-2ba563a869a5.png)

</details>

<details>
<summary>During (one-time)</summary>

![selection](https://user-images.githubusercontent.com/16024985/91189667-94499a80-e6a7-11ea-97e7-7063448c5492.png)

</details>

<details>
<summary>After</summary>

![workspace](https://user-images.githubusercontent.com/16024985/91189629-87c54200-e6a7-11ea-9c75-bf13a6275f10.png)

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
