### PR TITLE
fix(codegen): checkstyle violations

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -43,7 +43,7 @@ import software.amazon.smithy.utils.MapUtils;
  *     <li>credentialDefaultProvider: Provides credentials if no credentials
  *     are explicitly provided.</li>
  *     <li>region: The AWS region to which this client will send requests</li>
- *     <li>maxAttempts: Provides value for how many times a request will be 
+ *     <li>maxAttempts: Provides value for how many times a request will be
  *     made at most in case of retry.</li>
  * </ul>
  *
@@ -53,7 +53,7 @@ import software.amazon.smithy.utils.MapUtils;
  *     <li>signingName: Sets this to the signing name derived from the model.</li>
  *     <li>credentialDefaultProvider: Uses the default credential provider that
  *     checks things like environment variables and the AWS config file.</li>
- *     <li>region: Uses the default region provider that checks things like 
+ *     <li>region: Uses the default region provider that checks things like
  *      environment variables and the AWS config file.</li>
  *     <li>maxAttempts: Uses the default maxAttempts provider that checks things
  *     like environment variables and the AWS config file.</li>
@@ -147,7 +147,8 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         },
                         "maxAttempts", writer -> {
                             writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);
-                            writer.addImport("DEFAULT_MAX_ATTEMPTS", "DEFAULT_MAX_ATTEMPTS", TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
+                            writer.addImport("DEFAULT_MAX_ATTEMPTS", "DEFAULT_MAX_ATTEMPTS",
+                                    TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
                             writer.write("maxAttempts: DEFAULT_MAX_ATTEMPTS,");
                         }
                 );
@@ -161,12 +162,12 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         },
                         "region", writer -> {
                             writer.addDependency(AwsDependency.NODE_CONFIG_PROVIDER);
-                            writer.addImport("loadConfig", "loadNodeConfig", 
+                            writer.addImport("loadConfig", "loadNodeConfig",
                                     AwsDependency.NODE_CONFIG_PROVIDER.packageName);
                             writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
                             writer.addImport("NODE_REGION_CONFIG_OPTIONS", "NODE_REGION_CONFIG_OPTIONS",
                                     TypeScriptDependency.CONFIG_RESOLVER.packageName);
-                            writer.addImport("NODE_REGION_CONFIG_FILE_OPTIONS", "NODE_REGION_CONFIG_FILE_OPTIONS", 
+                            writer.addImport("NODE_REGION_CONFIG_FILE_OPTIONS", "NODE_REGION_CONFIG_FILE_OPTIONS",
                                     TypeScriptDependency.CONFIG_RESOLVER.packageName);
                             writer.write(
                                 "region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),");
@@ -201,7 +202,8 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         },
                         "maxAttempts", writer -> {
                             writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);
-                            writer.addImport("DEFAULT_MAX_ATTEMPTS", "DEFAULT_MAX_ATTEMPTS", TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
+                            writer.addImport("DEFAULT_MAX_ATTEMPTS", "DEFAULT_MAX_ATTEMPTS",
+                                    TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
                             writer.write("maxAttempts: DEFAULT_MAX_ATTEMPTS,");
                         }
                 );
@@ -220,12 +222,12 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         },
                         "region", writer -> {
                             writer.addDependency(AwsDependency.NODE_CONFIG_PROVIDER);
-                            writer.addImport("loadConfig", "loadNodeConfig", 
+                            writer.addImport("loadConfig", "loadNodeConfig",
                                     AwsDependency.NODE_CONFIG_PROVIDER.packageName);
                             writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
                             writer.addImport("NODE_REGION_CONFIG_OPTIONS", "NODE_REGION_CONFIG_OPTIONS",
                                     TypeScriptDependency.CONFIG_RESOLVER.packageName);
-                            writer.addImport("NODE_REGION_CONFIG_FILE_OPTIONS", "NODE_REGION_CONFIG_FILE_OPTIONS", 
+                            writer.addImport("NODE_REGION_CONFIG_FILE_OPTIONS", "NODE_REGION_CONFIG_FILE_OPTIONS",
                                     TypeScriptDependency.CONFIG_RESOLVER.packageName);
                             writer.write(
                                 "region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -44,7 +44,8 @@ public final class AddS3Config implements TypeScriptIntegration {
         writer.writeDocs("Whether to escape request path when signing the request.")
                 .write("signingEscapePath?: boolean;\n");
         writer.writeDocs(
-                "Whether to override the request region with the region inferred from requested resource's ARN. Defaults to false.")
+                "Whether to override the request region with the region inferred from requested resource's ARN."
+                        + " Defaults to false.")
                 .addImport("Provider", "Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName)
                 .write("useArnRegion?: boolean | Provider<boolean>;");
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -172,7 +172,7 @@ final class EndpointGenerator implements Runnable {
                     writer.openBlock("regionInfo = {", "};", () -> {
                         String template = partition.templateVariableName;
                         writer.write("hostname: $L.replace(\"{region}\", region),", template);
-                        writer.write("partition: $S,", partition.ID);
+                        writer.write("partition: $S,", partition.identifier);
                         writeAdditionalEndpointSettings(partition.getDefaults());
                     });
                 }
@@ -183,7 +183,7 @@ final class EndpointGenerator implements Runnable {
         String hostname = resolved.expectStringMember("hostname").getValue();
         writer.openBlock("regionInfo = {", "};", () -> {
             writer.write("hostname: $S,", hostname);
-            writer.write("partition: $S,", regionPartitionsMap.get(region).ID);
+            writer.write("partition: $S,", regionPartitionsMap.get(region).identifier);
             writeAdditionalEndpointSettings(resolved);
         });
     }
@@ -206,7 +206,7 @@ final class EndpointGenerator implements Runnable {
         final String templateVariableName;
         final String templateValue;
         final String dnsSuffix;
-        final String ID;
+        final String identifier;
         private final ObjectNode config;
 
         private Partition(ObjectNode config, String partition) {
@@ -227,7 +227,7 @@ final class EndpointGenerator implements Runnable {
             regionVariableName = snakePartition + "_REGIONS";
 
             dnsSuffix = config.expectStringMember("dnsSuffix").getValue();
-            ID = partition;
+            identifier = partition;
         }
 
         ObjectNode getDefaults() {


### PR DESCRIPTION
Fixes checkstyle error violations for `RegexpSingleline`, `LineLength` and `MemberName`.

Removes trailing spaces, lines longer than 150 chars and invalid member names.

These violations are returned as errors when running the `./gradlew build` from the `codegen` directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
