### PR TITLE
chore: publish /src to npm and other fixes for sourcemap debugging

### DIFF
--- a/packages/abort-controller/.npmignore
+++ b/packages/abort-controller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/abort-controller/.npmignore
+++ b/packages/abort-controller/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/abort-controller/.npmignore
+++ b/packages/abort-controller/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/body-checksum-browser/.npmignore
+++ b/packages/body-checksum-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/body-checksum-browser/.npmignore
+++ b/packages/body-checksum-browser/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/body-checksum-browser/.npmignore
+++ b/packages/body-checksum-browser/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/body-checksum-node/.npmignore
+++ b/packages/body-checksum-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/body-checksum-node/.npmignore
+++ b/packages/body-checksum-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/body-checksum-node/.npmignore
+++ b/packages/body-checksum-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/chunked-blob-reader-native/.npmignore
+++ b/packages/chunked-blob-reader-native/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/chunked-blob-reader-native/.npmignore
+++ b/packages/chunked-blob-reader-native/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/chunked-blob-reader-native/.npmignore
+++ b/packages/chunked-blob-reader-native/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/chunked-blob-reader/.npmignore
+++ b/packages/chunked-blob-reader/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/chunked-blob-reader/.npmignore
+++ b/packages/chunked-blob-reader/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/chunked-blob-reader/.npmignore
+++ b/packages/chunked-blob-reader/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/chunked-stream-reader-node/.npmignore
+++ b/packages/chunked-stream-reader-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/chunked-stream-reader-node/.npmignore
+++ b/packages/chunked-stream-reader-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/chunked-stream-reader-node/.npmignore
+++ b/packages/chunked-stream-reader-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/client-documentation-generator/.npmignore
+++ b/packages/client-documentation-generator/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/client-documentation-generator/.npmignore
+++ b/packages/client-documentation-generator/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/client-documentation-generator/.npmignore
+++ b/packages/client-documentation-generator/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/config-resolver/.npmignore
+++ b/packages/config-resolver/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/config-resolver/.npmignore
+++ b/packages/config-resolver/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/config-resolver/.npmignore
+++ b/packages/config-resolver/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-cognito-identity/.npmignore
+++ b/packages/credential-provider-cognito-identity/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/credential-provider-cognito-identity/.npmignore
+++ b/packages/credential-provider-cognito-identity/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/credential-provider-cognito-identity/.npmignore
+++ b/packages/credential-provider-cognito-identity/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-env/.npmignore
+++ b/packages/credential-provider-env/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-env/.npmignore
+++ b/packages/credential-provider-env/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-env/.npmignore
+++ b/packages/credential-provider-env/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "strict": true,
     "sourceMap": false,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -4,7 +4,7 @@
     "strict": true,
     "sourceMap": false,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/credential-provider-imds/.npmignore
+++ b/packages/credential-provider-imds/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-imds/.npmignore
+++ b/packages/credential-provider-imds/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-imds/.npmignore
+++ b/packages/credential-provider-imds/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noEmitHelpers": true,
     "inlineSourceMap": true,

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "noEmitHelpers": true,
     "inlineSourceMap": true,

--- a/packages/credential-provider-ini/.npmignore
+++ b/packages/credential-provider-ini/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-ini/.npmignore
+++ b/packages/credential-provider-ini/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-ini/.npmignore
+++ b/packages/credential-provider-ini/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noEmitHelpers": true,
     "inlineSourceMap": true,

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "noEmitHelpers": true,
     "inlineSourceMap": true,

--- a/packages/credential-provider-node/.npmignore
+++ b/packages/credential-provider-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-node/.npmignore
+++ b/packages/credential-provider-node/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-node/.npmignore
+++ b/packages/credential-provider-node/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/credential-provider-process/.npmignore
+++ b/packages/credential-provider-process/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/credential-provider-process/.npmignore
+++ b/packages/credential-provider-process/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/credential-provider-process/.npmignore
+++ b/packages/credential-provider-process/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noEmitHelpers": true,
     "inlineSourceMap": true,

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "importHelpers": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "noEmitHelpers": true,
     "inlineSourceMap": true,

