### PR TITLE
fix(property-provider): memoize provider after the first evoke

### DIFF
--- a/packages/property-provider/src/memoize.spec.ts
+++ b/packages/property-provider/src/memoize.spec.ts
@@ -15,9 +15,10 @@ describe("memoize", () => {
 
   describe("static memoization", () => {
     it("should cache the resolved provider", async () => {
-      expect.assertions(repeatTimes * 2);
+      expect.assertions(repeatTimes * 2 + 1);
 
       const memoized = memoize(provider);
+      expect(provider).toHaveBeenCalledTimes(0);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       for (const index in [...Array(repeatTimes).keys()]) {
         expect(await memoized()).toStrictEqual(mockReturn);
@@ -51,6 +52,7 @@ describe("memoize", () => {
       const isExpiredFalseTest = async (requiresRefresh?: any) => {
         isExpired.mockReturnValue(false);
         const memoized = memoize(provider, isExpired, requiresRefresh);
+        expect(provider).toHaveBeenCalledTimes(0);
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const index in [...Array(repeatTimes).keys()]) {
           expect(await memoized()).toEqual(mockReturn);

--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -43,16 +43,26 @@ export const memoize: MemoizeOverload = <T>(
   isExpired?: (resolved: T) => boolean,
   requiresRefresh?: (resolved: T) => boolean
 ): Provider<T> => {
+  let result: any;
+  let hasResult: boolean;
   if (isExpired === undefined) {
     // This is a static memoization; no need to incorporate refreshing
-    const result = provider();
-    return () => result;
+    return () => {
+      if (!hasResult) {
+        result = provider();
+        hasResult = true;
+      }
+      return result;
+    };
   }
 
-  let result = provider();
   let isConstant = false;
 
   return async () => {
+    if (!hasResult) {
+      result = provider();
+      hasResult = true;
+    }
     if (isConstant) {
       return result;
     }


### PR DESCRIPTION
Resolves #1466 

*Description of changes:*
This change makes the memoize function loads the value after the first invoke instead of immediately when calling `memoize()`.

Detailed root cause is stated in the original issue: https://github.com/aws/aws-sdk-js-v3/issues/1466#issuecomment-681147889. This issue was not caught because all of the environments we run CI, and developers machine, already has `AWS_REGION` value set. 

To prevent it happens again, we need to check and clean the environment of our CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
