### PR TITLE
chore: gitignore Android related files in react-native tests

### DIFF
--- a/tests/react-native/End2End/.gitignore
+++ b/tests/react-native/End2End/.gitignore
@@ -29,6 +29,9 @@ build/
 .gradle
 local.properties
 *.iml
+.project
+.settings
+.classpath
 
 # node.js
 #


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1468

*Description of changes:*
gitignore Android related files in react-native tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