--- a/packages/eventstream-handler-node/.npmignore
+++ b/packages/eventstream-handler-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/eventstream-handler-node/.npmignore
+++ b/packages/eventstream-handler-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/eventstream-handler-node/.npmignore
+++ b/packages/eventstream-handler-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/eventstream-marshaller/.npmignore
+++ b/packages/eventstream-marshaller/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/eventstream-marshaller/.npmignore
+++ b/packages/eventstream-marshaller/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/eventstream-marshaller/.npmignore
+++ b/packages/eventstream-marshaller/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/eventstream-serde-browser/.npmignore
+++ b/packages/eventstream-serde-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/eventstream-serde-browser/.npmignore
+++ b/packages/eventstream-serde-browser/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/eventstream-serde-browser/.npmignore
+++ b/packages/eventstream-serde-browser/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/eventstream-serde-config-resolver/.npmignore
+++ b/packages/eventstream-serde-config-resolver/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/eventstream-serde-config-resolver/.npmignore
+++ b/packages/eventstream-serde-config-resolver/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/eventstream-serde-config-resolver/.npmignore
+++ b/packages/eventstream-serde-config-resolver/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/eventstream-serde-node/.npmignore
+++ b/packages/eventstream-serde-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/eventstream-serde-node/.npmignore
+++ b/packages/eventstream-serde-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/eventstream-serde-node/.npmignore
+++ b/packages/eventstream-serde-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/eventstream-serde-universal/.npmignore
+++ b/packages/eventstream-serde-universal/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/eventstream-serde-universal/.npmignore
+++ b/packages/eventstream-serde-universal/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/eventstream-serde-universal/.npmignore
+++ b/packages/eventstream-serde-universal/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/fetch-http-handler/.npmignore
+++ b/packages/fetch-http-handler/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/fetch-http-handler/.npmignore
+++ b/packages/fetch-http-handler/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/fetch-http-handler/.npmignore
+++ b/packages/fetch-http-handler/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/hash-blob-browser/.npmignore
+++ b/packages/hash-blob-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/hash-blob-browser/.npmignore
+++ b/packages/hash-blob-browser/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/hash-blob-browser/.npmignore
+++ b/packages/hash-blob-browser/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/hash-node/.npmignore
+++ b/packages/hash-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/hash-node/.npmignore
+++ b/packages/hash-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/hash-node/.npmignore
+++ b/packages/hash-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/hash-stream-node/.npmignore
+++ b/packages/hash-stream-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/hash-stream-node/.npmignore
+++ b/packages/hash-stream-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/hash-stream-node/.npmignore
+++ b/packages/hash-stream-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/invalid-dependency/.npmignore
+++ b/packages/invalid-dependency/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/invalid-dependency/.npmignore
+++ b/packages/invalid-dependency/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/invalid-dependency/.npmignore
+++ b/packages/invalid-dependency/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/is-array-buffer/.npmignore
+++ b/packages/is-array-buffer/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/is-array-buffer/.npmignore
+++ b/packages/is-array-buffer/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/is-array-buffer/.npmignore
+++ b/packages/is-array-buffer/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "strict": true,
     "sourceMap": false,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "strict": true,
     "sourceMap": false,
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/karma-credential-loader/.npmignore
+++ b/packages/karma-credential-loader/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/karma-credential-loader/.npmignore
+++ b/packages/karma-credential-loader/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/karma-credential-loader/.npmignore
+++ b/packages/karma-credential-loader/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/md5-js/.npmignore
+++ b/packages/md5-js/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/md5-js/.npmignore
+++ b/packages/md5-js/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/md5-js/.npmignore
+++ b/packages/md5-js/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-apply-body-checksum/.npmignore
+++ b/packages/middleware-apply-body-checksum/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-apply-body-checksum/.npmignore
+++ b/packages/middleware-apply-body-checksum/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-apply-body-checksum/.npmignore
+++ b/packages/middleware-apply-body-checksum/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-bucket-endpoint/.npmignore
+++ b/packages/middleware-bucket-endpoint/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-bucket-endpoint/.npmignore
+++ b/packages/middleware-bucket-endpoint/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-bucket-endpoint/.npmignore
+++ b/packages/middleware-bucket-endpoint/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-content-length/.npmignore
+++ b/packages/middleware-content-length/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-content-length/.npmignore
+++ b/packages/middleware-content-length/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-content-length/.npmignore
+++ b/packages/middleware-content-length/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-eventstream/.npmignore
+++ b/packages/middleware-eventstream/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-eventstream/.npmignore
+++ b/packages/middleware-eventstream/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-eventstream/.npmignore
+++ b/packages/middleware-eventstream/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-expect-continue/.npmignore
+++ b/packages/middleware-expect-continue/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-expect-continue/.npmignore
+++ b/packages/middleware-expect-continue/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-expect-continue/.npmignore
+++ b/packages/middleware-expect-continue/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-header-default/.npmignore
+++ b/packages/middleware-header-default/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-header-default/.npmignore
+++ b/packages/middleware-header-default/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-header-default/.npmignore
+++ b/packages/middleware-header-default/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-host-header/.npmignore
+++ b/packages/middleware-host-header/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-host-header/.npmignore
+++ b/packages/middleware-host-header/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-host-header/.npmignore
+++ b/packages/middleware-host-header/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-location-constraint/.npmignore
+++ b/packages/middleware-location-constraint/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-location-constraint/.npmignore
+++ b/packages/middleware-location-constraint/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-location-constraint/.npmignore
+++ b/packages/middleware-location-constraint/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-retry/.npmignore
+++ b/packages/middleware-retry/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-retry/.npmignore
+++ b/packages/middleware-retry/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-retry/.npmignore
+++ b/packages/middleware-retry/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-api-gateway/.npmignore
+++ b/packages/middleware-sdk-api-gateway/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-api-gateway/.npmignore
+++ b/packages/middleware-sdk-api-gateway/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-api-gateway/.npmignore
+++ b/packages/middleware-sdk-api-gateway/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-ec2/.npmignore
+++ b/packages/middleware-sdk-ec2/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-ec2/.npmignore
+++ b/packages/middleware-sdk-ec2/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-ec2/.npmignore
+++ b/packages/middleware-sdk-ec2/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-glacier/.npmignore
+++ b/packages/middleware-sdk-glacier/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-glacier/.npmignore
+++ b/packages/middleware-sdk-glacier/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-glacier/.npmignore
+++ b/packages/middleware-sdk-glacier/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-machinelearning/.npmignore
+++ b/packages/middleware-sdk-machinelearning/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-machinelearning/.npmignore
+++ b/packages/middleware-sdk-machinelearning/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-machinelearning/.npmignore
+++ b/packages/middleware-sdk-machinelearning/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-rds/.npmignore
+++ b/packages/middleware-sdk-rds/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-rds/.npmignore
+++ b/packages/middleware-sdk-rds/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-rds/.npmignore
+++ b/packages/middleware-sdk-rds/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-route53/.npmignore
+++ b/packages/middleware-sdk-route53/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-route53/.npmignore
+++ b/packages/middleware-sdk-route53/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-route53/.npmignore
+++ b/packages/middleware-sdk-route53/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-s3-control/.npmignore
+++ b/packages/middleware-sdk-s3-control/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-s3-control/.npmignore
+++ b/packages/middleware-sdk-s3-control/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-s3-control/.npmignore
+++ b/packages/middleware-sdk-s3-control/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-s3/.npmignore
+++ b/packages/middleware-sdk-s3/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-s3/.npmignore
+++ b/packages/middleware-sdk-s3/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-s3/.npmignore
+++ b/packages/middleware-sdk-s3/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-sqs/.npmignore
+++ b/packages/middleware-sdk-sqs/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-sqs/.npmignore
+++ b/packages/middleware-sdk-sqs/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-sqs/.npmignore
+++ b/packages/middleware-sdk-sqs/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-sdk-transcribe-streaming/.npmignore
+++ b/packages/middleware-sdk-transcribe-streaming/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-sdk-transcribe-streaming/.npmignore
+++ b/packages/middleware-sdk-transcribe-streaming/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-sdk-transcribe-streaming/.npmignore
+++ b/packages/middleware-sdk-transcribe-streaming/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-serde/.npmignore
+++ b/packages/middleware-serde/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-serde/.npmignore
+++ b/packages/middleware-serde/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-serde/.npmignore
+++ b/packages/middleware-serde/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-signing/.npmignore
+++ b/packages/middleware-signing/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-signing/.npmignore
+++ b/packages/middleware-signing/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-signing/.npmignore
+++ b/packages/middleware-signing/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-ssec/.npmignore
+++ b/packages/middleware-ssec/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-ssec/.npmignore
+++ b/packages/middleware-ssec/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-ssec/.npmignore
+++ b/packages/middleware-ssec/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-stack/.npmignore
+++ b/packages/middleware-stack/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/middleware-stack/.npmignore
+++ b/packages/middleware-stack/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/middleware-stack/.npmignore
+++ b/packages/middleware-stack/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-user-agent/.npmignore
+++ b/packages/middleware-user-agent/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/middleware-user-agent/.npmignore
+++ b/packages/middleware-user-agent/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/middleware-user-agent/.npmignore
+++ b/packages/middleware-user-agent/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/node-http-handler/.npmignore
+++ b/packages/node-http-handler/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/node-http-handler/.npmignore
+++ b/packages/node-http-handler/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/node-http-handler/.npmignore
+++ b/packages/node-http-handler/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/property-provider/.npmignore
+++ b/packages/property-provider/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/property-provider/.npmignore
+++ b/packages/property-provider/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/property-provider/.npmignore
+++ b/packages/property-provider/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/protocol-http/.npmignore
+++ b/packages/protocol-http/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/protocol-http/.npmignore
+++ b/packages/protocol-http/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/protocol-http/.npmignore
+++ b/packages/protocol-http/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/querystring-builder/.npmignore
+++ b/packages/querystring-builder/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/querystring-builder/.npmignore
+++ b/packages/querystring-builder/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/querystring-builder/.npmignore
+++ b/packages/querystring-builder/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/querystring-parser/.npmignore
+++ b/packages/querystring-parser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/querystring-parser/.npmignore
+++ b/packages/querystring-parser/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/querystring-parser/.npmignore
+++ b/packages/querystring-parser/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/s3-request-presigner/.npmignore
+++ b/packages/s3-request-presigner/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/s3-request-presigner/.npmignore
+++ b/packages/s3-request-presigner/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/s3-request-presigner/.npmignore
+++ b/packages/s3-request-presigner/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/service-error-classification/.npmignore
+++ b/packages/service-error-classification/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/service-error-classification/.npmignore
+++ b/packages/service-error-classification/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/service-error-classification/.npmignore
+++ b/packages/service-error-classification/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/sha256-tree-hash/.npmignore
+++ b/packages/sha256-tree-hash/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/sha256-tree-hash/.npmignore
+++ b/packages/sha256-tree-hash/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/sha256-tree-hash/.npmignore
+++ b/packages/sha256-tree-hash/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/shared-ini-file-loader/.npmignore
+++ b/packages/shared-ini-file-loader/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/shared-ini-file-loader/.npmignore
+++ b/packages/shared-ini-file-loader/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/shared-ini-file-loader/.npmignore
+++ b/packages/shared-ini-file-loader/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "declaration": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "declaration": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/signature-v4/.npmignore
+++ b/packages/signature-v4/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /suite/
 /scripts/

--- a/packages/signature-v4/.npmignore
+++ b/packages/signature-v4/.npmignore
@@ -6,5 +6,6 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map

--- a/packages/signature-v4/.npmignore
+++ b/packages/signature-v4/.npmignore
@@ -3,6 +3,7 @@
 /scripts/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/smithy-client/.npmignore
+++ b/packages/smithy-client/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/smithy-client/.npmignore
+++ b/packages/smithy-client/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/smithy-client/.npmignore
+++ b/packages/smithy-client/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/url-parser-browser/.npmignore
+++ b/packages/url-parser-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/url-parser-browser/.npmignore
+++ b/packages/url-parser-browser/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/url-parser-browser/.npmignore
+++ b/packages/url-parser-browser/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/url-parser-node/.npmignore
+++ b/packages/url-parser-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/url-parser-node/.npmignore
+++ b/packages/url-parser-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/url-parser-node/.npmignore
+++ b/packages/url-parser-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-arn-parser/.npmignore
+++ b/packages/util-arn-parser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-arn-parser/.npmignore
+++ b/packages/util-arn-parser/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-arn-parser/.npmignore
+++ b/packages/util-arn-parser/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-base64-browser/.npmignore
+++ b/packages/util-base64-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-base64-browser/.npmignore
+++ b/packages/util-base64-browser/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-base64-browser/.npmignore
+++ b/packages/util-base64-browser/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-base64-node/.npmignore
+++ b/packages/util-base64-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-base64-node/.npmignore
+++ b/packages/util-base64-node/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-base64-node/.npmignore
+++ b/packages/util-base64-node/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-body-length-browser/.npmignore
+++ b/packages/util-body-length-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-body-length-browser/.npmignore
+++ b/packages/util-body-length-browser/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-body-length-browser/.npmignore
+++ b/packages/util-body-length-browser/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-body-length-node/.npmignore
+++ b/packages/util-body-length-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-body-length-node/.npmignore
+++ b/packages/util-body-length-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-body-length-node/.npmignore
+++ b/packages/util-body-length-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-buffer-from/.npmignore
+++ b/packages/util-buffer-from/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-buffer-from/.npmignore
+++ b/packages/util-buffer-from/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-buffer-from/.npmignore
+++ b/packages/util-buffer-from/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "strict": true,
     "lib": ["es5", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "strict": true,
     "lib": ["es5", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-create-request/.npmignore
+++ b/packages/util-create-request/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-create-request/.npmignore
+++ b/packages/util-create-request/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-create-request/.npmignore
+++ b/packages/util-create-request/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-format-url/.npmignore
+++ b/packages/util-format-url/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-format-url/.npmignore
+++ b/packages/util-format-url/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-format-url/.npmignore
+++ b/packages/util-format-url/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-hex-encoding/.npmignore
+++ b/packages/util-hex-encoding/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-hex-encoding/.npmignore
+++ b/packages/util-hex-encoding/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-hex-encoding/.npmignore
+++ b/packages/util-hex-encoding/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "strict": true,
     "sourceMap": false,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -4,7 +4,7 @@
     "strict": true,
     "sourceMap": false,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "sourceRoot": "./src",
+    "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-locate-window/.npmignore
+++ b/packages/util-locate-window/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-locate-window/.npmignore
+++ b/packages/util-locate-window/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-locate-window/.npmignore
+++ b/packages/util-locate-window/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-uri-escape/.npmignore
+++ b/packages/util-uri-escape/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-uri-escape/.npmignore
+++ b/packages/util-uri-escape/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-uri-escape/.npmignore
+++ b/packages/util-uri-escape/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-user-agent-browser/.npmignore
+++ b/packages/util-user-agent-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-user-agent-browser/.npmignore
+++ b/packages/util-user-agent-browser/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-user-agent-browser/.npmignore
+++ b/packages/util-user-agent-browser/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-user-agent-node/.npmignore
+++ b/packages/util-user-agent-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 /docs/
 tsconfig.test.json

--- a/packages/util-user-agent-node/.npmignore
+++ b/packages/util-user-agent-node/.npmignore
@@ -2,6 +2,7 @@
 /docs/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-user-agent-node/.npmignore
+++ b/packages/util-user-agent-node/.npmignore
@@ -5,6 +5,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-utf8-browser/.npmignore
+++ b/packages/util-utf8-browser/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-utf8-browser/.npmignore
+++ b/packages/util-utf8-browser/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-utf8-browser/.npmignore
+++ b/packages/util-utf8-browser/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/util-utf8-node/.npmignore
+++ b/packages/util-utf8-node/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/util-utf8-node/.npmignore
+++ b/packages/util-utf8-node/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/util-utf8-node/.npmignore
+++ b/packages/util-utf8-node/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts

--- a/packages/xml-builder/.npmignore
+++ b/packages/xml-builder/.npmignore
@@ -1,4 +1,3 @@
-/src/
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo

--- a/packages/xml-builder/.npmignore
+++ b/packages/xml-builder/.npmignore
@@ -4,6 +4,7 @@ tsconfig.test.json
 jest.config.js
 
 *.spec.js
+*.spec.ts
 *.spec.d.ts
 *.spec.js.map
 

--- a/packages/xml-builder/.npmignore
+++ b/packages/xml-builder/.npmignore
@@ -1,6 +1,7 @@
 /coverage/
 tsconfig.test.json
 *.tsbuildinfo
+jest.config.js
 
 *.spec.js
 *.spec.d.ts


### PR DESCRIPTION
_This PR replaces #393. @trivikr closed that PR in January 2020 because another PR was supposed to include the same fixes, but #393 contained other fixes to problems that are still broken. Hence this PR with the remaining fixes, including updates to account for changes since Jan 2020. Content below is shamelessly copied from #393._

Currently, SDKV3 publishes sourcemaps to npm but doesn't publish the source files that those sourcemaps point to. This missing source files breaks debugging use-cases, especially for VSCode users because the VSCode debugger relies on source files for setting breakpoints in the debugger, for debugger call stacks, for "step into" original source, and any other debugger use-cases. Even outside of debugging use-cases, it's helpful for developers consuming transpiled libraries to have original source so they can better understand what the library is doing. Finally, some tools will show warnings when sourcemaps are present but source files are missing, and this PR will fix these warnings.

This PR:

* Removes /src from .npmignore for non-client packages, for reasons discussed above.
* Adds `jest.config.js` and `*.spec.ts` to non-client packages' .npmignore because test files shouldn't be in an NPM download.
* ~~Removes `*.ts` from npm for client packages. (also removes `!*.d.ts` which is now unnecessary)~~ _(This is the one part of #393 that is already fixed so is excluded from this PR)_
* In 8 non-client packages, changes `sourceRoot` to `rootDir` in tsconfig.json. The latter setting is used by all other SDKV3 packages, and it produces sourcemaps with an empty `sourceRoot` field. This is ideal, because the `sourceRoot` feature turned out to be buggy in some sourcemap-reading and sourcemap-writing tools. Leaving it blank maximizes compatibility with more tools.

This PR is similar to aws/aws-sdk-js-crypto-helpers#5 in the AWS Crypto Helpers library, and aws-amplify/amplify-js#2680 which made similar changes to AWS Amplify library earlier this year.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
